### PR TITLE
`filer.backup` use `source.filer`

### DIFF
--- a/weed/command/filer_backup.go
+++ b/weed/command/filer_backup.go
@@ -83,6 +83,11 @@ func doFilerBackup(grpcDialOption grpc.DialOption, backupOption *FilerBackupOpti
 	if dataSink == nil {
 		return fmt.Errorf("no data sink configured in replication.toml")
 	}
+	if config.GetBool("source.filer.enabled") {
+		*backupOption.filer = config.GetString("source.filer.address")
+		*backupOption.path = config.GetString("source.filer.directory")
+		*backupOption.excludePaths = config.GetString("source.filer.excludeDirectories")
+	}
 
 	sourceFiler := pb.ServerAddress(*backupOption.filer)
 	sourcePath := *backupOption.path

--- a/weed/command/filer_replication.go
+++ b/weed/command/filer_replication.go
@@ -59,7 +59,7 @@ func runFilerReplicate(cmd *Command, args []string) bool {
 
 	// avoid recursive replication
 	if config.GetBool("notification.source.filer.enabled") && config.GetBool("notification.sink.filer.enabled") {
-		if config.GetString("source.filer.grpcAddress") == config.GetString("sink.filer.grpcAddress") {
+		if config.GetString("source.filer.address") == config.GetString("sink.filer.address") {
 			fromDir := config.GetString("source.filer.directory")
 			toDir := config.GetString("sink.filer.directory")
 			if strings.HasPrefix(toDir, fromDir) {

--- a/weed/command/scaffold/replication.toml
+++ b/weed/command/scaffold/replication.toml
@@ -8,7 +8,7 @@
 
 [source.filer]  # deprecated. Only useful with "weed filer.replicate"
 enabled = true
-grpcAddress = "localhost:18888"
+address = "localhost:8888"
 # all files under this directory tree are replicated.
 # this is not a directory on your hard drive, but on your filer.
 # i.e., all files with this "prefix" are sent to notification message queue.
@@ -25,7 +25,7 @@ is_incremental = false
 
 [sink.filer]
 enabled = false
-grpcAddress = "localhost:18888"
+address = "localhost:8888"
 # all replicated files are under this directory tree
 # this is not a directory on your hard drive, but on your filer.
 # i.e., all received files will be "prefixed" to this directory.

--- a/weed/replication/sink/filersink/filer_sink.go
+++ b/weed/replication/sink/filersink/filer_sink.go
@@ -54,9 +54,10 @@ func (fs *FilerSink) IsIncremental() bool {
 func (fs *FilerSink) Initialize(configuration util.Configuration, prefix string) error {
 	fs.isIncremental = configuration.GetBool(prefix + "is_incremental")
 	fs.dataCenter = configuration.GetString(prefix + "dataCenter")
+	filerAddress := pb.ServerAddress(configuration.GetString(prefix + "address"))
 	return fs.DoInitialize(
-		"",
-		configuration.GetString(prefix+"grpcAddress"),
+		filerAddress.ToHttpAddress(),
+		filerAddress.ToGrpcAddress(),
 		configuration.GetString(prefix+"directory"),
 		configuration.GetString(prefix+"replication"),
 		configuration.GetString(prefix+"collection"),

--- a/weed/replication/source/filer_source.go
+++ b/weed/replication/source/filer_source.go
@@ -32,9 +32,10 @@ type FilerSource struct {
 
 func (fs *FilerSource) Initialize(configuration util.Configuration, prefix string) error {
 	fs.dataCenter = configuration.GetString(prefix + "dataCenter")
+	filerAddress := pb.ServerAddress(configuration.GetString(prefix + "address"))
 	return fs.DoInitialize(
-		"",
-		configuration.GetString(prefix+"grpcAddress"),
+		filerAddress.ToHttpAddress(),
+		filerAddress.ToGrpcAddress(),
 		configuration.GetString(prefix+"directory"),
 		false,
 	)


### PR DESCRIPTION
# What problem are we solving?
Can easily configure more excluded paths.

# How are we solving the problem?
`filer.backup` use `replication.toml` >`source.filer`

# How is the PR tested?


# Checks
- [] I have added unit tests if possible.
- [] I will add related wiki document changes and link to this PR after merging.
