### PR TITLE
docs: `indicates` readability comment fix

### DIFF
--- a/weed/wdclient/net2/managed_connection.go
+++ b/weed/wdclient/net2/managed_connection.go
@@ -31,7 +31,7 @@ type ManagedConn interface {
 	// This returns the connection pool which owns this connection.
 	Owner() ConnectionPool
 
-	// This indictes a user is done with the connection and releases the
+	// This indicates a user is done with the connection and releases the
 	// connection back to the connection pool.
 	ReleaseConnection() error
 

--- a/weed/wdclient/resource_pool/managed_handle.go
+++ b/weed/wdclient/resource_pool/managed_handle.go
@@ -24,7 +24,7 @@ type ManagedHandle interface {
 	// owns the resource.
 	ReleaseUnderlyingHandle() interface{}
 
-	// This indictes a user is done with the handle and releases the handle
+	// This indicates a user is done with the handle and releases the handle
 	// back to the resource pool.
 	Release() error
 


### PR DESCRIPTION
Signed-off-by: Ryan Russell <git@ryanrussell.org>

# What problem are we solving?

```bash
grep -r indictes
wdclient/resource_pool/managed_handle.go:	// This indictes a user is done with the handle and releases the handle
wdclient/net2/managed_connection.go:	// This indictes a user is done with the connection and releases the
```

# How are we solving the problem?

`indictes` -> `indicates`


# Notes for merger
Feel free to let me know if you prefer these small, specific PR's, or would rather me lump comment readability things into a more signficant PR.

Best,
Ryan