### PR TITLE
mute log filer: no entry is found in filer store

### DIFF
--- a/weed/server/filer_server_handlers_write.go
+++ b/weed/server/filer_server_handlers_write.go
@@ -195,6 +195,8 @@ func (fs *FilerServer) DeleteHandler(w http.ResponseWriter, r *http.Request) {
 		httpStatus := http.StatusInternalServerError
 		if err == filer_pb.ErrNotFound {
 			httpStatus = http.StatusNoContent
+			writeJsonQuiet(w, r, httpStatus, nil)
+			return
 		}
 		writeJsonError(w, r, httpStatus, err)
 		return


### PR DESCRIPTION
# What problem are we solving?

mute messages in log:
```
Sep 16, 2022 @ 15:35:26.142 | I0916 10:35:26.141851 common.go:113 error JSON response status 204: filer: no entry is found in filer store | fast-api-6d74b546d7-28466
Sep 16, 2022 @ 15:35:25.828 | I0916 10:35:25.828112 common.go:113 error JSON response status 204: filer: no entry is found in filer store | fast-api-6d74b546d7-28466
Sep 16, 2022 @ 15:35:25.396 | I0916 10:35:25.396755 common.go:113 error JSON response status 204: filer: no entry is found in filer store | fast-api-6d74b546d7-ljrzs
Sep 16, 2022 @ 15:34:18.617 | I0916 10:34:18.617726 common.go:113 error JSON response status 204: filer: no entry is found in filer store | fast-api-6d74b546d7-8xqlv
Sep 16, 2022 @ 15:32:53.717 | I0916 10:32:53.717126 common.go:113 error JSON response status 204: filer: no entry is found in filer store | fast-api-57d49bf758-n7v6g
Sep 16, 2022 @ 15:32:34.016 | I0916 10:32:34.016671 common.go:113 error JSON response status 204: filer: no entry is found in filer store | fast-api-6d74b546d7-28466
```

# How are we solving the problem?

do not print err on log

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
