### PR TITLE
Detailed metrics VolumeServerRequestHistogram for writing to disk and replication

### DIFF
--- a/weed/server/volume_server_handlers_read.go
+++ b/weed/server/volume_server_handlers_read.go
@@ -20,7 +20,6 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/images"
 	"github.com/seaweedfs/seaweedfs/weed/operation"
-	"github.com/seaweedfs/seaweedfs/weed/stats"
 	"github.com/seaweedfs/seaweedfs/weed/storage"
 	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
 	"github.com/seaweedfs/seaweedfs/weed/util"
@@ -29,11 +28,6 @@ import (
 var fileNameEscaper = strings.NewReplacer(`\`, `\\`, `"`, `\"`)
 
 func (vs *VolumeServer) GetOrHeadHandler(w http.ResponseWriter, r *http.Request) {
-
-	stats.VolumeServerRequestCounter.WithLabelValues("get").Inc()
-	start := time.Now()
-	defer func() { stats.VolumeServerRequestHistogram.WithLabelValues("get").Observe(time.Since(start).Seconds()) }()
-
 	n := new(needle.Needle)
 	vid, fid, filename, ext, _ := parseURLPath(r.URL.Path)
 

--- a/weed/server/volume_server_handlers_write.go
+++ b/weed/server/volume_server_handlers_write.go
@@ -11,19 +11,11 @@ import (
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/operation"
-	"github.com/seaweedfs/seaweedfs/weed/stats"
 	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
 	"github.com/seaweedfs/seaweedfs/weed/topology"
 )
 
 func (vs *VolumeServer) PostHandler(w http.ResponseWriter, r *http.Request) {
-
-	stats.VolumeServerRequestCounter.WithLabelValues("post").Inc()
-	start := time.Now()
-	defer func() {
-		stats.VolumeServerRequestHistogram.WithLabelValues("post").Observe(time.Since(start).Seconds())
-	}()
-
 	if e := r.ParseForm(); e != nil {
 		glog.V(0).Infoln("form parse error:", e)
 		writeJsonError(w, r, http.StatusBadRequest, e)
@@ -79,13 +71,6 @@ func (vs *VolumeServer) PostHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (vs *VolumeServer) DeleteHandler(w http.ResponseWriter, r *http.Request) {
-
-	stats.VolumeServerRequestCounter.WithLabelValues("delete").Inc()
-	start := time.Now()
-	defer func() {
-		stats.VolumeServerRequestHistogram.WithLabelValues("delete").Observe(time.Since(start).Seconds())
-	}()
-
 	n := new(needle.Needle)
 	vid, fid, _, _, _ := parseURLPath(r.URL.Path)
 	volumeId, _ := needle.NewVolumeId(vid)

--- a/weed/stats/metrics_names.go
+++ b/weed/stats/metrics_names.go
@@ -4,7 +4,8 @@ package stats
 // The naming convention is ErrorSomeThing = "error.some.thing"
 const (
 	// volume server
-	LocalWrite                  = "localWrite"
+	WriteToLocalDisk            = "writeToLocalDisk"
+	WriteToReplicas             = "writeToReplicas"
 	ReplicatedWrite             = "replicatedWrite"
 	ErrorSizeMismatchOffsetSize = "errorSizeMismatchOffsetSize"
 	ErrorSizeMismatch           = "errorSizeMismatch"

--- a/weed/stats/metrics_names.go
+++ b/weed/stats/metrics_names.go
@@ -6,7 +6,6 @@ const (
 	// volume server
 	WriteToLocalDisk            = "writeToLocalDisk"
 	WriteToReplicas             = "writeToReplicas"
-	ReplicatedWrite             = "replicatedWrite"
 	ErrorSizeMismatchOffsetSize = "errorSizeMismatchOffsetSize"
 	ErrorSizeMismatch           = "errorSizeMismatch"
 	ErrorCRC                    = "errorCRC"

--- a/weed/stats/metrics_names.go
+++ b/weed/stats/metrics_names.go
@@ -4,6 +4,8 @@ package stats
 // The naming convention is ErrorSomeThing = "error.some.thing"
 const (
 	// volume server
+	LocalWrite                  = "localWrite"
+	ReplicatedWrite             = "replicatedWrite"
 	ErrorSizeMismatchOffsetSize = "errorSizeMismatchOffsetSize"
 	ErrorSizeMismatch           = "errorSizeMismatch"
 	ErrorCRC                    = "errorCRC"

--- a/weed/topology/store_replicate.go
+++ b/weed/topology/store_replicate.go
@@ -46,7 +46,7 @@ func ReplicatedWrite(masterFn operation.GetMasterFn, grpcDialOption grpc.DialOpt
 	if s.GetVolume(volumeId) != nil {
 		start := time.Now()
 		isUnchanged, err = s.WriteVolumeNeedle(volumeId, n, true, fsync)
-		stats.VolumeServerRequestHistogram.WithLabelValues("write").Observe(time.Since(start).Seconds())
+		stats.VolumeServerRequestHistogram.WithLabelValues("localWrite").Observe(time.Since(start).Seconds())
 		if err != nil {
 			stats.VolumeServerRequestCounter.WithLabelValues(stats.ErrorWriteToLocalDisk).Inc()
 			err = fmt.Errorf("failed to write to local disk: %v", err)
@@ -102,7 +102,7 @@ func ReplicatedWrite(masterFn operation.GetMasterFn, grpcDialOption grpc.DialOpt
 			_, err := operation.UploadData(n.Data, uploadOption)
 			return err
 		})
-		stats.VolumeServerRequestHistogram.WithLabelValues("replicate").Observe(time.Since(start).Seconds())
+		stats.VolumeServerRequestHistogram.WithLabelValues("replicatedWrite").Observe(time.Since(start).Seconds())
 		if err != nil {
 			stats.VolumeServerRequestCounter.WithLabelValues(stats.ErrorWriteToReplicas).Inc()
 			err = fmt.Errorf("failed to write to replicas for volume %d: %v", volumeId, err)

--- a/weed/topology/store_replicate.go
+++ b/weed/topology/store_replicate.go
@@ -46,7 +46,7 @@ func ReplicatedWrite(masterFn operation.GetMasterFn, grpcDialOption grpc.DialOpt
 	if s.GetVolume(volumeId) != nil {
 		start := time.Now()
 		isUnchanged, err = s.WriteVolumeNeedle(volumeId, n, true, fsync)
-		stats.VolumeServerRequestHistogram.WithLabelValues("localWrite").Observe(time.Since(start).Seconds())
+		stats.VolumeServerRequestHistogram.WithLabelValues(stats.LocalWrite).Observe(time.Since(start).Seconds())
 		if err != nil {
 			stats.VolumeServerRequestCounter.WithLabelValues(stats.ErrorWriteToLocalDisk).Inc()
 			err = fmt.Errorf("failed to write to local disk: %v", err)
@@ -102,7 +102,7 @@ func ReplicatedWrite(masterFn operation.GetMasterFn, grpcDialOption grpc.DialOpt
 			_, err := operation.UploadData(n.Data, uploadOption)
 			return err
 		})
-		stats.VolumeServerRequestHistogram.WithLabelValues("replicatedWrite").Observe(time.Since(start).Seconds())
+		stats.VolumeServerRequestHistogram.WithLabelValues(stats.ReplicatedWrite).Observe(time.Since(start).Seconds())
 		if err != nil {
 			stats.VolumeServerRequestCounter.WithLabelValues(stats.ErrorWriteToReplicas).Inc()
 			err = fmt.Errorf("failed to write to replicas for volume %d: %v", volumeId, err)

--- a/weed/topology/store_replicate.go
+++ b/weed/topology/store_replicate.go
@@ -46,7 +46,7 @@ func ReplicatedWrite(masterFn operation.GetMasterFn, grpcDialOption grpc.DialOpt
 	if s.GetVolume(volumeId) != nil {
 		start := time.Now()
 		isUnchanged, err = s.WriteVolumeNeedle(volumeId, n, true, fsync)
-		stats.VolumeServerRequestHistogram.WithLabelValues(stats.LocalWrite).Observe(time.Since(start).Seconds())
+		stats.VolumeServerRequestHistogram.WithLabelValues(stats.WriteToLocalDisk).Observe(time.Since(start).Seconds())
 		if err != nil {
 			stats.VolumeServerRequestCounter.WithLabelValues(stats.ErrorWriteToLocalDisk).Inc()
 			err = fmt.Errorf("failed to write to local disk: %v", err)
@@ -102,7 +102,7 @@ func ReplicatedWrite(masterFn operation.GetMasterFn, grpcDialOption grpc.DialOpt
 			_, err := operation.UploadData(n.Data, uploadOption)
 			return err
 		})
-		stats.VolumeServerRequestHistogram.WithLabelValues(stats.ReplicatedWrite).Observe(time.Since(start).Seconds())
+		stats.VolumeServerRequestHistogram.WithLabelValues(stats.WriteToReplicas).Observe(time.Since(start).Seconds())
 		if err != nil {
 			stats.VolumeServerRequestCounter.WithLabelValues(stats.ErrorWriteToReplicas).Inc()
 			err = fmt.Errorf("failed to write to replicas for volume %d: %v", volumeId, err)


### PR DESCRIPTION
# What problem are we solving?

According to the time metrics for requests per volume, the server does not understand how much time it will take to write to disk, and how much to replicate.

https://github.com/seaweedfs/seaweedfs/issues/3369

# How are we solving the problem?

Added write and replicate types to VolumeServerRequestHistogram metric

https://github.com/seaweedfs/seaweedfs/issues/3369

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
