### PR TITLE
fix volume statefulset helm chart's tolerations

### DIFF
--- a/k8s/helm_charts2/templates/volume-statefulset.yaml
+++ b/k8s/helm_charts2/templates/volume-statefulset.yaml
@@ -34,7 +34,7 @@ spec:
       restartPolicy: {{ default .Values.global.restartPolicy .Values.volume.restartPolicy }}
       {{- if .Values.volume.tolerations }}
       tolerations:
-      {{ tpl .Values.volume.tolerations . | nindent 8 | trim }}
+        {{ tpl .Values.volume.tolerations . | nindent 8 | trim }}
       {{- end }}
       {{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
# What problem are we solving?

when trying to set `tolerations` in the helm chart's `values.yaml` I received an error
```
Error: YAML parse error on seaweedfs/templates/volume-statefulset.yaml: error converting YAML to JSON: yaml: line 40: did not find expected key
```


# How are we solving the problem?

the other statefulset templates have correctly intended the `tolerations` but `volume-statefulset.yaml` was incorrect


# How is the PR tested?

I am now able to set tolerations in my fork of this helm chart 😄 

# Checks
- [x] I have added unit tests if possible. - not relevant
- [x] I will add related wiki document changes and link to this PR after merging. - not required
