### PR TITLE
Avoid race conditions when opening and working on files in parallel in FUSE mounts

### DIFF
--- a/weed/mount/filehandle_map.go
+++ b/weed/mount/filehandle_map.go
@@ -1,8 +1,9 @@
 package mount
 
 import (
-	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"sync"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 )
 
 type FileHandleToInode struct {
@@ -49,7 +50,11 @@ func (i *FileHandleToInode) AcquireFileHandle(wfs *WFS, inode uint64, entry *fil
 	} else {
 		fh.counter++
 	}
+
+	fh.entryLock.Lock()
 	fh.entry = entry
+	fh.entryLock.Unlock()
+
 	return fh
 }
 


### PR DESCRIPTION
# What problem are we solving?
Avoid race conditions when opening and working on files in parallel in FUSE mounts.


# How are we solving the problem?
Avoid re-setting the same instance of `filer_pb.Entry` to `FileHandle.entry` on every `Open` call.
Once a file has been opened for the first time, the entry is set and does not change anymore.


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
