### PR TITLE
Fix `mount -t weed` with extra options

### DIFF
--- a/weed/command/fuse.go
+++ b/weed/command/fuse.go
@@ -47,7 +47,10 @@ func runFuse(cmd *Command, args []string) bool {
 			for i++; i < rawArgsLen && rawArgs[i] != ' '; i++ {
 				option.WriteByte(rawArgs[i])
 			}
-			options = append(options, parameter{option.String(), "true"})
+			// ignore "-o"
+			if option.String() != "o" {
+				options = append(options, parameter{option.String(), "true"})
+			}
 			option.Reset()
 
 			// equal separator start option with pending value


### PR DESCRIPTION
# What problem are we solving?

In current version, fuse takes "-o" as a parameter, so "o" is in `mountOptions.extraOptions`, it causes `mount` fails silently.
Fixes #3790

# How are we solving the problem?

Check the "o" option explicitly and ignore it.

# How is the PR tested?

It's tested on ubuntu 22.04, and `mount` takes extra options normally.

# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
