### PR TITLE
refactor(command_fs_rm): `entiries` -> `entries`

### DIFF
--- a/weed/shell/command_fs_rm.go
+++ b/weed/shell/command_fs_rm.go
@@ -37,10 +37,10 @@ func (c *commandFsRm) Help() string {
 func (c *commandFsRm) Do(args []string, commandEnv *CommandEnv, writer io.Writer) (err error) {
 	isRecursive := false
 	ignoreRecursiveError := false
-	var entiries []string
+	var entries []string
 	for _, arg := range args {
 		if !strings.HasPrefix(arg, "-") {
-			entiries = append(entiries, arg)
+			entries = append(entries, arg)
 			continue
 		}
 		for _, t := range arg {
@@ -52,12 +52,12 @@ func (c *commandFsRm) Do(args []string, commandEnv *CommandEnv, writer io.Writer
 			}
 		}
 	}
-	if len(entiries) < 1 {
+	if len(entries) < 1 {
 		return fmt.Errorf("need to have arguments")
 	}
 
 	commandEnv.WithFilerClient(false, func(client filer_pb.SeaweedFilerClient) error {
-		for _, entry := range entiries {
+		for _, entry := range entries {
 			targetPath, err := commandEnv.parseUrl(entry)
 			if err != nil {
 				fmt.Fprintf(writer, "rm: %s: %v\n", targetPath, err)


### PR DESCRIPTION
Signed-off-by: Ryan Russell <git@ryanrussell.org>

# What problem are we solving?

```bash
grep -ri entiries
shell/command_fs_rm.go:	var entiries []string
shell/command_fs_rm.go:			entiries = append(entiries, arg)
shell/command_fs_rm.go:	if len(entiries) < 1 {
shell/command_fs_rm.go:		for _, entry := range entiries {
```

# How are we solving the problem?

`entiries` -> `entries`

# How is the PR tested?

`grep -ri entiries` has no remaining results
