### PR TITLE
fix:avoid data race on createDc

### DIFF
--- a/weed/topology/data_center.go
+++ b/weed/topology/data_center.go
@@ -3,9 +3,11 @@ package topology
 import (
 	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
 	"golang.org/x/exp/slices"
+	"sync"
 )
 
 type DataCenter struct {
+	CreateRackLock sync.RWMutex
 	NodeImpl
 }
 
@@ -20,6 +22,9 @@ func NewDataCenter(id string) *DataCenter {
 }
 
 func (dc *DataCenter) GetOrCreateRack(rackName string) *Rack {
+	dc.CreateRackLock.Lock()
+	defer dc.CreateRackLock.Unlock()
+
 	for _, c := range dc.Children() {
 		rack := c.(*Rack)
 		if string(rack.Id()) == rackName {

--- a/weed/topology/topology.go
+++ b/weed/topology/topology.go
@@ -47,6 +47,7 @@ type Topology struct {
 	RaftServerAccessLock sync.RWMutex
 	HashicorpRaft        *hashicorpRaft.Raft
 	UuidAccessLock       sync.RWMutex
+	CreateDCLock         sync.RWMutex
 	UuidMap              map[string][]string
 }
 
@@ -258,6 +259,9 @@ func (t *Topology) UnRegisterVolumeLayout(v storage.VolumeInfo, dn *DataNode) {
 }
 
 func (t *Topology) GetOrCreateDataCenter(dcName string) *DataCenter {
+	t.CreateDCLock.Lock()
+	defer t.CreateDCLock.Unlock()
+
 	for _, c := range t.Children() {
 		dc := c.(*DataCenter)
 		if string(dc.Id()) == dcName {


### PR DESCRIPTION
# What problem are we solving?
Some volume nodes are lost after reselecting the master node
<img width="1166" alt="image" src="https://user-images.githubusercontent.com/10348876/189031366-c4225905-e644-49d3-8088-3329a29a17e5.png">
As shown above, not `topo.idc1:rack2`
Created multiple 'dc', some were replaced,So some nodes cannot be added to `topo`


# How are we solving the problem?
add a lock

