### PR TITLE
filter system log dir does not make subscribe event

### DIFF
--- a/weed/filer/filer.go
+++ b/weed/filer/filer.go
@@ -3,13 +3,14 @@ package filer
 import (
 	"context"
 	"fmt"
-	"github.com/seaweedfs/seaweedfs/weed/cluster"
-	"github.com/seaweedfs/seaweedfs/weed/pb"
-	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
 	"os"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/cluster"
+	"github.com/seaweedfs/seaweedfs/weed/pb"
+	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
 
 	"google.golang.org/grpc"
 
@@ -254,7 +255,9 @@ func (f *Filer) ensureParentDirectoryEntry(ctx context.Context, entry *Entry, di
 				return fmt.Errorf("mkdir %s: %v", dirPath, mkdirErr)
 			}
 		} else {
-			f.NotifyUpdateEvent(ctx, nil, dirEntry, false, isFromOtherCluster, nil)
+			if !strings.HasPrefix("/"+util.Join(dirParts[:]...), SystemLogDir) {
+				f.NotifyUpdateEvent(ctx, nil, dirEntry, false, isFromOtherCluster, nil)
+			}
 		}
 
 	} else if !dirEntry.IsDirectory() {


### PR DESCRIPTION
Signed-off-by: Neo <zhaoxiaolong@virtaitech.com>

# What problem are we solving?
1. mount will seen directory of topics by subscribe which is created to save logs and should not be show to users.


# How are we solving the problem?
1. system log dir may create through ensureParentDirectoryEntry. For example, the directory of /topics/.system/log/2022-xx-yy
will have 3 keys in filer: /topics, /topics/.system/,/topics/.sysmem/log.
2. the key of /topics will generate subscribe event which is not filer by the micro of SystemLogDir.
3. filter the system dir before subscribe event generated in ensureParentDirectoryEntry.


# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
