### PR TITLE
feat: Add support for k8s Init-Containers.

### DIFF
--- a/k8s/helm_charts2/templates/_helpers.tpl
+++ b/k8s/helm_charts2/templates/_helpers.tpl
@@ -174,3 +174,12 @@ Inject extra environment vars in the format key:value, if populated
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/* check if any InitContainers exist for Volumes */}}
+{{- define "volume.initContainers_exists" -}}
+{{- if or (not (empty .Values.volume.dir_idx )) (not (empty .Values.volume.initContainers )) -}}
+{{- printf "true" -}}
+{{- else -}}
+{{- printf "false" -}}
+{{- end -}}
+{{- end -}}

--- a/k8s/helm_charts2/templates/filer-statefulset.yaml
+++ b/k8s/helm_charts2/templates/filer-statefulset.yaml
@@ -52,6 +52,10 @@ spec:
       priorityClassName: {{ .Values.filer.priorityClassName | quote }}
       {{- end }}
       enableServiceLinks: false
+      {{- if .Values.filer.initContainers }}
+      initContainers:
+        {{ tpl .Values.filer.initContainers . | nindent 8 | trim }}
+      {{- end }}
       containers:
         - name: seaweedfs
           image: {{ template "filer.image" . }}

--- a/k8s/helm_charts2/templates/master-statefulset.yaml
+++ b/k8s/helm_charts2/templates/master-statefulset.yaml
@@ -51,6 +51,10 @@ spec:
       priorityClassName: {{ .Values.master.priorityClassName | quote }}
       {{- end }}
       enableServiceLinks: false
+      {{- if .Values.master.initContainers }}
+      initContainers:
+        {{ tpl .Values.master.initContainers . | nindent 8 | trim }}
+      {{- end }}
       containers:
         - name: seaweedfs
           image: {{ template "master.image" . }}

--- a/k8s/helm_charts2/templates/s3-deployment.yaml
+++ b/k8s/helm_charts2/templates/s3-deployment.yaml
@@ -39,6 +39,10 @@ spec:
       priorityClassName: {{ .Values.s3.priorityClassName | quote }}
       {{- end }}
       enableServiceLinks: false
+      {{- if .Values.s3.initContainers }}
+      initContainers:
+        {{ tpl .Values.s3.initContainers . | nindent 8 | trim }}
+      {{- end }}
       containers:
         - name: seaweedfs
           image: {{ template "s3.image" . }}

--- a/k8s/helm_charts2/templates/volume-statefulset.yaml
+++ b/k8s/helm_charts2/templates/volume-statefulset.yaml
@@ -45,18 +45,24 @@ spec:
       priorityClassName: {{ .Values.volume.priorityClassName | quote }}
       {{- end }}
       enableServiceLinks: false
-      {{- if .Values.volume.dir_idx }}
+      {{- $initContainers_exists := include "volume.initContainers_exists" . -}}
+      {{- if $initContainers_exists }}
       initContainers:
+        {{- if .Values.volume.dir_idx }}
         - name: seaweedfs-vol-move-idx
           image: {{ template "volume.image" . }}
-          imagePullPolicy: {{ .Values.global.pullPolicy | default "IfNotPresent" }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}
           command: [ '/bin/sh', '-c' ]
-          args: ['if ls {{ .Values.volume.dir }}/*.idx >/dev/null 2>&1; then mv {{ .Values.volume.dir }}/*.idx {{ .Values.volume.dir_idx }}/; fi;']
+          args: [ 'if ls {{ .Values.volume.dir }}/*.idx >/dev/null 2>&1; then mv {{ .Values.volume.dir }}/*.idx {{ .Values.volume.dir_idx }}/; fi;' ]
           volumeMounts:
-          - name: idx
-            mountPath: {{ .Values.volume.dir_idx }}
-          - name: data
-            mountPath: {{ .Values.volume.dir }}
+            - name: idx
+              mountPath: {{ .Values.volume.dir_idx }}
+            - name: data
+              mountPath: {{ .Values.volume.dir }}
+        {{- end }}
+        {{- if .Values.volume.initContainers }}
+        {{ tpl .Values.volume.initContainers . | nindent 8 | trim }}
+        {{- end }}
       {{- end }}
       containers:
         - name: seaweedfs

--- a/k8s/helm_charts2/values.yaml
+++ b/k8s/helm_charts2/values.yaml
@@ -73,6 +73,8 @@ master:
     size: ""
     storageClass: ""
 
+  initContainers: ""
+
   extraVolumes: ""
   extraVolumeMounts: ""
 
@@ -210,6 +212,8 @@ volume:
   # Adjust jpg orientation when uploading.
   imagesFixOrientation: false
 
+  initContainers: ""
+
   extraVolumes: ""
   extraVolumeMounts: ""
 
@@ -308,6 +312,8 @@ filer:
     type: "hostPath"
     size: ""
     storageClass: ""
+
+  initContainers: ""
 
   extraVolumes: ""
   extraVolumeMounts: ""
@@ -423,6 +429,8 @@ s3:
 
   # Suffix of the host name, {bucket}.{domainName}
   domainName: ""
+
+  initContainers: ""
 
   extraVolumes: ""
   extraVolumeMounts: ""


### PR DESCRIPTION
# What problem are we solving?

We want external [Filer-Stores](https://github.com/seaweedfs/seaweedfs/wiki/Filer-Stores) to be installed, and be ready before starting Filer. Otherwise Filer will Crashloop until the external Filer-Stores are ready.

# How are we solving the problem?

Add support for user-defined [Init Containers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/). These Init-Containers can check if the external Filer-Store is ready. 

We are adding init-containers to all components here, so users can use them as needed.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
