### PR TITLE
fix:Sometimes a nil pointer exception is thrown

### DIFF
--- a/weed/server/master_grpc_server.go
+++ b/weed/server/master_grpc_server.go
@@ -228,7 +228,11 @@ func (ms *MasterServer) SendHeartbeat(stream master_pb.Seaweed_SendHeartbeatServ
 		if err := stream.Send(&master_pb.HeartbeatResponse{
 			Leader: string(newLeader),
 		}); err != nil {
-			glog.Warningf("SendHeartbeat.Send response to to %s:%d %v", dn.Ip, dn.Port, err)
+			if dn != nil {
+				glog.Warningf("SendHeartbeat.Send response to %s:%d %v", dn.Ip, dn.Port, err)
+			} else {
+				glog.Warningf("SendHeartbeat.Send response %v", err)
+			}
 			return err
 		}
 	}


### PR DESCRIPTION
# What problem are we solving?
A `null pointer` appears when `dn` is nil


<img width="1388" alt="image" src="https://user-images.githubusercontent.com/10348876/189015009-68d2ce48-9bf3-46e3-9613-e081fd5a10a4.png">

test code.
<img width="940" alt="image" src="https://user-images.githubusercontent.com/10348876/189015203-786a1cde-0492-4c18-b3b0-30c28869d279.png">
