### PR TITLE
fix:Handle preflight cors requests

### DIFF
--- a/weed/s3api/s3api_server.go
+++ b/weed/s3api/s3api_server.go
@@ -88,9 +88,11 @@ func (s3a *S3ApiServer) registerRouter(router *mux.Router) {
 	apiRouter.Methods("GET").Path("/status").HandlerFunc(s3a.StatusHandler)
 
 	apiRouter.Methods("OPTIONS").HandlerFunc(
-		func(w http.ResponseWriter, r *http.Request){
+		func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Access-Control-Allow-Origin", "*")
-			w.Header().Set("Access-Control-Allow-Credentials", "true")
+			w.Header().Set("Access-Control-Expose-Headers", "*")
+			w.Header().Set("Access-Control-Allow-Methods", "*")
+			w.Header().Set("Access-Control-Allow-Headers", "*")
 			writeSuccessResponseEmpty(w, r)
 		})
 


### PR DESCRIPTION
# What problem are we solving?
awsjs sdk needs to send a preflight request first, and these 4 headers are required。

