### PR TITLE
feat: Remove volume download lock

### DIFF
--- a/weed/storage/volume.go
+++ b/weed/storage/volume.go
@@ -37,6 +37,7 @@ type Volume struct {
 
 	dataFileAccessLock    sync.RWMutex
 	superBlockAccessLock  sync.Mutex
+	compactAccessLock  sync.RWMutex
 	asyncRequestsChan     chan *needle.AsyncRequest
 	lastModifiedTsSeconds uint64 // unix time in seconds
 	lastAppendAtNs        uint64 // unix time in nanoseconds

--- a/weed/storage/volume_read.go
+++ b/weed/storage/volume_read.go
@@ -100,9 +100,6 @@ func (v *Volume) readNeedleMetaAt(n *needle.Needle, offset int64, size int32) (e
 
 // read fills in Needle content by looking up n.Id from NeedleMapper
 func (v *Volume) readNeedleDataInto(n *needle.Needle, readOption *ReadOption, writer io.Writer, offset int64, size int64) (err error) {
-	v.dataFileAccessLock.RLock()
-	defer v.dataFileAccessLock.RUnlock()
-
 	nv, ok := v.nm.Get(n.Id)
 	if !ok || nv.Offset.IsZero() {
 		return ErrorNotFound

--- a/weed/storage/volume_read.go
+++ b/weed/storage/volume_read.go
@@ -100,6 +100,9 @@ func (v *Volume) readNeedleMetaAt(n *needle.Needle, offset int64, size int32) (e
 
 // read fills in Needle content by looking up n.Id from NeedleMapper
 func (v *Volume) readNeedleDataInto(n *needle.Needle, readOption *ReadOption, writer io.Writer, offset int64, size int64) (err error) {
+	v.compactAccessLock.RLock()
+	defer v.compactAccessLock.RUnlock()
+
 	nv, ok := v.nm.Get(n.Id)
 	if !ok || nv.Offset.IsZero() {
 		return ErrorNotFound

--- a/weed/storage/volume_vacuum.go
+++ b/weed/storage/volume_vacuum.go
@@ -114,6 +114,9 @@ func (v *Volume) CommitCompact() error {
 	v.dataFileAccessLock.Lock()
 	defer v.dataFileAccessLock.Unlock()
 
+	v.compactAccessLock.Lock()
+	defer v.compactAccessLock.Unlock()
+
 	glog.V(3).Infof("Got volume %d committing lock...", v.Id)
 	if v.nm != nil {
 		v.nm.Close()


### PR DESCRIPTION
# What problem are we solving?
The download of online services is sometimes very very slow. I added some debugging logs and found that when there is a very slow upload, the download side needs to wait for a long time to get the lock.
Because the entire `volume` is an append operation, there is no update operation, I did not expect the function of this `lock`, so deleted it
<img width="1241" alt="wecom-temp-195a08c56813a114dc0df566b84add56" src="https://user-images.githubusercontent.com/10348876/188824957-40da7bdc-6ef1-4df1-819b-38cfd4d52bf5.png">
<img width="359" alt="wecom-temp-2faef2712b503d3b306a95c9e6f229f9" src="https://user-images.githubusercontent.com/10348876/188824979-2b036962-059c-434c-9f84-0742c8465d7e.png">

filer maxMB:32M