### PR TITLE
[filer] Fix uri escape during renaming

### DIFF
--- a/weed/server/filer_ui/filer.html
+++ b/weed/server/filer_ui/filer.html
@@ -337,7 +337,7 @@
         }
         var url = basePath + encodeURIComponent(newName);
         var originPath = basePath + originName;
-        url += '?mv.from=' + originPath;
+        url += '?mv.from=' + encodeURIComponent(originPath);
         var xhr = new XMLHttpRequest();
         xhr.open('POST', url, false);
         xhr.setRequestHeader('Content-Type', '');


### PR DESCRIPTION
# What problem are we solving?
Renaming doesn't work with symbol plus in name. This PR solves my issue #3969.


# How are we solving the problem?
Added URI escaping.


# How is the PR tested?
Compiled locally, ran and check renaming process.
