### PR TITLE
refactor(filechunk_manifest): `localProcesed` -> `localProcessed`

### DIFF
--- a/weed/filer/filechunk_manifest.go
+++ b/weed/filer/filechunk_manifest.go
@@ -169,19 +169,19 @@ func retriedStreamFetchChunkData(writer io.Writer, urlStrings []string, cipherKe
 
 	for waitTime := time.Second; waitTime < util.RetryWaitTime; waitTime += waitTime / 2 {
 		for _, urlString := range urlStrings {
-			var localProcesed int
+			var localProcessed int
 			shouldRetry, err = util.ReadUrlAsStream(urlString+"?readDeleted=true", cipherKey, isGzipped, isFullChunk, offset, size, func(data []byte) {
-				if totalWritten > localProcesed {
-					toBeSkipped := totalWritten - localProcesed
+				if totalWritten > localProcessed {
+					toBeSkipped := totalWritten - localProcessed
 					if len(data) <= toBeSkipped {
-						localProcesed += len(data)
+						localProcessed += len(data)
 						return // skip if already processed
 					}
 					data = data[toBeSkipped:]
-					localProcesed += toBeSkipped
+					localProcessed += toBeSkipped
 				}
 				writer.Write(data)
-				localProcesed += len(data)
+				localProcessed += len(data)
 				totalWritten += len(data)
 			})
 			if !shouldRetry {


### PR DESCRIPTION
Signed-off-by: Ryan Russell <git@ryanrussell.org>

# What problem are we solving?

```bash
grep -ri Procesed
weed/filer/filechunk_manifest.go:			var localProcesed int
weed/filer/filechunk_manifest.go:				if totalWritten > localProcesed {
weed/filer/filechunk_manifest.go:					toBeSkipped := totalWritten - localProcesed
weed/filer/filechunk_manifest.go:						localProcesed += len(data)
weed/filer/filechunk_manifest.go:					localProcesed += toBeSkipped
weed/filer/filechunk_manifest.go:				localProcesed += len(data)
```

# How are we solving the problem?

`localProcesed` -> `localProcessed`

# How is the PR tested?

`grep -ri Procesed` has no results after updates
