### PR TITLE
s3: add account

### DIFF
--- a/weed/s3api/s3api_account.go
+++ b/weed/s3api/s3api_account.go
@@ -1,0 +1,69 @@
+package s3api
+
+import (
+	"sync"
+)
+
+//Predefined Accounts
+var (
+	// AccountAdmin is used as the default account for IAM-Credentials access without Account configured
+	AccountAdmin = Account{
+		Name:         "admin",
+		EmailAddress: "admin@example.com",
+		Id:           "admin",
+	}
+
+	// AccountAnonymous is used to represent the account for anonymous access
+	AccountAnonymous = Account{
+		Name:         "anonymous",
+		EmailAddress: "anonymous@example.com",
+		Id:           "anonymous",
+	}
+)
+
+//Account represents a system user, a system user can
+//configure multiple IAM-Users, IAM-Users can configure
+//permissions respectively, and each IAM-User can
+//configure multiple security credentials
+type Account struct {
+	//Name is also used to display the "DisplayName" as the owner of the bucket or object
+	Name         string
+	EmailAddress string
+
+	//Id is used to identify an Account when granting cross-account access(ACLs) to buckets and objects
+	Id string
+}
+
+type AccountManager struct {
+	sync.Mutex
+	s3a *S3ApiServer
+
+	IdNameMapping  map[string]string
+	EmailIdMapping map[string]string
+}
+
+func NewAccountManager(s3a *S3ApiServer) *AccountManager {
+	am := &AccountManager{
+		s3a:            s3a,
+		IdNameMapping:  make(map[string]string),
+		EmailIdMapping: make(map[string]string),
+	}
+	am.initialize()
+	return am
+}
+
+func (am *AccountManager) GetAccountNameById(canonicalId string) string {
+	return am.IdNameMapping[canonicalId]
+}
+
+func (am *AccountManager) GetAccountIdByEmail(email string) string {
+	return am.EmailIdMapping[email]
+}
+
+func (am *AccountManager) initialize() {
+	// load predefined Accounts
+	for _, account := range []Account{AccountAdmin, AccountAnonymous} {
+		am.IdNameMapping[account.Id] = account.Name
+		am.EmailIdMapping[account.EmailAddress] = account.Id
+	}
+}

--- a/weed/s3api/s3api_server.go
+++ b/weed/s3api/s3api_server.go
@@ -40,6 +40,7 @@ type S3ApiServer struct {
 	randomClientId int32
 	filerGuard     *security.Guard
 	client         *http.Client
+	accountManager *AccountManager
 }
 
 func NewS3ApiServer(router *mux.Router, option *S3ApiServerOption) (s3ApiServer *S3ApiServer, err error) {
@@ -59,6 +60,7 @@ func NewS3ApiServer(router *mux.Router, option *S3ApiServerOption) (s3ApiServer 
 		filerGuard:     security.NewGuard([]string{}, signingKey, expiresAfterSec, readSigningKey, readExpiresAfterSec),
 		cb:             NewCircuitBreaker(option),
 	}
+	s3ApiServer.accountManager = NewAccountManager(s3ApiServer)
 	if option.LocalFilerSocket == "" {
 		s3ApiServer.client = &http.Client{Transport: &http.Transport{
 			MaxIdleConns:        1024,


### PR DESCRIPTION
# What problem are we solving?

In order to introduce s3 Acl related functions, it is necessary to add an Account structure to manage IAM-User, and use AccountId as the owner of the bucket/object instead of IAM-User (Identity) as the Owner, to ensure that IAM-Users under the same account will not Limited access due to Owner inconsistency

# How are we solving the problem?


# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
