### PR TITLE
refactor(command_ec_decode): `exisitngEcIndexBits` -> `existingEcInde…

### DIFF
--- a/weed/shell/command_ec_decode.go
+++ b/weed/shell/command_ec_decode.go
@@ -171,13 +171,13 @@ func generateNormalVolume(grpcDialOption grpc.DialOption, vid needle.VolumeId, c
 func collectEcShards(commandEnv *CommandEnv, nodeToEcIndexBits map[pb.ServerAddress]erasure_coding.ShardBits, collection string, vid needle.VolumeId) (targetNodeLocation pb.ServerAddress, err error) {
 
 	maxShardCount := 0
-	var exisitngEcIndexBits erasure_coding.ShardBits
+	var existingEcIndexBits erasure_coding.ShardBits
 	for loc, ecIndexBits := range nodeToEcIndexBits {
 		toBeCopiedShardCount := ecIndexBits.MinusParityShards().ShardIdCount()
 		if toBeCopiedShardCount > maxShardCount {
 			maxShardCount = toBeCopiedShardCount
 			targetNodeLocation = loc
-			exisitngEcIndexBits = ecIndexBits
+			existingEcIndexBits = ecIndexBits
 		}
 	}
 
@@ -189,7 +189,7 @@ func collectEcShards(commandEnv *CommandEnv, nodeToEcIndexBits map[pb.ServerAddr
 			continue
 		}
 
-		needToCopyEcIndexBits := ecIndexBits.Minus(exisitngEcIndexBits).MinusParityShards()
+		needToCopyEcIndexBits := ecIndexBits.Minus(existingEcIndexBits).MinusParityShards()
 		if needToCopyEcIndexBits.ShardIdCount() == 0 {
 			continue
 		}
@@ -222,7 +222,7 @@ func collectEcShards(commandEnv *CommandEnv, nodeToEcIndexBits map[pb.ServerAddr
 
 	}
 
-	nodeToEcIndexBits[targetNodeLocation] = exisitngEcIndexBits.Plus(copiedEcIndexBits)
+	nodeToEcIndexBits[targetNodeLocation] = existingEcIndexBits.Plus(copiedEcIndexBits)
 
 	return targetNodeLocation, err
 


### PR DESCRIPTION
…xBits`

Signed-off-by: Ryan Russell <git@ryanrussell.org>

# What problem are we solving?

```bash
grep -r exisitngEcIndexBits
shell/command_ec_decode.go:	var exisitngEcIndexBits erasure_coding.ShardBits
shell/command_ec_decode.go:			exisitngEcIndexBits = ecIndexBits
shell/command_ec_decode.go:		needToCopyEcIndexBits := ecIndexBits.Minus(exisitngEcIndexBits).MinusParityShards()
shell/command_ec_decode.go:	nodeToEcIndexBits[targetNodeLocation] = exisitngEcIndexBits.Plus(copiedEcIndexBits)

```

# How are we solving the problem?

`exisitngEcIndexBits` -> `existingEcIndexBits`

# How is the PR tested?
`grep -ri exisitng` has no results left
