### PR TITLE
skip pathPrefix prefix processing if `pathPrefix` is empty

### DIFF
--- a/weed/server/filer_grpc_server_sub_meta.go
+++ b/weed/server/filer_grpc_server_sub_meta.go
@@ -226,6 +226,9 @@ func (fs *FilerServer) eachEventNotificationFn(req *filer_pb.SubscribeMetadataRe
 		} else if matchByDirectory(dirPath, req.Directories) {
 			// good
 		} else {
+			if req.PathPrefix == "" {
+				return nil
+			}
 			if !strings.HasPrefix(fullpath, req.PathPrefix) {
 				if eventNotification.NewParentPath != "" {
 					newFullPath := util.Join(eventNotification.NewParentPath, entryName)


### PR DESCRIPTION
# What problem are we solving?

Not specifying pathPrefix (empty string) causes subscription to all events

# How are we solving the problem?

skip pathPrefix prefix processing if `pathPrefix` is empty

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
