### PR TITLE
[metrics] Add the ability to control bind ip

### DIFF
--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -162,7 +162,7 @@ func runFiler(cmd *Command, args []string) bool {
 
 	util.LoadConfiguration("security", false)
 
-	go stats_collect.StartMetricsServer(*f.metricsHttpPort)
+	go stats_collect.StartMetricsServer(*f.bindIp, *f.metricsHttpPort)
 
 	filerAddress := util.JoinHostPort(*f.ip, *f.port)
 	startDelay := time.Duration(2)

--- a/weed/command/filer_sync.go
+++ b/weed/command/filer_sync.go
@@ -43,6 +43,7 @@ type SyncOptions struct {
 	bFromTsMs       *int64
 	aProxyByFiler   *bool
 	bProxyByFiler   *bool
+	metricsHttpIp   *string
 	metricsHttpPort *int
 	concurrency     *int
 	clientId        int32
@@ -86,6 +87,7 @@ func init() {
 	syncOptions.concurrency = cmdFilerSynchronize.Flag.Int("concurrency", DefaultConcurrencyLimit, "The maximum number of files that will be synced concurrently.")
 	syncCpuProfile = cmdFilerSynchronize.Flag.String("cpuprofile", "", "cpu profile output file")
 	syncMemProfile = cmdFilerSynchronize.Flag.String("memprofile", "", "memory profile output file")
+	syncOptions.metricsHttpIp = cmdFilerSynchronize.Flag.String("metricsIp", "", "metrics listen ip")
 	syncOptions.metricsHttpPort = cmdFilerSynchronize.Flag.Int("metricsPort", 0, "metrics listen port")
 	syncOptions.clientId = util.RandomInt32()
 }
@@ -119,7 +121,7 @@ func runFilerSynchronize(cmd *Command, args []string) bool {
 	filerB := pb.ServerAddress(*syncOptions.filerB)
 
 	// start filer.sync metrics server
-	go statsCollect.StartMetricsServer(*syncOptions.metricsHttpPort)
+	go statsCollect.StartMetricsServer(*syncOptions.metricsHttpIp, *syncOptions.metricsHttpPort)
 
 	// read a filer signature
 	aFilerSignature, aFilerErr := replication.ReadFilerSignature(grpcDialOption, filerA)

--- a/weed/command/master.go
+++ b/weed/command/master.go
@@ -119,7 +119,7 @@ func runMaster(cmd *Command, args []string) bool {
 		glog.Fatalf("volumeSizeLimitMB should be smaller than 30000")
 	}
 
-	go stats_collect.StartMetricsServer(*m.metricsHttpPort)
+	go stats_collect.StartMetricsServer(*m.ipBind, *m.metricsHttpPort)
 	startMaster(m, masterWhiteList)
 
 	return true

--- a/weed/command/s3.go
+++ b/weed/command/s3.go
@@ -144,7 +144,7 @@ func runS3(cmd *Command, args []string) bool {
 
 	util.LoadConfiguration("security", false)
 
-	go stats_collect.StartMetricsServer(*s3StandaloneOptions.metricsHttpPort)
+	go stats_collect.StartMetricsServer(*s3StandaloneOptions.bindIp, *s3StandaloneOptions.metricsHttpPort)
 
 	return s3StandaloneOptions.startS3Server()
 

--- a/weed/command/server.go
+++ b/weed/command/server.go
@@ -233,7 +233,7 @@ func runServer(cmd *Command, args []string) bool {
 	webdavOptions.filer = &filerAddress
 	mqBrokerOptions.filerGroup = filerOptions.filerGroup
 
-	go stats_collect.StartMetricsServer(*serverMetricsHttpPort)
+	go stats_collect.StartMetricsServer(*serverBindIp, *serverMetricsHttpPort)
 
 	folders := strings.Split(*volumeDataFolders, ",")
 

--- a/weed/command/volume.go
+++ b/weed/command/volume.go
@@ -130,7 +130,7 @@ func runVolume(cmd *Command, args []string) bool {
 		grace.SetupProfiling(*v.cpuProfile, *v.memProfile)
 	}
 
-	go stats_collect.StartMetricsServer(*v.metricsHttpPort)
+	go stats_collect.StartMetricsServer(*v.bindIp, *v.metricsHttpPort)
 
 	minFreeSpaces := util.MustParseMinFreeSpace(*minFreeSpace, *minFreeSpacePercent)
 	v.masters = pb.ServerAddresses(*v.mastersString).ToAddresses()

--- a/weed/stats/metrics.go
+++ b/weed/stats/metrics.go
@@ -282,12 +282,12 @@ func LoopPushingMetric(name, instance, addr string, intervalSeconds int) {
 	}
 }
 
-func StartMetricsServer(port int) {
+func StartMetricsServer(ip string, port int) {
 	if port == 0 {
 		return
 	}
 	http.Handle("/metrics", promhttp.HandlerFor(Gather, promhttp.HandlerOpts{}))
-	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", port), nil))
+	log.Fatal(http.ListenAndServe(fmt.Sprintf("%s:%d", ip, port), nil))
 }
 
 func SourceName(port uint32) string {


### PR DESCRIPTION
# What problem are we solving?
IP of the metrics is bind to 0.0.0.0 at the moment. It cannot be changed to other IP (for example 127.0.0.1).


# How are we solving the problem?
I added the ability to control the address of the metrics by analogy with the rest of the Seaweedfs components - using `ip.bind` option.


# How is the PR tested?
Compiled locally, ran and check output with `netstat -tunelp | grep -i weed`.
