### PR TITLE
add supplement for access control of the directories under buckets

### DIFF
--- a/weed/iamapi/iamapi_test.go
+++ b/weed/iamapi/iamapi_test.go
@@ -138,7 +138,10 @@ func TestPutUserPolicy(t *testing.T) {
 					  ],
 					  "Resource": [
 						"arn:aws:s3:::EXAMPLE-BUCKET",
-						"arn:aws:s3:::EXAMPLE-BUCKET/*"
+						"arn:aws:s3:::EXAMPLE-BUCKET/*",
+						"arn:aws:s3:::my-bucket/shared/*",
+						"arn:aws:s3:::my-bucket/*",
+						"arn:aws:s3:::my-bucket-prefix-*"
 					  ]
 					}
 				  ]

--- a/weed/shell/command_s3_configure.go
+++ b/weed/shell/command_s3_configure.go
@@ -38,7 +38,7 @@ func (c *commandS3Configure) Do(args []string, commandEnv *CommandEnv, writer io
 	s3ConfigureCommand := flag.NewFlagSet(c.Name(), flag.ContinueOnError)
 	actions := s3ConfigureCommand.String("actions", "", "comma separated actions names: Read,Write,List,Tagging,Admin")
 	user := s3ConfigureCommand.String("user", "", "user name")
-	resourcePaths := s3ConfigureCommand.String("resource_paths", "", "comma separated resource paths: bucket-1,bucket-2/*,bucket-3/dir/*,my-bucket-*")
+	buckets := s3ConfigureCommand.String("buckets", "", "bucket name")
 	accessKey := s3ConfigureCommand.String("access_key", "", "specify the access key")
 	secretKey := s3ConfigureCommand.String("secret_key", "", "specify the secret key")
 	isDelete := s3ConfigureCommand.Bool("delete", false, "delete users, actions or access keys")
@@ -74,10 +74,10 @@ func (c *commandS3Configure) Do(args []string, commandEnv *CommandEnv, writer io
 	}
 	var cmdActions []string
 	for _, action := range strings.Split(*actions, ",") {
-		if *resourcePaths == "" {
+		if *buckets == "" {
 			cmdActions = append(cmdActions, action)
 		} else {
-			for _, bucket := range strings.Split(*resourcePaths, ",") {
+			for _, bucket := range strings.Split(*buckets, ",") {
 				cmdActions = append(cmdActions, fmt.Sprintf("%s:%s", action, bucket))
 			}
 		}
@@ -116,7 +116,7 @@ func (c *commandS3Configure) Do(args []string, commandEnv *CommandEnv, writer io
 				}
 
 			}
-			if *actions == "" && *accessKey == "" && *resourcePaths == "" {
+			if *actions == "" && *accessKey == "" && *buckets == "" {
 				s3cfg.Identities = append(s3cfg.Identities[:idx], s3cfg.Identities[idx+1:]...)
 			}
 		} else {

--- a/weed/shell/command_s3_configure.go
+++ b/weed/shell/command_s3_configure.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"github.com/chrislusf/seaweedfs/weed/filer"
 	"io"
 	"sort"
 	"strings"
+
+	"github.com/chrislusf/seaweedfs/weed/filer"
 
 	"github.com/chrislusf/seaweedfs/weed/pb/filer_pb"
 	"github.com/chrislusf/seaweedfs/weed/pb/iam_pb"
@@ -37,7 +38,7 @@ func (c *commandS3Configure) Do(args []string, commandEnv *CommandEnv, writer io
 	s3ConfigureCommand := flag.NewFlagSet(c.Name(), flag.ContinueOnError)
 	actions := s3ConfigureCommand.String("actions", "", "comma separated actions names: Read,Write,List,Tagging,Admin")
 	user := s3ConfigureCommand.String("user", "", "user name")
-	buckets := s3ConfigureCommand.String("buckets", "", "bucket name")
+	resourcePaths := s3ConfigureCommand.String("resource_paths", "", "comma separated resource paths: bucket-1,bucket-2/*,bucket-3/dir/*,my-bucket-*")
 	accessKey := s3ConfigureCommand.String("access_key", "", "specify the access key")
 	secretKey := s3ConfigureCommand.String("secret_key", "", "specify the secret key")
 	isDelete := s3ConfigureCommand.Bool("delete", false, "delete users, actions or access keys")
@@ -73,10 +74,10 @@ func (c *commandS3Configure) Do(args []string, commandEnv *CommandEnv, writer io
 	}
 	var cmdActions []string
 	for _, action := range strings.Split(*actions, ",") {
-		if *buckets == "" {
+		if *resourcePaths == "" {
 			cmdActions = append(cmdActions, action)
 		} else {
-			for _, bucket := range strings.Split(*buckets, ",") {
+			for _, bucket := range strings.Split(*resourcePaths, ",") {
 				cmdActions = append(cmdActions, fmt.Sprintf("%s:%s", action, bucket))
 			}
 		}
@@ -115,7 +116,7 @@ func (c *commandS3Configure) Do(args []string, commandEnv *CommandEnv, writer io
 				}
 
 			}
-			if *actions == "" && *accessKey == "" && *buckets == "" {
+			if *actions == "" && *accessKey == "" && *resourcePaths == "" {
 				s3cfg.Identities = append(s3cfg.Identities[:idx], s3cfg.Identities[idx+1:]...)
 			}
 		} else {


### PR DESCRIPTION
# What problem are we solving?

#2334

# How are we solving the problem?

Because Seaweedfs already support the function of access control of the directories under buckets, see the `canDo` function: 
https://github.com/chrislusf/seaweedfs/blob/f90926572103c0c6d2dbf025b9e09e62d2137b23/weed/s3api/auth_credentials.go#L316
what I do is some trivial refinement:
1. refine the APIs `GetUserPolicy` and `GetActions` to give users a more AWS policy style output
~~2. change s3.configure flag `buckets` to `resource_paths` which indicates to users that you can give all AWS support paths here. It's consistent with [the static configuration](https://github.com/chrislusf/seaweedfs/wiki/Amazon-S3-API#actions-with-wildcard).~~

# Checks
- [√] I have added unit tests if possible.
- [√] I will add related wiki document changes and link to this PR after merging.
