### PR TITLE
refactor(webdav_server): `modifiledTime` -> `modifiedTime`

### DIFF
--- a/weed/server/webdav_server.go
+++ b/weed/server/webdav_server.go
@@ -84,14 +84,14 @@ type FileInfo struct {
 	name          string
 	size          int64
 	mode          os.FileMode
-	modifiledTime time.Time
+	modifiedTime time.Time
 	isDirectory   bool
 }
 
 func (fi *FileInfo) Name() string       { return fi.name }
 func (fi *FileInfo) Size() int64        { return fi.size }
 func (fi *FileInfo) Mode() os.FileMode  { return fi.mode }
-func (fi *FileInfo) ModTime() time.Time { return fi.modifiledTime }
+func (fi *FileInfo) ModTime() time.Time { return fi.modifiedTime }
 func (fi *FileInfo) IsDir() bool        { return fi.isDirectory }
 func (fi *FileInfo) Sys() interface{}   { return nil }
 
@@ -356,11 +356,11 @@ func (fs *WebDavFileSystem) stat(ctx context.Context, fullFilePath string) (os.F
 	fi.size = int64(filer.FileSize(entry))
 	fi.name = string(fullpath)
 	fi.mode = os.FileMode(entry.Attributes.FileMode)
-	fi.modifiledTime = time.Unix(entry.Attributes.Mtime, 0)
+	fi.modifiedTime = time.Unix(entry.Attributes.Mtime, 0)
 	fi.isDirectory = entry.IsDirectory
 
 	if fi.name == "/" {
-		fi.modifiledTime = time.Now()
+		fi.modifiedTime = time.Now()
 		fi.isDirectory = true
 	}
 	return &fi, nil
@@ -546,7 +546,7 @@ func (f *WebDavFile) Readdir(count int) (ret []os.FileInfo, err error) {
 			size:          int64(filer.FileSize(entry)),
 			name:          entry.Name,
 			mode:          os.FileMode(entry.Attributes.FileMode),
-			modifiledTime: time.Unix(entry.Attributes.Mtime, 0),
+			modifiedTime: time.Unix(entry.Attributes.Mtime, 0),
 			isDirectory:   entry.IsDirectory,
 		}
 


### PR DESCRIPTION
Signed-off-by: Ryan Russell <git@ryanrussell.org>

# What problem are we solving?

```bash
grep -r modifiled
server/webdav_server.go:	modifiledTime time.Time
server/webdav_server.go:func (fi *FileInfo) ModTime() time.Time { return fi.modifiledTime }
server/webdav_server.go:	fi.modifiledTime = time.Unix(entry.Attributes.Mtime, 0)
server/webdav_server.go:		fi.modifiledTime = time.Now()
server/webdav_server.go:			modifiledTime: time.Unix(entry.Attributes.Mtime, 0),
```

# How are we solving the problem?

`modifiledTime` -> `modifiedTime`

# How is the PR tested?
`grep -ri modifiled` has no results left