### PR TITLE
Refactor for Sync method

### DIFF
--- a/weed/storage/backend/disk_file.go
+++ b/weed/storage/backend/disk_file.go
@@ -1,10 +1,11 @@
 package backend
 
 import (
-	"github.com/seaweedfs/seaweedfs/weed/glog"
-	. "github.com/seaweedfs/seaweedfs/weed/storage/types"
 	"os"
 	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/glog"
+	. "github.com/seaweedfs/seaweedfs/weed/storage/types"
 )
 
 var (
@@ -78,9 +79,4 @@ func (df *DiskFile) GetStat() (datSize int64, modTime time.Time, err error) {
 
 func (df *DiskFile) Name() string {
 	return df.fullFilePath
-}
-
-func (df *DiskFile) Sync() error {
-	return nil
-	// return df.File.Sync()
 }

--- a/weed/storage/backend/disk_file_darwin.go
+++ b/weed/storage/backend/disk_file_darwin.go
@@ -1,0 +1,41 @@
+//go:build darwin
+// +build darwin
+
+package backend
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	// Using default File.Sync function
+	DM_SYNC = 1
+
+	// Using syscall.Fsync function
+	DM_FSYNC = 2
+
+	// Using fcntl with F_BARRIERFSYNC parameter
+	DM_BFSYNC = 3
+
+	F_BARRIERFSYNC = 85
+)
+
+var (
+	DarwinSyncMode = DM_BFSYNC
+)
+
+func (df *DiskFile) Sync() error {
+	switch DarwinSyncMode {
+	case DM_SYNC:
+		return df.File.Sync()
+	case DM_BFSYNC:
+		fd := df.File.Fd()
+		_, err := unix.FcntlInt(fd, F_BARRIERFSYNC, 0)
+		return err
+	default:
+		fd := df.File.Fd()
+		return syscall.Fsync(int(fd))
+	}
+}

--- a/weed/storage/backend/disk_file_darwin.go
+++ b/weed/storage/backend/disk_file_darwin.go
@@ -10,19 +10,21 @@ import (
 )
 
 const (
-	// Using default File.Sync function
+	// Using default File.Sync function, same as fcntl(fd, F_FULLFSYNC)
 	DM_SYNC = 1
 
-	// Using syscall.Fsync function
+	// Using syscall.Fsync function, for MacOS this is not safe but is very fast.
 	DM_FSYNC = 2
 
-	// Using fcntl with F_BARRIERFSYNC parameter
+	// Using fcntl with F_BARRIERFSYNC parameter, for more details please refer:
+	// https://developer.apple.com/documentation/xcode/reducing-disk-writes
 	DM_BFSYNC = 3
 
 	F_BARRIERFSYNC = 85
 )
 
 var (
+	// By default using F_BARRIERFSYNC
 	DarwinSyncMode = DM_BFSYNC
 )
 

--- a/weed/storage/backend/disk_file_linux.go
+++ b/weed/storage/backend/disk_file_linux.go
@@ -1,0 +1,14 @@
+//go:build linux
+// +build linux
+
+package backend
+
+import (
+	"syscall"
+)
+
+// Using Fdatasync to optimize file sync operation
+func (df *DiskFile) Sync() error {
+	fd := df.File.Fd()
+	return syscall.Fdatasync(int(fd))
+}

--- a/weed/storage/backend/disk_file_others.go
+++ b/weed/storage/backend/disk_file_others.go
@@ -1,0 +1,9 @@
+//go:build !linux && !darwin
+// +build !linux,!darwin
+
+package backend
+
+// Using default sync operation
+func (df *DiskFile) Sync() error {
+	return df.File.Sync()
+}


### PR DESCRIPTION
# What problem are we solving?

Restore Sync operation back.

# How are we solving the problem?

For different system using different method to sync file data:

* For Linux using `fdatasync` make less IO operation (ignore sync metadata)
* For MacOS default is using `fcntl` with `F_BARRIERFSYNC`, this will resolve MacOS with ARM CPU version sync data too slow issue. As golang default implementation,  File.Sync is using `fcntl(fd, F_FULLFSYNC)` call which will flush all file system dirty data to disk and this is very very slow with MacOS running on ARM cpu. Using `F_BARRIERFSYNC` will make ARM CPU version's Mac running fast.
* For other OS just using `File.Sync`

# How is the PR tested?

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
