### PR TITLE
`command_s3_configure` to specify 'accountId'

### DIFF
--- a/weed/shell/command_s3_configure.go
+++ b/weed/shell/command_s3_configure.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3account"
 	"io"
 	"sort"
 	"strings"
@@ -38,6 +39,7 @@ func (c *commandS3Configure) Do(args []string, commandEnv *CommandEnv, writer io
 	s3ConfigureCommand := flag.NewFlagSet(c.Name(), flag.ContinueOnError)
 	actions := s3ConfigureCommand.String("actions", "", "comma separated actions names: Read,Write,List,Tagging,Admin")
 	user := s3ConfigureCommand.String("user", "", "user name")
+	accountId := s3ConfigureCommand.String("accountId", "", "account id")
 	buckets := s3ConfigureCommand.String("buckets", "", "bucket name")
 	accessKey := s3ConfigureCommand.String("access_key", "", "specify the access key")
 	secretKey := s3ConfigureCommand.String("secret_key", "", "specify the secret key")
@@ -149,6 +151,13 @@ func (c *commandS3Configure) Do(args []string, commandEnv *CommandEnv, writer io
 						SecretKey: *secretKey,
 					})
 				}
+			}
+			if *accountId != "" {
+				accountManager := s3account.NewAccountManager(commandEnv)
+				if _, ok := accountManager.IdNameMapping[*accountId]; !ok {
+					return fmt.Errorf("accountId[%s] not exists", *accountId)
+				}
+				s3cfg.Identities[idx].AccountId = *accountId
 			}
 		}
 	} else if *user != "" && *actions != "" {


### PR DESCRIPTION
Signed-off-by: changlin.shi <changlin.shi@ly.com>

# What problem are we solving?

`command_s3_configure` to specify 'accountId'

# How are we solving the problem?

Add the command line parameter `accountId`, if `accountId` is not empty, it will be checked first, and an error message will be returned if it not exists

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
