### PR TITLE
revert disabling FSync for non Mac

### DIFF
--- a/weed/storage/backend/disk_file.go
+++ b/weed/storage/backend/disk_file.go
@@ -4,12 +4,15 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	. "github.com/seaweedfs/seaweedfs/weed/storage/types"
 	"os"
+	"runtime"
 	"time"
 )
 
 var (
 	_ BackendStorageFile = &DiskFile{}
 )
+
+const isMac = runtime.GOOS == "darwin"
 
 type DiskFile struct {
 	File         *os.File
@@ -81,6 +84,11 @@ func (df *DiskFile) Name() string {
 }
 
 func (df *DiskFile) Sync() error {
-	return nil
-	// return df.File.Sync()
+	if df.File == nil {
+		return os.ErrInvalid
+	}
+	if isMac {
+		return nil
+	}
+	return df.File.Sync()
 }


### PR DESCRIPTION
https://github.com/seaweedfs/seaweedfs/commit/52580743b9de1931b149e1df40e27048d99ca3bf

# What problem are we solving?

When the memory limit is reached in the virtualization environment (k8s), during the execution of vaccum, an OOM killer may come and unexpectedly kill the container with the volume and break the volum files

# How are we solving the problem?

To minimize  OOM killer effect, do a forced fsync on every vaccum step

https://github.com/golang/go/issues/26650

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
