### PR TITLE
Allow postgresql to use standard environment variables for connection

### DIFF
--- a/weed/filer/postgres/postgres_store.go
+++ b/weed/filer/postgres/postgres_store.go
@@ -3,16 +3,13 @@ package postgres
 import (
 	"database/sql"
 	"fmt"
+	"strconv"
 	"time"
 
 	_ "github.com/lib/pq"
 	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/filer/abstract_sql"
 	"github.com/seaweedfs/seaweedfs/weed/util"
-)
-
-const (
-	CONNECTION_URL_PATTERN = "host=%s port=%d sslmode=%s connect_timeout=30"
 )
 
 func init() {
@@ -56,7 +53,16 @@ func (store *PostgresStore) initialize(upsertQuery string, enableUpsert bool, us
 		UpsertQueryTemplate:    upsertQuery,
 	}
 
-	sqlUrl := fmt.Sprintf(CONNECTION_URL_PATTERN, hostname, port, sslmode)
+	sqlUrl := "connect_timeout=30"
+	if hostname != "" {
+		sqlUrl += " host=" + hostname
+	}
+	if port != 0 {
+		sqlUrl += " port=" + strconv.Itoa(port)
+	}
+	if sslmode != "" {
+		sqlUrl += " sslmode=" + sslmode
+	}
 	if user != "" {
 		sqlUrl += " user=" + user
 	}

--- a/weed/filer/postgres2/postgres2_store.go
+++ b/weed/filer/postgres2/postgres2_store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strconv"
 	"time"
 
 	_ "github.com/lib/pq"
@@ -11,10 +12,6 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/filer/abstract_sql"
 	"github.com/seaweedfs/seaweedfs/weed/filer/postgres"
 	"github.com/seaweedfs/seaweedfs/weed/util"
-)
-
-const (
-	CONNECTION_URL_PATTERN = "host=%s port=%d sslmode=%s connect_timeout=30"
 )
 
 var _ filer.BucketAware = (*PostgresStore2)(nil)
@@ -61,7 +58,16 @@ func (store *PostgresStore2) initialize(createTable, upsertQuery string, enableU
 		UpsertQueryTemplate:    upsertQuery,
 	}
 
-	sqlUrl := fmt.Sprintf(CONNECTION_URL_PATTERN, hostname, port, sslmode)
+	sqlUrl := "connect_timeout=30"
+	if hostname != "" {
+		sqlUrl += " host=" + hostname
+	}
+	if port != 0 {
+	  sqlUrl += " port=" + strconv.Itoa(port)
+	}
+	if sslmode != "" {
+		sqlUrl += " sslmode=" + sslmode
+	}
 	if user != "" {
 		sqlUrl += " user=" + user
 	}


### PR DESCRIPTION
# What problem are we solving?
I prefer to use PostgreSQL environment variables (i.e. PGDATABASE) to set connection parameters.

# How are we solving the problem?
By simply removing "forced/required" parameters for the PostgreSQL connection uri. 

This allows the database driver to use the default option of grabbing the environment variables. The exception is connect_timeout which is hard coded at the moment anyways so I left that alone.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
