### PR TITLE
[mount] fix metacache update

### DIFF
--- a/weed/mount/meta_cache/meta_cache.go
+++ b/weed/mount/meta_cache/meta_cache.go
@@ -70,8 +70,12 @@ func (mc *MetaCache) AtomicUpdateEntryFromFiler(ctx context.Context, oldPath uti
 	//mc.Lock()
 	//defer mc.Unlock()
 
-	oldDir, _ := oldPath.DirAndName()
-	if mc.isCachedFn(util.FullPath(oldDir)) {
+	entry, err := mc.FindEntry(ctx, oldPath)
+	if err != nil && err != filer_pb.ErrNotFound {
+		glog.Errorf("Metacache: find entry error: %v", err)
+		return err
+	}
+	if entry != nil {
 		if oldPath != "" {
 			if newEntry != nil && oldPath == newEntry.FullPath {
 				// skip the unnecessary deletion


### PR DESCRIPTION
# What problem are we solving?
The mv operation does not delete the file on the mount side, but only deletes the directory.

For example, for directory A, we do "mv A B", and "cp -r  /tmp/A A".  
we get "cp: cannot create regular file './A/a.txt': File exists" 

or if we do "mv A B", and "mkdir A", we can see there are files  in the A directory.


# How are we solving the problem?

In mount side, for newEntry, we have:
sourceInode, targetInode := wfs.inodeToPath.MovePath(oldPath, newPath)
It set oldPath.isChildrenCached to "false",  so  we can't delete oldentry in metacache if we use IsChildrenCached. 

We can replace isCachedFn with FindEntry to resolve this porblem.

# How is the PR tested?
There are files in the A directory, and we do
mv A B
mkdir A
To observe if there are files in directory A.



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
