### PR TITLE
Implement copy_file_range syscall in FUSE

### DIFF
--- a/weed/mount/filehandle_read.go
+++ b/weed/mount/filehandle_read.go
@@ -3,10 +3,11 @@ package mount
 import (
 	"context"
 	"fmt"
+	"io"
+
 	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
-	"io"
 )
 
 func (fh *FileHandle) lockForRead(startOffset int64, size int) {
@@ -24,9 +25,6 @@ func (fh *FileHandle) readFromDirtyPages(buff []byte, startOffset int64) (maxSto
 func (fh *FileHandle) readFromChunks(buff []byte, offset int64) (int64, error) {
 
 	fileFullPath := fh.FullPath()
-
-	fh.entryLock.Lock()
-	defer fh.entryLock.Unlock()
 
 	entry := fh.entry
 	if entry == nil {

--- a/weed/mount/weedfs_file_copy_range.go
+++ b/weed/mount/weedfs_file_copy_range.go
@@ -1,0 +1,120 @@
+package mount
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/hanwen/go-fuse/v2/fuse"
+
+	"github.com/seaweedfs/seaweedfs/weed/glog"
+)
+
+// CopyFileRange copies data from one file to another from and to specified offsets.
+//
+// See https://man7.org/linux/man-pages/man2/copy_file_range.2.html
+// See https://github.com/libfuse/libfuse/commit/fe4f9428fc403fa8b99051f52d84ea5bd13f3855
+/**
+ * Copy a range of data from one file to another
+ *
+ * Niels de Vos: • libfuse: add copy_file_range() support
+ *
+ * Performs an optimized copy between two file descriptors without the
+ * additional cost of transferring data through the FUSE kernel module
+ * to user space (glibc) and then back into the FUSE filesystem again.
+ *
+ * In case this method is not implemented, applications are expected to
+ * fall back to a regular file copy.   (Some glibc versions did this
+ * emulation automatically, but the emulation has been removed from all
+ * glibc release branches.)
+ */
+func (wfs *WFS) CopyFileRange(cancel <-chan struct{}, in *fuse.CopyFileRangeIn) (written uint32, code fuse.Status) {
+	// flags must equal 0 for this syscall as of now
+	if in.Flags != 0 {
+		return 0, fuse.EINVAL
+	}
+
+	// files must exist
+	fhOut := wfs.GetHandle(FileHandleId(in.FhOut))
+	if fhOut == nil {
+		return 0, fuse.EBADF
+	}
+	fhIn := wfs.GetHandle(FileHandleId(in.FhIn))
+	if fhIn == nil {
+		return 0, fuse.EBADF
+	}
+
+	// lock source and target file handles
+	fhOut.Lock()
+	defer fhOut.Unlock()
+	fhOut.entryLock.Lock()
+	defer fhOut.entryLock.Unlock()
+
+	if fhOut.entry == nil {
+		return 0, fuse.ENOENT
+	}
+
+	if fhIn.fh != fhOut.fh {
+		fhIn.Lock()
+		defer fhIn.Unlock()
+		fhIn.entryLock.Lock()
+		defer fhIn.entryLock.Unlock()
+	}
+
+	// directories are not supported
+	if fhIn.entry.IsDirectory || fhOut.entry.IsDirectory {
+		return 0, fuse.EISDIR
+	}
+
+	// cannot copy data to an overlapping range of the same file
+	offInEnd := in.OffIn + in.Len - 1
+	offOutEnd := in.OffOut + in.Len - 1
+
+	if fhIn.inode == fhOut.inode && in.OffIn <= offOutEnd && offInEnd >= in.OffOut {
+		return 0, fuse.EINVAL
+	}
+
+	glog.V(4).Infof(
+		"CopyFileRange %s fhIn %d -> %s fhOut %d, %d:%d -> %d:%d",
+		fhIn.FullPath(), fhIn.fh,
+		fhOut.FullPath(), fhOut.fh,
+		in.OffIn, offInEnd,
+		in.OffOut, offOutEnd,
+	)
+
+	// read data from source file
+	fhIn.lockForRead(int64(in.OffIn), int(in.Len))
+	defer fhIn.unlockForRead(int64(in.OffIn), int(in.Len))
+
+	data := make([]byte, int(in.Len))
+	totalRead, err := fhIn.readFromChunks(data, int64(in.OffIn))
+	if err == nil || err == io.EOF {
+		maxStop := fhIn.readFromDirtyPages(data, int64(in.OffIn))
+		totalRead = max(maxStop-int64(in.OffIn), totalRead)
+	}
+	if err == io.EOF {
+		err = nil
+	}
+	if err != nil {
+		glog.Warningf("file handle read %s %d: %v", fhIn.FullPath(), totalRead, err)
+		return 0, fuse.EIO
+	}
+
+	if totalRead == 0 {
+		return 0, fuse.OK
+	}
+
+	// put data at the specified offset in target file
+	fhOut.dirtyPages.writerPattern.MonitorWriteAt(int64(in.OffOut), int(in.Len))
+	fhOut.entry.Content = nil
+	fhOut.dirtyPages.AddPage(int64(in.OffOut), data, fhOut.dirtyPages.writerPattern.IsSequentialMode())
+	fhOut.entry.Attributes.FileSize = uint64(max(int64(in.OffOut)+totalRead, int64(fhOut.entry.Attributes.FileSize)))
+	fhOut.dirtyMetadata = true
+	written = uint32(totalRead)
+
+	// detect mime type
+	if written > 0 && in.OffOut <= 512 {
+		fhOut.contentType = http.DetectContentType(data[:min(totalRead, 512)-1])
+	}
+
+	return written, fuse.OK
+}

--- a/weed/mount/weedfs_file_read.go
+++ b/weed/mount/weedfs_file_read.go
@@ -1,9 +1,11 @@
 package mount
 
 import (
-	"github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"io"
+
+	"github.com/hanwen/go-fuse/v2/fuse"
+
+	"github.com/seaweedfs/seaweedfs/weed/glog"
 )
 
 /**
@@ -36,6 +38,9 @@ func (wfs *WFS) Read(cancel <-chan struct{}, in *fuse.ReadIn, buff []byte) (fuse
 	if fh == nil {
 		return nil, fuse.ENOENT
 	}
+
+	fh.entryLock.Lock()
+	defer fh.entryLock.Unlock()
 
 	offset := int64(in.Offset)
 	fh.lockForRead(offset, len(buff))

--- a/weed/mount/weedfs_unsupported.go
+++ b/weed/mount/weedfs_unsupported.go
@@ -5,22 +5,6 @@ import "github.com/hanwen/go-fuse/v2/fuse"
 // https://github.com/libfuse/libfuse/blob/48ae2e72b39b6a31cb2194f6f11786b7ca06aac6/include/fuse.h#L778
 
 /**
- * Copy a range of data from one file to anotherNiels de Vos, 4 years ago: • libfuse: add copy_file_range() support
- *
- * Performs an optimized copy between two file descriptors without the
- * additional cost of transferring data through the FUSE kernel module
- * to user space (glibc) and then back into the FUSE filesystem again.
- *
- * In case this method is not implemented, applications are expected to
- * fall back to a regular file copy.   (Some glibc versions did this
- * emulation automatically, but the emulation has been removed from all
- * glibc release branches.)
- */
-func (wfs *WFS) CopyFileRange(cancel <-chan struct{}, in *fuse.CopyFileRangeIn) (written uint32, code fuse.Status) {
-	return 0, fuse.ENOSYS
-}
-
-/**
  * Allocates space for an open file
  *
  * This function ensures that required space is allocated for specified


### PR DESCRIPTION
This is a FUSE implementation of the `copy_file_range` syscall.
See the man page for more information: https://man7.org/linux/man-pages/man2/copy_file_range.2.html


# How is the PR tested?
With a modified piece of C code taken from the man page. Find it below for reference.
Usage: `copy_file_range <source> <destination> [<src-offset> [<dst-offset> [<len>]]]`

```
#define _GNU_SOURCE
#include <fcntl.h>
#include <stdio.h>
#include <stdlib.h>
#include <sys/stat.h>
#include <unistd.h>

int main(int argc, char *argv[])
{
   int fd_in, fd_out;
   struct stat stat;
   off64_t len, ret;
   off64_t *src_offset = NULL;
   off64_t *dst_offset = NULL;

   if (argc < 3) {
       fprintf(stderr, "Usage: %s <source> <destination> [<src-offset> [<dst-offset> [<len>]]]\n", argv[0]);
       exit(EXIT_FAILURE);
   }

   fd_in = open(argv[1], O_RDONLY);
   if (fd_in == -1) {
       perror("open (argv[1])");
       exit(EXIT_FAILURE);
   }

   if (fstat(fd_in, &stat) == -1) {
       perror("fstat");
       exit(EXIT_FAILURE);
   }

   len = stat.st_size;

   fd_out = open(argv[2], O_CREAT | O_WRONLY, 0644);
   if (fd_out == -1) {
       perror("open (argv[2])");
       exit(EXIT_FAILURE);
   }

   if (argc >= 4) {
       off64_t res = atoi(argv[3]);
       src_offset = &res;
   }
   if (argc >= 5) {
       off64_t res = atoi(argv[4]);
       dst_offset = &res;
   }
   if (argc >= 6) {
       len = atoi(argv[5]);
   }

   do {
       ret = copy_file_range(fd_in, src_offset, fd_out, dst_offset, len, 0);
       if (ret == -1) {
           perror("copy_file_range");
           exit(EXIT_FAILURE);
       }

       len -= ret;
   } while (len > 0 && ret > 0);

   close(fd_in);
   close(fd_out);
   exit(EXIT_SUCCESS);
}
```


# Checks
- [ ] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
