### PR TITLE
enable faster vacuuming with concurrency

### DIFF
--- a/weed/command/master.go
+++ b/weed/command/master.go
@@ -2,12 +2,13 @@ package command
 
 import (
 	"fmt"
-	hashicorpRaft "github.com/hashicorp/raft"
 	"net/http"
 	"os"
 	"path"
 	"strings"
 	"time"
+
+	hashicorpRaft "github.com/hashicorp/raft"
 
 	"golang.org/x/exp/slices"
 
@@ -45,6 +46,7 @@ type MasterOptions struct {
 	// pulseSeconds       *int
 	defaultReplication *string
 	garbageThreshold   *float64
+	vacuumConcurrency  *int
 	whiteList          *string
 	disableHttp        *bool
 	metricsAddress     *string
@@ -70,6 +72,7 @@ func init() {
 	// m.pulseSeconds = cmdMaster.Flag.Int("pulseSeconds", 5, "number of seconds between heartbeats")
 	m.defaultReplication = cmdMaster.Flag.String("defaultReplication", "", "Default replication type if not specified.")
 	m.garbageThreshold = cmdMaster.Flag.Float64("garbageThreshold", 0.3, "threshold to vacuum and reclaim spaces")
+	m.vacuumConcurrency = cmdMaster.Flag.Int("vacuumConcurrency", 1, "number of volumes to concurrently vacuum")
 	m.whiteList = cmdMaster.Flag.String("whiteList", "", "comma separated Ip addresses having write permission. No limit if empty.")
 	m.disableHttp = cmdMaster.Flag.Bool("disableHttp", false, "disable http requests, only gRPC operations are allowed.")
 	m.metricsAddress = cmdMaster.Flag.String("metrics.address", "", "Prometheus gateway address <host>:<port>")
@@ -306,6 +309,7 @@ func (m *MasterOptions) toMasterOption(whiteList []string) *weed_server.MasterOp
 		// PulseSeconds:            *m.pulseSeconds,
 		DefaultReplicaPlacement: *m.defaultReplication,
 		GarbageThreshold:        *m.garbageThreshold,
+		VacuumConcurrency:       *m.vacuumConcurrency,
 		WhiteList:               whiteList,
 		DisableHttp:             *m.disableHttp,
 		MetricsAddress:          *m.metricsAddress,

--- a/weed/server/master_server.go
+++ b/weed/server/master_server.go
@@ -45,6 +45,7 @@ type MasterOption struct {
 	// PulseSeconds            int
 	DefaultReplicaPlacement string
 	GarbageThreshold        float64
+	VacuumConcurrency       int
 	WhiteList               []string
 	DisableHttp             bool
 	MetricsAddress          string
@@ -122,9 +123,10 @@ func NewMasterServer(r *mux.Router, option *MasterOption, peers map[string]pb.Se
 	if nil == seq {
 		glog.Fatalf("create sequencer failed.")
 	}
-	ms.Topo = topology.NewTopology("topo", seq, uint64(ms.option.VolumeSizeLimitMB)*1024*1024, 5, replicationAsMin)
+	ms.Topo = topology.NewTopology("topo", seq, uint64(ms.option.VolumeSizeLimitMB)*1024*1024, 5, replicationAsMin, option.VacuumConcurrency)
 	ms.vg = topology.NewDefaultVolumeGrowth()
 	glog.V(0).Infoln("Volume Size Limit is", ms.option.VolumeSizeLimitMB, "MB")
+	glog.V(0).Infoln("Vacuum Concurrency is", ms.option.VacuumConcurrency)
 
 	ms.guard = security.NewGuard(ms.option.WhiteList, signingKey, expiresAfterSec, readSigningKey, readExpiresAfterSec)
 

--- a/weed/topology/topology.go
+++ b/weed/topology/topology.go
@@ -33,8 +33,9 @@ type Topology struct {
 
 	pulse int64
 
-	volumeSizeLimit  uint64
-	replicationAsMin bool
+	volumeSizeLimit   uint64
+	replicationAsMin  bool
+	vacuumConcurrency int
 
 	Sequence sequence.Sequencer
 
@@ -50,7 +51,7 @@ type Topology struct {
 	UuidMap              map[string][]string
 }
 
-func NewTopology(id string, seq sequence.Sequencer, volumeSizeLimit uint64, pulse int, replicationAsMin bool) *Topology {
+func NewTopology(id string, seq sequence.Sequencer, volumeSizeLimit uint64, pulse int, replicationAsMin bool, vacuumConcurrency int) *Topology {
 	t := &Topology{}
 	t.id = NodeId(id)
 	t.nodeType = "Topology"
@@ -62,6 +63,7 @@ func NewTopology(id string, seq sequence.Sequencer, volumeSizeLimit uint64, puls
 	t.pulse = int64(pulse)
 	t.volumeSizeLimit = volumeSizeLimit
 	t.replicationAsMin = replicationAsMin
+	t.vacuumConcurrency = vacuumConcurrency
 
 	t.Sequence = seq
 

--- a/weed/topology/topology_test.go
+++ b/weed/topology/topology_test.go
@@ -24,7 +24,7 @@ func TestRemoveDataCenter(t *testing.T) {
 }
 
 func TestHandlingVolumeServerHeartbeat(t *testing.T) {
-	topo := NewTopology("weedfs", sequence.NewMemorySequencer(), 32*1024, 5, false)
+	topo := NewTopology("weedfs", sequence.NewMemorySequencer(), 32*1024, 5, false, 1)
 
 	dc := topo.GetOrCreateDataCenter("dc1")
 	rack := dc.GetOrCreateRack("rack1")
@@ -170,7 +170,7 @@ func assert(t *testing.T, message string, actual, expected int) {
 
 func TestAddRemoveVolume(t *testing.T) {
 
-	topo := NewTopology("weedfs", sequence.NewMemorySequencer(), 32*1024, 5, false)
+	topo := NewTopology("weedfs", sequence.NewMemorySequencer(), 32*1024, 5, false, 1)
 
 	dc := topo.GetOrCreateDataCenter("dc1")
 	rack := dc.GetOrCreateRack("rack1")

--- a/weed/topology/volume_growth_test.go
+++ b/weed/topology/volume_growth_test.go
@@ -81,7 +81,7 @@ func setup(topologyLayout string) *Topology {
 	fmt.Println("data:", data)
 
 	//need to connect all nodes first before server adding volumes
-	topo := NewTopology("weedfs", sequence.NewMemorySequencer(), 32*1024, 5, false)
+	topo := NewTopology("weedfs", sequence.NewMemorySequencer(), 32*1024, 5, false, 1)
 	mTopology := data.(map[string]interface{})
 	for dcKey, dcValue := range mTopology {
 		dc := NewDataCenter(dcKey)


### PR DESCRIPTION
# What problem are we solving?
Due to the single threaded nature of the vacuum implementation, it is possible for high write volume clusters with low TTLs to be unable to actually evict the cache contents at a rate the operator desires.

# How are we solving the problem?
Utilize all existing volume vacuum logic but enable it to run on multiple volumes at the same time via a go routine worker pool. The pool size can be grown via a flag.

# How is the PR tested?
Set the flag to >1 and both logs and disk usage metrics will show the system is able to vacuum multiple volumes at a time such that the garbage collection and compaction can occur much quicker.

# Checks
- [ ] ~I have added unit tests if possible.~ - **This code relies on existing unit tests as it wraps an existing implementation.**
- [x] I will add related wiki document changes and link to this PR after merging.
