### PR TITLE
docs(filer_deletion): `fildIdsToDelete` -> `filledIdsToDelete`

### DIFF
--- a/weed/filer/filer_deletion.go
+++ b/weed/filer/filer_deletion.go
@@ -94,10 +94,10 @@ func (f *Filer) doDeleteFileIds(fileIds []string) {
 }
 
 func (f *Filer) DirectDeleteChunks(chunks []*filer_pb.FileChunk) {
-	var fildIdsToDelete []string
+	var filledIdsToDelete []string
 	for _, chunk := range chunks {
 		if !chunk.IsChunkManifest {
-			fildIdsToDelete = append(fildIdsToDelete, chunk.GetFileIdString())
+			filledIdsToDelete = append(filledIdsToDelete, chunk.GetFileIdString())
 			continue
 		}
 		dataChunks, manifestResolveErr := ResolveOneChunkManifest(f.MasterClient.LookupFileId, chunk)
@@ -105,12 +105,12 @@ func (f *Filer) DirectDeleteChunks(chunks []*filer_pb.FileChunk) {
 			glog.V(0).Infof("failed to resolve manifest %s: %v", chunk.FileId, manifestResolveErr)
 		}
 		for _, dChunk := range dataChunks {
-			fildIdsToDelete = append(fildIdsToDelete, dChunk.GetFileIdString())
+			filledIdsToDelete = append(filledIdsToDelete, dChunk.GetFileIdString())
 		}
-		fildIdsToDelete = append(fildIdsToDelete, chunk.GetFileIdString())
+		filledIdsToDelete = append(filledIdsToDelete, chunk.GetFileIdString())
 	}
 
-	f.doDeleteFileIds(fildIdsToDelete)
+	f.doDeleteFileIds(filledIdsToDelete)
 }
 
 func (f *Filer) DeleteChunks(chunks []*filer_pb.FileChunk) {


### PR DESCRIPTION
Signed-off-by: Ryan Russell <git@ryanrussell.org>

# What problem are we solving?

```bash
grep -r fild
weed/filer/filer_deletion.go:	var fildIdsToDelete []string
weed/filer/filer_deletion.go:			fildIdsToDelete = append(fildIdsToDelete, chunk.GetFileIdString())
weed/filer/filer_deletion.go:			fildIdsToDelete = append(fildIdsToDelete, dChunk.GetFileIdString())
weed/filer/filer_deletion.go:		fildIdsToDelete = append(fildIdsToDelete, chunk.GetFileIdString())
weed/filer/filer_deletion.go:	f.doDeleteFileIds(fildIdsToDelete)
```

# How are we solving the problem?

`fildIdsToDelete` -> `filledIdsToDelete`

# How is the PR tested?

`grep -r fild` has no remaining results