### PR TITLE
Reuse readDataByFileHandle in Read call

### DIFF
--- a/weed/mount/weedfs_file_read.go
+++ b/weed/mount/weedfs_file_read.go
@@ -43,22 +43,28 @@ func (wfs *WFS) Read(cancel <-chan struct{}, in *fuse.ReadIn, buff []byte) (fuse
 	defer fh.entryLock.Unlock()
 
 	offset := int64(in.Offset)
-	fh.lockForRead(offset, len(buff))
-	defer fh.unlockForRead(offset, len(buff))
-
-	totalRead, err := fh.readFromChunks(buff, offset)
-	if err == nil || err == io.EOF {
-		maxStop := fh.readFromDirtyPages(buff, offset)
-		totalRead = max(maxStop-offset, totalRead)
-	}
-	if err == io.EOF {
-		err = nil
-	}
-
+	totalRead, err := readDataByFileHandle(buff, fh, offset)
 	if err != nil {
 		glog.Warningf("file handle read %s %d: %v", fh.FullPath(), totalRead, err)
 		return nil, fuse.EIO
 	}
 
 	return fuse.ReadResultData(buff[:totalRead]), fuse.OK
+}
+
+func readDataByFileHandle(buff []byte, fhIn *FileHandle, offset int64) (int64, error) {
+	// read data from source file
+	size := len(buff)
+	fhIn.lockForRead(offset, size)
+	defer fhIn.unlockForRead(offset, size)
+
+	n, err := fhIn.readFromChunks(buff, offset)
+	if err == nil || err == io.EOF {
+		maxStop := fhIn.readFromDirtyPages(buff, offset)
+		n = max(maxStop-offset, n)
+	}
+	if err == io.EOF {
+		err = nil
+	}
+	return n, err
 }


### PR DESCRIPTION
Reuse the readDataByFileHandle method in Read calls as well.