### PR TITLE
Add healthy indicator for raft status

### DIFF
--- a/weed/command/master.go
+++ b/weed/command/master.go
@@ -2,18 +2,20 @@ package command
 
 import (
 	"fmt"
-	"golang.org/x/exp/slices"
 	"net/http"
 	"os"
 	"path"
 	"strings"
 	"time"
 
+	"golang.org/x/exp/slices"
+
 	"github.com/gorilla/mux"
 	"github.com/seaweedfs/raft/protobuf"
-	stats_collect "github.com/seaweedfs/seaweedfs/weed/stats"
 	"github.com/spf13/viper"
 	"google.golang.org/grpc/reflection"
+
+	stats_collect "github.com/seaweedfs/seaweedfs/weed/stats"
 
 	"github.com/seaweedfs/seaweedfs/weed/util/grace"
 
@@ -179,6 +181,7 @@ func startMaster(masterOption MasterOptions, masterWhiteList []string) {
 	}
 	ms.SetRaftServer(raftServer)
 	r.HandleFunc("/cluster/status", raftServer.StatusHandler).Methods("GET")
+	r.HandleFunc("/cluster/healthz", raftServer.HealthzHandler).Methods("GET", "HEAD")
 	if *m.raftHashicorp {
 		r.HandleFunc("/raft/stats", raftServer.StatsRaftHandler).Methods("GET")
 	}

--- a/weed/server/raft_server_handlers.go
+++ b/weed/server/raft_server_handlers.go
@@ -26,6 +26,15 @@ func (s *RaftServer) StatusHandler(w http.ResponseWriter, r *http.Request) {
 	writeJsonQuiet(w, r, http.StatusOK, ret)
 }
 
+func (s *RaftServer) HealthzHandler(w http.ResponseWriter, r *http.Request) {
+	_, err := s.topo.Leader()
+	if err != nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	} else {
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
 func (s *RaftServer) StatsRaftHandler(w http.ResponseWriter, r *http.Request) {
 	if s.RaftHashicorp == nil {
 		writeJsonQuiet(w, r, http.StatusNotFound, nil)


### PR DESCRIPTION
This adds a `/cluster/healthz` route to the master servers. It returns a status code based on raft that can be used as a health check. This might solve part of #1953.
I made it similar to the `/healthz` route of the volume server api