### PR TITLE
Avoid OOM when trying to consider all in some cases millions msg in queue

### DIFF
--- a/weed/command/scaffold/notification.toml
+++ b/weed/command/scaffold/notification.toml
@@ -52,3 +52,8 @@ enabled = false
 # create binding myexchange => myqueue
 topic_url = "rabbit://myexchange"
 sub_url = "rabbit://myqueue"
+# With a prefetch count greater than zero, the server will deliver that many
+# messages to consumers before acknowledgments are received.  The server ignores
+# this option when consumers are started with noAck because no acknowledgments
+# are expected or sent. https://blog.rabbitmq.com/posts/2012/04/rabbitmq-performance-measurements-part-2
+prefetchCount = 100

--- a/weed/replication/sub/notification_gocdk_pub_sub.go
+++ b/weed/replication/sub/notification_gocdk_pub_sub.go
@@ -5,6 +5,7 @@ package sub
 
 import (
 	"context"
+	"fmt"
 	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"

--- a/weed/replication/sub/notification_gocdk_pub_sub.go
+++ b/weed/replication/sub/notification_gocdk_pub_sub.go
@@ -134,7 +134,8 @@ func (k *GoCDKPubSubInput) ReceiveMessage() (key string, message *filer_pb.Event
 				time.Sleep(time.Second)
 				return
 			}
-			if k.prefetchCount > 0 {
+			k.sub = rabbitpubsub.OpenSubscription(conn, getPath(k.subURL), nil)
+			if k.prefetchCount > 0 && k.sub.As(&conn) {
 				if ch, err := conn.Channel(); err == nil {
 					defer ch.Close()
 					if err = ch.Qos(k.prefetchCount, 0, false); err != nil {
@@ -144,7 +145,6 @@ func (k *GoCDKPubSubInput) ReceiveMessage() (key string, message *filer_pb.Event
 					glog.Error(fmt.Errorf("get channel: %v", err))
 				}
 			}
-			k.sub = rabbitpubsub.OpenSubscription(conn, getPath(k.subURL), nil)
 			return
 		}
 		// This is permanent cached sub err

--- a/weed/replication/sub/notification_gocdk_pub_sub.go
+++ b/weed/replication/sub/notification_gocdk_pub_sub.go
@@ -88,6 +88,7 @@ func (k *GoCDKPubSubInput) GetName() string {
 }
 
 func (k *GoCDKPubSubInput) Initialize(configuration util.Configuration, prefix string) error {
+	prefetchCount := configuration.GetInt(prefix + "prefetchCount")
 	topicUrl := configuration.GetString(prefix + "topic_url")
 	k.subURL = configuration.GetString(prefix + "sub_url")
 	glog.V(0).Infof("notification.gocdk_pub_sub.sub_url: %v", k.subURL)
@@ -102,6 +103,12 @@ func (k *GoCDKPubSubInput) Initialize(configuration util.Configuration, prefix s
 			return err
 		}
 		defer ch.Close()
+		if prefetchCount > 0 {
+			err = ch.Qos(prefetchCount, 0, false)
+			if err != nil {
+				return fmt.Errorf("set basic.qos: %v", err)
+			}
+		}
 		_, err = ch.QueueInspect(getPath(k.subURL))
 		if err != nil {
 			if strings.HasPrefix(err.Error(), "Exception (404) Reason") {


### PR DESCRIPTION
# What problem are we solving?

If replication has not worked for some time, then a large number of messages can accumulate in the queue, which are trying to be subtracted at one time, which leads to a memory load on the rabbitry server and the replicator may run out of memory

# How are we solving the problem?

Add a prefetchCount parameter to notification.gocdk_pub_sub which limits the number of messages received at a time

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
