### PR TITLE
fix bug due to data racing on VidMap

### DIFF
--- a/weed/wdclient/masterclient.go
+++ b/weed/wdclient/masterclient.go
@@ -27,7 +27,7 @@ type MasterClient struct {
 	masters           map[string]pb.ServerAddress
 	grpcDialOption    grpc.DialOption
 
-	vidMap
+	*vidMap
 	vidMapCacheSize  int
 	OnPeerUpdate     func(update *master_pb.ClusterNodeUpdate, startFrom time.Time)
 	OnPeerUpdateLock sync.RWMutex
@@ -303,9 +303,12 @@ func (mc *MasterClient) resetVidMap() {
 		DataCenter:      mc.DataCenter,
 		cache:           mc.cache,
 	}
-	mc.vidMap = newVidMap(mc.DataCenter)
-	mc.vidMap.cache = tail
 
+	nvm := newVidMap(mc.DataCenter)
+	nvm.cache = tail
+	mc.vidMap = nvm
+
+	//trim
 	for i := 0; i < mc.vidMapCacheSize && tail.cache != nil; i++ {
 		if i == mc.vidMapCacheSize-1 {
 			tail.cache = nil

--- a/weed/wdclient/vid_map.go
+++ b/weed/wdclient/vid_map.go
@@ -43,8 +43,8 @@ type vidMap struct {
 	cache           *vidMap
 }
 
-func newVidMap(dataCenter string) vidMap {
-	return vidMap{
+func newVidMap(dataCenter string) *vidMap {
+	return &vidMap{
 		vid2Locations:   make(map[uint32][]Location),
 		ecVid2Locations: make(map[uint32][]Location),
 		DataCenter:      dataCenter,


### PR DESCRIPTION
# What problem are we solving?

## `weed/wdclient/masterclient.go:20`
```go
type MasterClient struct {
         vidMap
         ......
}
```
Since the vidMap of the masterClient is not a pointer type, and the receiver of the GetLocation method is a pointer type, during the leader switching process, after calling `resetVidMap`, the vidMap of the masterClient changes, in the GetLocation method `defer vc.RUnlock()` The vc used is the new vidMap, causing `fatal error: sync: RUnlock of unlocked RWMutex`
```txt
=== RUN   TestConcurrentGetLocations
fatal error: sync: RUnlock of unlocked RWMutex

goroutine 57 [running]:
runtime.throw({0x105339556?, 0x10531b8d4?})
	/Users/lhhdz/wd/soft/go-1.18.1/src/runtime/panic.go:992 +0x50 fp=0x14000412dd0 sp=0x14000412da0 pc=0x104d3be00
sync.throw({0x105339556?, 0x100010000?})
	/Users/lhhdz/wd/soft/go-1.18.1/src/runtime/panic.go:978 +0x24 fp=0x14000412df0 sp=0x14000412dd0 pc=0x104d69d64
sync.(*RWMutex).rUnlockSlow(0x140001e22a8, 0x531b9d0?)
	/Users/lhhdz/wd/soft/go-1.18.1/src/sync/rwmutex.go:121 +0x48 fp=0x14000412e20 sp=0x14000412df0 pc=0x104d79dc8
sync.(*RWMutex).RUnlock(0x3?)
	/Users/lhhdz/wd/soft/go-1.18.1/src/sync/rwmutex.go:111 +0x68 fp=0x14000412e40 sp=0x14000412e20 pc=0x104d79d58
github.com/seaweedfs/seaweedfs/weed/wdclient.(*vidMap).getLocations.func1()
	/Users/lhhdz/wd/projects/go/seaweedfs/weed/wdclient/vid_map.go:146 +0x2c fp=0x14000412e60 sp=0x14000412e40 pc=0x10531bb3c
github.com/seaweedfs/seaweedfs/weed/wdclient.(*vidMap).getLocations(0x140001e22a8, 0x0?)
	/Users/lhhdz/wd/projects/go/seaweedfs/weed/wdclient/vid_map.go:150 +0x10c fp=0x14000412ec0 sp=0x14000412e60 pc=0x10531ba4c
github.com/seaweedfs/seaweedfs/weed/wdclient.(*vidMap).GetLocations(0x140001e22a8, 0x0?)
	/Users/lhhdz/wd/projects/go/seaweedfs/weed/wdclient/vid_map.go:132 +0xb4 fp=0x14000412f40 sp=0x14000412ec0 pc=0x10531b8d4
github.com/seaweedfs/seaweedfs/weed/wdclient.TestDataRacing.func1()
	/Users/lhhdz/wd/projects/go/seaweedfs/weed/wdclient/vid_map_test.go:153 +0xac fp=0x14000412fd0 sp=0x14000412f40 pc=0x10531dc6c
runtime.goexit()
	/Users/lhhdz/wd/soft/go-1.18.1/src/runtime/asm_arm64.s:1259 +0x4 fp=0x14000412fd0 sp=0x14000412fd0 pc=0x104d6eff4
created by github.com/seaweedfs/seaweedfs/weed/wdclient.TestDataRacing
	/Users/lhhdz/wd/projects/go/seaweedfs/weed/wdclient/vid_map_test.go:146 +0x178
```

## `weed/wdclient/masterclient.go:307`
```go
	mc.vidMap = newVidMap(mc.DataCenter)
	mc.vidMap.cache = tail
```
After executing the first line of code, since the cache of vidMap has not been assigned, when `data race` occurs, the cache will not be read.
![](https://user-images.githubusercontent.com/9497591/188466295-9bf15910-b5ba-4372-ac96-b2679aec7745.png)

# How are we solving the problem?

1. Modify the vidMap of the masterClient to a pointer type, so that when calling `GetLocations`, the `vidMap` corresponding to `lock` and `unlock` are executed consistently2. 

2. In the `resetVidMap` method, for the new vidMap, first construct the cache, and then assign a value to the masterClient to avoid accessing the cache

# How is the PR tested?

added `TestConcurrentGetLocations` at  `weed/wdclient/vid_map_test.go:137`

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
