### PR TITLE
don't set destination when copy object

### DIFF
--- a/weed/s3api/s3api_object_copy_handlers.go
+++ b/weed/s3api/s3api_object_copy_handlers.go
@@ -98,8 +98,7 @@ func (s3a *S3ApiServer) CopyObjectHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 	glog.V(2).Infof("copy from %s to %s", srcUrl, dstUrl)
-	destination := fmt.Sprintf("%s/%s%s", s3a.option.BucketsPath, dstBucket, dstObject)
-	etag, errCode := s3a.putToFiler(r, dstUrl, resp.Body, destination)
+	etag, errCode := s3a.putToFiler(r, dstUrl, resp.Body, "")
 
 	if errCode != s3err.ErrNone {
 		s3err.WriteErrorResponse(w, r, errCode)


### PR DESCRIPTION
Signed-off-by: changlin.shi <changlin.shi@ly.com>

# What problem are we solving?

When testing the s3 interface, many buckets will be created. When the CopyObject interface is called, because the custom destination header is overwritten, each bucket will create some volumes, which will cause a large amount of disk space to be occupied.

In addition, I see that when the filer is processed, if the destination header is not set, the collection will be selected according to the url, so this change will not cause other effects

# How are we solving the problem?

When S3 CopyObject calls the filer, do not pass the destination parameter, which will overwrite the custom destination header

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
