### PR TITLE
Fix a few data races when reading files in mount

### DIFF
--- a/weed/mount/filehandle.go
+++ b/weed/mount/filehandle.go
@@ -1,12 +1,14 @@
 package mount
 
 import (
+	"sync"
+
+	"golang.org/x/exp/slices"
+
 	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/util"
-	"golang.org/x/exp/slices"
-	"sync"
 )
 
 type FileHandleId uint64
@@ -57,10 +59,18 @@ func (fh *FileHandle) GetEntry() *filer_pb.Entry {
 	defer fh.entryLock.Unlock()
 	return fh.entry
 }
+
 func (fh *FileHandle) SetEntry(entry *filer_pb.Entry) {
 	fh.entryLock.Lock()
 	defer fh.entryLock.Unlock()
 	fh.entry = entry
+}
+
+func (fh *FileHandle) UpdateEntry(fn func(entry *filer_pb.Entry)) *filer_pb.Entry {
+	fh.entryLock.Lock()
+	defer fh.entryLock.Unlock()
+	fn(fh.entry)
+	return fh.entry
 }
 
 func (fh *FileHandle) AddChunks(chunks []*filer_pb.FileChunk) {

--- a/weed/mount/filehandle_map.go
+++ b/weed/mount/filehandle_map.go
@@ -1,8 +1,9 @@
 package mount
 
 import (
-	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"sync"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 )
 
 type FileHandleToInode struct {
@@ -49,7 +50,9 @@ func (i *FileHandleToInode) AcquireFileHandle(wfs *WFS, inode uint64, entry *fil
 	} else {
 		fh.counter++
 	}
-	fh.entry = entry
+	if fh.entry != entry {
+		fh.SetEntry(entry)
+	}
 	return fh
 }
 

--- a/weed/mount/weedfs.go
+++ b/weed/mount/weedfs.go
@@ -135,10 +135,11 @@ func (wfs *WFS) maybeReadEntry(inode uint64) (path util.FullPath, fh *FileHandle
 	}
 	var found bool
 	if fh, found = wfs.fhmap.FindFileHandle(inode); found {
-		entry = fh.GetEntry()
-		if entry != nil && fh.entry.Attributes == nil {
-			entry.Attributes = &filer_pb.FuseAttributes{}
-		}
+		entry = fh.UpdateEntry(func(entry *filer_pb.Entry) {
+			if entry != nil && fh.entry.Attributes == nil {
+				entry.Attributes = &filer_pb.FuseAttributes{}
+			}
+		})
 	} else {
 		entry, status = wfs.maybeLoadEntry(path)
 	}


### PR DESCRIPTION
# What problem are we solving?
Fix a few data races when reading files in mount, especially with concurrent operations.


# How are we solving the problem?
Employ locks and atomic operations to update states.


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
