### PR TITLE
Allow parallel volume loading from different dirs during startup.

### DIFF
--- a/weed/storage/store.go
+++ b/weed/storage/store.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 
 	"github.com/seaweedfs/seaweedfs/weed/pb"
@@ -82,12 +83,21 @@ func NewStore(grpcDialOption grpc.DialOption, ip string, port int, grpcPort int,
 	minFreeSpaces []util.MinFreeSpace, idxFolder string, needleMapKind NeedleMapKind, diskTypes []DiskType) (s *Store) {
 	s = &Store{grpcDialOption: grpcDialOption, Port: port, Ip: ip, GrpcPort: grpcPort, PublicUrl: publicUrl, NeedleMapKind: needleMapKind}
 	s.Locations = make([]*DiskLocation, 0)
+
+	var wg sync.WaitGroup
 	for i := 0; i < len(dirnames); i++ {
 		location := NewDiskLocation(dirnames[i], int32(maxVolumeCounts[i]), minFreeSpaces[i], idxFolder, diskTypes[i])
-		location.loadExistingVolumes(needleMapKind)
 		s.Locations = append(s.Locations, location)
 		stats.VolumeServerMaxVolumeCounter.Add(float64(maxVolumeCounts[i]))
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			location.loadExistingVolumes(needleMapKind)
+		}()
 	}
+	wg.Wait()
+
 	s.NewVolumesChan = make(chan master_pb.VolumeShortInformationMessage, 3)
 	s.DeletedVolumesChan = make(chan master_pb.VolumeShortInformationMessage, 3)
 


### PR DESCRIPTION
# What problem are we solving?

Normally you use multiple dirs for data when you have several separate drives for data. When using large HDD's parallel loading may greatly reduce startup time.

# How is the PR tested?

This change was tested on machine with 10x 18TB hdd drives. Each drive had approx 2TB data already with approx 2000 volumes / index files. Startup time was reduced exactly 10x times (number of drives) while cpu load was almost same as without parallel loading.