### PR TITLE
[shell] unconditional repair if missing needles lt 30 for volume.check.disk

### DIFF
--- a/weed/shell/command_volume_check_disk.go
+++ b/weed/shell/command_volume_check_disk.go
@@ -14,6 +14,8 @@ import (
 	"math"
 )
 
+const unconditionalRepair = 30
+
 func init() {
 	Commands = append(Commands, &commandVolumeCheckDisk{})
 }
@@ -158,7 +160,7 @@ func (c *commandVolumeCheckDisk) doVolumeCheckDisk(minuend, subtrahend *needle_m
 	}
 
 	missingNeedlesFraction := float64(len(missingNeedles)) / float64(counter)
-	if missingNeedlesFraction > nonRepairThreshold {
+	if len(missingNeedles) > unconditionalRepair && missingNeedlesFraction > nonRepairThreshold {
 		return false, fmt.Errorf(
 			"failed to start repair volume %d, percentage of missing keys is greater than the threshold: %.2f > %.2f",
 			source.info.Id, missingNeedlesFraction, nonRepairThreshold)


### PR DESCRIPTION
# What problem are we solving?

failed to start repair for volumes with small few files
```
volume 2708 fast-volume-6:8080 has 6 entries, fast-volume-4:8080 missed 0 entries
volume 2708 fast-volume-4:8080 has 15 entries, fast-volume-6:8080 missed 9 entries
sync volume 2708 on fast-volume-4 and fast-volume-6: doVolumeCheckDisk source:fast-volume-4:8080 target:fast-volume-6:8080 volume 2708: failed to start repair volume 2708, percentage of missing keys is greater than the threshold: 0.60 > 0.30
```

# How are we solving the problem?

Unconditional repair for a small number of files, for example, less than 30

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
