### PR TITLE
Remove duplicate slashes in object path to prevent 500 errors

### DIFF
--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -130,9 +130,30 @@ func urlPathEscape(object string) string {
 	return strings.Join(escapedParts, "/")
 }
 
+func removeDuplicateSlashes(object string) string {
+	result := strings.Builder{}
+	result.Grow(len(object))
+
+	isLastSlash := false
+	for _, r := range object {
+		switch r {
+		case '/':
+			if !isLastSlash {
+				result.WriteRune(r)
+			}
+			isLastSlash = true
+		default:
+			result.WriteRune(r)
+			isLastSlash = false
+		}
+	}
+	return result.String()
+}
+
 func (s3a *S3ApiServer) toFilerUrl(bucket, object string) string {
+	object = urlPathEscape(removeDuplicateSlashes(object))
 	destUrl := fmt.Sprintf("http://%s%s/%s%s",
-		s3a.option.Filer.ToHttpAddress(), s3a.option.BucketsPath, bucket, urlPathEscape(object))
+		s3a.option.Filer.ToHttpAddress(), s3a.option.BucketsPath, bucket, object)
 	return destUrl
 }
 

--- a/weed/s3api/s3api_object_handlers_test.go
+++ b/weed/s3api/s3api_object_handlers_test.go
@@ -1,0 +1,48 @@
+package s3api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemoveDuplicateSlashes(t *testing.T) {
+	tests := []struct {
+		name           string
+		path           string
+		expectedResult string
+	}{
+		{
+			name:           "empty",
+			path:           "",
+			expectedResult: "",
+		},
+		{
+			name:           "slash",
+			path:           "/",
+			expectedResult: "/",
+		},
+		{
+			name:           "object",
+			path:           "object",
+			expectedResult: "object",
+		},
+		{
+			name:           "correct path",
+			path:           "/path/to/object",
+			expectedResult: "/path/to/object",
+		},
+		{
+			name:           "path with duplicates",
+			path:           "///path//to/object//",
+			expectedResult: "/path/to/object/",
+		},
+	}
+
+	for _, tst := range tests {
+		t.Run(tst.name, func(t *testing.T) {
+			obj := removeDuplicateSlashes(tst.path)
+			assert.Equal(t, tst.expectedResult, obj)
+		})
+	}
+}


### PR DESCRIPTION
# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/2792

# How are we solving the problem?

The current implementation does PUT/POST/DELETE requests from s3 API to filer with duplicate slashes in object path (if duplicate slashes were in object path). This leads to 301 Moved Permanently response from filer with `Location` that has duplicate slashes removed. When HTTP client in s3 API does second request to the redirected URL, it changes `PUT` method to `GET`. The workaround cleans the object path from duplicate slashes to prevent 301 redirect.

# How is the PR tested?

Tested in `local-dev-compose.yml`, the command sequence is the following:
```
aws --endpoint-url=http://localhost:8333 s3api create-bucket --bucket testbucket
aws --endpoint-url=http://localhost:8333 s3api put-object --bucket testbucket --key testdir//testfile --body ./testfile.obj
aws --endpoint-url=http://localhost:8333 s3api put-object --bucket testbucket --key //testdir/testfile --body ./testfile.obj
```
Added unit tests.

# Checks
- [✓] I have added unit tests if possible.
- [✓] I will add related wiki document changes and link to this PR after merging.
