### PR TITLE
truncate: don't drop chunk when truncate-size aligns with chunk length

### DIFF
--- a/weed/mount/weedfs_attr.go
+++ b/weed/mount/weedfs_attr.go
@@ -57,7 +57,7 @@ func (wfs *WFS) SetAttr(cancel <-chan struct{}, input *fuse.SetAttrIn, out *fuse
 			var truncatedChunks []*filer_pb.FileChunk
 			for _, chunk := range entry.Chunks {
 				int64Size := int64(chunk.Size)
-				if chunk.Offset+int64Size > int64(size) {
+				if chunk.Offset+int64Size >= int64(size) {
 					// this chunk is truncated
 					int64Size = int64(size) - chunk.Offset
 					if int64Size > 0 {


### PR DESCRIPTION

# What problem are we solving?

Fixes: https://github.com/seaweedfs/seaweedfs/issues/3384
Fixes: https://github.com/seaweedfs/seaweedfs/issues/2609


# How are we solving the problem?

The issue concerning Plex (3384) and issue 2609 are the same.  Plex regularly performs a `VACUUM` on its internal SQLlite database, leading to DB corruption when run on SeaweedFS.

In `chinook.db` test from issue 2609, SQLIite will open the file `O_RDWR` the original DB length is `884736` bytes (chunk 0).  The VACUUM re-writes the whole DB file, leading to a shortened chunk 1 of `845824` bytes:

```
I0806 19:34:40.725022 weedfs_file_sync.go:151 /chinook.db set chunks: 2
I0806 19:34:40.725033 weedfs_file_sync.go:153 /chinook.db chunks 0: 7,4f98f31455 [0,884736)
I0806 19:34:40.725040 weedfs_file_sync.go:153 /chinook.db chunks 1: 4,52894a594f [0,845824)
```

The final intention is to write the shorter chunk back to disk, so `truncate(fd, 845824)` is called on the open file. Because this truncate() matches the same size as chunk 1, the current logic drops the chunk.  Chunk 0 ends up being re-written to disk and the database truncated, leading to the original non-vacuumed data being stored, albeit truncated and corrupted.

```
I0806 20:11:36.990496 slot_pool.go:60 --> 0
I0806 20:11:36.990509 weedfs_file_sync.go:151 /chinook.db set chunks: 2
I0806 20:11:36.990516 weedfs_file_sync.go:153 /chinook.db chunks 0: 3,5d19478b30 [0,884736)
I0806 20:11:36.990523 weedfs_file_sync.go:153 /chinook.db chunks 1: 4,60bed2ceb5 [0,845824)
I0806 20:11:36.991481 weedfs_file_sync.go:102 doFlush /chinook.db-journal fh 0
I0806 20:11:36.991562 weedfs_file_mkrm.go:133 remove file: /chinook.db-journal
I0806 20:11:36.992872 weedfs_attr.go:53 /chinook.db setattr set size=845824 filersize=884736 chunks=2
I0806 20:11:36.992887 weedfs_attr.go:66 truncated chunk 3,5d19478b30 from 884736 to 845824
I0806 20:11:36.993485 weedfs_file_sync.go:102 doFlush /chinook.db fh 0
I0806 20:11:36.993528 weedfs_file_sync.go:151 /chinook.db set chunks: 1
I0806 20:11:36.993537 weedfs_file_sync.go:153 /chinook.db chunks 0: 3,5d19478b30 [0,845824)
```


The fix corrects for the off-by-one error, retaining the re-written chunk:

```
I0806 19:34:40.725022 weedfs_file_sync.go:151 /chinook.db set chunks: 2
I0806 19:34:40.725033 weedfs_file_sync.go:153 /chinook.db chunks 0: 7,4f98f31455 [0,884736)
I0806 19:34:40.725040 weedfs_file_sync.go:153 /chinook.db chunks 1: 4,52894a594f [0,845824)
I0806 19:34:40.725501 weedfs_file_sync.go:102 doFlush /chinook.db-journal fh 0
I0806 19:34:40.725584 weedfs_file_mkrm.go:133 remove file: /chinook.db-journal
I0806 19:34:40.726720 weedfs_attr.go:53 /chinook.db setattr set size=845824 chunks=2
I0806 19:34:40.726739 weedfs_attr.go:65 truncated chunk 7,4f98f31455 from 884736 to 845824
I0806 19:34:40.726750 weedfs_attr.go:65 truncated chunk 4,52894a594f from 845824 to 845824
```


