### PR TITLE
Use semver 2 in  Chart.yaml

### DIFF
--- a/k8s/helm_charts2/Chart.yaml
+++ b/k8s/helm_charts2/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: SeaweedFS
 name: seaweedfs
-appVersion: "latest"
-version: "latest"
+appVersion: "3.40"
+version: "3.40"


### PR DESCRIPTION
# What problem are we solving?
As of Helm 3.3.2, semver 2 is required. Setting anything else, breaks helm.

https://helm.sh/docs/topics/charts/#charts-and-versioning


# How are we solving the problem?
chart version and appVersion `must` follow semver

