### PR TITLE
ADHOC: filter deleted files from idx file binary search

### DIFF
--- a/weed/shell/command_volume_fsck.go
+++ b/weed/shell/command_volume_fsck.go
@@ -393,8 +393,9 @@ func (c *commandVolumeFsck) collectOneVolumeFileIds(tempFolder string, dataNodeI
 			}
 			buf.Write(resp.FileContent)
 		}
+		fileredBuf := filterDeletedNeedleFromIdx(buf.Bytes())
 		if vinfo.isReadOnly == false {
-			index, err := idx.FirstInvalidIndex(buf.Bytes(), func(key types.NeedleId, offset types.Offset, size types.Size) (bool, error) {
+			index, err := idx.FirstInvalidIndex(fileredBuf.Bytes(), func(key types.NeedleId, offset types.Offset, size types.Size) (bool, error) {
 				resp, err := volumeServerClient.ReadNeedleMeta(context.Background(), &volume_server_pb.ReadNeedleMetaRequest{
 					VolumeId: volumeId,
 					NeedleId: uint64(key),
@@ -409,11 +410,11 @@ func (c *commandVolumeFsck) collectOneVolumeFileIds(tempFolder string, dataNodeI
 			if err != nil {
 				fmt.Fprintf(writer, "Failed to search for last valid index on volume %d with error %v", volumeId, err)
 			} else {
-				buf.Truncate(index * types.NeedleMapEntrySize)
+				fileredBuf.Truncate(index * types.NeedleMapEntrySize)
 			}
 		}
 		idxFilename := getVolumeFileIdFile(tempFolder, dataNodeId, volumeId)
-		err = writeToFile(buf.Bytes(), idxFilename)
+		err = writeToFile(fileredBuf.Bytes(), idxFilename)
 		if err != nil {
 			return fmt.Errorf("failed to copy %d%s from %s: %v", volumeId, ext, vinfo.server, err)
 		}
@@ -718,4 +719,15 @@ func writeToFile(bytes []byte, fileName string) error {
 
 	dst.Write(bytes)
 	return nil
+}
+
+func filterDeletedNeedleFromIdx(arr []byte) bytes.Buffer {
+	var filteredBuf bytes.Buffer
+	for i := 0; i < len(arr); i += types.NeedleMapEntrySize {
+		size := types.BytesToSize(arr[i+types.NeedleIdSize+types.OffsetSize : i+types.NeedleIdSize+types.OffsetSize+types.SizeSize])
+		if size > 0 {
+			filteredBuf.Write(arr[i : i+types.NeedleIdSize+types.OffsetSize+types.SizeSize])
+		}
+	}
+	return filteredBuf
 }

--- a/weed/storage/volume_read.go
+++ b/weed/storage/volume_read.go
@@ -84,10 +84,6 @@ func (v *Volume) readNeedle(n *needle.Needle, readOption *ReadOption, onReadSize
 func (v *Volume) readNeedleMetaAt(n *needle.Needle, offset int64, size int32) (err error) {
 	v.dataFileAccessLock.RLock()
 	defer v.dataFileAccessLock.RUnlock()
-	// read deleted meta data
-	if size < 0 {
-		size = -size
-	}
 	err = n.ReadNeedleMeta(v.DataBackend, offset, Size(size), v.Version())
 	if err == needle.ErrorSizeMismatch && OffsetSize == 4 {
 		err = n.ReadNeedleMeta(v.DataBackend, offset+int64(MaxPossibleVolumeSize), Size(size), v.Version())


### PR DESCRIPTION
# What problem are we solving?
https://github.com/seaweedfs/seaweedfs/issues/3746
volume fsck code eof
this is because there are deleted file entrys with negative size on the idx file, when we look up meta data it will result in a size mismatch. and will trigger another look up at offset with `offset+int64(MaxPossibleVolumeSize)` which will result in EOF

# How are we solving the problem?
we can solve this problem by filtering all the deleted files from idx files before we binary search the last modified ts. because the purpose for volume fsck is to identify the isolated files on volume the deleted files should not matter.


# How is the PR tested?
I repro the error with negative index
```
root@xxxxxx:/tmp# see_idx -dir=. -volumeId=4
key:2 offset:1 size:271(271 B)
key:3 offset:39 size:193(193 B)
key:5 offset:67 size:4194329(4.00 MiB)
key:f offset:524362 size:1529875(1.46 MiB)
key:f offset:715600 size:-1(16.00 EiB)
key:17 offset:715604 size:7481(7.31 KiB)
```

and the change fixed it
master: localhost:9333 filers: [192.168.144.108:8888]
```
> lock
> volume.fsck -v -findMissingChunksInFiler -findMissingChunksInFilerPath /
working directory: /tmp/sw_fsck1871085358
collecting volume id and locations from master ...
collected 1 volumes and locations.
collecting volume 2 file ids from 192.168.144.108:8078 ...
collecting volume 3 file ids from 192.168.144.108:8078 ...
collecting volume 7 file ids from 192.168.144.108:8078 ...
collecting volume 6 file ids from 192.168.144.108:8078 ...
collecting volume 4 file ids from 192.168.144.108:8078 ...
collecting volume 1 file ids from 192.168.144.108:8078 ...
collecting volume 5 file ids from 192.168.144.108:8078 ...
checking each file from filer ...
checking directory /test
checking directory /topics
checking directory /test/123
checking directory /topics/.system
checking directory /topics/.system/log
find missing file chunks in dataNodeId 192.168.144.108:8078 volume 5 ...
find missing file chunks in dataNodeId 192.168.144.108:8078 volume 2 ...
find missing file chunks in dataNodeId 192.168.144.108:8078 volume 3 ...
find missing file chunks in dataNodeId 192.168.144.108:8078 volume 7 ...
find missing file chunks in dataNodeId 192.168.144.108:8078 volume 6 ...
find missing file chunks in dataNodeId 192.168.144.108:8078 volume 4 ...
find missing file chunks in dataNodeId 192.168.144.108:8078 volume 1 ...

```

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
