### PR TITLE
mount: fix new inode allocation

### DIFF
--- a/weed/mount/inode_to_path.go
+++ b/weed/mount/inode_to_path.go
@@ -80,7 +80,7 @@ func (i *InodeToPath) Lookup(path util.FullPath, unixTime int64, isDirectory boo
 		}
 		if !isHardlink {
 			for _, found := i.inode2path[inode]; found; inode++ {
-				_, found = i.inode2path[inode]
+				_, found = i.inode2path[inode+1]
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: fuweiwei <fuweiwei@virtaitech.com>

# What problem are we solving?
In weed_mount, during file lookup, it will try to allocate a new inode for a new file.
Upon inode conflicts, it will allocate the next inode number. But it will actually allocate the "n+2" inode number, and further allocation will still allocate the "n+2" number, leading to inode conflicts.

