### PR TITLE
avoid increasing the coordinates of metric labels

### DIFF
--- a/weed/s3api/stats.go
+++ b/weed/s3api/stats.go
@@ -33,6 +33,12 @@ func track(f http.HandlerFunc, action string) http.HandlerFunc {
 		recorder := NewStatusResponseWriter(w)
 		start := time.Now()
 		f(recorder, r)
+		if recorder.Status == http.StatusForbidden {
+			if m, _ := stats_collect.S3RequestCounter.GetMetricWithLabelValues(
+				action, strconv.Itoa(http.StatusOK), bucket); m == nil {
+				bucket = ""
+			}
+		}
 		stats_collect.S3RequestHistogram.WithLabelValues(action, bucket).Observe(time.Since(start).Seconds())
 		stats_collect.S3RequestCounter.WithLabelValues(action, strconv.Itoa(recorder.Status), bucket).Inc()
 	}


### PR DESCRIPTION
# What problem are we solving?

![Screenshot 2022-10-04 at 12 56 32](https://user-images.githubusercontent.com/9497591/193765652-bf51eadf-6c08-4f36-90c7-a323f69dcf15.png)

Due to probe-bucket-sign, the number of labels in metrics has become so much that scraping stopped working in 1 minute

# How are we solving the problem?

Do not create bucket label for metrics on 403 response code

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
