### PR TITLE
Fix race conditions during in-flight size checks

### DIFF
--- a/weed/filer/reader_cache.go
+++ b/weed/filer/reader_cache.go
@@ -186,8 +186,8 @@ func (s *SingleChunkCacher) destroy() {
 	if s.data != nil {
 		mem.Free(s.data)
 		s.data = nil
+		close(s.cacheStartedCh)
 	}
-	close(s.cacheStartedCh)
 }
 
 func (s *SingleChunkCacher) readChunkAt(buf []byte, offset int64) (int, error) {


### PR DESCRIPTION
# What problem are we solving?
Fix race conditions during in-flight size checks. Therefore, it should be more accurate now.


# How are we solving the problem?
Atomically checking for sizes.


# How is the PR tested?
Upload and download bigger chunks of data in parallel, for example like this:

`echo {1..100} | xargs -P100 -n1 sh -c 'dd if=/dev/zero bs=1m count=1 2>/dev/null | tee mount/patrick2 | tee mount/patrick3 | tee mount/patrick4 | tee mount/patrick5 >/dev/null'; md5sum <(cat mount/patrick2) <(cat mount/patrick3) <(cat mount/patrick4) <(cat mount/patrick5)`


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
