### PR TITLE
filer.store.mysql: Use utf8mb4 instead of 3 byte UTF8

### DIFF
--- a/docker/seaweedfs.sql
+++ b/docker/seaweedfs.sql
@@ -3,10 +3,10 @@ CREATE USER IF NOT EXISTS 'seaweedfs'@'%' IDENTIFIED BY 'secret';
 GRANT ALL PRIVILEGES ON seaweedfs.* TO 'seaweedfs'@'%';
 FLUSH PRIVILEGES;
 USE seaweedfs;
-CREATE TABLE IF NOT EXISTS filemeta (
-    dirhash     BIGINT         COMMENT 'first 64 bits of MD5 hash value of directory field',
-    name        VARCHAR(1000)  COMMENT 'directory or file name',
-    directory   TEXT           COMMENT 'full path to parent directory',
-    meta        LONGBLOB,
-    PRIMARY KEY (dirhash, name)
-) DEFAULT CHARSET=utf8;
+CREATE TABLE IF NOT EXISTS `filemeta` (
+    `dirhash`   BIGINT NOT NULL       COMMENT 'first 64 bits of MD5 hash value of directory field',
+    `name`      VARCHAR(766) NOT NULL COMMENT 'directory or file name',
+    `directory` TEXT NOT NULL         COMMENT 'full path to parent directory',
+    `meta`      LONGBLOB,
+    PRIMARY KEY (`dirhash`, `name`)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;

--- a/k8s/helm_charts2/README.md
+++ b/k8s/helm_charts2/README.md
@@ -14,13 +14,13 @@ with ENV.
 A running MySQL-compatible database is expected by default, as specified in the `values.yaml` at `filer.extraEnvironmentVars`. 
 This database should be pre-configured and initialized by running:
 ```sql
-CREATE TABLE IF NOT EXISTS filemeta (
-  dirhash     BIGINT               COMMENT 'first 64 bits of MD5 hash value of directory field',
-  name        VARCHAR(1000) BINARY COMMENT 'directory or file name',
-  directory   TEXT BINARY          COMMENT 'full path to parent directory',
-  meta        LONGBLOB,
-  PRIMARY KEY (dirhash, name)
-) DEFAULT CHARSET=utf8;
+CREATE TABLE IF NOT EXISTS `filemeta` (
+  `dirhash`   BIGINT NOT NULL       COMMENT 'first 64 bits of MD5 hash value of directory field',
+  `name`      VARCHAR(766) NOT NULL COMMENT 'directory or file name',
+  `directory` TEXT NOT NULL         COMMENT 'full path to parent directory',
+  `meta`      LONGBLOB,
+  PRIMARY KEY (`dirhash`, `name`)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 ```
 
 Alternative database can also be configured (e.g. leveldb) following the instructions at `filer.extraEnvironmentVars`.

--- a/weed/command/scaffold/filer.toml
+++ b/weed/command/scaffold/filer.toml
@@ -41,13 +41,13 @@ enabled = false
 dbFile = "./filer.db"                # sqlite db file
 
 [mysql]  # or memsql, tidb
-# CREATE TABLE IF NOT EXISTS filemeta (
-#   dirhash     BIGINT               COMMENT 'first 64 bits of MD5 hash value of directory field',
-#   name        VARCHAR(1000) BINARY COMMENT 'directory or file name',
-#   directory   TEXT BINARY          COMMENT 'full path to parent directory',
-#   meta        LONGBLOB,
-#   PRIMARY KEY (dirhash, name)
-# ) DEFAULT CHARSET=utf8;
+# CREATE TABLE IF NOT EXISTS `filemeta` (
+#   `dirhash`   BIGINT NOT NULL       COMMENT 'first 64 bits of MD5 hash value of directory field',
+#   `name`      VARCHAR(766) NOT NULL COMMENT 'directory or file name',
+#   `directory` TEXT NOT NULL         COMMENT 'full path to parent directory',
+#   `meta`      LONGBLOB,
+#   PRIMARY KEY (`dirhash`, `name`)
+# ) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 
 enabled = false
 hostname = "localhost"
@@ -67,12 +67,12 @@ upsertQuery = """INSERT INTO `%s` (dirhash,name,directory,meta) VALUES(?,?,?,?) 
 enabled = false
 createTable = """
   CREATE TABLE IF NOT EXISTS `%s` (
-    dirhash BIGINT,
-    name VARCHAR(1000) BINARY,
-    directory TEXT BINARY,
-    meta LONGBLOB,
-    PRIMARY KEY (dirhash, name)
-  ) DEFAULT CHARSET=utf8;
+    `dirhash`   BIGINT NOT NULL,
+    `name`      VARCHAR(766) NOT NULL,
+    `directory` TEXT NOT NULL,
+    `meta`      LONGBLOB,
+    PRIMARY KEY (`dirhash`, `name`)
+  ) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
 """
 hostname = "localhost"
 port = 3306

--- a/weed/filer/mysql/mysql_store.go
+++ b/weed/filer/mysql/mysql_store.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	CONNECTION_URL_PATTERN = "%s:%s@tcp(%s:%d)/%s?charset=utf8"
+	CONNECTION_URL_PATTERN = "%s:%s@tcp(%s:%d)/%s?collation=utf8mb4_bin"
 )
 
 func init() {

--- a/weed/filer/mysql2/mysql2_store.go
+++ b/weed/filer/mysql2/mysql2_store.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	CONNECTION_URL_PATTERN = "%s:%s@tcp(%s:%d)/%s?charset=utf8"
+	CONNECTION_URL_PATTERN = "%s:%s@tcp(%s:%d)/%s?collation=utf8mb4_bin"
 )
 
 var _ filer.BucketAware = (*MysqlStore2)(nil)


### PR DESCRIPTION
This PR was part of #4093

# What problem are we solving?
Allow all UTF8 chars in files or directories instead of just 3 byte UTF8 ones.


# How are we solving the problem?
Switching mysql tables from utf8 to utf8mb4. I chose utf8mb4_bin as COLLATE instead of the [better](https://dba.stackexchange.com/questions/278010/what-is-the-difference-between-different-utf8mb4-binary-collations) utf8mb4_0900_bin because it has wider support across different mysql versions. utf8mb4_0900_bin would basically require mysql 8.0 and exclude mariadb and probably some more.


# How is the PR tested?
I tested these changes locally on a mysql 8.0 server and everything worked as expected


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
