### PR TITLE
Return ETag from remote when file doesn't exist on Filer

### DIFF
--- a/weed/filer/filechunks.go
+++ b/weed/filer/filechunks.go
@@ -42,7 +42,7 @@ func ETag(entry *filer_pb.Entry) (etag string) {
 }
 
 func ETagEntry(entry *Entry) (etag string) {
-        if entry.Remote != nil && len(entry.Chunks) == 0 {
+        if entry.IsInRemoteOnly() {
 		return entry.Remote.RemoteETag
 	}
 	if entry.Attr.Md5 == nil {

--- a/weed/filer/filechunks.go
+++ b/weed/filer/filechunks.go
@@ -42,6 +42,9 @@ func ETag(entry *filer_pb.Entry) (etag string) {
 }
 
 func ETagEntry(entry *Entry) (etag string) {
+        if entry.Remote != nil && len(entry.Chunks) == 0 {
+		return entry.Remote.RemoteETag
+	}
 	if entry.Attr.Md5 == nil {
 		return ETagChunks(entry.GetChunks())
 	}


### PR DESCRIPTION
# What problem are we solving?
https://github.com/seaweedfs/seaweedfs/issues/3987
Currently, the ETag for a file that exists ONLY in remote is always `d41d8cd98f00b204e9800998ecf8427e-0` which is MD5 of empty string.

# How are we solving the problem?
Doing a check if file is not saved in Volume server, then return the ETag as set by the remote

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
