### PR TITLE
fix 'localFilerSocket' nil pointer

### DIFF
--- a/weed/command/s3.go
+++ b/weed/command/s3.go
@@ -57,6 +57,7 @@ func init() {
 	s3StandaloneOptions.metricsHttpPort = cmdS3.Flag.Int("metricsPort", 0, "Prometheus metrics listen port")
 	s3StandaloneOptions.allowEmptyFolder = cmdS3.Flag.Bool("allowEmptyFolder", true, "allow empty folders")
 	s3StandaloneOptions.allowDeleteBucketNotEmpty = cmdS3.Flag.Bool("allowDeleteBucketNotEmpty", true, "allow recursive deleting all entries along with bucket")
+	s3StandaloneOptions.localFilerSocket = cmdS3.Flag.String("localFilerSocket", "", "local filer socket path")
 }
 
 var cmdS3 = &Command{


### PR DESCRIPTION
# What problem are we solving?
'localFilerSocket' uninitialized causing nil pointer error when tart s3server standalone
```txt
I0914 17:41:27.582435 s3.go:172 S3 read filer buckets dir: /buckets
I0914 17:41:27.582450 s3.go:179 connected to filer localhost:8888 grpc address localhost:18888
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x10279000c]

goroutine 1 [running]:
github.com/seaweedfs/seaweedfs/weed/command.(*S3Options).startS3Server(0x10420c060)
        /Users/lhhdz/wd/projects/go/seaweedfs/weed/command/s3.go:197 +0x68c
github.com/seaweedfs/seaweedfs/weed/command.runS3(0x1041ef840, {0x1400004e1d0, 0x0, 0x0})
        /Users/lhhdz/wd/projects/go/seaweedfs/weed/command/s3.go:148 +0x9c
main.main()
        /Users/lhhdz/wd/projects/go/seaweedfs/weed/weed.go:81 +0x528
Exiting.
```

# How are we solving the problem?

Add to cmd parameter to initialize

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
