### PR TITLE
fix: set user metadata key to lowercase

### DIFF
--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -415,17 +415,13 @@ func (s3a *S3ApiServer) proxyToFiler(w http.ResponseWriter, r *http.Request, des
 }
 
 func setUserMetadataKeyToLowercase(resp *http.Response) {
-	newHeader := make(map[string][]string)
-
 	for key, value := range resp.Header {
 		if strings.HasPrefix(key, s3_constants.AmzUserMetaPrefix) {
-			newHeader[strings.ToLower(key)] = value
+			resp.Header[strings.ToLower(key)] = value
+			delete(resp.Header,key)
 			continue
 		}
-		newHeader[key] = value
 	}
-
-	resp.Header = newHeader
 }
 
 func passThroughResponse(proxyResponse *http.Response, w http.ResponseWriter) (statusCode int) {

--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -408,8 +408,24 @@ func (s3a *S3ApiServer) proxyToFiler(w http.ResponseWriter, r *http.Request, des
 		return
 	}
 
+	setUserMetadataKeyToLowercase(resp)
+
 	responseStatusCode := responseFn(resp, w)
 	s3err.PostLog(r, responseStatusCode, s3err.ErrNone)
+}
+
+func setUserMetadataKeyToLowercase(resp *http.Response) {
+	newHeader := make(map[string][]string)
+
+	for key, value := range resp.Header {
+		if strings.HasPrefix(key, s3_constants.AmzUserMetaPrefix) {
+			newHeader[strings.ToLower(key)] = value
+			continue
+		}
+		newHeader[key] = value
+	}
+
+	resp.Header = newHeader
 }
 
 func passThroughResponse(proxyResponse *http.Response, w http.ResponseWriter) (statusCode int) {


### PR DESCRIPTION
# What problem are we solving?

<img width="1143" alt="image" src="https://user-images.githubusercontent.com/10348876/197510021-0b2152f0-caea-4bd1-a8dc-e8d1b16c75c1.png">

After we migrated from `ceph s3` to `SeaweedFS`, we found that the metadata key has changed, so we changed the returned key according to the `aws` standard

# How are we solving the problem?

replace return result

