### PR TITLE
Filer upload from URL

### DIFF
--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -59,6 +59,7 @@ type FilerOptions struct {
 	debugPort               *int
 	localSocket             *string
 	showUIDirectoryDelete   *bool
+	enableUploadFromUrl     *bool
 }
 
 func init() {
@@ -87,6 +88,7 @@ func init() {
 	f.debugPort = cmdFiler.Flag.Int("debug.port", 6060, "http port for debugging")
 	f.localSocket = cmdFiler.Flag.String("localSocket", "", "default to /tmp/seaweedfs-filer-<port>.sock")
 	f.showUIDirectoryDelete = cmdFiler.Flag.Bool("ui.deleteDir", true, "enable filer UI show delete directory button")
+	f.enableUploadFromUrl = cmdFiler.Flag.Bool("uploadFromUrl", false, "enable filer upload from URL feature")
 
 	// start s3 on filer
 	filerStartS3 = cmdFiler.Flag.Bool("s3", false, "whether to start S3 gateway")
@@ -235,6 +237,7 @@ func (fo *FilerOptions) startFiler() {
 		SaveToFilerLimit:      int64(*fo.saveToFilerLimit),
 		ConcurrentUploadLimit: int64(*fo.concurrentUploadLimitMB) * 1024 * 1024,
 		ShowUIDirectoryDelete: *fo.showUIDirectoryDelete,
+		EnableUploadFromUrl:   *fo.enableUploadFromUrl,
 	})
 	if nfs_err != nil {
 		glog.Fatalf("Filer startup error: %v", nfs_err)

--- a/weed/command/server.go
+++ b/weed/command/server.go
@@ -115,6 +115,7 @@ func init() {
 	filerOptions.concurrentUploadLimitMB = cmdServer.Flag.Int("filer.concurrentUploadLimitMB", 64, "limit total concurrent upload size")
 	filerOptions.localSocket = cmdServer.Flag.String("filer.localSocket", "", "default to /tmp/seaweedfs-filer-<port>.sock")
 	filerOptions.showUIDirectoryDelete = cmdServer.Flag.Bool("filer.ui.deleteDir", true, "enable filer UI show delete directory button")
+	filerOptions.enableUploadFromUrl = cmdServer.Flag.Bool("uploadFromUrl", false, "enable filer upload from URL feature")
 
 	serverOptions.v.port = cmdServer.Flag.Int("volume.port", 8080, "volume server http listen port")
 	serverOptions.v.portGrpc = cmdServer.Flag.Int("volume.port.grpc", 0, "volume server grpc listen port")

--- a/weed/server/filer_server.go
+++ b/weed/server/filer_server.go
@@ -68,6 +68,7 @@ type FilerOption struct {
 	SaveToFilerLimit      int64
 	ConcurrentUploadLimit int64
 	ShowUIDirectoryDelete bool
+	EnableUploadFromUrl   bool
 }
 
 type FilerServer struct {

--- a/weed/server/filer_server_handlers_read_dir.go
+++ b/weed/server/filer_server_handlers_read_dir.go
@@ -82,6 +82,7 @@ func (fs *FilerServer) listDirectoryHandler(w http.ResponseWriter, r *http.Reque
 		ShouldDisplayLoadMore bool
 		EmptyFolder           bool
 		ShowDirectoryDelete   bool
+		EnableUploadFromUrl   bool
 	}{
 		path,
 		ui.ToBreadcrumb(path),
@@ -91,6 +92,7 @@ func (fs *FilerServer) listDirectoryHandler(w http.ResponseWriter, r *http.Reque
 		shouldDisplayLoadMore,
 		emptyFolder,
 		fs.option.ShowUIDirectoryDelete,
+		fs.option.EnableUploadFromUrl,
 	})
 	if err != nil {
 		glog.V(0).Infof("Template Execute Error: %v", err)

--- a/weed/server/filer_server_handlers_write.go
+++ b/weed/server/filer_server_handlers_write.go
@@ -115,7 +115,11 @@ func (fs *FilerServer) uploadFromSourceURL(ctx context.Context, w http.ResponseW
 		writeJsonError(w, r, http.StatusBadRequest, err)
 		return
 	}
-	req.Header.Set("User-Agent", "curl/7.68.0")
+	ua := r.Header.Get("User-Agent")
+	if ua == "" {
+		ua = "curl/7.68.0"
+	}
+	req.Header.Set("User-Agent", ua)
 	req.Header.Set("Accept", "*/*")
 	client := &http.Client{}
 	resp, err := client.Do(req)

--- a/weed/server/filer_server_handlers_write.go
+++ b/weed/server/filer_server_handlers_write.go
@@ -110,8 +110,15 @@ func (fs *FilerServer) uploadFromSourceURL(ctx context.Context, w http.ResponseW
 		writeJsonError(w, r, http.StatusBadRequest, fmt.Errorf("Invalid protocol: %s", srcUrl.Scheme))
 		return
 	}
-
-	resp, err := http.Get(srcUrl.String())
+	req, err := http.NewRequest("GET", srcUrl.String(), nil)
+	if err != nil {
+		writeJsonError(w, r, http.StatusBadRequest, err)
+		return
+	}
+	req.Header.Set("User-Agent", "curl/7.68.0")
+	req.Header.Set("Accept", "*/*")
+	client := &http.Client{}
+	resp, err := client.Do(req)
 	if err != nil {
 		writeJsonError(w, r, http.StatusBadRequest, err)
 		return

--- a/weed/server/filer_server_handlers_write.go
+++ b/weed/server/filer_server_handlers_write.go
@@ -21,6 +21,11 @@ import (
 	"github.com/chrislusf/seaweedfs/weed/util"
 )
 
+const (
+	QS_MOVE_FROM = "mv.from"
+	QS_FROM_URL  = "from.url"
+)
+
 var (
 	OS_UID = uint32(os.Getuid())
 	OS_GID = uint32(os.Getgid())
@@ -87,9 +92,9 @@ func (fs *FilerServer) PostHandler(w http.ResponseWriter, r *http.Request, conte
 		return
 	}
 
-	if query.Has("mv.from") {
+	if query.Has(QS_MOVE_FROM) {
 		fs.move(ctx, w, r, so)
-	} else if query.Has("source_url") {
+	} else if query.Has(QS_FROM_URL) {
 		fs.uploadFromSourceURL(ctx, w, r, so)
 	} else {
 		fs.autoChunk(ctx, w, r, contentLength, so)
@@ -100,7 +105,7 @@ func (fs *FilerServer) PostHandler(w http.ResponseWriter, r *http.Request, conte
 }
 
 func (fs *FilerServer) uploadFromSourceURL(ctx context.Context, w http.ResponseWriter, r *http.Request, so *operation.StorageOption) {
-	sourceUrl := r.URL.Query().Get("source_url")
+	sourceUrl := r.URL.Query().Get(QS_FROM_URL)
 	srcUrl, err := url.ParseRequestURI(sourceUrl)
 	if err != nil {
 		writeJsonError(w, r, http.StatusBadRequest, err)
@@ -142,7 +147,7 @@ func (fs *FilerServer) uploadFromSourceURL(ctx context.Context, w http.ResponseW
 }
 
 func (fs *FilerServer) move(ctx context.Context, w http.ResponseWriter, r *http.Request, so *operation.StorageOption) {
-	src := r.URL.Query().Get("mv.from")
+	src := r.URL.Query().Get(QS_MOVE_FROM)
 	dst := r.URL.Path
 
 	glog.V(2).Infof("FilerServer.move %v to %v", src, dst)

--- a/weed/server/filer_server_handlers_write.go
+++ b/weed/server/filer_server_handlers_write.go
@@ -94,7 +94,7 @@ func (fs *FilerServer) PostHandler(w http.ResponseWriter, r *http.Request, conte
 
 	if query.Has(QS_MOVE_FROM) {
 		fs.move(ctx, w, r, so)
-	} else if query.Has(QS_FROM_URL) {
+	} else if fs.option.EnableUploadFromUrl && query.Has(QS_FROM_URL) {
 		fs.uploadFromSourceURL(ctx, w, r, so)
 	} else {
 		fs.autoChunk(ctx, w, r, contentLength, so)

--- a/weed/server/filer_server_handlers_write.go
+++ b/weed/server/filer_server_handlers_write.go
@@ -106,7 +106,7 @@ func (fs *FilerServer) uploadFromSourceURL(ctx context.Context, w http.ResponseW
 		writeJsonError(w, r, http.StatusBadRequest, err)
 		return
 	}
-	if srcUrl.Scheme != "http" || srcUrl.Scheme != "https" {
+	if srcUrl.Scheme != "http" && srcUrl.Scheme != "https" {
 		writeJsonError(w, r, http.StatusBadRequest, fmt.Errorf("Invalid protocol: %s", srcUrl.Scheme))
 		return
 	}

--- a/weed/server/filer_server_handlers_write.go
+++ b/weed/server/filer_server_handlers_write.go
@@ -125,7 +125,7 @@ func (fs *FilerServer) uploadFromSourceURL(ctx context.Context, w http.ResponseW
 
 	contentLength := resp.ContentLength
 	contentType := resp.Header.Get("Content-Type")
-	fs.autoChunkWithOtherStream(ctx, w, r, resp.Body, contentLength, contentType, so)
+	fs.autoChunkWithStream(ctx, w, r, resp.Body, contentLength, contentType, so)
 
 	util.CloseRequest(r)
 }

--- a/weed/server/filer_server_handlers_write.go
+++ b/weed/server/filer_server_handlers_write.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -100,7 +101,17 @@ func (fs *FilerServer) PostHandler(w http.ResponseWriter, r *http.Request, conte
 
 func (fs *FilerServer) uploadFromSourceURL(ctx context.Context, w http.ResponseWriter, r *http.Request, so *operation.StorageOption) {
 	sourceUrl := r.URL.Query().Get("source_url")
-	resp, err := http.Get(sourceUrl)
+	srcUrl, err := url.ParseRequestURI(sourceUrl)
+	if err != nil {
+		writeJsonError(w, r, http.StatusBadRequest, err)
+		return
+	}
+	if srcUrl.Scheme != "http" || srcUrl.Scheme != "https" {
+		writeJsonError(w, r, http.StatusBadRequest, fmt.Errorf("Invalid protocol: %s", srcUrl.Scheme))
+		return
+	}
+
+	resp, err := http.Get(srcUrl.String())
 	if err != nil {
 		writeJsonError(w, r, http.StatusBadRequest, err)
 		return

--- a/weed/server/filer_server_handlers_write_autochunk.go
+++ b/weed/server/filer_server_handlers_write_autochunk.go
@@ -3,7 +3,6 @@ package weed_server
 import (
 	"context"
 	"fmt"
-	"github.com/chrislusf/seaweedfs/weed/s3api/s3_constants"
 	"io"
 	"net/http"
 	"os"
@@ -11,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/chrislusf/seaweedfs/weed/s3api/s3_constants"
 
 	"github.com/chrislusf/seaweedfs/weed/filer"
 	"github.com/chrislusf/seaweedfs/weed/glog"
@@ -67,6 +68,56 @@ func (fs *FilerServer) autoChunk(ctx context.Context, w http.ResponseWriter, r *
 		}
 		writeJsonQuiet(w, r, http.StatusCreated, reply)
 	}
+}
+
+func (fs *FilerServer) autoChunkWithOtherStream(ctx context.Context, w http.ResponseWriter, r *http.Request, stream io.Reader, contentLength int64, contentType string, so *operation.StorageOption) {
+	maxMB := int32(fs.option.MaxMB)
+
+	chunkSize := 1024 * 1024 * maxMB
+
+	stats.FilerRequestCounter.WithLabelValues("chunk").Inc()
+	start := time.Now()
+	defer func() {
+		stats.FilerRequestHistogram.WithLabelValues("chunk").Observe(time.Since(start).Seconds())
+	}()
+
+	reply, md5bytes, err := fs.doAutoChunkWithOtherStream(ctx, w, r, stream, chunkSize, contentLength, contentType, so)
+	if err != nil {
+		if strings.HasPrefix(err.Error(), "read input:") {
+			writeJsonError(w, r, 499, err)
+		} else if strings.HasSuffix(err.Error(), "is a file") {
+			writeJsonError(w, r, http.StatusConflict, err)
+		} else {
+			writeJsonError(w, r, http.StatusInternalServerError, err)
+		}
+	} else if reply != nil {
+		if len(md5bytes) > 0 {
+			md5InBase64 := util.Base64Encode(md5bytes)
+			w.Header().Set("Content-MD5", md5InBase64)
+		}
+		writeJsonQuiet(w, r, http.StatusCreated, reply)
+	}
+}
+
+func (fs *FilerServer) doAutoChunkWithOtherStream(ctx context.Context, w http.ResponseWriter, r *http.Request, stream io.Reader, chunkSize int32, contentLength int64, contentType string, so *operation.StorageOption) (filerResult *FilerPostResult, md5bytes []byte, replyerr error) {
+
+	fileName := path.Base(r.URL.Path)
+	if contentType == "application/octet-stream" {
+		contentType = ""
+	}
+
+	fileChunks, md5Hash, chunkOffset, err, smallContent := fs.uploadReaderToChunks(w, r, stream, chunkSize, fileName, contentType, contentLength, so)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	md5bytes = md5Hash.Sum(nil)
+	filerResult, replyerr = fs.saveMetaData(ctx, r, fileName, contentType, so, md5bytes, fileChunks, chunkOffset, smallContent)
+	if replyerr != nil {
+		fs.filer.DeleteChunks(fileChunks)
+	}
+
+	return
 }
 
 func (fs *FilerServer) doPostAutoChunk(ctx context.Context, w http.ResponseWriter, r *http.Request, chunkSize int32, contentLength int64, so *operation.StorageOption) (filerResult *FilerPostResult, md5bytes []byte, replyerr error) {

--- a/weed/server/filer_server_handlers_write_autochunk.go
+++ b/weed/server/filer_server_handlers_write_autochunk.go
@@ -70,7 +70,7 @@ func (fs *FilerServer) autoChunk(ctx context.Context, w http.ResponseWriter, r *
 	}
 }
 
-func (fs *FilerServer) autoChunkWithOtherStream(ctx context.Context, w http.ResponseWriter, r *http.Request, stream io.Reader, contentLength int64, contentType string, so *operation.StorageOption) {
+func (fs *FilerServer) autoChunkWithStream(ctx context.Context, w http.ResponseWriter, r *http.Request, stream io.Reader, contentLength int64, contentType string, so *operation.StorageOption) {
 	maxMB := int32(fs.option.MaxMB)
 
 	chunkSize := 1024 * 1024 * maxMB
@@ -81,7 +81,7 @@ func (fs *FilerServer) autoChunkWithOtherStream(ctx context.Context, w http.Resp
 		stats.FilerRequestHistogram.WithLabelValues("chunk").Observe(time.Since(start).Seconds())
 	}()
 
-	reply, md5bytes, err := fs.doAutoChunkWithOtherStream(ctx, w, r, stream, chunkSize, contentLength, contentType, so)
+	reply, md5bytes, err := fs.doAutoChunkWithStream(ctx, w, r, stream, chunkSize, contentLength, contentType, so)
 	if err != nil {
 		if strings.HasPrefix(err.Error(), "read input:") {
 			writeJsonError(w, r, 499, err)
@@ -99,7 +99,7 @@ func (fs *FilerServer) autoChunkWithOtherStream(ctx context.Context, w http.Resp
 	}
 }
 
-func (fs *FilerServer) doAutoChunkWithOtherStream(ctx context.Context, w http.ResponseWriter, r *http.Request, stream io.Reader, chunkSize int32, contentLength int64, contentType string, so *operation.StorageOption) (filerResult *FilerPostResult, md5bytes []byte, replyerr error) {
+func (fs *FilerServer) doAutoChunkWithStream(ctx context.Context, w http.ResponseWriter, r *http.Request, stream io.Reader, chunkSize int32, contentLength int64, contentType string, so *operation.StorageOption) (filerResult *FilerPostResult, md5bytes []byte, replyerr error) {
 
 	fileName := path.Base(r.URL.Path)
 	if contentType == "application/octet-stream" {

--- a/weed/server/filer_ui/filer.html
+++ b/weed/server/filer_ui/filer.html
@@ -382,7 +382,7 @@
         if (!baseUrl.endsWith('/')) {
             baseUrl += '/';
         }
-        var url = baseUrl + fname + '?source_url=' + srcUrl;
+        var url = baseUrl + fname + '?from.url=' + srcUrl;
         var xhr = new XMLHttpRequest();
         xhr.open('POST', url);
         xhr.setRequestHeader('Content-Type', '');

--- a/weed/server/filer_ui/filer.html
+++ b/weed/server/filer_ui/filer.html
@@ -94,9 +94,11 @@
                 <label class="btn btn-default" for="fileElem">
                     <span class="glyphicon glyphicon-cloud-upload" aria-hidden="true"></span> Upload
                 </label>
+                {{ if .EnableUploadFromUrl  }}
                 <label class="btn btn-default" onclick="handleUploadFromUrl()">
                     <span class="glyphicon glyphicon-cloud-upload" aria-hidden="true"></span> Upload From URL
                 </label>
+                {{ end }}
             </div>
             <ol class="breadcrumb">
             {{ range $entry := .Breadcrumbs }}

--- a/weed/server/filer_ui/filer.html
+++ b/weed/server/filer_ui/filer.html
@@ -94,6 +94,9 @@
                 <label class="btn btn-default" for="fileElem">
                     <span class="glyphicon glyphicon-cloud-upload" aria-hidden="true"></span> Upload
                 </label>
+                <label class="btn btn-default" onclick="handleUploadFromUrl()">
+                    <span class="glyphicon glyphicon-cloud-upload" aria-hidden="true"></span> Upload From URL
+                </label>
             </div>
             <ol class="breadcrumb">
             {{ range $entry := .Breadcrumbs }}
@@ -234,7 +237,7 @@
     function handleFiles(files) {
         files = [...files];
         files.forEach(startUpload);
-        renderProgress();
+        renderProgress(false);
         files.forEach(uploadFile);
     }
 
@@ -242,18 +245,22 @@
         uploadList[file.name] = {'name': file.name, 'percent': 0, 'finish': false};
     }
 
-    function renderProgress() {
+    function renderProgress(forceLoading) {
         var values = Object.values(uploadList);
         var html = '<table class="table">\n<tr><th>Uploading</th><\/tr>\n';
         for (let i of values) {
             var progressBarClass = 'progress-bar-striped active';
-            if (i.percent >= 100) {
+            if (i.percent >= 100 && !forceLoading) {
                 progressBarClass = 'progress-bar-success';
             }
             html += '<tr>\n<td>\n';
             html += '<div class="progress" style="margin-bottom: 2px;">\n';
             html += '<div class="progress-bar ' + progressBarClass + '" role="progressbar" aria-valuenow="' + '100" aria-valuemin="0" aria-valuemax="100" style="width:' + i.percent + '%;">';
-            html += '<span style="margin-right: 10px;">' + i.name + '</span>' + i.percent + '%<\/div>';
+            if (forceLoading) {
+                html += '<span style="margin-right: 10px;">' + i.name + '</span><\/div>';
+            } else {
+                html += '<span style="margin-right: 10px;">' + i.name + '</span>' + i.percent + '%<\/div>';
+            }
             html += '<\/div>\n<\/td>\n<\/tr>\n';
         }
         html += '<\/table>\n';
@@ -266,12 +273,12 @@
     function reportProgress(file, percent) {
         var item = uploadList[file]
         item.percent = percent;
-        renderProgress();
+        renderProgress(false);
     }
 
     function finishUpload(file) {
         uploadList[file]['finish'] = true;
-        renderProgress();
+        renderProgress(false);
         var allFinish = true;
         for (let i of Object.values(uploadList)) {
             if (!i.finish) {
@@ -353,6 +360,44 @@
         xhr.open('DELETE', url, false);
         xhr.send();
         reloadPage();
+    }
+
+    function handleUploadFromUrl() {
+        var srcUrl = prompt('URL:', '');
+        srcUrl = srcUrl.trim();
+        if (srcUrl == null || srcUrl == '') {
+            return;
+        }
+        var fname = new URL(srcUrl).pathname.split('/').pop();
+        fname = fname.trim();
+        if (fname == '') {
+            return;
+        }
+        var baseUrl = window.location.href;
+        if (!baseUrl.endsWith('/')) {
+            baseUrl += '/';
+        }
+        var url = baseUrl + fname + '?source_url=' + srcUrl;
+        console.log(url);
+        var xhr = new XMLHttpRequest();
+        xhr.open('POST', url);
+        xhr.setRequestHeader('Content-Type', '');
+        xhr.onreadystatechange = function () {
+            // In local files, status is 0 upon success in Mozilla Firefox
+            console.log(xhr.readyState);
+            console.log(xhr.status);
+            if(xhr.readyState === XMLHttpRequest.DONE) {
+                var status = xhr.status;
+                if (status > 200 && status < 400) {
+                    reloadPage();
+                } else {
+                    alert('Upload from ' + srcUrl + ' got error');
+                }
+            }
+        };
+        xhr.send();
+        uploadList[fname] = {'name': fname, 'percent': 100, 'finish': false};
+        renderProgress(true);
     }
 </script>
 </html>

--- a/weed/server/filer_ui/filer.html
+++ b/weed/server/filer_ui/filer.html
@@ -270,6 +270,11 @@
         }
     }
 
+    function hideProgress() {
+        progressArea.innerHTML = '';
+        progressArea.attributes.style.value = 'display: none;';
+    }
+
     function reportProgress(file, percent) {
         var item = uploadList[file]
         item.percent = percent;
@@ -378,20 +383,18 @@
             baseUrl += '/';
         }
         var url = baseUrl + fname + '?source_url=' + srcUrl;
-        console.log(url);
         var xhr = new XMLHttpRequest();
         xhr.open('POST', url);
         xhr.setRequestHeader('Content-Type', '');
         xhr.onreadystatechange = function () {
-            // In local files, status is 0 upon success in Mozilla Firefox
-            console.log(xhr.readyState);
-            console.log(xhr.status);
             if(xhr.readyState === XMLHttpRequest.DONE) {
                 var status = xhr.status;
                 if (status > 200 && status < 400) {
                     reloadPage();
                 } else {
                     alert('Upload from ' + srcUrl + ' got error');
+                    uploadList = {};
+                    hideProgress();
                 }
             }
         };


### PR DESCRIPTION
# What problem are we solving?

Support upload a file to filer from URL. And provide filer UI a button `Upload From URL` to upload a file from URL.

Without this feature user should download a file to local and then upload it to filer. After provide this features user can just input a download URL and confirm, filer server can handle the rest.

# How are we solving the problem?

Just check query string with `source_url` field and using HTTP download stream to `autoChunk` logic. The downloaded file will inherate the URL response's content type and content length.

# Usage

Make a `POST` or `PUT` request with `from.url` query parameter.

```
curl -XPOST "http://[FILER_IP]:[FILER_PORT]/path/alpine-standard-3.16.0_rc1-x86_64.iso?from.url=http://mirrors.edge.kernel.org/alpine/latest-stable/releases/x86_64/alpine-standard-3.16.0_rc1-x86_64.iso"
```
This also provide an option for enable or disable this feature: `-uploadFromUrl`, default set to false. If want use this feature just start filer server with `-uploadFromUrl` option.

```
./weed filer -uploadFromUrl
```

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
