### PR TITLE
feat: Support for obtaining gzip files without passing accept-encoding header

### DIFF
--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -376,6 +376,13 @@ func (s3a *S3ApiServer) proxyToFiler(w http.ResponseWriter, r *http.Request, des
 	s3a.maybeAddFilerJwtAuthorization(proxyReq, isWrite)
 	resp, postErr := s3a.client.Do(proxyReq)
 
+	if resp.Uncompressed && r.Header.Get("Accept-Encoding") == "" {
+		r.Header.Set("Accept-Encoding","gzip")
+		util.CloseResponse(resp)
+		s3a.proxyToFiler(w, r, destUrl, false, passThroughResponse)
+		return
+	}
+
 	if postErr != nil {
 		glog.Errorf("post to filer: %v", postErr)
 		s3err.WriteErrorResponse(w, r, s3err.ErrInternalError)


### PR DESCRIPTION
# What problem are we solving?
Get the gzip file, if no `accept-encoding` header  is passed, it will return `404`.

Because golang made this restriction. But ceph or other s3 storage will return 200 normally.Not passing `accept-encoding` header is an incorrect way to use it, but other storage does support it


`/net/http/transport.go:2196`
<img width="1033" alt="image" src="https://user-images.githubusercontent.com/10348876/203710848-49dc3551-2815-4710-b84b-21fe2ca3ea12.png">
