### PR TITLE
add s3 acl support

### DIFF
--- a/weed/s3api/auth_credentials_test.go
+++ b/weed/s3api/auth_credentials_test.go
@@ -2,6 +2,7 @@ package s3api
 
 import (
 	. "github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3account"
 	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
@@ -150,7 +151,7 @@ func TestLoadS3ApiConfiguration(t *testing.T) {
 			},
 			expectIdent: &Identity{
 				Name:      "notSpecifyAccountId",
-				AccountId: AccountAdmin.Id,
+				AccountId: s3account.AccountAdmin.Id,
 				Actions: []Action{
 					"Read",
 					"Write",

--- a/weed/s3api/bucket_metadata.go
+++ b/weed/s3api/bucket_metadata.go
@@ -1,15 +1,13 @@
 package s3api
 
 import (
-	"bytes"
 	"encoding/json"
-	"github.com/aws/aws-sdk-go/private/protocol/json/jsonutil"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3account"
 
-	//"github.com/seaweedfs/seaweedfs/weed/s3api"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
 	"github.com/seaweedfs/seaweedfs/weed/util"
 	"math"
@@ -22,7 +20,7 @@ var loadBucketMetadataFromFiler = func(r *BucketRegistry, bucketName string) (*B
 		return nil, err
 	}
 
-	return buildBucketMetadata(entry), nil
+	return buildBucketMetadata(r.s3a.accountManager, entry), nil
 }
 
 type BucketMetaData struct {
@@ -76,13 +74,13 @@ func (r *BucketRegistry) init() error {
 }
 
 func (r *BucketRegistry) LoadBucketMetadata(entry *filer_pb.Entry) {
-	bucketMetadata := buildBucketMetadata(entry)
+	bucketMetadata := buildBucketMetadata(r.s3a.accountManager, entry)
 	r.metadataCacheLock.Lock()
 	defer r.metadataCacheLock.Unlock()
 	r.metadataCache[entry.Name] = bucketMetadata
 }
 
-func buildBucketMetadata(entry *filer_pb.Entry) *BucketMetaData {
+func buildBucketMetadata(accountManager *s3account.AccountManager, entry *filer_pb.Entry) *BucketMetaData {
 	entryJson, _ := json.Marshal(entry)
 	glog.V(3).Infof("build bucket metadata,entry=%s", entryJson)
 	bucketMetadata := &BucketMetaData{
@@ -93,8 +91,8 @@ func buildBucketMetadata(entry *filer_pb.Entry) *BucketMetaData {
 
 		// Default owner: `AccountAdmin`
 		Owner: &s3.Owner{
-			ID:          &AccountAdmin.Id,
-			DisplayName: &AccountAdmin.Name,
+			ID:          &s3account.AccountAdmin.Id,
+			DisplayName: &s3account.AccountAdmin.Name,
 		},
 	}
 	if entry.Extended != nil {
@@ -111,22 +109,29 @@ func buildBucketMetadata(entry *filer_pb.Entry) *BucketMetaData {
 		}
 
 		//access control policy
-		acpBytes, ok := entry.Extended[s3_constants.ExtAcpKey]
-		if ok {
-			var acp s3.AccessControlPolicy
-			err := jsonutil.UnmarshalJSON(&acp, bytes.NewReader(acpBytes))
-			if err == nil {
-				//validate owner
-				if acp.Owner != nil && acp.Owner.ID != nil {
-					bucketMetadata.Owner = acp.Owner
-				} else {
-					glog.Warningf("bucket ownerId is empty! bucket: %s", bucketMetadata.Name)
-				}
-
-				//acl
-				bucketMetadata.Acl = acp.Grants
+		//owner
+		acpOwnerBytes, ok := entry.Extended[s3_constants.ExtAmzOwnerKey]
+		if ok && len(acpOwnerBytes) > 0 {
+			ownerAccountId := string(acpOwnerBytes)
+			ownerAccountName, exists := accountManager.IdNameMapping[ownerAccountId]
+			if !exists {
+				glog.Warningf("owner[id=%s] is invalid, bucket: %s", ownerAccountId, bucketMetadata.Name)
 			} else {
-				glog.Warningf("Unmarshal ACP: %s(%v), bucket: %s", string(acpBytes), err, bucketMetadata.Name)
+				bucketMetadata.Owner = &s3.Owner{
+					ID:          &ownerAccountId,
+					DisplayName: &ownerAccountName,
+				}
+			}
+		}
+		//grants
+		acpGrantsBytes, ok := entry.Extended[s3_constants.ExtAmzAclKey]
+		if ok && len(acpGrantsBytes) > 0 {
+			var grants []*s3.Grant
+			err := json.Unmarshal(acpGrantsBytes, &grants)
+			if err == nil {
+				bucketMetadata.Acl = grants
+			} else {
+				glog.Warningf("Unmarshal ACP grants: %s(%v), bucket: %s", string(acpGrantsBytes), err, bucketMetadata.Name)
 			}
 		}
 	}
@@ -173,6 +178,11 @@ func (r *BucketRegistry) LoadBucketMetadataFromFiler(bucketName string) (*Bucket
 	r.metadataCacheLock.RUnlock()
 	if ok {
 		return bucketMetaData, s3err.ErrNone
+	}
+
+	_, ok = r.notFound[bucketName]
+	if ok {
+		return nil, s3err.ErrNoSuchBucket
 	}
 
 	//if not exists, load from filer

--- a/weed/s3api/bucket_metadata_test.go
+++ b/weed/s3api/bucket_metadata_test.go
@@ -1,11 +1,12 @@
 package s3api
 
 import (
+	"encoding/json"
 	"fmt"
-	"github.com/aws/aws-sdk-go/private/protocol/json/jsonutil"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3account"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
 	"reflect"
 	"sync"
@@ -25,18 +26,13 @@ var (
 	}
 
 	//good entry
-	goodEntryAcp, _ = jsonutil.BuildJSON(&s3.AccessControlPolicy{
-		Owner: &s3.Owner{
-			DisplayName: &AccountAdmin.Name,
-			ID:          &AccountAdmin.Id,
-		},
-		Grants: s3_constants.PublicRead,
-	})
-	goodEntry = &filer_pb.Entry{
+	goodEntryAcl, _ = json.Marshal(s3_constants.PublicRead)
+	goodEntry       = &filer_pb.Entry{
 		Name: "entryWithValidAcp",
 		Extended: map[string][]byte{
 			s3_constants.ExtOwnershipKey: []byte(s3_constants.OwnershipBucketOwnerEnforced),
-			s3_constants.ExtAcpKey:       goodEntryAcp,
+			s3_constants.ExtAmzOwnerKey:  []byte(s3account.AccountAdmin.Name),
+			s3_constants.ExtAmzAclKey:    goodEntryAcl,
 		},
 	}
 
@@ -56,35 +52,28 @@ var (
 		},
 	}
 
-	//acp is ""
+	//owner is ""
 	acpEmptyStr = &filer_pb.Entry{
 		Name: "acpEmptyStr",
 		Extended: map[string][]byte{
-			s3_constants.ExtAcpKey: []byte(""),
+			s3_constants.ExtAmzOwnerKey: []byte(""),
 		},
 	}
 
-	//acp is empty object
-	acpEmptyObjectAcp, _ = jsonutil.BuildJSON(&s3.AccessControlPolicy{
-		Owner:  nil,
-		Grants: nil,
-	})
+	//owner not exists
 	acpEmptyObject = &filer_pb.Entry{
 		Name: "acpEmptyObject",
 		Extended: map[string][]byte{
-			s3_constants.ExtAcpKey: acpEmptyObjectAcp,
+			s3_constants.ExtAmzOwnerKey: []byte("xxxxx"),
 		},
 	}
 
-	//acp owner is nil
-	acpOwnerNilAcp, _ = jsonutil.BuildJSON(&s3.AccessControlPolicy{
-		Owner:  nil,
-		Grants: make([]*s3.Grant, 1),
-	})
-	acpOwnerNil = &filer_pb.Entry{
+	//grants is nil
+	acpOwnerNilAcp, _ = json.Marshal(make([]*s3.Grant, 0))
+	acpOwnerNil       = &filer_pb.Entry{
 		Name: "acpOwnerNil",
 		Extended: map[string][]byte{
-			s3_constants.ExtAcpKey: acpOwnerNilAcp,
+			s3_constants.ExtAmzAclKey: acpOwnerNilAcp,
 		},
 	}
 
@@ -99,8 +88,8 @@ var tcs = []*BucketMetadataTestCase{
 			Name:            badEntry.Name,
 			ObjectOwnership: s3_constants.DefaultOwnershipForExists,
 			Owner: &s3.Owner{
-				DisplayName: &AccountAdmin.Name,
-				ID:          &AccountAdmin.Id,
+				DisplayName: &s3account.AccountAdmin.Name,
+				ID:          &s3account.AccountAdmin.Id,
 			},
 			Acl: nil,
 		},
@@ -110,8 +99,8 @@ var tcs = []*BucketMetadataTestCase{
 			Name:            goodEntry.Name,
 			ObjectOwnership: s3_constants.OwnershipBucketOwnerEnforced,
 			Owner: &s3.Owner{
-				DisplayName: &AccountAdmin.Name,
-				ID:          &AccountAdmin.Id,
+				DisplayName: &s3account.AccountAdmin.Name,
+				ID:          &s3account.AccountAdmin.Id,
 			},
 			Acl: s3_constants.PublicRead,
 		},
@@ -121,8 +110,8 @@ var tcs = []*BucketMetadataTestCase{
 			Name:            ownershipEmptyStr.Name,
 			ObjectOwnership: s3_constants.DefaultOwnershipForExists,
 			Owner: &s3.Owner{
-				DisplayName: &AccountAdmin.Name,
-				ID:          &AccountAdmin.Id,
+				DisplayName: &s3account.AccountAdmin.Name,
+				ID:          &s3account.AccountAdmin.Id,
 			},
 			Acl: nil,
 		},
@@ -132,8 +121,8 @@ var tcs = []*BucketMetadataTestCase{
 			Name:            ownershipValid.Name,
 			ObjectOwnership: s3_constants.OwnershipBucketOwnerEnforced,
 			Owner: &s3.Owner{
-				DisplayName: &AccountAdmin.Name,
-				ID:          &AccountAdmin.Id,
+				DisplayName: &s3account.AccountAdmin.Name,
+				ID:          &s3account.AccountAdmin.Id,
 			},
 			Acl: nil,
 		},
@@ -143,8 +132,8 @@ var tcs = []*BucketMetadataTestCase{
 			Name:            acpEmptyStr.Name,
 			ObjectOwnership: s3_constants.DefaultOwnershipForExists,
 			Owner: &s3.Owner{
-				DisplayName: &AccountAdmin.Name,
-				ID:          &AccountAdmin.Id,
+				DisplayName: &s3account.AccountAdmin.Name,
+				ID:          &s3account.AccountAdmin.Id,
 			},
 			Acl: nil,
 		},
@@ -154,8 +143,8 @@ var tcs = []*BucketMetadataTestCase{
 			Name:            acpEmptyObject.Name,
 			ObjectOwnership: s3_constants.DefaultOwnershipForExists,
 			Owner: &s3.Owner{
-				DisplayName: &AccountAdmin.Name,
-				ID:          &AccountAdmin.Id,
+				DisplayName: &s3account.AccountAdmin.Name,
+				ID:          &s3account.AccountAdmin.Id,
 			},
 			Acl: nil,
 		},
@@ -165,8 +154,8 @@ var tcs = []*BucketMetadataTestCase{
 			Name:            acpOwnerNil.Name,
 			ObjectOwnership: s3_constants.DefaultOwnershipForExists,
 			Owner: &s3.Owner{
-				DisplayName: &AccountAdmin.Name,
-				ID:          &AccountAdmin.Id,
+				DisplayName: &s3account.AccountAdmin.Name,
+				ID:          &s3account.AccountAdmin.Id,
 			},
 			Acl: make([]*s3.Grant, 0),
 		},
@@ -174,8 +163,14 @@ var tcs = []*BucketMetadataTestCase{
 }
 
 func TestBuildBucketMetadata(t *testing.T) {
+	accountManager := &s3account.AccountManager{
+		IdNameMapping: map[string]string{
+			s3account.AccountAdmin.Id:     s3account.AccountAdmin.Name,
+			s3account.AccountAnonymous.Id: s3account.AccountAnonymous.Name,
+		},
+	}
 	for _, tc := range tcs {
-		resultBucketMetadata := buildBucketMetadata(tc.filerEntry)
+		resultBucketMetadata := buildBucketMetadata(accountManager, tc.filerEntry)
 		if !reflect.DeepEqual(resultBucketMetadata, tc.expectBucketMetadata) {
 			t.Fatalf("result is unexpect: \nresult: %v, \nexpect: %v", resultBucketMetadata, tc.expectBucketMetadata)
 		}

--- a/weed/s3api/s3_constants/acp_grantee_group.go
+++ b/weed/s3api/s3_constants/acp_grantee_group.go
@@ -6,3 +6,15 @@ var (
 	GranteeGroupAuthenticatedUsers = "http://acs.amazonaws.com/groups/global/AuthenticatedUsers"
 	GranteeGroupLogDelivery        = "http://acs.amazonaws.com/groups/s3/LogDelivery"
 )
+
+func ValidateGroup(group string) bool {
+	valid := true
+	switch group {
+	case GranteeGroupAllUsers:
+	case GranteeGroupLogDelivery:
+	case GranteeGroupAuthenticatedUsers:
+	default:
+		valid = false
+	}
+	return valid
+}

--- a/weed/s3api/s3_constants/extend_key.go
+++ b/weed/s3api/s3_constants/extend_key.go
@@ -1,6 +1,7 @@
 package s3_constants
 
 const (
-	ExtAcpKey       = "Seaweed-X-Amz-Acp"
+	ExtAmzOwnerKey  = "Seaweed-X-Amz-Owner"
+	ExtAmzAclKey    = "Seaweed-X-Amz-Acl"
 	ExtOwnershipKey = "Seaweed-X-Amz-Ownership"
 )

--- a/weed/s3api/s3_constants/header.go
+++ b/weed/s3api/s3_constants/header.go
@@ -37,7 +37,18 @@ const (
 	AmzObjectTaggingDirective = "X-Amz-Tagging-Directive"
 	AmzTagCount               = "x-amz-tagging-count"
 
+	// S3 ACL headers
+	AmzCannedAcl      = "X-Amz-Acl"
+	AmzAclFullControl = "X-Amz-Grant-Full-Control"
+	AmzAclRead        = "X-Amz-Grant-Read"
+	AmzAclWrite       = "X-Amz-Grant-Write"
+	AmzAclReadAcp     = "X-Amz-Grant-Read-Acp"
+	AmzAclWriteAcp    = "X-Amz-Grant-Write-Acp"
+
 	X_SeaweedFS_Header_Directory_Key = "x-seaweedfs-is-directory-key"
+
+	//s3 acl offload header
+	X_SeaweedFS_Header_Amz_Bucket_Owner_Id = "x-seaweedfs-amz-bucket-owner-id"
 )
 
 // Non-Standard S3 HTTP request constants

--- a/weed/s3api/s3account/account.go
+++ b/weed/s3api/s3account/account.go
@@ -1,4 +1,4 @@
-package s3api
+package s3account
 
 import (
 	"sync"
@@ -36,28 +36,18 @@ type Account struct {
 
 type AccountManager struct {
 	sync.Mutex
-	s3a *S3ApiServer
 
 	IdNameMapping  map[string]string
 	EmailIdMapping map[string]string
 }
 
-func NewAccountManager(s3a *S3ApiServer) *AccountManager {
+func NewAccountManager() *AccountManager {
 	am := &AccountManager{
-		s3a:            s3a,
 		IdNameMapping:  make(map[string]string),
 		EmailIdMapping: make(map[string]string),
 	}
 	am.initialize()
 	return am
-}
-
-func (am *AccountManager) GetAccountNameById(canonicalId string) string {
-	return am.IdNameMapping[canonicalId]
-}
-
-func (am *AccountManager) GetAccountIdByEmail(email string) string {
-	return am.EmailIdMapping[email]
 }
 
 func (am *AccountManager) initialize() {

--- a/weed/s3api/s3acl/acl.go
+++ b/weed/s3api/s3acl/acl.go
@@ -1,0 +1,511 @@
+package s3acl
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/seaweedfs/seaweedfs/weed/filer"
+	"github.com/seaweedfs/seaweedfs/weed/glog"
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3account"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+	"net/http"
+	"strings"
+)
+
+func CheckObjectAccessForReadObject(r *http.Request, w http.ResponseWriter, entry *filer.Entry, bucketOwnerId string) (statusCode int, ok bool) {
+	if entry.IsDirectory() {
+		w.Header().Set(s3_constants.X_SeaweedFS_Header_Directory_Key, "true")
+		return http.StatusMethodNotAllowed, false
+	}
+
+	accountId := GetAccountId(r)
+	if len(accountId) == 0 {
+		glog.Warning("#checkObjectAccessForReadObject header[accountId] not exists!")
+		return http.StatusForbidden, false
+	}
+
+	//owner access
+	objectOwner := GetAcpOwner(entry.Extended, bucketOwnerId)
+	if accountId == objectOwner {
+		return http.StatusOK, true
+	}
+
+	//find in Grants
+	acpGrants := GetAcpGrants(entry.Extended)
+	if acpGrants != nil {
+		reqGrants := DetermineReqGrants(accountId, s3_constants.PermissionRead)
+		for _, requiredGrant := range reqGrants {
+			for _, grant := range acpGrants {
+				if GrantEquals(requiredGrant, grant) {
+					return http.StatusOK, true
+				}
+			}
+		}
+	}
+
+	glog.V(3).Infof("acl denied! request account id: %s", accountId)
+	return http.StatusForbidden, false
+}
+
+func GetAccountId(r *http.Request) string {
+	id := r.Header.Get(s3_constants.AmzAccountId)
+	if len(id) == 0 {
+		return s3account.AccountAnonymous.Id
+	} else {
+		return id
+	}
+}
+
+// ExtractAcl extracts the acl from the request body, or from the header if request body is empty
+func ExtractAcl(r *http.Request, accountManager *s3account.AccountManager, ownership, bucketOwnerId, ownerId, accountId string) (grants []*s3.Grant, errCode s3err.ErrorCode) {
+	if r.Body != nil && r.Body != http.NoBody {
+		defer util.CloseRequest(r)
+
+		var acp s3.AccessControlPolicy
+		err := xmlutil.UnmarshalXML(&acp, xml.NewDecoder(r.Body), "")
+		if err != nil {
+			return nil, s3err.ErrInvalidRequest
+		}
+
+		//owner should present && owner is immutable
+		if acp.Owner == nil || acp.Owner.ID == nil || *acp.Owner.ID != ownerId {
+			glog.V(3).Infof("set acl denied! owner account is not consistent, request account id: %s, expect account id: %s", accountId, ownerId)
+			return nil, s3err.ErrAccessDenied
+		}
+
+		return ValidateAndTransferGrants(accountManager, acp.Grants)
+	} else {
+		_, grants, errCode = ParseAndValidateAclHeaders(r, accountManager, ownership, bucketOwnerId, accountId, true)
+		return grants, errCode
+	}
+}
+
+func ParseAndValidateAclHeaders(r *http.Request, accountManager *s3account.AccountManager, ownership, bucketOwnerId, accountId string, putAcl bool) (ownerId string, grants []*s3.Grant, errCode s3err.ErrorCode) {
+	ownerId, grants, errCode = ParseAclHeaders(r, ownership, bucketOwnerId, accountId, putAcl)
+	if errCode != s3err.ErrNone {
+		return
+	}
+	grants, errCode = ValidateAndTransferGrants(accountManager, grants)
+	return
+}
+
+func ParseAclHeaders(r *http.Request, ownership, bucketOwnerId, accountId string, putAcl bool) (ownerId string, grants []*s3.Grant, errCode s3err.ErrorCode) {
+	// If request is not PutObjectAcl/PutBucketAcl, then, parse acl from header
+	if !putAcl {
+		errCode = ParseCustomAclHeaders(r, &grants)
+		if errCode != s3err.ErrNone {
+			return "", nil, errCode
+		}
+	}
+	if len(grants) > 0 {
+		return accountId, grants, s3err.ErrNone
+	}
+
+	cannedAcl := r.Header.Get(s3_constants.AmzCannedAcl)
+	if len(cannedAcl) == 0 {
+		//if no acl(both customAcl and cannedAcl) specified, grant object writer full control
+		grants = append(grants, &s3.Grant{
+			Grantee: &s3.Grantee{
+				Type: &s3_constants.GrantTypeCanonicalUser,
+				ID:   &accountId,
+			},
+			Permission: &s3_constants.PermissionFullControl,
+		})
+		return accountId, grants, s3err.ErrNone
+	}
+
+	//if canned acl specified, parse cannedAcl (lower priority to custom acl)
+	ownerId, grants, errCode = ParseCannedAclHeader(ownership, bucketOwnerId, accountId, cannedAcl, putAcl)
+	if errCode != s3err.ErrNone {
+		return "", nil, errCode
+	}
+	return ownerId, grants, errCode
+}
+
+func ParseCustomAclHeaders(r *http.Request, grants *[]*s3.Grant) s3err.ErrorCode {
+	customAclHeaders := []string{s3_constants.AmzAclFullControl, s3_constants.AmzAclRead, s3_constants.AmzAclReadAcp, s3_constants.AmzAclWrite, s3_constants.AmzAclWriteAcp}
+	var errCode s3err.ErrorCode
+	for _, customAclHeader := range customAclHeaders {
+		headerValue := r.Header.Get(customAclHeader)
+		switch customAclHeader {
+		case s3_constants.AmzAclRead:
+			errCode = ParseCustomAclHeader(headerValue, s3_constants.PermissionRead, grants)
+		case s3_constants.AmzAclWrite:
+			errCode = ParseCustomAclHeader(headerValue, s3_constants.PermissionWrite, grants)
+		case s3_constants.AmzAclReadAcp:
+			errCode = ParseCustomAclHeader(headerValue, s3_constants.PermissionReadAcp, grants)
+		case s3_constants.AmzAclWriteAcp:
+			errCode = ParseCustomAclHeader(headerValue, s3_constants.PermissionWriteAcp, grants)
+		case s3_constants.AmzAclFullControl:
+			errCode = ParseCustomAclHeader(headerValue, s3_constants.PermissionFullControl, grants)
+		}
+		if errCode != s3err.ErrNone {
+			return errCode
+		}
+	}
+	return s3err.ErrNone
+}
+
+func ParseCustomAclHeader(headerValue, permission string, grants *[]*s3.Grant) s3err.ErrorCode {
+	if len(headerValue) > 0 {
+		split := strings.Split(headerValue, ", ")
+		for _, grantStr := range split {
+			kv := strings.Split(grantStr, "=")
+			if len(kv) != 2 {
+				return s3err.ErrInvalidRequest
+			}
+
+			switch kv[0] {
+			case "id":
+				var accountId string
+				_ = json.Unmarshal([]byte(kv[1]), &accountId)
+				*grants = append(*grants, &s3.Grant{
+					Grantee: &s3.Grantee{
+						Type: &s3_constants.GrantTypeCanonicalUser,
+						ID:   &accountId,
+					},
+					Permission: &permission,
+				})
+			case "emailAddress":
+				var emailAddress string
+				_ = json.Unmarshal([]byte(kv[1]), &emailAddress)
+				*grants = append(*grants, &s3.Grant{
+					Grantee: &s3.Grantee{
+						Type:         &s3_constants.GrantTypeAmazonCustomerByEmail,
+						EmailAddress: &emailAddress,
+					},
+					Permission: &permission,
+				})
+			case "uri":
+				var groupName string
+				_ = json.Unmarshal([]byte(kv[1]), &groupName)
+				*grants = append(*grants, &s3.Grant{
+					Grantee: &s3.Grantee{
+						Type: &s3_constants.GrantTypeGroup,
+						URI:  &groupName,
+					},
+					Permission: &permission,
+				})
+			}
+		}
+	}
+	return s3err.ErrNone
+
+}
+
+func ParseCannedAclHeader(bucketOwnership, bucketOwnerId, accountId, cannedAcl string, putAcl bool) (ownerId string, grants []*s3.Grant, err s3err.ErrorCode) {
+	err = s3err.ErrNone
+	ownerId = accountId
+
+	//objectWrite automatically has full control on current object
+	objectWriterFullControl := &s3.Grant{
+		Grantee: &s3.Grantee{
+			ID:   &accountId,
+			Type: &s3_constants.GrantTypeCanonicalUser,
+		},
+		Permission: &s3_constants.PermissionFullControl,
+	}
+
+	switch cannedAcl {
+	case s3_constants.CannedAclPrivate:
+		grants = append(grants, objectWriterFullControl)
+	case s3_constants.CannedAclPublicRead:
+		grants = append(grants, objectWriterFullControl)
+		grants = append(grants, s3_constants.PublicRead...)
+	case s3_constants.CannedAclPublicReadWrite:
+		grants = append(grants, objectWriterFullControl)
+		grants = append(grants, s3_constants.PublicReadWrite...)
+	case s3_constants.CannedAclAuthenticatedRead:
+		grants = append(grants, objectWriterFullControl)
+		grants = append(grants, s3_constants.AuthenticatedRead...)
+	case s3_constants.CannedAclLogDeliveryWrite:
+		grants = append(grants, objectWriterFullControl)
+		grants = append(grants, s3_constants.LogDeliveryWrite...)
+	case s3_constants.CannedAclBucketOwnerRead:
+		grants = append(grants, objectWriterFullControl)
+		if bucketOwnerId != "" && bucketOwnerId != accountId {
+			grants = append(grants,
+				&s3.Grant{
+					Grantee: &s3.Grantee{
+						Type: &s3_constants.GrantTypeCanonicalUser,
+						ID:   &bucketOwnerId,
+					},
+					Permission: &s3_constants.PermissionRead,
+				})
+		}
+	case s3_constants.CannedAclBucketOwnerFullControl:
+		if bucketOwnerId != "" {
+			// if set ownership to 'BucketOwnerPreferred' when upload object, the bucket owner will be the object owner
+			if !putAcl && bucketOwnership == s3_constants.OwnershipBucketOwnerPreferred {
+				ownerId = bucketOwnerId
+				grants = append(grants,
+					&s3.Grant{
+						Grantee: &s3.Grantee{
+							Type: &s3_constants.GrantTypeCanonicalUser,
+							ID:   &bucketOwnerId,
+						},
+						Permission: &s3_constants.PermissionFullControl,
+					})
+			} else {
+				grants = append(grants, objectWriterFullControl)
+				if accountId != bucketOwnerId {
+					grants = append(grants,
+						&s3.Grant{
+							Grantee: &s3.Grantee{
+								Type: &s3_constants.GrantTypeCanonicalUser,
+								ID:   &bucketOwnerId,
+							},
+							Permission: &s3_constants.PermissionFullControl,
+						})
+				}
+			}
+		}
+	case s3_constants.CannedAclAwsExecRead:
+		err = s3err.ErrNotImplemented
+	default:
+		err = s3err.ErrNotImplemented
+	}
+	return
+}
+
+// ValidateAndTransferGrants validate grant & transfer Email-Grant to Id-Grant
+func ValidateAndTransferGrants(accountManager *s3account.AccountManager, grants []*s3.Grant) ([]*s3.Grant, s3err.ErrorCode) {
+	var result []*s3.Grant
+	for _, grant := range grants {
+		grantee := grant.Grantee
+		if grantee == nil || grantee.Type == nil {
+			glog.Warning("invalid grantee! grantee or granteeType is nil")
+			return nil, s3err.ErrInvalidRequest
+		}
+
+		switch *grantee.Type {
+		case s3_constants.GrantTypeGroup:
+			if grantee.URI == nil {
+				glog.Warning("invalid group grantee! group URI is nil")
+				return nil, s3err.ErrInvalidRequest
+			}
+			ok := s3_constants.ValidateGroup(*grantee.URI)
+			if !ok {
+				glog.Warningf("invalid group grantee! group name[%s] is not valid", *grantee.URI)
+				return nil, s3err.ErrInvalidRequest
+			}
+			result = append(result, grant)
+		case s3_constants.GrantTypeCanonicalUser:
+			if grantee.ID == nil {
+				glog.Warning("invalid canonical grantee! account id is nil")
+				return nil, s3err.ErrInvalidRequest
+			}
+			_, ok := accountManager.IdNameMapping[*grantee.ID]
+			if !ok {
+				glog.Warningf("invalid canonical grantee! account id[%s] is not exists", *grantee.ID)
+				return nil, s3err.ErrInvalidRequest
+			}
+			result = append(result, grant)
+		case s3_constants.GrantTypeAmazonCustomerByEmail:
+			if grantee.EmailAddress == nil {
+				glog.Warning("invalid email grantee! email address is nil")
+				return nil, s3err.ErrInvalidRequest
+			}
+			accountId, ok := accountManager.EmailIdMapping[*grantee.EmailAddress]
+			if !ok {
+				glog.Warningf("invalid email grantee! email address[%s] is not exists", *grantee.EmailAddress)
+				return nil, s3err.ErrInvalidRequest
+			}
+			result = append(result, &s3.Grant{
+				Grantee: &s3.Grantee{
+					Type: &s3_constants.GrantTypeCanonicalUser,
+					ID:   &accountId,
+				},
+				Permission: grant.Permission,
+			})
+		default:
+			return nil, s3err.ErrInvalidRequest
+		}
+	}
+	return result, s3err.ErrNone
+}
+
+//Calculate the ACL permission set (Grants) according to accountId and reqPermission.
+//As long as the current account complies with any of these Grants,
+//the request will be admitted.
+func DetermineReqGrants(accountId, aclAction string) (grants []*s3.Grant) {
+	// group grantee (AllUsers)
+	grants = append(grants, &s3.Grant{
+		Grantee: &s3.Grantee{
+			Type: &s3_constants.GrantTypeGroup,
+			URI:  &s3_constants.GranteeGroupAllUsers,
+		},
+		Permission: &aclAction,
+	})
+	grants = append(grants, &s3.Grant{
+		Grantee: &s3.Grantee{
+			Type: &s3_constants.GrantTypeGroup,
+			URI:  &s3_constants.GranteeGroupAllUsers,
+		},
+		Permission: &s3_constants.PermissionFullControl,
+	})
+
+	// canonical grantee (accountId)
+	grants = append(grants, &s3.Grant{
+		Grantee: &s3.Grantee{
+			Type: &s3_constants.GrantTypeCanonicalUser,
+			ID:   &accountId,
+		},
+		Permission: &aclAction,
+	})
+	grants = append(grants, &s3.Grant{
+		Grantee: &s3.Grantee{
+			Type: &s3_constants.GrantTypeCanonicalUser,
+			ID:   &accountId,
+		},
+		Permission: &s3_constants.PermissionFullControl,
+	})
+
+	// group grantee (AuthenticateUsers)
+	if accountId != s3account.AccountAnonymous.Id {
+		grants = append(grants, &s3.Grant{
+			Grantee: &s3.Grantee{
+				Type: &s3_constants.GrantTypeGroup,
+				URI:  &s3_constants.GranteeGroupAuthenticatedUsers,
+			},
+			Permission: &aclAction,
+		})
+		grants = append(grants, &s3.Grant{
+			Grantee: &s3.Grantee{
+				Type: &s3_constants.GrantTypeGroup,
+				URI:  &s3_constants.GranteeGroupAuthenticatedUsers,
+			},
+			Permission: &s3_constants.PermissionFullControl,
+		})
+	}
+	return
+}
+
+func SetAcpOwnerHeader(r *http.Request, acpOwnerId string) {
+	r.Header.Set(s3_constants.ExtAmzOwnerKey, acpOwnerId)
+}
+
+func GetAcpOwner(entryExtended map[string][]byte, defaultOwner string) string {
+	ownerIdBytes, ok := entryExtended[s3_constants.ExtAmzOwnerKey]
+	if ok {
+		return string(ownerIdBytes)
+	}
+	return defaultOwner
+}
+
+func SetAcpGrantsHeader(r *http.Request, acpGrants []*s3.Grant) {
+	if len(acpGrants) > 0 {
+		a, err := json.Marshal(acpGrants)
+		if err == nil {
+			r.Header.Set(s3_constants.ExtAmzAclKey, string(a))
+		} else {
+			glog.Warning("Marshal acp grants err", err)
+		}
+	}
+}
+
+func GetAcpGrants(entryExtended map[string][]byte) []*s3.Grant {
+	acpBytes, ok := entryExtended[s3_constants.ExtAmzAclKey]
+	if ok {
+		var grants []*s3.Grant
+		err := json.Unmarshal(acpBytes, &grants)
+		if err == nil {
+			return grants
+		}
+	}
+	return nil
+}
+
+func AssembleEntryWithAcp(objectEntry *filer_pb.Entry, objectOwner string, grants []*s3.Grant) s3err.ErrorCode {
+	objectEntry.Extended[s3_constants.ExtAmzOwnerKey] = []byte(objectOwner)
+	grantsBytes, err := json.Marshal(grants)
+	if err != nil {
+		glog.Warning("assemble acp to entry:", err)
+		return s3err.ErrInvalidRequest
+	}
+	objectEntry.Extended[s3_constants.ExtAmzAclKey] = grantsBytes
+	return s3err.ErrNone
+}
+
+// GrantEquals Compare whether two Grants are equal in meaning, not completely
+// equal (compare Grantee.Type and the corresponding Value for equality, other
+// fields of Grantee are ignored)
+func GrantEquals(a, b *s3.Grant) bool {
+	// grant
+	if a == b {
+		return true
+	}
+
+	if a == nil || b == nil {
+		return false
+	}
+
+	// grant.Permission
+	if a.Permission != b.Permission {
+		if a.Permission == nil || b.Permission == nil {
+			return false
+		}
+
+		if *a.Permission != *b.Permission {
+			return false
+		}
+	}
+
+	// grant.Grantee
+	ag := a.Grantee
+	bg := b.Grantee
+	if ag != bg {
+		if ag == nil || bg == nil {
+			return false
+		}
+		// grantee.Type
+		if ag.Type != bg.Type {
+			if ag.Type == nil || bg.Type == nil {
+				return false
+			}
+			if *ag.Type != *bg.Type {
+				return false
+			}
+		}
+		// value corresponding to granteeType
+		if ag.Type != nil {
+			switch *ag.Type {
+			case s3_constants.GrantTypeGroup:
+				if ag.URI != bg.URI {
+					if ag.URI == nil || bg.URI == nil {
+						return false
+					}
+
+					if *ag.URI != *bg.URI {
+						return false
+					}
+				}
+			case s3_constants.GrantTypeCanonicalUser:
+				if ag.ID != bg.ID {
+					if ag.ID == nil || bg.ID == nil {
+						return false
+					}
+
+					if *ag.ID != *bg.ID {
+						return false
+					}
+				}
+			case s3_constants.GrantTypeAmazonCustomerByEmail:
+				if ag.EmailAddress != bg.EmailAddress {
+					if ag.EmailAddress == nil || bg.EmailAddress == nil {
+						return false
+					}
+
+					if *ag.EmailAddress != *bg.EmailAddress {
+						return false
+					}
+				}
+			}
+		}
+	}
+	return true
+}

--- a/weed/s3api/s3acl/acl_test.go
+++ b/weed/s3api/s3acl/acl_test.go
@@ -1,0 +1,220 @@
+package s3acl
+
+import (
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3account"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
+	"testing"
+)
+
+func TestParseAclHeaders(t *testing.T) {
+	accountManager := &s3account.AccountManager{
+		IdNameMapping: map[string]string{
+			s3account.AccountAdmin.Id:     s3account.AccountAdmin.Name,
+			s3account.AccountAnonymous.Id: s3account.AccountAnonymous.Name,
+		},
+		EmailIdMapping: map[string]string{
+			s3account.AccountAdmin.EmailAddress:     s3account.AccountAdmin.Id,
+			s3account.AccountAnonymous.EmailAddress: s3account.AccountAnonymous.Id,
+		},
+	}
+
+	//good value
+	grants := make([]*s3.Grant, 0)
+	validHeaderValue := `uri="http://acs.amazonaws.com/groups/global/AllUsers", id="anonymous", emailAddress="admin@example.com"`
+	errCode := ParseCustomAclHeader(validHeaderValue, s3_constants.PermissionFullControl, &grants)
+	if errCode != s3err.ErrNone {
+		t.Fatal(errCode)
+	}
+	_, errCode = ValidateAndTransferGrants(accountManager, grants)
+	if errCode != s3err.ErrNone {
+		t.Fatal(errCode)
+	}
+
+	//bad case: acl header format error
+	grants = make([]*s3.Grant, 0)
+	formatErrCase := `uri, id="anonymous", emailAddress="admin@example.com"`
+	errCode = ParseCustomAclHeader(formatErrCase, s3_constants.PermissionFullControl, &grants)
+	if errCode != s3err.ErrInvalidRequest {
+		t.Fatal(errCode)
+	}
+
+	//bad case: email not exists
+	grants = make([]*s3.Grant, 0)
+	badCaseOfEmail := `uri="http://acs.amazonaws.com/groups/global/AllUsers", id="anonymous", emailAddress="admin@example1.com"`
+	errCode = ParseCustomAclHeader(badCaseOfEmail, s3_constants.PermissionFullControl, &grants)
+	if errCode != s3err.ErrNone {
+		t.Fatal(errCode)
+	}
+	_, errCode = ValidateAndTransferGrants(accountManager, grants)
+	if errCode != s3err.ErrInvalidRequest {
+		t.Fatal(errCode)
+	}
+
+	//bad case: account id not exists
+	grants = make([]*s3.Grant, 0)
+	badCaseOfAccountId := "uri=\"http://acs.amazonaws.com/groups/global/AllUsers\", id=\"xxxxxx\", emailAddress=\"admin@example.com\""
+	errCode = ParseCustomAclHeader(badCaseOfAccountId, s3_constants.PermissionFullControl, &grants)
+	if errCode != s3err.ErrNone {
+		t.Fatal(errCode)
+	}
+	_, errCode = ValidateAndTransferGrants(accountManager, grants)
+	if errCode != s3err.ErrInvalidRequest {
+		t.Fatal(errCode)
+	}
+
+	//bad case: group url not valid
+	grants = make([]*s3.Grant, 0)
+	badCaseOfURL := "uri=\"http://acs.amazonaws.com/groups/global/AllUsers111xxxx\", id=\"anonymous\", emailAddress=\"admin@example.com\""
+	errCode = ParseCustomAclHeader(badCaseOfURL, s3_constants.PermissionFullControl, &grants)
+	if errCode != s3err.ErrNone {
+		t.Fatal(errCode)
+	}
+	_, errCode = ValidateAndTransferGrants(accountManager, grants)
+	if errCode != s3err.ErrInvalidRequest {
+		t.Fatal(errCode)
+	}
+}
+
+func TestGrantEquals(t *testing.T) {
+	testCases := map[bool]bool{
+		GrantEquals(nil, nil): true,
+
+		GrantEquals(&s3.Grant{}, nil): false,
+
+		GrantEquals(&s3.Grant{}, &s3.Grant{}): true,
+
+		GrantEquals(&s3.Grant{
+			Permission: &s3_constants.PermissionRead,
+		}, &s3.Grant{}): false,
+
+		GrantEquals(&s3.Grant{
+			Permission: &s3_constants.PermissionRead,
+		}, &s3.Grant{
+			Permission: &s3_constants.PermissionRead,
+		}): true,
+
+		GrantEquals(&s3.Grant{
+			Permission: &s3_constants.PermissionRead,
+			Grantee:    &s3.Grantee{},
+		}, &s3.Grant{
+			Permission: &s3_constants.PermissionRead,
+			Grantee:    &s3.Grantee{},
+		}): true,
+
+		GrantEquals(&s3.Grant{
+			Permission: &s3_constants.PermissionRead,
+			Grantee: &s3.Grantee{
+				Type: &s3_constants.GrantTypeGroup,
+			},
+		}, &s3.Grant{
+			Permission: &s3_constants.PermissionRead,
+			Grantee:    &s3.Grantee{},
+		}): false,
+
+		//type not present, compare other fields of grant is meaningless
+		GrantEquals(&s3.Grant{
+			Permission: &s3_constants.PermissionRead,
+			Grantee: &s3.Grantee{
+				ID:           &s3account.AccountAdmin.Id,
+				EmailAddress: &s3account.AccountAdmin.EmailAddress,
+			},
+		}, &s3.Grant{
+			Permission: &s3_constants.PermissionRead,
+			Grantee: &s3.Grantee{
+				ID: &s3account.AccountAdmin.Id,
+			},
+		}): true,
+
+		GrantEquals(&s3.Grant{
+			Permission: &s3_constants.PermissionRead,
+			Grantee: &s3.Grantee{
+				Type: &s3_constants.GrantTypeGroup,
+			},
+		}, &s3.Grant{
+			Permission: &s3_constants.PermissionRead,
+			Grantee: &s3.Grantee{
+				Type: &s3_constants.GrantTypeGroup,
+			},
+		}): true,
+
+		GrantEquals(&s3.Grant{
+			Permission: &s3_constants.PermissionRead,
+			Grantee: &s3.Grantee{
+				Type: &s3_constants.GrantTypeGroup,
+				URI:  &s3_constants.GranteeGroupAllUsers,
+			},
+		}, &s3.Grant{
+			Permission: &s3_constants.PermissionRead,
+			Grantee: &s3.Grantee{
+				Type: &s3_constants.GrantTypeGroup,
+				URI:  &s3_constants.GranteeGroupAllUsers,
+			},
+		}): true,
+
+		GrantEquals(&s3.Grant{
+			Permission: &s3_constants.PermissionWrite,
+			Grantee: &s3.Grantee{
+				Type: &s3_constants.GrantTypeGroup,
+				URI:  &s3_constants.GranteeGroupAllUsers,
+			},
+		}, &s3.Grant{
+			Permission: &s3_constants.PermissionRead,
+			Grantee: &s3.Grantee{
+				Type: &s3_constants.GrantTypeGroup,
+				URI:  &s3_constants.GranteeGroupAllUsers,
+			},
+		}): false,
+
+		GrantEquals(&s3.Grant{
+			Permission: &s3_constants.PermissionRead,
+			Grantee: &s3.Grantee{
+				Type: &s3_constants.GrantTypeGroup,
+				ID:   &s3account.AccountAdmin.Id,
+			},
+		}, &s3.Grant{
+			Permission: &s3_constants.PermissionRead,
+			Grantee: &s3.Grantee{
+				Type: &s3_constants.GrantTypeGroup,
+				ID:   &s3account.AccountAdmin.Id,
+			},
+		}): true,
+
+		GrantEquals(&s3.Grant{
+			Permission: &s3_constants.PermissionRead,
+			Grantee: &s3.Grantee{
+				Type: &s3_constants.GrantTypeGroup,
+				ID:   &s3account.AccountAdmin.Id,
+				URI:  &s3_constants.GranteeGroupAllUsers,
+			},
+		}, &s3.Grant{
+			Permission: &s3_constants.PermissionRead,
+			Grantee: &s3.Grantee{
+				Type: &s3_constants.GrantTypeGroup,
+				ID:   &s3account.AccountAdmin.Id,
+			},
+		}): false,
+
+		GrantEquals(&s3.Grant{
+			Permission: &s3_constants.PermissionRead,
+			Grantee: &s3.Grantee{
+				Type: &s3_constants.GrantTypeGroup,
+				ID:   &s3account.AccountAdmin.Id,
+				URI:  &s3_constants.GranteeGroupAllUsers,
+			},
+		}, &s3.Grant{
+			Permission: &s3_constants.PermissionRead,
+			Grantee: &s3.Grantee{
+				Type: &s3_constants.GrantTypeGroup,
+				URI:  &s3_constants.GranteeGroupAllUsers,
+			},
+		}): true,
+	}
+
+	for tc, expect := range testCases {
+		if tc != expect {
+			t.Fatal("TestGrantEquals not expect!")
+		}
+	}
+}

--- a/weed/s3api/s3api_acp.go
+++ b/weed/s3api/s3api_acp.go
@@ -1,28 +1,328 @@
 package s3api
 
 import (
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/seaweedfs/seaweedfs/weed/glog"
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3account"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3acl"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
+	"github.com/seaweedfs/seaweedfs/weed/util"
 	"net/http"
 )
 
-func getAccountId(r *http.Request) string {
-	id := r.Header.Get(s3_constants.AmzAccountId)
-	if len(id) == 0 {
-		return AccountAnonymous.Id
-	} else {
-		return id
-	}
-}
-
 func (s3a *S3ApiServer) checkAccessByOwnership(r *http.Request, bucket string) s3err.ErrorCode {
-	metadata, errCode := s3a.bucketRegistry.GetBucketMetadata(bucket)
+	bucketMetadata, errCode := s3a.bucketRegistry.GetBucketMetadata(bucket)
 	if errCode != s3err.ErrNone {
 		return errCode
 	}
-	accountId := getAccountId(r)
-	if accountId == AccountAdmin.Id || accountId == *metadata.Owner.ID {
+	accountId := s3acl.GetAccountId(r)
+	if accountId == s3account.AccountAdmin.Id || accountId == *bucketMetadata.Owner.ID {
 		return s3err.ErrNone
 	}
+	glog.V(3).Infof("acl denied! request account id: %s, expect account id: %s", accountId, *bucketMetadata.Owner.ID)
 	return s3err.ErrAccessDenied
+}
+
+func (s3a *S3ApiServer) checkAccessForPutBucketAcl(accountId, bucket string) (*BucketMetaData, s3err.ErrorCode) {
+	bucketMetadata, errCode := s3a.bucketRegistry.GetBucketMetadata(bucket)
+	if errCode != s3err.ErrNone {
+		return nil, errCode
+	}
+
+	if bucketMetadata.ObjectOwnership == s3_constants.OwnershipBucketOwnerEnforced {
+		return nil, s3err.AccessControlListNotSupported
+	}
+
+	if accountId == s3account.AccountAdmin.Id || accountId == *bucketMetadata.Owner.ID {
+		return bucketMetadata, s3err.ErrNone
+	}
+
+	if len(bucketMetadata.Acl) > 0 {
+		reqGrants := s3acl.DetermineReqGrants(accountId, s3_constants.PermissionWriteAcp)
+		for _, bucketGrant := range bucketMetadata.Acl {
+			for _, reqGrant := range reqGrants {
+				if s3acl.GrantEquals(bucketGrant, reqGrant) {
+					return bucketMetadata, s3err.ErrNone
+				}
+			}
+		}
+	}
+	glog.V(3).Infof("acl denied! request account id: %s", accountId)
+	return nil, s3err.ErrAccessDenied
+}
+
+// Check Bucket/BucketAcl Read related access
+// includes:
+// - HeadBucketHandler
+// - GetBucketAclHandler
+// - ListObjectsV1Handler
+// - ListObjectsV2Handler
+func (s3a *S3ApiServer) checkAccessForReadBucket(r *http.Request, bucket, aclAction string) (*BucketMetaData, s3err.ErrorCode) {
+	bucketMetadata, errCode := s3a.bucketRegistry.GetBucketMetadata(bucket)
+	if errCode != s3err.ErrNone {
+		return nil, errCode
+	}
+
+	if bucketMetadata.ObjectOwnership == s3_constants.OwnershipBucketOwnerEnforced {
+		return bucketMetadata, s3err.ErrNone
+	}
+
+	accountId := s3acl.GetAccountId(r)
+	if accountId == s3account.AccountAdmin.Id || accountId == *bucketMetadata.Owner.ID {
+		return bucketMetadata, s3err.ErrNone
+	}
+
+	if len(bucketMetadata.Acl) > 0 {
+		reqGrants := s3acl.DetermineReqGrants(accountId, aclAction)
+		for _, bucketGrant := range bucketMetadata.Acl {
+			for _, reqGrant := range reqGrants {
+				if s3acl.GrantEquals(bucketGrant, reqGrant) {
+					return bucketMetadata, s3err.ErrNone
+				}
+			}
+		}
+	}
+
+	glog.V(3).Infof("acl denied! request account id: %s", accountId)
+	return nil, s3err.ErrAccessDenied
+}
+
+// Check Object-Write related access
+// includes:
+// - PutObjectHandler
+// - PutObjectPartHandler
+func (s3a *S3ApiServer) checkAccessForWriteObject(r *http.Request, bucket, object string) s3err.ErrorCode {
+	bucketMetadata, errCode := s3a.bucketRegistry.GetBucketMetadata(bucket)
+	if errCode != s3err.ErrNone {
+		return errCode
+	}
+
+	accountId := s3acl.GetAccountId(r)
+	if bucketMetadata.ObjectOwnership == s3_constants.OwnershipBucketOwnerEnforced {
+		s3acl.SetAcpOwnerHeader(r, accountId)
+		return s3err.ErrNone
+	}
+
+	//bucket access allowed
+	bucketAclAllowed := false
+	if accountId == *bucketMetadata.Owner.ID {
+		bucketAclAllowed = true
+	} else {
+		if len(bucketMetadata.Acl) > 0 {
+			reqGrants := s3acl.DetermineReqGrants(accountId, s3_constants.PermissionWrite)
+		bucketLoop:
+			for _, bucketGrant := range bucketMetadata.Acl {
+				for _, requiredGrant := range reqGrants {
+					if s3acl.GrantEquals(bucketGrant, requiredGrant) {
+						bucketAclAllowed = true
+						break bucketLoop
+					}
+				}
+			}
+		}
+	}
+	if !bucketAclAllowed {
+		glog.V(3).Infof("acl denied! request account id: %s", accountId)
+		return s3err.ErrAccessDenied
+	}
+
+	//object access allowed
+	entry, err := getObjectEntry(s3a, bucket, object)
+	if err != nil {
+		if err != filer_pb.ErrNotFound {
+			return s3err.ErrInternalError
+		}
+	} else {
+		if entry.IsDirectory {
+			return s3err.ErrExistingObjectIsDirectory
+		}
+
+		//Only the owner of the bucket and the owner of the object can overwrite the object
+		objectOwner := s3acl.GetAcpOwner(entry.Extended, *bucketMetadata.Owner.ID)
+		if accountId != objectOwner && accountId != *bucketMetadata.Owner.ID {
+			glog.V(3).Infof("acl denied! request account id: %s, expect account id: %s", accountId, *bucketMetadata.Owner.ID)
+			return s3err.ErrAccessDenied
+		}
+	}
+
+	ownerId, grants, errCode := s3acl.ParseAndValidateAclHeaders(r, s3a.accountManager, bucketMetadata.ObjectOwnership, *bucketMetadata.Owner.ID, accountId, false)
+	if errCode != s3err.ErrNone {
+		return errCode
+	}
+
+	s3acl.SetAcpOwnerHeader(r, ownerId)
+	s3acl.SetAcpGrantsHeader(r, grants)
+
+	return s3err.ErrNone
+}
+
+// Check ObjectAcl-Write related access
+// includes:
+// - PutObjectAclHandler
+func (s3a *S3ApiServer) checkAccessForWriteObjectAcl(accountId, bucket, object string) (bucketMetadata *BucketMetaData, objectEntry *filer_pb.Entry, objectOwner string, errCode s3err.ErrorCode) {
+	bucketMetadata, errCode = s3a.bucketRegistry.GetBucketMetadata(bucket)
+	if errCode != s3err.ErrNone {
+		return nil, nil, "", errCode
+	}
+
+	if bucketMetadata.ObjectOwnership == s3_constants.OwnershipBucketOwnerEnforced {
+		return nil, nil, "", s3err.AccessControlListNotSupported
+	}
+
+	//bucket acl
+	bucketAclAllowed := false
+	reqGrants := s3acl.DetermineReqGrants(accountId, s3_constants.PermissionWrite)
+	if accountId != *bucketMetadata.Owner.ID {
+		if bucketMetadata.Acl != nil {
+		bucketLoop:
+			for _, bucketGrant := range bucketMetadata.Acl {
+				for _, requiredGrant := range reqGrants {
+					if s3acl.GrantEquals(bucketGrant, requiredGrant) {
+						bucketAclAllowed = true
+						break bucketLoop
+					}
+				}
+			}
+		}
+	}
+	if !bucketAclAllowed {
+		return nil, nil, "", s3err.ErrAccessDenied
+	}
+
+	//object acl
+	objectEntry, err := getObjectEntry(s3a, bucket, object)
+	if err != nil {
+		if err == filer_pb.ErrNotFound {
+			return nil, nil, "", s3err.ErrNoSuchKey
+		}
+		return nil, nil, "", s3err.ErrInternalError
+	}
+
+	if objectEntry.IsDirectory {
+		return nil, nil, "", s3err.ErrExistingObjectIsDirectory
+	}
+
+	objectOwner = s3acl.GetAcpOwner(objectEntry.Extended, *bucketMetadata.Owner.ID)
+	if accountId == objectOwner {
+		return bucketMetadata, objectEntry, objectOwner, s3err.ErrNone
+	}
+
+	objectGrants := s3acl.GetAcpGrants(objectEntry.Extended)
+	if objectGrants != nil {
+		for _, objectGrant := range objectGrants {
+			for _, requiredGrant := range reqGrants {
+				if s3acl.GrantEquals(objectGrant, requiredGrant) {
+					return bucketMetadata, objectEntry, objectOwner, s3err.ErrNone
+				}
+			}
+		}
+	}
+
+	glog.V(3).Infof("acl denied! request account id: %s", accountId)
+	return nil, nil, "", s3err.ErrAccessDenied
+}
+
+// Check Object-Read related access
+// includes:
+// - GetObjectHandler
+//
+// offload object access validation to Filer layer
+// - s3acl.CheckObjectAccessForReadObject
+func (s3a *S3ApiServer) checkBucketAccessForReadObject(r *http.Request, bucket, object string) s3err.ErrorCode {
+	bucketMetadata, errCode := s3a.bucketRegistry.GetBucketMetadata(bucket)
+	if errCode != s3err.ErrNone {
+		return errCode
+	}
+
+	if bucketMetadata.ObjectOwnership != s3_constants.OwnershipBucketOwnerEnforced {
+		//offload object acl validation to filer layer
+		r.Header.Set(s3_constants.X_SeaweedFS_Header_Amz_Bucket_Owner_Id, *bucketMetadata.Owner.ID)
+	}
+
+	return s3err.ErrNone
+}
+
+//Check ObjectAcl-Read related access
+// includes:
+// - GetObjectAclHandler
+func (s3a *S3ApiServer) checkAccessForReadObjectAcl(r *http.Request, bucket, object string) (acp *s3.AccessControlPolicy, errCode s3err.ErrorCode) {
+	bucketMetadata, errCode := s3a.bucketRegistry.GetBucketMetadata(bucket)
+	if errCode != s3err.ErrNone {
+		return nil, errCode
+	}
+
+	getAcpFunc := func() (*s3.AccessControlPolicy, s3err.ErrorCode) {
+		entry, err := getObjectEntry(s3a, bucket, object)
+		if err != nil {
+			if err == filer_pb.ErrNotFound {
+				return nil, s3err.ErrNoSuchKey
+			} else {
+				return nil, s3err.ErrInternalError
+			}
+		}
+
+		if entry.IsDirectory {
+			return nil, s3err.ErrExistingObjectIsDirectory
+		}
+
+		acpOwnerId := s3acl.GetAcpOwner(entry.Extended, *bucketMetadata.Owner.ID)
+		acpOwnerName := s3a.accountManager.IdNameMapping[acpOwnerId]
+		acpGrants := s3acl.GetAcpGrants(entry.Extended)
+		acp = &s3.AccessControlPolicy{
+			Owner: &s3.Owner{
+				ID:          &acpOwnerId,
+				DisplayName: &acpOwnerName,
+			},
+			Grants: acpGrants,
+		}
+		return acp, s3err.ErrNone
+	}
+
+	if bucketMetadata.ObjectOwnership == s3_constants.OwnershipBucketOwnerEnforced {
+		return getAcpFunc()
+	} else {
+		accountId := s3acl.GetAccountId(r)
+
+		acp, errCode := getAcpFunc()
+		if errCode != s3err.ErrNone {
+			return nil, errCode
+		}
+
+		if accountId == *acp.Owner.ID {
+			return acp, s3err.ErrNone
+		}
+
+		//find in Grants
+		if acp.Grants != nil {
+			reqGrants := s3acl.DetermineReqGrants(accountId, s3_constants.PermissionReadAcp)
+			for _, requiredGrant := range reqGrants {
+				for _, grant := range acp.Grants {
+					if s3acl.GrantEquals(requiredGrant, grant) {
+						return acp, s3err.ErrNone
+					}
+				}
+			}
+		}
+
+		glog.V(3).Infof("acl denied! request account id: %s", accountId)
+		return nil, s3err.ErrAccessDenied
+	}
+}
+
+func getObjectEntry(s3a *S3ApiServer, bucket, object string) (*filer_pb.Entry, error) {
+	return s3a.getEntry(util.Join(s3a.option.BucketsPath, bucket), object)
+}
+
+func getBucketEntry(s3a *S3ApiServer, bucket *string) (*filer_pb.Entry, error) {
+	return s3a.getEntry(s3a.option.BucketsPath, *bucket)
+}
+
+func updateObjectEntry(s3a *S3ApiServer, bucket string, entry *filer_pb.Entry) error {
+	return s3a.updateEntry(util.Join(s3a.option.BucketsPath, bucket), entry)
+}
+
+func updateBucketEntry(s3a *S3ApiServer, entry *filer_pb.Entry) error {
+	return s3a.updateEntry(s3a.option.BucketsPath, entry)
 }

--- a/weed/s3api/s3api_bucket_skip_handlers.go
+++ b/weed/s3api/s3api_bucket_skip_handlers.go
@@ -41,9 +41,3 @@ func (s3a *S3ApiServer) PutBucketPolicyHandler(w http.ResponseWriter, r *http.Re
 func (s3a *S3ApiServer) DeleteBucketPolicyHandler(w http.ResponseWriter, r *http.Request) {
 	s3err.WriteErrorResponse(w, r, http.StatusNoContent)
 }
-
-// PutBucketAclHandler Put bucket ACL
-// https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketAcl.html
-func (s3a *S3ApiServer) PutBucketAclHandler(w http.ResponseWriter, r *http.Request) {
-	s3err.WriteErrorResponse(w, r, s3err.ErrNotImplemented)
-}

--- a/weed/s3api/s3api_object_skip_handlers.go
+++ b/weed/s3api/s3api_object_skip_handlers.go
@@ -4,22 +4,6 @@ import (
 	"net/http"
 )
 
-// GetObjectAclHandler Put object ACL
-// https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAcl.html
-func (s3a *S3ApiServer) GetObjectAclHandler(w http.ResponseWriter, r *http.Request) {
-
-	w.WriteHeader(http.StatusNoContent)
-
-}
-
-// PutObjectAclHandler Put object ACL
-// https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectAcl.html
-func (s3a *S3ApiServer) PutObjectAclHandler(w http.ResponseWriter, r *http.Request) {
-
-	w.WriteHeader(http.StatusNoContent)
-
-}
-
 // PutObjectRetentionHandler Put object Retention
 // https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectRetention.html
 func (s3a *S3ApiServer) PutObjectRetentionHandler(w http.ResponseWriter, r *http.Request) {

--- a/weed/s3api/s3api_objects_list_handlers.go
+++ b/weed/s3api/s3api_objects_list_handlers.go
@@ -41,6 +41,12 @@ func (s3a *S3ApiServer) ListObjectsV2Handler(w http.ResponseWriter, r *http.Requ
 	bucket, _ := s3_constants.GetBucketAndObject(r)
 	glog.V(3).Infof("ListObjectsV2Handler %s", bucket)
 
+	_, errCode := s3a.checkAccessForReadBucket(r, bucket, s3_constants.PermissionRead)
+	if errCode != s3err.ErrNone {
+		s3err.WriteErrorResponse(w, r, errCode)
+		return
+	}
+
 	originalPrefix, continuationToken, startAfter, delimiter, _, maxKeys := getListObjectsV2Args(r.URL.Query())
 
 	if maxKeys < 0 {
@@ -96,6 +102,12 @@ func (s3a *S3ApiServer) ListObjectsV1Handler(w http.ResponseWriter, r *http.Requ
 	// collect parameters
 	bucket, _ := s3_constants.GetBucketAndObject(r)
 	glog.V(3).Infof("ListObjectsV1Handler %s", bucket)
+
+	_, errCode := s3a.checkAccessForReadBucket(r, bucket, s3_constants.PermissionRead)
+	if errCode != s3err.ErrNone {
+		s3err.WriteErrorResponse(w, r, errCode)
+		return
+	}
 
 	originalPrefix, marker, delimiter, maxKeys := getListObjectsV1Args(r.URL.Query())
 

--- a/weed/s3api/s3api_server.go
+++ b/weed/s3api/s3api_server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/pb/s3_pb"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3account"
 	"net"
 	"net/http"
 	"strings"
@@ -40,7 +41,7 @@ type S3ApiServer struct {
 	randomClientId int32
 	filerGuard     *security.Guard
 	client         *http.Client
-	accountManager *AccountManager
+	accountManager *s3account.AccountManager
 	bucketRegistry *BucketRegistry
 }
 
@@ -61,7 +62,7 @@ func NewS3ApiServer(router *mux.Router, option *S3ApiServerOption) (s3ApiServer 
 		filerGuard:     security.NewGuard([]string{}, signingKey, expiresAfterSec, readSigningKey, readExpiresAfterSec),
 		cb:             NewCircuitBreaker(option),
 	}
-	s3ApiServer.accountManager = NewAccountManager(s3ApiServer)
+	s3ApiServer.accountManager = s3account.NewAccountManager()
 	s3ApiServer.bucketRegistry = NewBucketRegistry(s3ApiServer)
 	if option.LocalFilerSocket == "" {
 		s3ApiServer.client = &http.Client{Transport: &http.Transport{

--- a/weed/s3api/s3err/s3api_errors.go
+++ b/weed/s3api/s3err/s3api_errors.go
@@ -109,6 +109,8 @@ const (
 	ErrRequestBytesExceed
 
 	OwnershipControlsNotFoundError
+	ErrAclInvalid
+	AccessControlListNotSupported
 )
 
 // error code to APIError structure, these fields carry respective
@@ -416,11 +418,20 @@ var errorCodeResponse = map[ErrorCode]APIError{
 		Description:    "Simultaneous request bytes exceed limitations",
 		HTTPStatusCode: http.StatusTooManyRequests,
 	},
-
 	OwnershipControlsNotFoundError: {
 		Code:           "OwnershipControlsNotFoundError",
 		Description:    "The bucket ownership controls were not found",
 		HTTPStatusCode: http.StatusNotFound,
+	},
+	ErrAclInvalid: {
+		Code:           "InvalidAccessControlPolicy",
+		Description:    "CannedAcl or CustomAcl is required",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	AccessControlListNotSupported: {
+		Code:           "AccessControlListNotSupported",
+		Description:    "The bucket does not allow ACLs",
+		HTTPStatusCode: http.StatusBadRequest,
 	},
 }
 

--- a/weed/server/filer_server_handlers_write_autochunk.go
+++ b/weed/server/filer_server_handlers_write_autochunk.go
@@ -375,10 +375,16 @@ func SaveAmzMetaData(r *http.Request, existing map[string][]byte, isReplace bool
 		}
 	}
 
-	//acp
-	acp := r.Header.Get(s3_constants.ExtAcpKey)
-	if len(acp) > 0 {
-		metadata[s3_constants.ExtAcpKey] = []byte(acp)
+	//acp-owner
+	acpOwner := r.Header.Get(s3_constants.ExtAmzOwnerKey)
+	if len(acpOwner) > 0 {
+		metadata[s3_constants.ExtAmzOwnerKey] = []byte(acpOwner)
+	}
+
+	//acp-grants
+	acpGrants := r.Header.Get(s3_constants.ExtAmzAclKey)
+	if len(acpOwner) > 0 {
+		metadata[s3_constants.ExtAmzAclKey] = []byte(acpGrants)
 	}
 
 	return

--- a/weed/shell/command_s3_configure.go
+++ b/weed/shell/command_s3_configure.go
@@ -38,6 +38,7 @@ func (c *commandS3Configure) Do(args []string, commandEnv *CommandEnv, writer io
 	s3ConfigureCommand := flag.NewFlagSet(c.Name(), flag.ContinueOnError)
 	actions := s3ConfigureCommand.String("actions", "", "comma separated actions names: Read,Write,List,Tagging,Admin")
 	user := s3ConfigureCommand.String("user", "", "user name")
+	accountId := s3ConfigureCommand.String("accountId", "", "account id")
 	buckets := s3ConfigureCommand.String("buckets", "", "bucket name")
 	accessKey := s3ConfigureCommand.String("access_key", "", "specify the access key")
 	secretKey := s3ConfigureCommand.String("secret_key", "", "specify the secret key")
@@ -149,6 +150,9 @@ func (c *commandS3Configure) Do(args []string, commandEnv *CommandEnv, writer io
 						SecretKey: *secretKey,
 					})
 				}
+			}
+			if *accountId != "" {
+				s3cfg.Identities[idx].AccountId = *accountId
 			}
 		}
 	} else if *user != "" && *actions != "" {


### PR DESCRIPTION
# What problem are we solving?

add s3 acl support
[## Access control list (ACL) overview](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html)

The permissions related to acl and the apis involved are as follows:
<img width="1000" alt="image" src="https://user-images.githubusercontent.com/48707349/193850558-02df4c1a-1f1d-4448-a5ff-3d74b8f7cd8e.png">

# How are we solving the problem?

Added ACL related processing in APIs such as PutObject/PutObjectAcl/GetObject/GetObjectAcl/PutBucket/PutBucketAcl/ListObjects/GetBucketAcl

# How is the PR tested?

The relevant functional tests have been made through the s3 sdk

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
