### PR TITLE
 make directory lister trigger if mime type is httpd/unix-directory

### DIFF
--- a/k8s/helm_charts2/Chart.yaml
+++ b/k8s/helm_charts2/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: SeaweedFS
 name: seaweedfs
-appVersion: "3.40"
-version: "3.40"
+appVersion: "3.41"
+version: "3.41"

--- a/weed/util/constants.go
+++ b/weed/util/constants.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	VERSION_NUMBER = fmt.Sprintf("%.02f", 3.40)
+	VERSION_NUMBER = fmt.Sprintf("%.02f", 3.41)
 	VERSION        = sizeLimit + " " + VERSION_NUMBER
 	COMMIT         = ""
 )


### PR DESCRIPTION
# What problem are we solving?

when folders are created via the s3 gateway, the mime type `httpd/unix-directory` is attached to the folder. https://github.com/seaweedfs/seaweedfs/blob/master/weed/s3api/s3api_object_handlers.go#L102

however, when listing files via the filer server, the filer checks if the mime type is empty to determine whether or not to display the folder listing. https://github.com/seaweedfs/seaweedfs/blob/master/weed/server/filer_server_handlers_read.go#L121

this causes folders uploaded via the s3 gateway to appear as blank white screen (404 error) when using the filer web ui

# How are we solving the problem?

have filer server check if the mime type is either `httpd/unix-directory` or empty, instead of just empty, which will make it properly show directory listing on directories uploaded with s3
