### PR TITLE
add -disk to filer command

### DIFF
--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -60,6 +60,7 @@ type FilerOptions struct {
 	localSocket             *string
 	showUIDirectoryDelete   *bool
 	downloadMaxMBps         *int
+	diskType                *string
 }
 
 func init() {
@@ -89,6 +90,7 @@ func init() {
 	f.localSocket = cmdFiler.Flag.String("localSocket", "", "default to /tmp/seaweedfs-filer-<port>.sock")
 	f.showUIDirectoryDelete = cmdFiler.Flag.Bool("ui.deleteDir", true, "enable filer UI show delete directory button")
 	f.downloadMaxMBps = cmdFiler.Flag.Int("downloadMaxMBps", 0, "download max speed for each download request, in MB per second")
+	f.diskType = cmdFiler.Flag.String("disk", "", "[hdd|ssd|<tag>] hard drive or solid state drive or any tag")
 
 	// start s3 on filer
 	filerStartS3 = cmdFiler.Flag.Bool("s3", false, "whether to start S3 gateway")
@@ -243,6 +245,7 @@ func (fo *FilerOptions) startFiler() {
 		ConcurrentUploadLimit: int64(*fo.concurrentUploadLimitMB) * 1024 * 1024,
 		ShowUIDirectoryDelete: *fo.showUIDirectoryDelete,
 		DownloadMaxBytesPs:    int64(*fo.downloadMaxMBps) * 1024 * 1024,
+		DiskType:              *fo.diskType,
 	})
 	if nfs_err != nil {
 		glog.Fatalf("Filer startup error: %v", nfs_err)

--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -185,6 +185,11 @@ func runFiler(cmd *Command, args []string) bool {
 
 	if *filerStartWebDav {
 		filerWebDavOptions.filer = &filerAddress
+
+		if *filerWebDavOptions.disk == "" {
+			filerWebDavOptions.disk = f.diskType
+		}
+
 		go func(delay time.Duration) {
 			time.Sleep(delay * time.Second)
 			filerWebDavOptions.startWebDav()

--- a/weed/command/server.go
+++ b/weed/command/server.go
@@ -115,6 +115,7 @@ func init() {
 	filerOptions.localSocket = cmdServer.Flag.String("filer.localSocket", "", "default to /tmp/seaweedfs-filer-<port>.sock")
 	filerOptions.showUIDirectoryDelete = cmdServer.Flag.Bool("filer.ui.deleteDir", true, "enable filer UI show delete directory button")
 	filerOptions.downloadMaxMBps = cmdServer.Flag.Int("filer.downloadMaxMBps", 0, "download max speed for each download request, in MB per second")
+	filerOptions.diskType = cmdServer.Flag.String("filer.disk", "", "[hdd|ssd|<tag>] hard drive or solid state drive or any tag")
 
 	serverOptions.v.port = cmdServer.Flag.Int("volume.port", 8080, "volume server http listen port")
 	serverOptions.v.portGrpc = cmdServer.Flag.Int("volume.port.grpc", 0, "volume server grpc listen port")
@@ -253,6 +254,9 @@ func runServer(cmd *Command, args []string) bool {
 	serverWhiteList := util.StringSplit(*serverWhiteListOption, ",")
 
 	if *isStartingFiler {
+		if *filerOptions.diskType == "" && *serverOptions.v.diskType != "" {
+			filerOptions.diskType = serverOptions.v.diskType
+		}
 		go func() {
 			time.Sleep(1 * time.Second)
 			filerOptions.startFiler()

--- a/weed/server/filer_grpc_server.go
+++ b/weed/server/filer_grpc_server.go
@@ -295,6 +295,10 @@ func (fs *FilerServer) DeleteEntry(ctx context.Context, req *filer_pb.DeleteEntr
 
 func (fs *FilerServer) AssignVolume(ctx context.Context, req *filer_pb.AssignVolumeRequest) (resp *filer_pb.AssignVolumeResponse, err error) {
 
+	if req.DiskType == "" {
+		req.DiskType = fs.option.DiskType
+	}
+
 	so, err := fs.detectStorageOption(req.Path, req.Collection, req.Replication, req.TtlSec, req.DiskType, req.DataCenter, req.Rack, req.DataNode)
 	if err != nil {
 		glog.V(3).Infof("AssignVolume: %v", err)

--- a/weed/server/filer_server.go
+++ b/weed/server/filer_server.go
@@ -69,6 +69,7 @@ type FilerOption struct {
 	ConcurrentUploadLimit int64
 	ShowUIDirectoryDelete bool
 	DownloadMaxBytesPs    int64
+	DiskType              string
 }
 
 type FilerServer struct {

--- a/weed/server/filer_server_handlers_write.go
+++ b/weed/server/filer_server_handlers_write.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 	"net/http"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/operation"
@@ -95,6 +96,11 @@ func (fs *FilerServer) PostHandler(w http.ResponseWriter, r *http.Request, conte
 			w.WriteHeader(http.StatusInternalServerError)
 		}
 		return
+	}
+
+	// When DiskType is empty,use filer's -disk
+	if so.DiskType == "" {
+		so.DiskType = fs.option.DiskType
 	}
 
 	if query.Has("mv.from") {


### PR DESCRIPTION
# What problem are we solving?
When I start the volume with ```-disk=nvme```,and use filer to upload files.The filer will prompt no free volumes left and upload failed.
```
E0225 11:45:13.938780 filer_server_handlers_write.go:48 failing to assign a file id: rpc error: code = Unknown desc = no free volumes left for {"replication":{},"ttl":{"Count":0,"Unit":0}}
E0225 11:45:13.939355 filer_server_handlers_write_upload.go:209 upload error: rpc error: code = Unknown desc = no free volumes left for {"replication":{},"ttl":{"Count":0,"Unit":0}}
I0225 11:45:13.939424 common.go:70 response method:POST URL:/ with httpStatus:500 and JSON:{"error":"rpc error: code = Unknown desc = no free volumes left for {\"replication\":{},\"ttl\":{\"Count\":0,\"Unit\":0}}"}
```
# How are we solving the problem?
I added - disk so that filer can write volume with same disk tag.


# How is the PR tested?
Start volume server with ```-disk=nvme```.
Start filer server with ```-disk=nvme```.
Upload the file to filer server.


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
