### PR TITLE
Fix corrupted mount reads after changes on fh

### DIFF
--- a/weed/mount/filehandle.go
+++ b/weed/mount/filehandle.go
@@ -110,7 +110,8 @@ func (fh *FileHandle) AddChunks(chunks []*filer_pb.FileChunk) {
 
 func (fh *FileHandle) CloseReader() {
 	if fh.reader != nil {
-		fh.reader.Close()
+		_ = fh.reader.Close()
+		fh.reader = nil
 	}
 }
 


### PR DESCRIPTION
# What problem are we solving?
Fix corrupted mount reads after changes on fh. See #3535.
When a file is opened multiple times - no matter if single- or multi-threaded - and something was written, or a metadata attribute was changed, then the following reads would always return wrong / old data until all file handles were closed and the file was reopened.


# How are we solving the problem?
The reason was that the outdated reader was not reset properly with a fresh chunk view.
The fix is to reset the reader instance on file handles properly.


# How is the PR tested?
With `dt` tool. See #3535.


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
