### PR TITLE
refactor(compose)!: upgrade to v2 closes #3699

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -39,63 +39,63 @@ s3tests_build:
 	docker build --no-cache -t chrislusf/ceph-s3-tests:local -f Dockerfile.s3tests .
 
 dev: build
-	docker-compose -f compose/local-dev-compose.yml -p seaweedfs up
+	docker compose -f compose/local-dev-compose.yml -p seaweedfs up
 
 dev_race: binary_race
-	docker-compose -f compose/local-dev-compose.yml -p seaweedfs up
+	docker compose -f compose/local-dev-compose.yml -p seaweedfs up
 
 dev_tls: build certstrap
-	ENV_FILE="tls.env" docker-compose -f compose/local-dev-compose.yml -p seaweedfs up
+	ENV_FILE="tls.env" docker compose -f compose/local-dev-compose.yml -p seaweedfs up
 
 dev_mount: build
-	docker-compose -f compose/local-mount-compose.yml -p seaweedfs up
+	docker compose -f compose/local-mount-compose.yml -p seaweedfs up
 
 run_image: build
 	docker run --rm -ti --device /dev/fuse --cap-add SYS_ADMIN --entrypoint /bin/sh chrislusf/seaweedfs:local
 
 profile_mount: build
-	docker-compose -f compose/local-mount-profile-compose.yml -p seaweedfs up
+	docker compose -f compose/local-mount-profile-compose.yml -p seaweedfs up
 
 k8s: build
-	docker-compose -f compose/local-k8s-compose.yml -p seaweedfs up
+	docker compose -f compose/local-k8s-compose.yml -p seaweedfs up
 
 dev_registry: build
-	docker-compose -f compose/local-registry-compose.yml -p seaweedfs up
+	docker compose -f compose/local-registry-compose.yml -p seaweedfs up
 
 dev_replicate: build
-	docker-compose -f compose/local-replicate-compose.yml -p seaweedfs up
+	docker compose -f compose/local-replicate-compose.yml -p seaweedfs up
 
 dev_auditlog: build
-	docker-compose -f compose/local-auditlog-compose.yml -p seaweedfs up
+	docker compose -f compose/local-auditlog-compose.yml -p seaweedfs up
 
 dev_nextcloud: build
-	docker-compose -f compose/local-nextcloud-compose.yml -p seaweedfs up
+	docker compose -f compose/local-nextcloud-compose.yml -p seaweedfs up
 
 cluster: build
-	docker-compose -f compose/local-cluster-compose.yml -p seaweedfs up
+	docker compose -f compose/local-cluster-compose.yml -p seaweedfs up
 
 2clusters: build
-	docker-compose -f compose/local-clusters-compose.yml -p seaweedfs up
+	docker compose -f compose/local-clusters-compose.yml -p seaweedfs up
 
 2mount: build
-	docker-compose -f compose/local-sync-mount-compose.yml -p seaweedfs up
+	docker compose -f compose/local-sync-mount-compose.yml -p seaweedfs up
 
 hashicorp_raft: build
-	docker-compose -f compose/local-hashicorp-raft-compose.yml -p seaweedfs up
+	docker compose -f compose/local-hashicorp-raft-compose.yml -p seaweedfs up
 
 s3tests: build s3tests_build
-	docker-compose -f compose/local-s3tests-compose.yml -p seaweedfs up
+	docker compose -f compose/local-s3tests-compose.yml -p seaweedfs up
 
 filer_etcd: build
 	docker stack deploy -c compose/swarm-etcd.yml fs
 
 test_etcd: build
-	docker-compose -f compose/test-etcd-filer.yml -p seaweedfs up
+	docker compose -f compose/test-etcd-filer.yml -p seaweedfs up
 
 test_ydb: tags = ydb
 test_ydb: build
 	export
-	docker-compose -f compose/test-ydb-filer.yml -p seaweedfs up
+	docker compose -f compose/test-ydb-filer.yml -p seaweedfs up
 
 clean:
 	rm ./weed

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,5 +1,15 @@
 # Docker
 
+## Compose V2 
+SeaweedFS now uses the `v2` syntax `docker compose`
+
+If you rely on using Docker Compose as docker-compose (with a hyphen), you can set up Compose V2 to act as a drop-in replacement of the previous docker-compose. Refer to the [Installing Compose](https://docs.docker.com/compose/install/) section for detailed instructions on upgrading.
+
+Confirm your system has docker compose v2 with a version check
+```bash
+$ docker compose version
+Docker Compose version v2.10.2
+```
 
 ## Try it out
 
@@ -7,7 +17,7 @@
 
 wget https://raw.githubusercontent.com/seaweedfs/seaweedfs/master/docker/seaweedfs-compose.yml
 
-docker-compose -f seaweedfs-compose.yml -p seaweedfs up
+docker compose -f seaweedfs-compose.yml -p seaweedfs up
 
 ```
 
@@ -17,7 +27,7 @@ docker-compose -f seaweedfs-compose.yml -p seaweedfs up
 
 wget https://raw.githubusercontent.com/seaweedfs/seaweedfs/master/docker/seaweedfs-dev-compose.yml
 
-docker-compose -f seaweedfs-dev-compose.yml -p seaweedfs up
+docker compose -f seaweedfs-dev-compose.yml -p seaweedfs up
 
 ```
 

--- a/docker/compose/local-auditlog-compose.yml
+++ b/docker/compose/local-auditlog-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.9'
 
 services:
   s3:

--- a/docker/compose/local-cluster-compose.yml
+++ b/docker/compose/local-cluster-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.9'
 
 services:
   master0:

--- a/docker/compose/local-clusters-compose.yml
+++ b/docker/compose/local-clusters-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.9'
 
 services:
   server1:

--- a/docker/compose/local-dev-compose.yml
+++ b/docker/compose/local-dev-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.9'
 
 services:
   master:

--- a/docker/compose/local-hashicorp-raft-compose.yml
+++ b/docker/compose/local-hashicorp-raft-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.9'
 
 services:
   master0:

--- a/docker/compose/local-k8s-compose.yml
+++ b/docker/compose/local-k8s-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.9'
 
 services:
   master:

--- a/docker/compose/local-minio-gateway-compose.yml
+++ b/docker/compose/local-minio-gateway-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.9'
 
 services:
   master:

--- a/docker/compose/local-mount-compose.yml
+++ b/docker/compose/local-mount-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.9'
 
 services:
   master:

--- a/docker/compose/local-mount-profile-compose.yml
+++ b/docker/compose/local-mount-profile-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.9'
 
 services:
   master:

--- a/docker/compose/local-nextcloud-compose.yml
+++ b/docker/compose/local-nextcloud-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.9'
 
 services:
   master:

--- a/docker/compose/local-registry-compose.yml
+++ b/docker/compose/local-registry-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.9'
 
 services:
   master:

--- a/docker/compose/local-replicate-compose.yml
+++ b/docker/compose/local-replicate-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.9'
 
 services:
   master:

--- a/docker/compose/local-s3tests-compose.yml
+++ b/docker/compose/local-s3tests-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.9'
 
 services:
   master:

--- a/docker/compose/test-etcd-filer.yml
+++ b/docker/compose/test-etcd-filer.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.9'
 
 services:
   etcd:

--- a/docker/compose/test-ydb-filer.yml
+++ b/docker/compose/test-ydb-filer.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.9'
 
 services:
   ydb:

--- a/docker/seaweedfs-compose.yml
+++ b/docker/seaweedfs-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.9'
 
 services:
   master:

--- a/docker/seaweedfs-dev-compose.yml
+++ b/docker/seaweedfs-dev-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.9'
 
 services:
   master:


### PR DESCRIPTION
# What problem are we solving?

- Upgrade from `docker-compose` to `docker compose`
- Upgrade the version in the compose yaml files from 2 -> 3.9

### This PR(!) has breaking changes

# How are we solving the problem?
- `README` updates with guide to install/confirm compose v2 is installed
- `Makefile` updates
- `*-compose.yml` update


# How is the PR tested?
Confirmed everything still works on Ubuntu 20.04 with this. 

** Not tested on other platforms(No logical reason it should not work other than old docker and/or compose versions) **

You will probably still get a few issues about this from people with older installs. 

Hopefully the additions to the [SeaweedFS Docker README](https://github.com/seaweedfs/seaweedfs/tree/master/docker) are sufficient to guide users to self-help.

## Notes for Chris
Please advise if there are any CI systems that I'm unaware of that will break with this `Makefile` upgrade. 

It works on my system :)

# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
