### PR TITLE
fix: isTruncated returns problematic

### DIFF
--- a/weed/s3api/s3api_objects_list_handlers.go
+++ b/weed/s3api/s3api_objects_list_handlers.go
@@ -297,7 +297,7 @@ func (s3a *S3ApiServer) doListFilerEntries(client filer_pb.SeaweedFilerClient, d
 		// finished processing this sub directory
 		marker = subDir
 	}
-	if cursor.maxKeys <= 0 {
+	if cursor.isTruncated {
 		return
 	}
 


### PR DESCRIPTION
# What problem are we solving?

<img width="1235" alt="image" src="https://user-images.githubusercontent.com/10348876/197677710-a2c4397e-2d62-40da-ae13-df20b8d966fe.png">

When the subdirectory traversal ends and maxKeys is satisfied, the returned `isTruncated` is wrong, causing the client to not be able to list all the data

The easiest case to reproduce, when `maxkeys` is set to 1, when the first subdirectory traversal ends, the return is an error

The judgment of `isTruncated` should also be added to the `eof` side.