### PR TITLE
Updated the deprecated ioutil dependency

### DIFF
--- a/weed/command/update.go
+++ b/weed/command/update.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -215,7 +214,7 @@ func GitHubLatestRelease(ctx context.Context, ver string, owner, repo string) (R
 		return Release{}, fmt.Errorf("unexpected status %v (%v) returned", res.StatusCode, res.Status)
 	}
 
-	buf, err := ioutil.ReadAll(res.Body)
+	buf, err := io.ReadAll(res.Body)
 	if err != nil {
 		return Release{}, err
 	}
@@ -265,7 +264,7 @@ func getGithubData(ctx context.Context, url string) ([]byte, error) {
 		return nil, fmt.Errorf("unexpected status %v (%v) returned", res.StatusCode, res.Status)
 	}
 
-	buf, err := ioutil.ReadAll(res.Body)
+	buf, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -337,7 +336,7 @@ func extractToFile(buf []byte, filename, target string) error {
 
 	// Write everything to a temp file
 	dir := filepath.Dir(target)
-	new, err := ioutil.TempFile(dir, "weed")
+	new, err := os.CreateTemp(dir, "weed")
 	if err != nil {
 		return err
 	}

--- a/weed/security/tls.go
+++ b/weed/security/tls.go
@@ -7,7 +7,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/credentials/tls/certprovider/pemfile"
 	"google.golang.org/grpc/security/advancedtls"
-	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -136,7 +136,7 @@ func LoadClientTLS(config *util.ViperProxy, component string) grpc.DialOption {
 }
 
 func LoadClientTLSHTTP(clientCertFile string) *tls.Config {
-	clientCerts, err := ioutil.ReadFile(clientCertFile)
+	clientCerts, err := os.ReadFile(clientCertFile)
 	if err != nil {
 		glog.Fatal(err)
 	}

--- a/weed/server/raft_server.go
+++ b/weed/server/raft_server.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	transport "github.com/Jille/raft-grpc-transport"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
@@ -90,7 +89,7 @@ func (s *StateMachine) Snapshot() (hashicorpRaft.FSMSnapshot, error) {
 }
 
 func (s *StateMachine) Restore(r io.ReadCloser) error {
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return err
 	}

--- a/weed/shell/command_volume_fsck.go
+++ b/weed/shell/command_volume_fsck.go
@@ -20,7 +20,6 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/storage/types"
 	"github.com/seaweedfs/seaweedfs/weed/util"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/http"
 	"net/url"
@@ -409,7 +408,7 @@ func (c *commandVolumeFsck) collectOneVolumeFileIds(dataNodeId string, volumeId 
 				}
 				buf.Write(resp.FileContent)
 			}
-			if vinfo.isReadOnly == false {
+			if !vinfo.isReadOnly {
 				index, err := idx.FirstInvalidIndex(buf.Bytes(),
 					func(key types.NeedleId, offset types.Offset, size types.Size) (bool, error) {
 						resp, err := volumeServerClient.ReadNeedleMeta(context.Background(), &volume_server_pb.ReadNeedleMetaRequest{
@@ -535,7 +534,7 @@ func (c *commandVolumeFsck) httpDelete(path util.FullPath) {
 	}
 	defer resp.Body.Close()
 
-	_, err = ioutil.ReadAll(resp.Body)
+	_, err = io.ReadAll(resp.Body)
 	if err != nil {
 		fmt.Fprintf(c.writer, "DELETE response error: %v\n", err)
 	}


### PR DESCRIPTION
# What problem are we solving?

The ioutil package has been deprecated as of Go v1.16: https://go.dev/doc/go1.16#ioutil

# How are we solving the problem?

This commit replaces ioutil functions with their respective io/os functions.

# How is the PR tested?



# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
