### PR TITLE
[volume] Add new volumes to HUP(reload) signal

### DIFF
--- a/weed/command/volume.go
+++ b/weed/command/volume.go
@@ -265,6 +265,8 @@ func (v VolumeServerOptions) startVolumeServer(volumeFolders, maxVolumeCounts, v
 	// starting the cluster http server
 	clusterHttpServer := v.startClusterHttpService(volumeMux)
 
+	grace.OnReload(volumeServer.LoadNewVolumes)
+
 	stopChan := make(chan bool)
 	grace.OnInterrupt(func() {
 		fmt.Println("volume server has been killed")

--- a/weed/server/volume_server.go
+++ b/weed/server/volume_server.go
@@ -137,6 +137,11 @@ func (vs *VolumeServer) SetStopping() {
 	vs.store.SetStopping()
 }
 
+func (vs *VolumeServer) LoadNewVolumes() {
+	glog.V(0).Infoln(" Loading new volume ids ...")
+	vs.store.LoadNewVolumes()
+}
+
 func (vs *VolumeServer) Shutdown() {
 	glog.V(0).Infoln("Shutting down volume server...")
 	vs.store.Close()

--- a/weed/storage/store.go
+++ b/weed/storage/store.go
@@ -361,6 +361,12 @@ func (s *Store) SetStopping() {
 	}
 }
 
+func (s *Store) LoadNewVolumes() {
+	for _, location := range s.Locations {
+		location.loadExistingVolumes(s.NeedleMapKind)
+	}
+}
+
 func (s *Store) Close() {
 	for _, location := range s.Locations {
 		location.Close()


### PR DESCRIPTION
# What problem are we solving?

It is necessary to be able to scan a folder with volume files to add new / restored files from a backup without stopping the service

# How are we solving the problem?

Added a HUP signal handler that adds new volume files

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
