### PR TITLE
fix: compact_map get error mismatching cokie

### DIFF
--- a/weed/storage/needle_map/compact_map.go
+++ b/weed/storage/needle_map/compact_map.go
@@ -145,7 +145,7 @@ func (cs *CompactSection) deleteOverflowEntry(key SectionalNeedleId) {
 // return old entry size
 func (cs *CompactSection) Delete(key NeedleId) Size {
 	cs.Lock()
-	defer cs.RUnlock()
+	defer cs.Unlock()
 	ret := Size(0)
 	if key > cs.end {
 		return ret

--- a/weed/storage/needle_map/compact_map_perf_test.go
+++ b/weed/storage/needle_map/compact_map_perf_test.go
@@ -90,34 +90,3 @@ func PrintMemUsage(totalRowCount uint64) {
 func bToMb(b uint64) uint64 {
 	return b / 1024 / 1024
 }
-
-func TestCompactSection_Get(t *testing.T) {
-	var maps []*CompactMap
-	totalRowCount := uint64(0)
-	indexFile, ie := os.OpenFile("../../1655451851227025229-502m-single-1_388.idx",
-		os.O_RDWR|os.O_RDONLY, 0644)
-	defer indexFile.Close()
-	if ie != nil {
-		log.Fatalln(ie)
-	}
-
-	m, rowCount := loadNewNeedleMap(indexFile)
-	maps = append(maps, m)
-	totalRowCount += rowCount
-	m.Set(1574318345753513987, ToOffset(10002), 10002)
-	nv,ok := m.Get(1574318345753513987)
-	if ok {
-		t.Log(uint64(nv.Key))
-	}
-
-	nv1,ok := m.Get(1574318350048481283)
-	if ok {
-		t.Log(uint64(nv1.Key))
-	}
-
-	m.Set(1574318350048481283, ToOffset(10002), 10002)
-	nv2,ok1 := m.Get(1574318350048481283)
-	if ok1 {
-		t.Log(uint64(nv2.Key))
-	}
-}

--- a/weed/storage/needle_map/compact_map_perf_test.go
+++ b/weed/storage/needle_map/compact_map_perf_test.go
@@ -90,3 +90,34 @@ func PrintMemUsage(totalRowCount uint64) {
 func bToMb(b uint64) uint64 {
 	return b / 1024 / 1024
 }
+
+func TestCompactSection_Get(t *testing.T) {
+	var maps []*CompactMap
+	totalRowCount := uint64(0)
+	indexFile, ie := os.OpenFile("../../1655451851227025229-502m-single-1_388.idx",
+		os.O_RDWR|os.O_RDONLY, 0644)
+	defer indexFile.Close()
+	if ie != nil {
+		log.Fatalln(ie)
+	}
+
+	m, rowCount := loadNewNeedleMap(indexFile)
+	maps = append(maps, m)
+	totalRowCount += rowCount
+	m.Set(1574318345753513987, ToOffset(10002), 10002)
+	nv,ok := m.Get(1574318345753513987)
+	if ok {
+		t.Log(uint64(nv.Key))
+	}
+
+	nv1,ok := m.Get(1574318350048481283)
+	if ok {
+		t.Log(uint64(nv1.Key))
+	}
+
+	m.Set(1574318350048481283, ToOffset(10002), 10002)
+	nv2,ok1 := m.Get(1574318350048481283)
+	if ok1 {
+		t.Log(uint64(nv2.Key))
+	}
+}

--- a/weed/storage/needle_map/compact_map_test.go
+++ b/weed/storage/needle_map/compact_map_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"github.com/seaweedfs/seaweedfs/weed/sequence"
 	. "github.com/seaweedfs/seaweedfs/weed/storage/types"
+	"log"
+	"os"
 	"testing"
 )
 
@@ -178,4 +180,41 @@ func TestOverflow(t *testing.T) {
 	}
 	println()
 
+}
+
+func TestCompactSection_Get(t *testing.T) {
+	var maps []*CompactMap
+	totalRowCount := uint64(0)
+	indexFile, ie := os.OpenFile("../../../test/data/sample.idx",
+		os.O_RDWR|os.O_RDONLY, 0644)
+	defer indexFile.Close()
+	if ie != nil {
+		log.Fatalln(ie)
+	}
+
+	m, rowCount := loadNewNeedleMap(indexFile)
+	maps = append(maps, m)
+	totalRowCount += rowCount
+	m.Set(1574318345753513987, ToOffset(10002), 10002)
+	nv,ok := m.Get(1574318345753513987)
+	if ok {
+		t.Log(uint64(nv.Key))
+	}
+
+	nv1, ok := m.Get(1574318350048481283)
+	if ok {
+		t.Error(uint64(nv1.Key))
+	}
+
+	m.Set(1574318350048481283, ToOffset(10002), 10002)
+	nv2,ok1 := m.Get(1574318350048481283)
+	if ok1 {
+		t.Log(uint64(nv2.Key))
+	}
+
+	m.Delete(nv2.Key)
+	nv3,has := m.Get(nv2.Key)
+	if has && nv3.Size > 0 {
+		t.Error(uint64(nv3.Size))
+	}
 }


### PR DESCRIPTION
# What problem are we solving?

when use snowflak gen id ，The following error occurs :
write to local disk: mismatching cookie xxxxxxx
the file write failue

# How are we solving the problem?

fix the bug of compact_map get error ; when the slot end small than the key return  nil false

# How is the PR tested?

add compact get test 
test idx  
[1655451851227025229-502m-single-1_388.idx.zip](https://github.com/seaweedfs/seaweedfs/files/9654785/1655451851227025229-502m-single-1_388.idx.zip)


# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
