### PR TITLE
Fix reload page before all file uploaded bug

### DIFF
--- a/weed/server/filer_ui/filer.html
+++ b/weed/server/filer_ui/filer.html
@@ -288,12 +288,12 @@
     function uploadFile(file, i) {
         var url = window.location.href;
         var xhr = new XMLHttpRequest();
+        var fileName = file.name;
         xhr.onreadystatechange = function() {
             if (xhr.readyState == XMLHttpRequest.DONE) {
-                location.reload();
+                finishUpload(fileName)
             }
         }
-        var fileName = file.name;
         xhr.upload.addEventListener('progress', function(e) {
             if (e.lengthComputable) {
                 var percent = Math.ceil((e.loaded / e.total) * 100);


### PR DESCRIPTION
# What problem are we solving?

Fix issue #3518 

# How are we solving the problem?

Do not reload page before all file uploaded.

# How is the PR tested?

Test manually, upload many files include big and small files.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
