### PR TITLE
refactor(s3api_object_handlers): `deleteMultipleObjectsLimmit` -> `de…

### DIFF
--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	deleteMultipleObjectsLimmit = 1000
+	deleteMultipleObjectsLimit = 1000
 )
 
 func mimeDetect(r *http.Request, dataReader io.Reader) io.ReadCloser {
@@ -250,7 +250,7 @@ func (s3a *S3ApiServer) DeleteMultipleObjectsHandler(w http.ResponseWriter, r *h
 		return
 	}
 
-	if len(deleteObjects.Objects) > deleteMultipleObjectsLimmit {
+	if len(deleteObjects.Objects) > deleteMultipleObjectsLimit {
 		s3err.WriteErrorResponse(w, r, s3err.ErrInvalidMaxDeleteObjects)
 		return
 	}


### PR DESCRIPTION
…leteMultipleObjectsLimit`

Signed-off-by: Ryan Russell <git@ryanrussell.org>

# What problem are we solving?
```bash
grep -ri Limmit
weed/s3api/s3api_object_handlers.go:	deleteMultipleObjectsLimmit = 1000
weed/s3api/s3api_object_handlers.go:	if len(deleteObjects.Objects) > deleteMultipleObjectsLimmit {
```


# How are we solving the problem?

`deleteMultipleObjectsLimmit` -> `deleteMultipleObjectsLimit`

# How is the PR tested?
`grep -ri Limmit` has no results left