### PR TITLE
refactor(shell): `Decending` -> `Descending`

### DIFF
--- a/weed/shell/command_ec_balance.go
+++ b/weed/shell/command_ec_balance.go
@@ -453,7 +453,7 @@ func doBalanceEcRack(commandEnv *CommandEnv, ecRack *EcRack, applyBalancing bool
 
 func pickOneEcNodeAndMoveOneShard(commandEnv *CommandEnv, averageShardsPerEcNode int, existingLocation *EcNode, collection string, vid needle.VolumeId, shardId erasure_coding.ShardId, possibleDestinationEcNodes []*EcNode, applyBalancing bool) error {
 
-	sortEcNodesByFreeslotsDecending(possibleDestinationEcNodes)
+	sortEcNodesByFreeslotsDescending(possibleDestinationEcNodes)
 
 	for _, destEcNode := range possibleDestinationEcNodes {
 		if destEcNode.info.Id == existingLocation.info.Id {

--- a/weed/shell/command_ec_common.go
+++ b/weed/shell/command_ec_common.go
@@ -118,7 +118,7 @@ func eachDataNode(topo *master_pb.TopologyInfo, fn func(dc string, rack RackId, 
 	}
 }
 
-func sortEcNodesByFreeslotsDecending(ecNodes []*EcNode) {
+func sortEcNodesByFreeslotsDescending(ecNodes []*EcNode) {
 	slices.SortFunc(ecNodes, func(a, b *EcNode) bool {
 		return a.freeEcSlot > b.freeEcSlot
 	})
@@ -217,7 +217,7 @@ func collectEcNodes(commandEnv *CommandEnv, selectedDataCenter string) (ecNodes 
 	// find out all volume servers with one slot left.
 	ecNodes, totalFreeEcSlots = collectEcVolumeServersByDc(topologyInfo, selectedDataCenter)
 
-	sortEcNodesByFreeslotsDecending(ecNodes)
+	sortEcNodesByFreeslotsDescending(ecNodes)
 
 	return
 }

--- a/weed/shell/command_ec_encode_test.go
+++ b/weed/shell/command_ec_encode_test.go
@@ -13,7 +13,7 @@ func TestEcDistribution(t *testing.T) {
 	// find out all volume servers with one slot left.
 	ecNodes, totalFreeEcSlots := collectEcVolumeServersByDc(topologyInfo, "")
 
-	sortEcNodesByFreeslotsDecending(ecNodes)
+	sortEcNodesByFreeslotsDescending(ecNodes)
 
 	if totalFreeEcSlots < erasure_coding.TotalShardsCount {
 		println("not enough free ec shard slots", totalFreeEcSlots)

--- a/weed/shell/command_ec_rebuild.go
+++ b/weed/shell/command_ec_rebuild.go
@@ -115,7 +115,7 @@ func rebuildEcVolumes(commandEnv *CommandEnv, allEcNodes []*EcNode, collection s
 			return fmt.Errorf("ec volume %d is unrepairable with %d shards\n", vid, shardCount)
 		}
 
-		sortEcNodesByFreeslotsDecending(allEcNodes)
+		sortEcNodesByFreeslotsDescending(allEcNodes)
 
 		if allEcNodes[0].freeEcSlot < erasure_coding.TotalShardsCount {
 			return fmt.Errorf("disk space is not enough")


### PR DESCRIPTION
Signed-off-by: Ryan Russell <git@ryanrussell.org>

# What problem are we solving?

```bash
grep -ri Decending
shell/command_ec_encode_test.go:	sortEcNodesByFreeslotsDecending(ecNodes)
shell/command_ec_rebuild.go:		sortEcNodesByFreeslotsDecending(allEcNodes)
shell/command_ec_common.go:func sortEcNodesByFreeslotsDecending(ecNodes []*EcNode) {
shell/command_ec_common.go:	sortEcNodesByFreeslotsDecending(ecNodes)
shell/command_ec_balance.go:	sortEcNodesByFreeslotsDecending(possibleDestinationEcNodes)
```

# How are we solving the problem?

`Decending` -> `Descending`

# How is the PR tested?

`grep -ri Decending` has no results left
