### PR TITLE
[mount] Fix read file-data in entry.content

### DIFF
--- a/weed/mount/filehandle_read.go
+++ b/weed/mount/filehandle_read.go
@@ -53,7 +53,7 @@ func (fh *FileHandle) readFromChunks(buff []byte, offset int64) (int64, int64, e
 		return 0, 0, io.EOF
 	}
 
-	if offset+int64(len(buff)) <= int64(len(entry.Content)) {
+	if offset < int64(len(entry.Content)) {
 		totalRead := copy(buff, entry.Content[offset:])
 		glog.V(4).Infof("file handle read cached %s [%d,%d] %d", fileFullPath, offset, offset+int64(totalRead), totalRead)
 		return int64(totalRead), 0, nil


### PR DESCRIPTION
# What problem are we solving?
command "cat" read a file(data in entry.content) return empty. 
len(buf) is 4096, if the length of content less than 4096, we can's get data from content.

# How are we solving the problem?
remove len(buf) 


# How is the PR tested?
cat a file with data in entry.content


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
