### PR TITLE
adjust log level

### DIFF
--- a/weed/filer/filer_deletion.go
+++ b/weed/filer/filer_deletion.go
@@ -58,7 +58,7 @@ func (f *Filer) loopProcessingDeletion() {
 						glog.V(0).Infof("deleting fileIds len=%d error: %v", deletionCount, err)
 					}
 				} else {
-					glog.V(1).Infof("deleting fileIds len=%d", deletionCount)
+					glog.V(2).Infof("deleting fileIds len=%d", deletionCount)
 				}
 			}
 		})


### PR DESCRIPTION
# What problem are we solving?
<img width="1399" alt="image" src="https://user-images.githubusercontent.com/10348876/188366830-d9332bbd-cdb9-4178-b994-9e0cdb82220f.png">
As the storage of the `docker registry`, a lot of delete requests will be sent, and there are too many such logs output by the filer.



