### PR TITLE
refactor(command_ec_rebuild): `rebultErr` -> `rebuildErr`

### DIFF
--- a/weed/shell/command_ec_rebuild.go
+++ b/weed/shell/command_ec_rebuild.go
@@ -178,14 +178,14 @@ func rebuildOneEcVolume(commandEnv *CommandEnv, rebuilder *EcNode, collection st
 func generateMissingShards(grpcDialOption grpc.DialOption, collection string, volumeId needle.VolumeId, sourceLocation pb.ServerAddress) (rebuiltShardIds []uint32, err error) {
 
 	err = operation.WithVolumeServerClient(false, sourceLocation, grpcDialOption, func(volumeServerClient volume_server_pb.VolumeServerClient) error {
-		resp, rebultErr := volumeServerClient.VolumeEcShardsRebuild(context.Background(), &volume_server_pb.VolumeEcShardsRebuildRequest{
+		resp, rebuildErr := volumeServerClient.VolumeEcShardsRebuild(context.Background(), &volume_server_pb.VolumeEcShardsRebuildRequest{
 			VolumeId:   uint32(volumeId),
 			Collection: collection,
 		})
-		if rebultErr == nil {
+		if rebuildErr == nil {
 			rebuiltShardIds = resp.RebuiltShardIds
 		}
-		return rebultErr
+		return rebuildErr
 	})
 	return
 }


### PR DESCRIPTION
Signed-off-by: Ryan Russell <git@ryanrussell.org>

# What problem are we solving?

```bash
grep -r rebult
shell/command_ec_rebuild.go:		resp, rebultErr := volumeServerClient.VolumeEcShardsRebuild(context.Background(), &volume_server_pb.VolumeEcShardsRebuildRequest{
shell/command_ec_rebuild.go:		if rebultErr == nil {
shell/command_ec_rebuild.go:		return rebultErr

```

# How are we solving the problem?

`rebultErr` -> `rebuildErr`

# How is the PR tested?
`grep -r rebult` has no results left

Calling it a day with this PR. That was really fun, thanks Chris!
