### PR TITLE
Bug fix: empty key in DeleteMultipleObjects request caused bucket delete

### DIFF
--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -277,6 +277,9 @@ func (s3a *S3ApiServer) DeleteMultipleObjectsHandler(w http.ResponseWriter, r *h
 
 		// delete file entries
 		for _, object := range deleteObjects.Objects {
+			if object.ObjectName == "" {
+				continue
+			}
 			lastSeparator := strings.LastIndex(object.ObjectName, "/")
 			parentDirectoryPath, entryName, isDeleteData, isRecursive := "", object.ObjectName, true, false
 			if lastSeparator > 0 && lastSeparator+1 < len(object.ObjectName) {


### PR DESCRIPTION
# What problem are we solving?
If somebody accidentally (or not) form a DeleteMultipleObjects request with empty Key field (like this 
```bash
curl -X POST "localhost:8333/test-bucket?delete=&x-id=DeleteObjects" -d '<?xml version="1.0" encoding="UTF-8"?><Delete xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Object><Key/></Object></Delete>'
```
), then seaweed will delete the whole bucket. Depending on Filer storage the bucket could be deleted even if it's not empty. If CanDropWholeBucket function returns true (like in case of Postgres storage) the non-empty bucket will be deleted (due to skip of isRecursive verification [here](https://github.com/seaweedfs/seaweedfs/blob/54d815fa0471034fbea4182675763d08b71310a9/weed/filer/filer_delete_entry.go#L72)). In other case, this bug will affect only empty buckets.


# How are we solving the problem?
Just skip empty object keys.


# How is the PR tested?
Bug does not reproduce using aforementioned request.


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
