### PR TITLE
add -filer.path to webdav command

### DIFF
--- a/weed/command/webdav.go
+++ b/weed/command/webdav.go
@@ -13,7 +13,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/security"
-	"github.com/seaweedfs/seaweedfs/weed/server"
+	weed_server "github.com/seaweedfs/seaweedfs/weed/server"
 	"github.com/seaweedfs/seaweedfs/weed/util"
 )
 
@@ -23,6 +23,7 @@ var (
 
 type WebDavOption struct {
 	filer          *string
+	filerRootPath  *string
 	port           *int
 	collection     *string
 	replication    *string
@@ -44,6 +45,7 @@ func init() {
 	webDavStandaloneOptions.tlsCertificate = cmdWebDav.Flag.String("cert.file", "", "path to the TLS certificate file")
 	webDavStandaloneOptions.cacheDir = cmdWebDav.Flag.String("cacheDir", os.TempDir(), "local cache directory for file chunks")
 	webDavStandaloneOptions.cacheSizeMB = cmdWebDav.Flag.Int64("cacheCapacityMB", 0, "local cache capacity in MB")
+	webDavStandaloneOptions.filerRootPath = cmdWebDav.Flag.String("filer.path", "/", "use this remote path from filer server")
 }
 
 var cmdWebDav = &Command{
@@ -104,6 +106,7 @@ func (wo *WebDavOption) startWebDav() bool {
 
 	ws, webdavServer_err := weed_server.NewWebDavServer(&weed_server.WebDavOption{
 		Filer:          filerAddress,
+		FilerRootPath:  *wo.filerRootPath,
 		GrpcDialOption: grpcDialOption,
 		Collection:     *wo.collection,
 		Replication:    *wo.replication,


### PR DESCRIPTION
# What problem are we solving?
The webdav protocol cannot use a special directory as the root directory.

# How are we solving the problem?
I added `-filer.path` options to the `weed webdav` command, just like the `weed mount -filer.path`.

# How is the PR tested?
The filer server start at http://127.0.0.1:8888
Create a folder named testPath

Run the command like this:
`weed webdav -filer=127.0.0.1:8888 -filer.path=/testPath`
Connect using the webdav client tool

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
