### PR TITLE
Volume fsck by volume

### DIFF
--- a/weed/shell/command_volume_fsck.go
+++ b/weed/shell/command_volume_fsck.go
@@ -127,7 +127,8 @@ func (c *commandVolumeFsck) Do(args []string, commandEnv *CommandEnv, writer io.
 				delete(volumeIdToVInfo, volumeId)
 				continue
 			}
-			if *c.collection != "" && vinfo.collection != *c.collection {
+			// or skip /topics/.system/log without collection name
+			if (*c.collection != "" && vinfo.collection != *c.collection) || vinfo.collection == "" {
 				delete(volumeIdToVInfo, volumeId)
 				continue
 			}


### PR DESCRIPTION
# What problem are we solving?

volume.fsck `-findMissingChunksInFiler` was broken due to incorrect collectMtime format
duplicate code

no way to check single collection or volum id after https://github.com/seaweedfs/seaweedfs/issues/3835

# How are we solving the problem?



# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
