### PR TITLE
refactor(volume_grpc_client_to_master): `grpcConection` -> `grpcConne…

### DIFF
--- a/weed/server/volume_grpc_client_to_master.go
+++ b/weed/server/volume_grpc_client_to_master.go
@@ -94,13 +94,13 @@ func (vs *VolumeServer) doHeartbeat(masterAddress pb.ServerAddress, grpcDialOpti
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	grpcConection, err := pb.GrpcDial(ctx, masterAddress.ToGrpcAddress(), false, grpcDialOption)
+	grpcConnection, err := pb.GrpcDial(ctx, masterAddress.ToGrpcAddress(), false, grpcDialOption)
 	if err != nil {
 		return "", fmt.Errorf("fail to dial %s : %v", masterAddress, err)
 	}
-	defer grpcConection.Close()
+	defer grpcConnection.Close()
 
-	client := master_pb.NewSeaweedClient(grpcConection)
+	client := master_pb.NewSeaweedClient(grpcConnection)
 	stream, err := client.SendHeartbeat(ctx)
 	if err != nil {
 		glog.V(0).Infof("SendHeartbeat to %s: %v", masterAddress, err)


### PR DESCRIPTION
…ction`

Signed-off-by: Ryan Russell <git@ryanrussell.org>

# What problem are we solving?

```bash
grep -r Conection
server/volume_grpc_client_to_master.go:	grpcConection, err := pb.GrpcDial(ctx, masterAddress.ToGrpcAddress(), false, grpcDialOption)
server/volume_grpc_client_to_master.go:	defer grpcConection.Close()
server/volume_grpc_client_to_master.go:	client := master_pb.NewSeaweedClient(grpcConection)
```

# How are we solving the problem?

`grpcConection` -> `grpcConnection`

# How is the PR tested?
`grep -ri Conection` has no remaining results
