### PR TITLE
fix deletecount bug

### DIFF
--- a/weed/storage/needle_map_metric.go
+++ b/weed/storage/needle_map_metric.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/seaweedfs/seaweedfs/weed/storage/idx"
 	. "github.com/seaweedfs/seaweedfs/weed/storage/types"
-	"github.com/tylertreat/BoomFilters"
+	boom "github.com/tylertreat/BoomFilters"
 )
 
 type mapMetric struct {
@@ -106,7 +106,12 @@ func newNeedleMapMetricFromIndexFile(r *os.File) (mm *mapMetric, err error) {
 		}
 
 		mm.FileCounter++
-		if bf.TestAndAdd(buf) {
+		if !bf.TestAndAdd(buf) {
+			// if !size.IsValid(), then this file is deleted already
+			if !size.IsValid() {
+				mm.DeletionCounter++
+			}
+		} else {
 			// deleted file
 			mm.DeletionCounter++
 			if size.IsValid() {


### PR DESCRIPTION
# What problem are we solving?
https://github.com/seaweedfs/seaweedfs/pull/3388#discussion_r951292287

If size is invalid, then this file is marked deleted.
 However multipal deleted files is also counted.

# How are we solving the problem?



# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
