### PR TITLE
refactor(exclusive_locker): `Interval` readability batch of updates

### DIFF
--- a/weed/filer/filechunk_manifest.go
+++ b/weed/filer/filechunk_manifest.go
@@ -169,19 +169,19 @@ func retriedStreamFetchChunkData(writer io.Writer, urlStrings []string, cipherKe
 
 	for waitTime := time.Second; waitTime < util.RetryWaitTime; waitTime += waitTime / 2 {
 		for _, urlString := range urlStrings {
-			var localProcesed int
+			var localProcessed int
 			shouldRetry, err = util.ReadUrlAsStream(urlString+"?readDeleted=true", cipherKey, isGzipped, isFullChunk, offset, size, func(data []byte) {
-				if totalWritten > localProcesed {
-					toBeSkipped := totalWritten - localProcesed
+				if totalWritten > localProcessed {
+					toBeSkipped := totalWritten - localProcessed
 					if len(data) <= toBeSkipped {
-						localProcesed += len(data)
+						localProcessed += len(data)
 						return // skip if already processed
 					}
 					data = data[toBeSkipped:]
-					localProcesed += toBeSkipped
+					localProcessed += toBeSkipped
 				}
 				writer.Write(data)
-				localProcesed += len(data)
+				localProcessed += len(data)
 				totalWritten += len(data)
 			})
 			if !shouldRetry {

--- a/weed/mount/dirty_pages_chunked.go
+++ b/weed/mount/dirty_pages_chunked.go
@@ -33,7 +33,7 @@ func newMemoryChunkPages(fh *FileHandle, chunkSize int64) *ChunkedDirtyPages {
 	swapFileDir := fh.wfs.option.getTempFilePageDir()
 
 	dirtyPages.uploadPipeline = page_writer.NewUploadPipeline(fh.wfs.concurrentWriters, chunkSize,
-		dirtyPages.saveChunkedFileIntevalToStorage, fh.wfs.option.ConcurrentWriters, swapFileDir)
+		dirtyPages.saveChunkedFileIntervalToStorage, fh.wfs.option.ConcurrentWriters, swapFileDir)
 
 	return dirtyPages
 }
@@ -65,7 +65,7 @@ func (pages *ChunkedDirtyPages) ReadDirtyDataAt(data []byte, startOffset int64) 
 	return pages.uploadPipeline.MaybeReadDataAt(data, startOffset)
 }
 
-func (pages *ChunkedDirtyPages) saveChunkedFileIntevalToStorage(reader io.Reader, offset int64, size int64, cleanupFn func()) {
+func (pages *ChunkedDirtyPages) saveChunkedFileIntervalToStorage(reader io.Reader, offset int64, size int64, cleanupFn func()) {
 
 	mtime := time.Now().UnixNano()
 	defer cleanupFn()

--- a/weed/wdclient/exclusive_locks/exclusive_locker.go
+++ b/weed/wdclient/exclusive_locks/exclusive_locker.go
@@ -13,7 +13,7 @@ import (
 const (
 	RenewInteval     = 4 * time.Second
 	SafeRenewInterval = 3 * time.Second
-	InitLockInteval  = 1 * time.Second
+	InitLockInterval  = 1 * time.Second
 )
 
 type ExclusiveLocker struct {
@@ -68,7 +68,7 @@ func (l *ExclusiveLocker) RequestLock(clientName string) {
 			return err
 		}); err != nil {
 			println("lock:", err.Error())
-			time.Sleep(InitLockInteval)
+			time.Sleep(InitLockInterval)
 		} else {
 			break
 		}

--- a/weed/wdclient/exclusive_locks/exclusive_locker.go
+++ b/weed/wdclient/exclusive_locks/exclusive_locker.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	RenewInteval     = 4 * time.Second
-	SafeRenewInteval = 3 * time.Second
+	SafeRenewInterval = 3 * time.Second
 	InitLockInteval  = 1 * time.Second
 )
 
@@ -37,7 +37,7 @@ func (l *ExclusiveLocker) IsLocked() bool {
 }
 
 func (l *ExclusiveLocker) GetToken() (token int64, lockTsNs int64) {
-	for time.Unix(0, atomic.LoadInt64(&l.lockTsNs)).Add(SafeRenewInteval).Before(time.Now()) {
+	for time.Unix(0, atomic.LoadInt64(&l.lockTsNs)).Add(SafeRenewInterval).Before(time.Now()) {
 		// wait until now is within the safe lock period, no immediate renewal to change the token
 		time.Sleep(100 * time.Millisecond)
 	}

--- a/weed/wdclient/exclusive_locks/exclusive_locker.go
+++ b/weed/wdclient/exclusive_locks/exclusive_locker.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	RenewInteval     = 4 * time.Second
+	RenewInterval     = 4 * time.Second
 	SafeRenewInterval = 3 * time.Second
 	InitLockInterval  = 1 * time.Second
 )
@@ -101,7 +101,7 @@ func (l *ExclusiveLocker) RequestLock(clientName string) {
 				l.isLocked = false
 				return
 			} else {
-				time.Sleep(RenewInteval)
+				time.Sleep(RenewInterval)
 			}
 
 		}


### PR DESCRIPTION
# What problem are we solving?

Another batch one, around the `interval` variables.

```bash
grep -ri Inteval
.git/COMMIT_EDITMSG:refactor: `saveChunkedFileIntevalToStorage` -> `saveChunkedFileIntervalToStorage`
.git/logs/refs/heads/interval-readability-batch:eff8f71957e5304e5114644a320471eb2a675ef4 5dcce0fa66a503ae27a9a5a16eb2095b2429bcd1 Ryan Russell <git@ryanrussell.org> 1663175974 -0500	commit: refactor: `saveChunkedFileIntevalToStorage` -> `saveChunkedFileIntervalToStorage`
.git/logs/HEAD:eff8f71957e5304e5114644a320471eb2a675ef4 5dcce0fa66a503ae27a9a5a16eb2095b2429bcd1 Ryan Russell <git@ryanrussell.org> 1663175974 -0500	commit: refactor: `saveChunkedFileIntevalToStorage` -> `saveChunkedFileIntervalToStorage`
weed/wdclient/exclusive_locks/exclusive_locker.go:	RenewInteval     = 4 * time.Second
weed/wdclient/exclusive_locks/exclusive_locker.go:	SafeRenewInteval = 3 * time.Second
weed/wdclient/exclusive_locks/exclusive_locker.go:	InitLockInteval  = 1 * time.Second
weed/wdclient/exclusive_locks/exclusive_locker.go:	for time.Unix(0, atomic.LoadInt64(&l.lockTsNs)).Add(SafeRenewInteval).Before(time.Now()) {
weed/wdclient/exclusive_locks/exclusive_locker.go:			time.Sleep(InitLockInteval)
weed/wdclient/exclusive_locks/exclusive_locker.go:				time.Sleep(RenewInteval)
```

# How are we solving the problem?

4 commits -one case sensitive for each pattern

# How is the PR tested?
`grep -ri Inteval` has no matches after updates


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
