### PR TITLE
fix: TestCommandEcBalanceSmall Unit test fails when CommandEnv is nil

### DIFF
--- a/weed/shell/commands.go
+++ b/weed/shell/commands.go
@@ -83,7 +83,7 @@ func (ce *CommandEnv) confirmIsLocked(args []string) error {
 }
 
 func (ce *CommandEnv) isLocked() bool {
-	return ce.locker.IsLocked()
+	return ce != nil && ce.locker.IsLocked()
 }
 
 func (ce *CommandEnv) checkDirectory(path string) error {


### PR DESCRIPTION
# What problem are we solving?
 TestCommandEcBalanceSmall Unit test fails when CommandEnv is nil

`weed/shell/command_ec_test.go:31`
`balanceEcVolumes(nil, "c1", allEcNodes, racks, false)`
