### PR TITLE
refactor(various): `Listner` -> `Listener` readability improvements

### DIFF
--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -250,7 +250,7 @@ func (fo *FilerOptions) startFiler() {
 	if *fo.publicPort != 0 {
 		publicListeningAddress := util.JoinHostPort(*fo.bindIp, *fo.publicPort)
 		glog.V(0).Infoln("Start Seaweed filer server", util.Version(), "public at", publicListeningAddress)
-		publicListener, localPublicListner, e := util.NewIpAndLocalListeners(*fo.bindIp, *fo.publicPort, 0)
+		publicListener, localPublicListener, e := util.NewIpAndLocalListeners(*fo.bindIp, *fo.publicPort, 0)
 		if e != nil {
 			glog.Fatalf("Filer server public listener error on port %d:%v", *fo.publicPort, e)
 		}
@@ -259,9 +259,9 @@ func (fo *FilerOptions) startFiler() {
 				glog.Fatalf("Volume server fail to serve public: %v", e)
 			}
 		}()
-		if localPublicListner != nil {
+		if localPublicListener != nil {
 			go func() {
-				if e := http.Serve(localPublicListner, publicVolumeMux); e != nil {
+				if e := http.Serve(localPublicListener, publicVolumeMux); e != nil {
 					glog.Errorf("Volume server fail to serve public: %v", e)
 				}
 			}()

--- a/weed/command/master.go
+++ b/weed/command/master.go
@@ -146,7 +146,7 @@ func startMaster(masterOption MasterOptions, masterWhiteList []string) {
 	ms := weed_server.NewMasterServer(r, masterOption.toMasterOption(masterWhiteList), masterPeers)
 	listeningAddress := util.JoinHostPort(*masterOption.ipBind, *masterOption.port)
 	glog.V(0).Infof("Start Seaweed Master %s at %s", util.Version(), listeningAddress)
-	masterListener, masterLocalListner, e := util.NewIpAndLocalListeners(*masterOption.ipBind, *masterOption.port, 0)
+	masterListener, masterLocalListener, e := util.NewIpAndLocalListeners(*masterOption.ipBind, *masterOption.port, 0)
 	if e != nil {
 		glog.Fatalf("Master startup error: %v", e)
 	}
@@ -239,8 +239,8 @@ func startMaster(masterOption MasterOptions, masterWhiteList []string) {
 	}
 
 	httpS := &http.Server{Handler: r}
-	if masterLocalListner != nil {
-		go httpS.Serve(masterLocalListner)
+	if masterLocalListener != nil {
+		go httpS.Serve(masterLocalListener)
 	}
 
 	if useMTLS {

--- a/weed/command/master_follower.go
+++ b/weed/command/master_follower.go
@@ -120,7 +120,7 @@ func startMasterFollower(masterOptions MasterOptions) {
 	ms := weed_server.NewMasterServer(r, option, masters)
 	listeningAddress := util.JoinHostPort(*masterOptions.ipBind, *masterOptions.port)
 	glog.V(0).Infof("Start Seaweed Master %s at %s", util.Version(), listeningAddress)
-	masterListener, masterLocalListner, e := util.NewIpAndLocalListeners(*masterOptions.ipBind, *masterOptions.port, 0)
+	masterListener, masterLocalListener, e := util.NewIpAndLocalListeners(*masterOptions.ipBind, *masterOptions.port, 0)
 	if e != nil {
 		glog.Fatalf("Master startup error: %v", e)
 	}
@@ -144,8 +144,8 @@ func startMasterFollower(masterOptions MasterOptions) {
 
 	// start http server
 	httpS := &http.Server{Handler: r}
-	if masterLocalListner != nil {
-		go httpS.Serve(masterLocalListner)
+	if masterLocalListener != nil {
+		go httpS.Serve(masterLocalListener)
 	}
 	go httpS.Serve(masterListener)
 

--- a/weed/command/s3.go
+++ b/weed/command/s3.go
@@ -215,7 +215,7 @@ func (s3opt *S3Options) startS3Server() bool {
 	}
 
 	listenAddress := fmt.Sprintf("%s:%d", *s3opt.bindIp, *s3opt.port)
-	s3ApiListener, s3ApiLocalListner, err := util.NewIpAndLocalListeners(*s3opt.bindIp, *s3opt.port, time.Duration(10)*time.Second)
+	s3ApiListener, s3ApiLocalListener, err := util.NewIpAndLocalListeners(*s3opt.bindIp, *s3opt.port, time.Duration(10)*time.Second)
 	if err != nil {
 		glog.Fatalf("S3 API Server listener on %s error: %v", listenAddress, err)
 	}
@@ -243,9 +243,9 @@ func (s3opt *S3Options) startS3Server() bool {
 
 	if *s3opt.tlsPrivateKey != "" {
 		glog.V(0).Infof("Start Seaweed S3 API Server %s at https port %d", util.Version(), *s3opt.port)
-		if s3ApiLocalListner != nil {
+		if s3ApiLocalListener != nil {
 			go func() {
-				if err = httpS.ServeTLS(s3ApiLocalListner, *s3opt.tlsCertificate, *s3opt.tlsPrivateKey); err != nil {
+				if err = httpS.ServeTLS(s3ApiLocalListener, *s3opt.tlsCertificate, *s3opt.tlsPrivateKey); err != nil {
 					glog.Fatalf("S3 API Server Fail to serve: %v", err)
 				}
 			}()
@@ -255,9 +255,9 @@ func (s3opt *S3Options) startS3Server() bool {
 		}
 	} else {
 		glog.V(0).Infof("Start Seaweed S3 API Server %s at http port %d", util.Version(), *s3opt.port)
-		if s3ApiLocalListner != nil {
+		if s3ApiLocalListener != nil {
 			go func() {
-				if err = httpS.Serve(s3ApiLocalListner); err != nil {
+				if err = httpS.Serve(s3ApiLocalListener); err != nil {
 					glog.Fatalf("S3 API Server Fail to serve: %v", err)
 				}
 			}()

--- a/weed/util/net_timeout.go
+++ b/weed/util/net_timeout.go
@@ -83,13 +83,13 @@ func (c *Conn) Close() error {
 	return err
 }
 
-func NewListener(addr string, timeout time.Duration) (ipListner net.Listener, err error) {
+func NewListener(addr string, timeout time.Duration) (ipListener net.Listener, err error) {
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
 		return
 	}
 
-	ipListner = &Listener{
+	ipListener = &Listener{
 		Listener:     listener,
 		ReadTimeout:  timeout,
 		WriteTimeout: timeout,
@@ -98,13 +98,13 @@ func NewListener(addr string, timeout time.Duration) (ipListner net.Listener, er
 	return
 }
 
-func NewIpAndLocalListeners(host string, port int, timeout time.Duration) (ipListner net.Listener, localListener net.Listener, err error) {
+func NewIpAndLocalListeners(host string, port int, timeout time.Duration) (ipListener net.Listener, localListener net.Listener, err error) {
 	listener, err := net.Listen("tcp", JoinHostPort(host, port))
 	if err != nil {
 		return
 	}
 
-	ipListner = &Listener{
+	ipListener = &Listener{
 		Listener:     listener,
 		ReadTimeout:  timeout,
 		WriteTimeout: timeout,
@@ -114,7 +114,7 @@ func NewIpAndLocalListeners(host string, port int, timeout time.Duration) (ipLis
 		listener, err = net.Listen("tcp", JoinHostPort("localhost", port))
 		if err != nil {
 			glog.V(0).Infof("skip starting on %s:%d: %v", host, port, err)
-			return ipListner, nil, nil
+			return ipListener, nil, nil
 		}
 
 		localListener = &Listener{

--- a/weed/util/net_timeout.go
+++ b/weed/util/net_timeout.go
@@ -84,13 +84,13 @@ func (c *Conn) Close() error {
 }
 
 func NewListener(addr string, timeout time.Duration) (ipListner net.Listener, err error) {
-	listner, err := net.Listen("tcp", addr)
+	listener, err := net.Listen("tcp", addr)
 	if err != nil {
 		return
 	}
 
 	ipListner = &Listener{
-		Listener:     listner,
+		Listener:     listener,
 		ReadTimeout:  timeout,
 		WriteTimeout: timeout,
 	}
@@ -99,26 +99,26 @@ func NewListener(addr string, timeout time.Duration) (ipListner net.Listener, er
 }
 
 func NewIpAndLocalListeners(host string, port int, timeout time.Duration) (ipListner net.Listener, localListener net.Listener, err error) {
-	listner, err := net.Listen("tcp", JoinHostPort(host, port))
+	listener, err := net.Listen("tcp", JoinHostPort(host, port))
 	if err != nil {
 		return
 	}
 
 	ipListner = &Listener{
-		Listener:     listner,
+		Listener:     listener,
 		ReadTimeout:  timeout,
 		WriteTimeout: timeout,
 	}
 
 	if host != "localhost" && host != "" && host != "0.0.0.0" && host != "127.0.0.1" && host != "[::]" && host != "[::1]" {
-		listner, err = net.Listen("tcp", JoinHostPort("localhost", port))
+		listener, err = net.Listen("tcp", JoinHostPort("localhost", port))
 		if err != nil {
 			glog.V(0).Infof("skip starting on %s:%d: %v", host, port, err)
 			return ipListner, nil, nil
 		}
 
 		localListener = &Listener{
-			Listener:     listner,
+			Listener:     listener,
 			ReadTimeout:  timeout,
 			WriteTimeout: timeout,
 		}


### PR DESCRIPTION
# What problem are we solving?

```bash
$ grep -r Listner | wc -l
19
$ grep -ri Listner | wc -l
25

$ grep -r Listner
util/net_timeout.go:func NewListener(addr string, timeout time.Duration) (ipListner net.Listener, err error) {
util/net_timeout.go:	ipListner = &Listener{
util/net_timeout.go:func NewIpAndLocalListeners(host string, port int, timeout time.Duration) (ipListner net.Listener, localListener net.Listener, err error) {
util/net_timeout.go:	ipListner = &Listener{
util/net_timeout.go:			return ipListner, nil, nil
command/s3.go:	s3ApiListener, s3ApiLocalListner, err := util.NewIpAndLocalListeners(*s3opt.bindIp, *s3opt.port, time.Duration(10)*time.Second)
command/s3.go:		if s3ApiLocalListner != nil {
command/s3.go:				if err = httpS.ServeTLS(s3ApiLocalListner, *s3opt.tlsCertificate, *s3opt.tlsPrivateKey); err != nil {
command/s3.go:		if s3ApiLocalListner != nil {
command/s3.go:				if err = httpS.Serve(s3ApiLocalListner); err != nil {
command/master.go:	masterListener, masterLocalListner, e := util.NewIpAndLocalListeners(*masterOption.ipBind, *masterOption.port, 0)
command/master.go:	if masterLocalListner != nil {
command/master.go:		go httpS.Serve(masterLocalListner)
command/filer.go:		publicListener, localPublicListner, e := util.NewIpAndLocalListeners(*fo.bindIp, *fo.publicPort, 0)
command/filer.go:		if localPublicListner != nil {
command/filer.go:				if e := http.Serve(localPublicListner, publicVolumeMux); e != nil {
command/master_follower.go:	masterListener, masterLocalListner, e := util.NewIpAndLocalListeners(*masterOptions.ipBind, *masterOptions.port, 0)
command/master_follower.go:	if masterLocalListner != nil {
command/master_follower.go:		go httpS.Serve(masterLocalListner)

$ grep -r listner
util/net_timeout.go:	listner, err := net.Listen("tcp", addr)
util/net_timeout.go:		Listener:     listner,
util/net_timeout.go:	listner, err := net.Listen("tcp", JoinHostPort(host, port))
util/net_timeout.go:		Listener:     listner,
util/net_timeout.go:		listner, err = net.Listen("tcp", JoinHostPort("localhost", port))
util/net_timeout.go:			Listener:     listner,
```

# How are we solving the problem?

5 case-sensitive commits representing the replacements

# How is the PR tested?

`grep -ri Listner` has no results left after these replacements
