### PR TITLE
refactor(volume_server): `charactoer` -> `character`

### DIFF
--- a/weed/pb/volume_server.proto
+++ b/weed/pb/volume_server.proto
@@ -545,7 +545,7 @@ message QueryRequest {
             string file_header_info = 1; // Valid values: NONE | USE | IGNORE
             string record_delimiter = 2; // Default: \n
             string field_delimiter = 3; // Default: ,
-            string quote_charactoer = 4; // Default: "
+            string quote_character = 4; // Default: "
             string quote_escape_character = 5; // Default: "
             string comments = 6; // Default: #
             // If true, records might contain record delimiters within quote characters
@@ -568,7 +568,7 @@ message QueryRequest {
             string quote_fields = 1; // Valid values: ALWAYS | ASNEEDED
             string record_delimiter = 2; // Default: \n
             string field_delimiter = 3; // Default: ,
-            string quote_charactoer = 4; // Default: "
+            string quote_character = 4; // Default: "
             string quote_escape_character = 5; // Default: "
         }
         message JSONOutput {

--- a/weed/pb/volume_server_pb/volume_server.pb.go
+++ b/weed/pb/volume_server_pb/volume_server.pb.go
@@ -5431,7 +5431,7 @@ type QueryRequest_InputSerialization_CSVInput struct {
 	FileHeaderInfo       string `protobuf:"bytes,1,opt,name=file_header_info,json=fileHeaderInfo,proto3" json:"file_header_info,omitempty"`                   // Valid values: NONE | USE | IGNORE
 	RecordDelimiter      string `protobuf:"bytes,2,opt,name=record_delimiter,json=recordDelimiter,proto3" json:"record_delimiter,omitempty"`                  // Default: \n
 	FieldDelimiter       string `protobuf:"bytes,3,opt,name=field_delimiter,json=fieldDelimiter,proto3" json:"field_delimiter,omitempty"`                     // Default: ,
-	QuoteCharactoer      string `protobuf:"bytes,4,opt,name=quote_charactoer,json=quoteCharactoer,proto3" json:"quote_charactoer,omitempty"`                  // Default: "
+	QuoteCharactoer      string `protobuf:"bytes,4,opt,name=quote_character,json=quoteCharactoer,proto3" json:"quote_character,omitempty"`                  // Default: "
 	QuoteEscapeCharacter string `protobuf:"bytes,5,opt,name=quote_escape_character,json=quoteEscapeCharacter,proto3" json:"quote_escape_character,omitempty"` // Default: "
 	Comments             string `protobuf:"bytes,6,opt,name=comments,proto3" json:"comments,omitempty"`                                                       // Default: #
 	// If true, records might contain record delimiters within quote characters
@@ -5612,7 +5612,7 @@ type QueryRequest_OutputSerialization_CSVOutput struct {
 	QuoteFields          string `protobuf:"bytes,1,opt,name=quote_fields,json=quoteFields,proto3" json:"quote_fields,omitempty"`                              // Valid values: ALWAYS | ASNEEDED
 	RecordDelimiter      string `protobuf:"bytes,2,opt,name=record_delimiter,json=recordDelimiter,proto3" json:"record_delimiter,omitempty"`                  // Default: \n
 	FieldDelimiter       string `protobuf:"bytes,3,opt,name=field_delimiter,json=fieldDelimiter,proto3" json:"field_delimiter,omitempty"`                     // Default: ,
-	QuoteCharactoer      string `protobuf:"bytes,4,opt,name=quote_charactoer,json=quoteCharactoer,proto3" json:"quote_charactoer,omitempty"`                  // Default: "
+	QuoteCharactoer      string `protobuf:"bytes,4,opt,name=quote_character,json=quoteCharactoer,proto3" json:"quote_character,omitempty"`                  // Default: "
 	QuoteEscapeCharacter string `protobuf:"bytes,5,opt,name=quote_escape_character,json=quoteEscapeCharacter,proto3" json:"quote_escape_character,omitempty"` // Default: "
 }
 

--- a/weed/pb/volume_server_pb/volume_server.pb.go
+++ b/weed/pb/volume_server_pb/volume_server.pb.go
@@ -5431,7 +5431,7 @@ type QueryRequest_InputSerialization_CSVInput struct {
 	FileHeaderInfo       string `protobuf:"bytes,1,opt,name=file_header_info,json=fileHeaderInfo,proto3" json:"file_header_info,omitempty"`                   // Valid values: NONE | USE | IGNORE
 	RecordDelimiter      string `protobuf:"bytes,2,opt,name=record_delimiter,json=recordDelimiter,proto3" json:"record_delimiter,omitempty"`                  // Default: \n
 	FieldDelimiter       string `protobuf:"bytes,3,opt,name=field_delimiter,json=fieldDelimiter,proto3" json:"field_delimiter,omitempty"`                     // Default: ,
-	QuoteCharacter      string `protobuf:"bytes,4,opt,name=quote_character,json=quoteCharactoer,proto3" json:"quote_character,omitempty"`                  // Default: "
+	QuoteCharacter      string `protobuf:"bytes,4,opt,name=quote_character,json=quoteCharacter,proto3" json:"quote_character,omitempty"`                  // Default: "
 	QuoteEscapeCharacter string `protobuf:"bytes,5,opt,name=quote_escape_character,json=quoteEscapeCharacter,proto3" json:"quote_escape_character,omitempty"` // Default: "
 	Comments             string `protobuf:"bytes,6,opt,name=comments,proto3" json:"comments,omitempty"`                                                       // Default: #
 	// If true, records might contain record delimiters within quote characters
@@ -5612,7 +5612,7 @@ type QueryRequest_OutputSerialization_CSVOutput struct {
 	QuoteFields          string `protobuf:"bytes,1,opt,name=quote_fields,json=quoteFields,proto3" json:"quote_fields,omitempty"`                              // Valid values: ALWAYS | ASNEEDED
 	RecordDelimiter      string `protobuf:"bytes,2,opt,name=record_delimiter,json=recordDelimiter,proto3" json:"record_delimiter,omitempty"`                  // Default: \n
 	FieldDelimiter       string `protobuf:"bytes,3,opt,name=field_delimiter,json=fieldDelimiter,proto3" json:"field_delimiter,omitempty"`                     // Default: ,
-	QuoteCharacter      string `protobuf:"bytes,4,opt,name=quote_character,json=quoteCharactoer,proto3" json:"quote_character,omitempty"`                  // Default: "
+	QuoteCharacter      string `protobuf:"bytes,4,opt,name=quote_character,json=quoteCharacter,proto3" json:"quote_character,omitempty"`                  // Default: "
 	QuoteEscapeCharacter string `protobuf:"bytes,5,opt,name=quote_escape_character,json=quoteEscapeCharacter,proto3" json:"quote_escape_character,omitempty"` // Default: "
 }
 

--- a/weed/pb/volume_server_pb/volume_server.pb.go
+++ b/weed/pb/volume_server_pb/volume_server.pb.go
@@ -5431,7 +5431,7 @@ type QueryRequest_InputSerialization_CSVInput struct {
 	FileHeaderInfo       string `protobuf:"bytes,1,opt,name=file_header_info,json=fileHeaderInfo,proto3" json:"file_header_info,omitempty"`                   // Valid values: NONE | USE | IGNORE
 	RecordDelimiter      string `protobuf:"bytes,2,opt,name=record_delimiter,json=recordDelimiter,proto3" json:"record_delimiter,omitempty"`                  // Default: \n
 	FieldDelimiter       string `protobuf:"bytes,3,opt,name=field_delimiter,json=fieldDelimiter,proto3" json:"field_delimiter,omitempty"`                     // Default: ,
-	QuoteCharactoer      string `protobuf:"bytes,4,opt,name=quote_character,json=quoteCharactoer,proto3" json:"quote_character,omitempty"`                  // Default: "
+	QuoteCharacter      string `protobuf:"bytes,4,opt,name=quote_character,json=quoteCharactoer,proto3" json:"quote_character,omitempty"`                  // Default: "
 	QuoteEscapeCharacter string `protobuf:"bytes,5,opt,name=quote_escape_character,json=quoteEscapeCharacter,proto3" json:"quote_escape_character,omitempty"` // Default: "
 	Comments             string `protobuf:"bytes,6,opt,name=comments,proto3" json:"comments,omitempty"`                                                       // Default: #
 	// If true, records might contain record delimiters within quote characters
@@ -5491,9 +5491,9 @@ func (x *QueryRequest_InputSerialization_CSVInput) GetFieldDelimiter() string {
 	return ""
 }
 
-func (x *QueryRequest_InputSerialization_CSVInput) GetQuoteCharactoer() string {
+func (x *QueryRequest_InputSerialization_CSVInput) GetQuoteCharacter() string {
 	if x != nil {
-		return x.QuoteCharactoer
+		return x.QuoteCharacter
 	}
 	return ""
 }
@@ -5612,7 +5612,7 @@ type QueryRequest_OutputSerialization_CSVOutput struct {
 	QuoteFields          string `protobuf:"bytes,1,opt,name=quote_fields,json=quoteFields,proto3" json:"quote_fields,omitempty"`                              // Valid values: ALWAYS | ASNEEDED
 	RecordDelimiter      string `protobuf:"bytes,2,opt,name=record_delimiter,json=recordDelimiter,proto3" json:"record_delimiter,omitempty"`                  // Default: \n
 	FieldDelimiter       string `protobuf:"bytes,3,opt,name=field_delimiter,json=fieldDelimiter,proto3" json:"field_delimiter,omitempty"`                     // Default: ,
-	QuoteCharactoer      string `protobuf:"bytes,4,opt,name=quote_character,json=quoteCharactoer,proto3" json:"quote_character,omitempty"`                  // Default: "
+	QuoteCharacter      string `protobuf:"bytes,4,opt,name=quote_character,json=quoteCharactoer,proto3" json:"quote_character,omitempty"`                  // Default: "
 	QuoteEscapeCharacter string `protobuf:"bytes,5,opt,name=quote_escape_character,json=quoteEscapeCharacter,proto3" json:"quote_escape_character,omitempty"` // Default: "
 }
 
@@ -5669,9 +5669,9 @@ func (x *QueryRequest_OutputSerialization_CSVOutput) GetFieldDelimiter() string 
 	return ""
 }
 
-func (x *QueryRequest_OutputSerialization_CSVOutput) GetQuoteCharactoer() string {
+func (x *QueryRequest_OutputSerialization_CSVOutput) GetQuoteCharacter() string {
 	if x != nil {
-		return x.QuoteCharactoer
+		return x.QuoteCharacter
 	}
 	return ""
 }


### PR DESCRIPTION
# What problem are we solving?

```bash
$ grep -r charactoer | wc -l
4
$ grep -ri charactoer | wc -l
8


$ grep -ri charactoer
pb/volume_server_pb/volume_server.pb.go:	QuoteCharactoer      string `protobuf:"bytes,4,opt,name=quote_charactoer,json=quoteCharactoer,proto3" json:"quote_charactoer,omitempty"`                  // Default: "
pb/volume_server_pb/volume_server.pb.go:func (x *QueryRequest_InputSerialization_CSVInput) GetQuoteCharactoer() string {
pb/volume_server_pb/volume_server.pb.go:		return x.QuoteCharactoer
pb/volume_server_pb/volume_server.pb.go:	QuoteCharactoer      string `protobuf:"bytes,4,opt,name=quote_charactoer,json=quoteCharactoer,proto3" json:"quote_charactoer,omitempty"`                  // Default: "
pb/volume_server_pb/volume_server.pb.go:func (x *QueryRequest_OutputSerialization_CSVOutput) GetQuoteCharactoer() string {
pb/volume_server_pb/volume_server.pb.go:		return x.QuoteCharactoer
pb/volume_server.proto:            string quote_charactoer = 4; // Default: "
pb/volume_server.proto:            string quote_charactoer = 4; // Default: "
```

# How are we solving the problem?

3 commits with case-sensitive replace patterns

# How is the PR tested?

`grep -ri charactoer` has no results left
