### PR TITLE
Fixes 4074: S3 Gateway fails to start when installed via Helm

### DIFF
--- a/k8s/helm_charts2/templates/s3-deployment.yaml
+++ b/k8s/helm_charts2/templates/s3-deployment.yaml
@@ -79,6 +79,7 @@ spec:
               -v={{ .Values.global.loggingLevel }} \
               {{- end }}
               s3 \
+              -ip.bind={{ .Values.s3.bindAddress }} \
               -port={{ .Values.s3.port }} \
               {{- if .Values.s3.metricsPort }}
               -metricsPort {{ .Values.s3.metricsPort }} \

--- a/k8s/helm_charts2/values.yaml
+++ b/k8s/helm_charts2/values.yaml
@@ -418,6 +418,7 @@ s3:
   imageTag: null
   restartPolicy: null
   replicas: 1
+  bindAddress: 0.0.0.0
   port: 8333
   metricsPort: 9327
   loggingOverrideLevel: null


### PR DESCRIPTION
# What problem are we solving?
Fixes https://github.com/seaweedfs/seaweedfs/issues/4074.
S3 Gateway fails to start because it is listening only on localhost.

# How are we solving the problem?
By binding to all interfaces.

# How is the PR tested?
Using k3s and AWS EKS.

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
