### PR TITLE
fs.meta.load load any dirs with prefix "important"

### DIFF
--- a/weed/shell/command_fs_meta_load.go
+++ b/weed/shell/command_fs_meta_load.go
@@ -46,7 +46,7 @@ func (c *commandFsMetaLoad) Do(args []string, commandEnv *CommandEnv, writer io.
 	fileName := args[len(args)-1]
 
 	metaLoadCommand := flag.NewFlagSet(c.Name(), flag.ContinueOnError)
-	c.dirPrefix = metaLoadCommand.String("dirPrefix", "", "match with wildcard characters '*' and '?'")
+	c.dirPrefix = metaLoadCommand.String("dirPrefix", "", "load entries only with directories matching prefix")
 	verbose := metaLoadCommand.Bool("v", true, "verbose mode")
 	if err = metaLoadCommand.Parse(args[0 : len(args)-1]); err != nil {
 		return nil


### PR DESCRIPTION
# What problem are we solving?

If you need to restore a specific bucket or volume file, you have to download all the meta data, and this is very long

# How are we solving the problem?

Added parameter dirPrefix

# How is the PR tested?

```
> fs.meta.load -v=false -dirPrefix=/buckets/scraper/ /data/filer.meta
load /buckets/scraper/1579/3919_scrap
load /buckets/scraper/1579/3919_scrap/51910

total 9 directories, 60 files
/data/filer.meta is loaded.
```

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
