### PR TITLE
fix: Lost Content-Encoding metadata

### DIFF
--- a/weed/server/filer_server_handlers_write_autochunk.go
+++ b/weed/server/filer_server_handlers_write_autochunk.go
@@ -356,6 +356,10 @@ func SaveAmzMetaData(r *http.Request, existing map[string][]byte, isReplace bool
 		metadata[s3_constants.AmzStorageClass] = []byte(sc)
 	}
 
+	if ce := r.Header.Get("Content-Encoding"); ce != "" {
+		metadata["Content-Encoding"] = []byte(ce)
+	}
+
 	if tags := r.Header.Get(s3_constants.AmzObjectTagging); tags != "" {
 		for _, v := range strings.Split(tags, "&") {
 			tag := strings.Split(v, "=")


### PR DESCRIPTION
# What problem are we solving?
related to [#4008](https://github.com/seaweedfs/seaweedfs/pull/4008),If the user directly uses gzip, `SeaweedFS` loses the original information of the header

for example,very common usage
<img width="671" alt="image" src="https://user-images.githubusercontent.com/10348876/203712170-bd73c728-ef27-4d7b-83fe-addfb5ae6ee4.png">
