### PR TITLE
s3: report metadata if the directory is explicitly created 

### DIFF
--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -94,12 +95,19 @@ func (s3a *S3ApiServer) PutObjectHandler(w http.ResponseWriter, r *http.Request)
 
 	objectContentType := r.Header.Get("Content-Type")
 	if strings.HasSuffix(object, "/") {
-		if err := s3a.mkdir(s3a.option.BucketsPath, bucket+strings.TrimSuffix(object, "/"), func(entry *filer_pb.Entry) {
-			if objectContentType == "" {
-				objectContentType = "httpd/unix-directory"
-			}
-			entry.Attributes.Mime = objectContentType
-		}); err != nil {
+		object = strings.TrimSuffix(object, "/")
+		entryName := filepath.Base(object)
+		dirName := filepath.Dir(object)
+		if err := s3a.mkFile(
+			fmt.Sprintf("%s/%s/%s", s3a.option.BucketsPath, bucket, strings.TrimSuffix(dirName, "/")),
+			entryName,
+			nil,
+			func(entry *filer_pb.Entry) {
+				if objectContentType == "" {
+					objectContentType = "httpd/unix-directory"
+				}
+				entry.Attributes.Mime = objectContentType
+			}); err != nil {
 			s3err.WriteErrorResponse(w, r, s3err.ErrInternalError)
 			return
 		}
@@ -314,7 +322,7 @@ func (s3a *S3ApiServer) DeleteMultipleObjectsHandler(w http.ResponseWriter, r *h
 
 func (s3a *S3ApiServer) doDeleteEmptyDirectories(client filer_pb.SeaweedFilerClient, directoriesWithDeletion map[string]int) (newDirectoriesWithDeletion map[string]int) {
 	var allDirs []string
-	for dir, _ := range directoriesWithDeletion {
+	for dir := range directoriesWithDeletion {
 		allDirs = append(allDirs, dir)
 	}
 	slices.SortFunc(allDirs, func(a, b string) bool {

--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -13,7 +13,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -95,13 +94,8 @@ func (s3a *S3ApiServer) PutObjectHandler(w http.ResponseWriter, r *http.Request)
 
 	objectContentType := r.Header.Get("Content-Type")
 	if strings.HasSuffix(object, "/") && r.ContentLength == 0 {
-		object = strings.TrimSuffix(object, "/")
-		entryName := filepath.Base(object)
-		dirName := fmt.Sprintf("%s/%s%s", s3a.option.BucketsPath, bucket, filepath.Dir(object))
-		if err := s3a.mkFile(
-			dirName,
-			entryName,
-			nil,
+		if err := s3a.mkdir(
+			s3a.option.BucketsPath, bucket+strings.TrimSuffix(object, "/"),
 			func(entry *filer_pb.Entry) {
 				if objectContentType == "" {
 					objectContentType = "httpd/unix-directory"

--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -94,12 +94,12 @@ func (s3a *S3ApiServer) PutObjectHandler(w http.ResponseWriter, r *http.Request)
 	defer dataReader.Close()
 
 	objectContentType := r.Header.Get("Content-Type")
-	if strings.HasSuffix(object, "/") {
+	if strings.HasSuffix(object, "/") && r.ContentLength == 0 {
 		object = strings.TrimSuffix(object, "/")
 		entryName := filepath.Base(object)
-		dirName := filepath.Dir(object)
+		dirName := fmt.Sprintf("%s/%s%s", s3a.option.BucketsPath, bucket, filepath.Dir(object))
 		if err := s3a.mkFile(
-			fmt.Sprintf("%s/%s/%s", s3a.option.BucketsPath, bucket, strings.TrimSuffix(dirName, "/")),
+			dirName,
 			entryName,
 			nil,
 			func(entry *filer_pb.Entry) {

--- a/weed/server/filer_server_handlers_read.go
+++ b/weed/server/filer_server_handlers_read.go
@@ -25,10 +25,11 @@ import (
 
 // Validates the preconditions. Returns true if GET/HEAD operation should not proceed.
 // Preconditions supported are:
-//  If-Modified-Since
-//  If-Unmodified-Since
-//  If-Match
-//  If-None-Match
+//
+//	If-Modified-Since
+//	If-Unmodified-Since
+//	If-Match
+//	If-None-Match
 func checkPreconditions(w http.ResponseWriter, r *http.Request, entry *filer.Entry) bool {
 
 	etag := filer.ETagEntry(entry)
@@ -111,12 +112,12 @@ func (fs *FilerServer) GetOrHeadHandler(w http.ResponseWriter, r *http.Request) 
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
-		if entry.Attr.Mime != "" {
-			// inform S3 API this is a user created directory key object
-			w.Header().Set(s3_constants.X_SeaweedFS_Header_Directory_Key, "true")
+		if entry.Attr.Mime == "" {
+			fs.listDirectoryHandler(w, r)
+			return
 		}
-		fs.listDirectoryHandler(w, r)
-		return
+		// inform S3 API this is a user created directory key object
+		w.Header().Set(s3_constants.X_SeaweedFS_Header_Directory_Key, "true")
 	}
 
 	if isForDirectory {


### PR DESCRIPTION
# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/3457


```
aws --endpoint-url http://127.0.0.1:8333 s3api put-object --bucket one --key bla/
MacBook-Pro-Lebedev:docker lebedev_k$ curl -I http://127.0.0.1:8333/one/bla/
HTTP/1.1 200 OK
Date: Tue, 23 Aug 2022 14:12:21 GMT
Server: SeaweedFS Filer 30GB 3.23
X-Seaweedfs-Is-Directory-Key: true
```

Must be
```
aws --endpoint-url http://127.0.0.1:8333 s3api put-object --bucket one --key bla/
curl -I http://127.0.0.1:8333/one/bla
HTTP/1.1 200 OK
Accept-Ranges: bytes
Access-Control-Expose-Headers: Content-Disposition
Content-Disposition: inline; filename="bla"
Content-Length: 0
Content-Type: httpd/unix-directory
Date: Tue, 23 Aug 2022 09:24:22 GMT
Etag: "d41d8cd98f00b204e9800998ecf8427e-0"
Last-Modified: Tue, 23 Aug 2022 09:24:18 GMT
Server: SeaweedFS Filer 30GB 3.23
```

# How are we solving the problem?

return metadata

# How is the PR tested?


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
