### PR TITLE
the statistical methord for fileCount should stay same

### DIFF
--- a/weed/storage/needle_map_memory.go
+++ b/weed/storage/needle_map_memory.go
@@ -35,8 +35,8 @@ func LoadCompactNeedleMap(file *os.File) (*NeedleMap, error) {
 func doLoading(file *os.File, nm *NeedleMap) (*NeedleMap, error) {
 	e := idx.WalkIndexFile(file, 0, func(key NeedleId, offset Offset, size Size) error {
 		nm.MaybeSetMaxFileKey(key)
+		nm.FileCounter++
 		if !offset.IsZero() && size.IsValid() {
-			nm.FileCounter++
 			nm.FileByteCounter = nm.FileByteCounter + uint64(size)
 			oldOffset, oldSize := nm.m.Set(NeedleId(key), offset, size)
 			if !oldOffset.IsZero() && oldSize.IsValid() {


### PR DESCRIPTION
They all equal to the entry count in .idx file.
related to commit https://github.com/seaweedfs/seaweedfs/commit/c7892bc7c4a5df48cc1db946243573b3ded3d711

# What problem are we solving?



# How are we solving the problem?



# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
