### PR TITLE
docs(docker): readability fixes

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -44,7 +44,7 @@ docker buildx build --pull --push --platform linux/386,linux/amd64,linux/arm64,l
 docker buildx stop $BUILDER
 ```
 
-## Minio debuging
+## Minio debugging
 ```
 mc config host add local http://127.0.0.1:9000 some_access_key1 some_secret_key1
 mc admin trace --all --verbose local

--- a/docker/compose/notification.toml
+++ b/docker/compose/notification.toml
@@ -1,5 +1,5 @@
 [notification.log]
-# this is only for debugging perpose and does not work with "weed filer.replicate"
+# this is only for debugging purpose and does not work with "weed filer.replicate"
 enabled = false
 
 


### PR DESCRIPTION
Signed-off-by: Ryan Russell <git@ryanrussell.org>

# What problem are we solving?

two one-off readability fixes in `/docker/*`

Completes this folder for typos.