### PR TITLE
avoid data race of TraverseBfs

### DIFF
--- a/weed/pb/filer_pb/filer_client_bfs.go
+++ b/weed/pb/filer_pb/filer_client_bfs.go
@@ -42,7 +42,6 @@ func TraverseBfs(filerClient FilerClient, parentPath util.FullPath, fn func(pare
 	}
 	jobQueueWg.Wait()
 	for i := 0; i < K; i++ {
-		terminates[i] <- true
 		close(terminates[i])
 	}
 	return

--- a/weed/pb/filer_pb/filer_client_bfs.go
+++ b/weed/pb/filer_pb/filer_client_bfs.go
@@ -9,37 +9,42 @@ import (
 )
 
 func TraverseBfs(filerClient FilerClient, parentPath util.FullPath, fn func(parentPath util.FullPath, entry *Entry)) (err error) {
-
 	K := 5
 
 	var jobQueueWg sync.WaitGroup
 	queue := util.NewQueue()
 	jobQueueWg.Add(1)
 	queue.Enqueue(parentPath)
-	var isTerminating bool
+	terminates := make([]chan bool, K)
 
 	for i := 0; i < K; i++ {
-		go func() {
+		terminates[i] = make(chan bool)
+		go func(j int) {
 			for {
-				if isTerminating {
-					break
+				select {
+				case <-terminates[j]:
+					return
+				default:
+					t := queue.Dequeue()
+					if t == nil {
+						time.Sleep(329 * time.Millisecond)
+						continue
+					}
+					dir := t.(util.FullPath)
+					processErr := processOneDirectory(filerClient, dir, queue, &jobQueueWg, fn)
+					if processErr != nil {
+						err = processErr
+					}
+					jobQueueWg.Done()
 				}
-				t := queue.Dequeue()
-				if t == nil {
-					time.Sleep(329 * time.Millisecond)
-					continue
-				}
-				dir := t.(util.FullPath)
-				processErr := processOneDirectory(filerClient, dir, queue, &jobQueueWg, fn)
-				if processErr != nil {
-					err = processErr
-				}
-				jobQueueWg.Done()
 			}
-		}()
+		}(i)
 	}
 	jobQueueWg.Wait()
-	isTerminating = true
+	for i := 0; i < K; i++ {
+		terminates[i] <- true
+		close(terminates[i])
+	}
 	return
 }
 

--- a/weed/storage/needle_map_sorted_file.go
+++ b/weed/storage/needle_map_sorted_file.go
@@ -94,6 +94,9 @@ func (m *SortedFileNeedleMap) Delete(key NeedleId, offset Offset) error {
 }
 
 func (m *SortedFileNeedleMap) Close() {
+	if m == nil {
+		return
+	}
 	if m.indexFile != nil {
 		m.indexFile.Close()
 	}


### PR DESCRIPTION
# What problem are we solving?

```
==================
WARNING: DATA RACE
Write at 0x00c0005b3f4f by main goroutine:
  github.com/seaweedfs/seaweedfs/weed/pb/filer_pb.TraverseBfs()
      /Users/kmlebedev/GolandProjects/seaweedfs/weed/pb/filer_pb/filer_client_bfs.go:42 +0x398
  github.com/seaweedfs/seaweedfs/weed/shell.doTraverseBfsAndSaving()
      /Users/kmlebedev/GolandProjects/seaweedfs/weed/shell/command_fs_meta_save.go:127 +0x3fd
  github.com/seaweedfs/seaweedfs/weed/shell.(*commandVolumeFsck).collectFilerFileIdAndPaths()
      /Users/kmlebedev/GolandProjects/seaweedfs/weed/shell/command_volume_fsck.go:200 +0x64b
  github.com/seaweedfs/seaweedfs/weed/shell.(*commandVolumeFsck).Do()
      /Users/kmlebedev/GolandProjects/seaweedfs/weed/shell/command_volume_fsck.go:164 +0x124a
  github.com/seaweedfs/seaweedfs/weed/shell.processEachCmd()
      /Users/kmlebedev/GolandProjects/seaweedfs/weed/shell/shell_liner.go:136 +0x4ac
  github.com/seaweedfs/seaweedfs/weed/shell.RunShell()
      /Users/kmlebedev/GolandProjects/seaweedfs/weed/shell/shell_liner.go:105 +0x92b
  github.com/seaweedfs/seaweedfs/weed/command.runShell()
      /Users/kmlebedev/GolandProjects/seaweedfs/weed/command/shell.go:60 +0x544
  main.main()
      /Users/kmlebedev/GolandProjects/seaweedfs/weed/weed.go:81 +0x943

Previous read at 0x00c0005b3f4f by goroutine 127:
  github.com/seaweedfs/seaweedfs/weed/pb/filer_pb.TraverseBfs.func1()
      /Users/kmlebedev/GolandProjects/seaweedfs/weed/pb/filer_pb/filer_client_bfs.go:24 +0x84
  github.com/seaweedfs/seaweedfs/weed/pb/filer_pb.TraverseBfs.func2()
      /Users/kmlebedev/GolandProjects/seaweedfs/weed/pb/filer_pb/filer_client_bfs.go:39 +0x47

Goroutine 127 (running) created at:
  github.com/seaweedfs/seaweedfs/weed/pb/filer_pb.TraverseBfs()
      /Users/kmlebedev/GolandProjects/seaweedfs/weed/pb/filer_pb/filer_client_bfs.go:22 +0x155
  github.com/seaweedfs/seaweedfs/weed/shell.doTraverseBfsAndSaving()
      /Users/kmlebedev/GolandProjects/seaweedfs/weed/shell/command_fs_meta_save.go:127 +0x3fd
  github.com/seaweedfs/seaweedfs/weed/shell.(*commandVolumeFsck).collectFilerFileIdAndPaths()
      /Users/kmlebedev/GolandProjects/seaweedfs/weed/shell/command_volume_fsck.go:200 +0x64b
  github.com/seaweedfs/seaweedfs/weed/shell.(*commandVolumeFsck).Do()
      /Users/kmlebedev/GolandProjects/seaweedfs/weed/shell/command_volume_fsck.go:164 +0x124a
  github.com/seaweedfs/seaweedfs/weed/shell.processEachCmd()
      /Users/kmlebedev/GolandProjects/seaweedfs/weed/shell/shell_liner.go:136 +0x4ac
  github.com/seaweedfs/seaweedfs/weed/shell.RunShell()
      /Users/kmlebedev/GolandProjects/seaweedfs/weed/shell/shell_liner.go:105 +0x92b
  github.com/seaweedfs/seaweedfs/weed/command.runShell()
      /Users/kmlebedev/GolandProjects/seaweedfs/weed/command/shell.go:60 +0x544
  main.main()
      /Users/kmlebedev/GolandProjects/seaweedfs/weed/weed.go:81 +0x943
==================
```


# How are we solving the problem?



# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
