### PR TITLE
Fix crash in arangodb filer when attempting to access a deleted bucket

### DIFF
--- a/weed/filer/arangodb/arangodb_store_bucket.go
+++ b/weed/filer/arangodb/arangodb_store_bucket.go
@@ -34,6 +34,9 @@ func (store *ArangodbStore) OnBucketDeletion(bucket string) {
 		glog.Errorf("bucket delete %s: %v", bucket, err)
 		return
 	}
+	store.mu.Lock()
+	delete(store.buckets, bucket)
+	store.mu.Unlock()
 }
 func (store *ArangodbStore) CanDropWholeBucket() bool {
 	return true

--- a/weed/filer/arangodb/helpers.go
+++ b/weed/filer/arangodb/helpers.go
@@ -86,7 +86,7 @@ func (store *ArangodbStore) ensureBucket(ctx context.Context, bucket string) (bc
 	store.mu.RLock()
 	bc, ok = store.buckets[bucket]
 	store.mu.RUnlock()
-	if ok {
+	if ok && bc != nil {
 		return bc, nil
 	}
 	store.mu.Lock()


### PR DESCRIPTION
# What problem are we solving?

The collection cache for buckets was not deleting from map, whilst also setting itself as a nil pointer, causing crash.

# How are we solving the problem?

both delete the bucket from the collection cache when bucket is deleted, and also do not return a nil collection from the collection cache. 