### PR TITLE
docs: `replicte` -> `replicate`

### DIFF
--- a/weed/replication/sink/filersink/filer_sink.go
+++ b/weed/replication/sink/filersink/filer_sink.go
@@ -195,7 +195,7 @@ func (fs *FilerSink) UpdateEntry(key string, oldEntry *filer_pb.Entry, newParent
 		// find out what changed
 		deletedChunks, newChunks, err := compareChunks(filer.LookupFn(fs), oldEntry, newEntry)
 		if err != nil {
-			return true, fmt.Errorf("replicte %s compare chunks error: %v", key, err)
+			return true, fmt.Errorf("replicate %s compare chunks error: %v", key, err)
 		}
 
 		// delete the chunks that are deleted from the source
@@ -207,7 +207,7 @@ func (fs *FilerSink) UpdateEntry(key string, oldEntry *filer_pb.Entry, newParent
 		// replicate the chunks that are new in the source
 		replicatedChunks, err := fs.replicateChunks(newChunks, key)
 		if err != nil {
-			return true, fmt.Errorf("replicte %s chunks error: %v", key, err)
+			return true, fmt.Errorf("replicate %s chunks error: %v", key, err)
 		}
 		existingEntry.Chunks = append(existingEntry.Chunks, replicatedChunks...)
 		existingEntry.Attributes = newEntry.Attributes


### PR DESCRIPTION
Signed-off-by: Ryan Russell <git@ryanrussell.org>

# What problem are we solving?
```bash
grep -r replicte
weed/replication/sink/filersink/filer_sink.go:			return true, fmt.Errorf("replicte %s compare chunks error: %v", key, err)
weed/replication/sink/filersink/filer_sink.go:			return true, fmt.Errorf("replicte %s chunks error: %v", key, err)
```

# How are we solving the problem?
`replicte` -> `replicate`

