### PR TITLE
[filer]: Fix http rename

### DIFF
--- a/weed/filer/filer_rename.go
+++ b/weed/filer/filer_rename.go
@@ -2,11 +2,17 @@ package filer
 
 import (
 	"fmt"
-	"github.com/seaweedfs/seaweedfs/weed/util"
 	"strings"
+
+	"github.com/seaweedfs/seaweedfs/weed/util"
 )
 
-func (f *Filer) CanRename(source, target util.FullPath) error {
+func (f *Filer) CanRename(source, target util.FullPath, oldName string) error {
+	sourcePath := source.Child(oldName)
+	if strings.HasPrefix(string(target), string(sourcePath)) {
+		return fmt.Errorf("mv: can not move directory to a subdirectory of itself")
+	}
+
 	sourceBucket := f.DetectBucket(source)
 	targetBucket := f.DetectBucket(target)
 	if sourceBucket != targetBucket {


### PR DESCRIPTION
# What problem are we solving?
Http api does not prevent parent directory from moving to its subdirectory which can result in filer corruption.


# How are we solving the problem?
Add parent-child directory relationship judgment.

# How is the PR tested?
curl -i -X POST 'http://localhost:8888/a/b/?mv.from=/a/' should be failed.


# Checks
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] I have added unit tests if possible.
