### PR TITLE
Fixes: 4076: Host path prefix should be configurable

### DIFF
--- a/k8s/helm_charts2/templates/filer-statefulset.yaml
+++ b/k8s/helm_charts2/templates/filer-statefulset.yaml
@@ -225,13 +225,13 @@ spec:
         {{- if eq .Values.filer.logs.type "hostPath" }}
         - name: seaweedfs-filer-log-volume
           hostPath:
-            path: /storage/logs/seaweedfs/filer
+            path: {{ .Values.filer.logs.hostPathPrefix }}/logs/seaweedfs/filer
             type: DirectoryOrCreate
         {{- end }}
         {{- if eq .Values.filer.data.type "hostPath" }}
         - name: data-filer
           hostPath:
-            path: /storage/filer_store
+            path: {{ .Values.filer.data.hostPathPrefix }}/filer_store
             type: DirectoryOrCreate
         {{- end }}
         - name: db-schema-config-volume

--- a/k8s/helm_charts2/templates/master-statefulset.yaml
+++ b/k8s/helm_charts2/templates/master-statefulset.yaml
@@ -196,13 +196,13 @@ spec:
         {{- if eq .Values.master.logs.type "hostPath" }}
         - name: seaweedfs-master-log-volume
           hostPath:
-            path: /storage/logs/seaweedfs/master
+            path: {{ .Values.master.logs.hostPathPrefix }}/logs/seaweedfs/master
             type: DirectoryOrCreate
         {{- end }}
         {{- if eq .Values.master.data.type "hostPath" }}
         - name: data-{{ .Release.Namespace }}
           hostPath:
-            path: /ssd/seaweed-master/
+            path: {{ .Values.master.data.hostPathPrefix }}/seaweed-master/
             type: DirectoryOrCreate
         {{- end }}
         {{- if .Values.global.enableSecurity }}

--- a/k8s/helm_charts2/templates/s3-deployment.yaml
+++ b/k8s/helm_charts2/templates/s3-deployment.yaml
@@ -167,7 +167,7 @@ spec:
         {{- if eq .Values.s3.logs.type "hostPath" }}
         - name: logs
           hostPath:
-            path: /storage/logs/seaweedfs/s3
+            path: {{ .Values.s3.logs.hostPathPrefix }}/logs/seaweedfs/s3
             type: DirectoryOrCreate
         {{- end }}
         {{- if .Values.global.enableSecurity }}

--- a/k8s/helm_charts2/templates/volume-statefulset.yaml
+++ b/k8s/helm_charts2/templates/volume-statefulset.yaml
@@ -206,19 +206,19 @@ spec:
         {{- if eq .Values.volume.data.type "hostPath" }}
         - name: data
           hostPath:
-            path: /storage/object_store/
+            path: {{ .Values.volume.data.hostPathPrefix }}/object_store/
             type: DirectoryOrCreate
         {{- end }}
         {{- if and (eq .Values.volume.idx.type "hostPath") .Values.volume.dir_idx }}
         - name: idx
           hostPath:
-            path: /ssd/seaweedfs-volume-idx/
+            path: {{ .Values.volume.idx.hostPathPrefix }}/seaweedfs-volume-idx/
             type: DirectoryOrCreate
         {{- end }}
         {{- if eq .Values.volume.logs.type "hostPath" }}
         - name: logs
           hostPath:
-            path: /storage/logs/seaweedfs/volume
+            path: {{ .Values.volume.logs.hostPathPrefix }}/logs/seaweedfs/volume
             type: DirectoryOrCreate
         {{- end }}
         {{- if .Values.global.enableSecurity }}

--- a/k8s/helm_charts2/values.yaml
+++ b/k8s/helm_charts2/values.yaml
@@ -68,11 +68,13 @@ master:
     type: "hostPath"
     size: ""
     storageClass: ""
+    hostPathPrefix: /ssd
 
   logs:
     type: "hostPath"
     size: ""
     storageClass: ""
+    hostPathPrefix: /storage
 
   initContainers: ""
 
@@ -176,15 +178,19 @@ volume:
     type: "hostPath"
     size: ""
     storageClass: ""
+    hostPathPrefix: /storage
+
   idx:
     type: "hostPath"
     size: ""
     storageClass: ""
+    hostPathPrefix: /ssd
 
   logs:
     type: "hostPath"
     size: ""
     storageClass: ""
+    hostPathPrefix: /storage
 
   # limit background compaction or copying speed in mega bytes per second
   compactionMBps: "50"
@@ -308,11 +314,13 @@ filer:
     type: "hostPath"
     size: ""
     storageClass: ""
+    hostPathPrefix: /storage
 
   logs:
     type: "hostPath"
     size: ""
     storageClass: ""
+    hostPathPrefix: /storage
 
   initContainers: ""
 
@@ -463,7 +471,7 @@ s3:
     type: "hostPath"
     size: ""
     storageClass: ""
-
+    hostPathPrefix: /storage
 
 certificates:
   commonName: "SeaweedFS CA"


### PR DESCRIPTION
# What problem are we solving?
Fixes: 4076. Host path prefix e.g. /storage should be configurable in values.yaml

# How are we solving the problem?
hostPathPrefix added to values.yaml.

# How is the PR tested?
Has been tested in k3s.

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
