### PR TITLE
refactor(master_grpc_server_cluster): `seletedSet` -> `selectedSet`

### DIFF
--- a/weed/server/master_grpc_server_cluster.go
+++ b/weed/server/master_grpc_server_cluster.go
@@ -57,15 +57,15 @@ func limitTo(nodes []*cluster.ClusterNode, limit int32) (selected []*cluster.Clu
 	if limit <= 0 || len(nodes) < int(limit) {
 		return nodes
 	}
-	seletedSet := make(map[pb.ServerAddress]*cluster.ClusterNode)
+	selectedSet := make(map[pb.ServerAddress]*cluster.ClusterNode)
 	for i := 0; i < int(limit)*3; i++ {
 		x := rand.Intn(len(nodes))
-		if _, found := seletedSet[nodes[x].Address]; found {
+		if _, found := selectedSet[nodes[x].Address]; found {
 			continue
 		}
-		seletedSet[nodes[x].Address] = nodes[x]
+		selectedSet[nodes[x].Address] = nodes[x]
 	}
-	for _, node := range seletedSet {
+	for _, node := range selectedSet {
 		selected = append(selected, node)
 	}
 	return


### PR DESCRIPTION
Signed-off-by: Ryan Russell <git@ryanrussell.org>

# What problem are we solving?

```bash
grep -r seleted
weed/server/master_grpc_server_cluster.go:	seletedSet := make(map[pb.ServerAddress]*cluster.ClusterNode)
weed/server/master_grpc_server_cluster.go:		if _, found := seletedSet[nodes[x].Address]; found {
weed/server/master_grpc_server_cluster.go:		seletedSet[nodes[x].Address] = nodes[x]
weed/server/master_grpc_server_cluster.go:	for _, node := range seletedSet {
```

# How are we solving the problem?

`seletedSet` -> `selectedSet`

# How is the PR tested?
`grep -ri seleted` has no remaining results