### PR TITLE
docs: `orignial` -> `original`

### DIFF
--- a/weed/command/update.go
+++ b/weed/command/update.go
@@ -69,7 +69,7 @@ func init() {
 	path, _ := os.Executable()
 	_, name := filepath.Split(path)
 	updateOpt.dir = cmdUpdate.Flag.String("dir", filepath.Dir(path), "directory to save new weed.")
-	updateOpt.name = cmdUpdate.Flag.String("name", name, "name of new weed. On windows, name shouldn't be same to the orignial name.")
+	updateOpt.name = cmdUpdate.Flag.String("name", name, "name of new weed. On windows, name shouldn't be same to the original name.")
 	updateOpt.Version = cmdUpdate.Flag.String("version", "0", "specific version of weed you want to download. If not specified, get the latest version.")
 	cmdUpdate.Run = runUpdate
 }
@@ -101,7 +101,7 @@ func runUpdate(cmd *Command, args []string) bool {
 
 	if runtime.GOOS == "windows" {
 		if target == path {
-			glog.Fatalf("On windows, name of the new weed shouldn't be same to the orignial name.")
+			glog.Fatalf("On windows, name of the new weed shouldn't be same to the original name.")
 			return false
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Ryan Russell <git@ryanrussell.org>

# What problem are we solving?
```bash
grep -r orignial
update.go:	updateOpt.name = cmdUpdate.Flag.String("name", name, "name of new weed. On windows, name shouldn't be same to the orignial name.")
update.go:			glog.Fatalf("On windows, name of the new weed shouldn't be same to the orignial name.")
```
# How are we solving the problem?



# How is the PR tested?
`orignial` -> `original`


### Notes
Chris, you're merging so fast, I'm reading through the code for my own use and will keep sending things I find... 

If it's too many PR's just tell me to stop or slow down :)