### PR TITLE
refactor(socket mount): Update socket mount pattern to `/tmp/seaweedf…

### DIFF
--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -295,7 +295,7 @@ func (fo *FilerOptions) startFiler() {
 	if runtime.GOOS != "windows" {
 		localSocket := *fo.localSocket
 		if localSocket == "" {
-			localSocket = fmt.Sprintf("/tmp/seaweefs-filer-%d.sock", *fo.port)
+			localSocket = fmt.Sprintf("/tmp/seaweedfs-filer-%d.sock", *fo.port)
 		}
 		if err := os.Remove(localSocket); err != nil && !os.IsNotExist(err) {
 			glog.Fatalf("Failed to remove %s, error: %s", localSocket, err.Error())

--- a/weed/command/mount_std.go
+++ b/weed/command/mount_std.go
@@ -107,7 +107,7 @@ func RunMount(option *MountOptions, umask os.FileMode) bool {
 		if mountDirHash < 0 {
 			mountDirHash = -mountDirHash
 		}
-		*option.localSocket = fmt.Sprintf("/tmp/seaweefs-mount-%d.sock", mountDirHash)
+		*option.localSocket = fmt.Sprintf("/tmp/seaweedfs-mount-%d.sock", mountDirHash)
 	}
 	if err := os.Remove(*option.localSocket); err != nil && !os.IsNotExist(err) {
 		glog.Fatalf("Failed to remove %s, error: %s", *option.localSocket, err.Error())

--- a/weed/shell/command_mount_configure.go
+++ b/weed/shell/command_mount_configure.go
@@ -47,7 +47,7 @@ func (c *commandMountConfigure) Do(args []string, commandEnv *CommandEnv, writer
 	if mountDirHash < 0 {
 		mountDirHash = -mountDirHash
 	}
-	localSocket := fmt.Sprintf("/tmp/seaweefs-mount-%d.sock", mountDirHash)
+	localSocket := fmt.Sprintf("/tmp/seaweedfs-mount-%d.sock", mountDirHash)
 
 	clientConn, err := grpc.Dial("passthrough:///unix://"+localSocket, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {


### PR DESCRIPTION
…s...`

Signed-off-by: Ryan Russell <git@ryanrussell.org>

# What problem are we solving?
Socket mounts would currently not match a grep for the product name. 

This is the first PR that makes a functional change.

I believe this is pretty straightforward, please let me know if there are other implications I'm missing and need to discuss in chat or an Issue first.

```bash
grep -r seaweefs
weed/shell/command_mount_configure.go:	localSocket := fmt.Sprintf("/tmp/seaweefs-mount-%d.sock", mountDirHash)
weed/command/filer.go:			localSocket = fmt.Sprintf("/tmp/seaweefs-filer-%d.sock", *fo.port)
weed/command/mount_std.go:		*option.localSocket = fmt.Sprintf("/tmp/seaweefs-mount-%d.sock", mountDirHash)
```


# How are we solving the problem?
Update the prefix the socket mount paths.
`/tmp/seaweefs` -> `/tmp/seaweedfs`

# How is the PR tested?

Ensured `grep -ri '/tmp/seaweefs'` has no more matches


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
