### PR TITLE
#4270 set http status code to 409 if dir already exists

### DIFF
--- a/weed/server/filer_server_handlers_write_autochunk.go
+++ b/weed/server/filer_server_handlers_write_autochunk.go
@@ -49,7 +49,7 @@ func (fs *FilerServer) autoChunk(ctx context.Context, w http.ResponseWriter, r *
 	if err != nil {
 		if strings.HasPrefix(err.Error(), "read input:") || err.Error() == io.ErrUnexpectedEOF.Error() {
 			writeJsonError(w, r, 499, err)
-		} else if strings.HasSuffix(err.Error(), "is a file") {
+		} else if strings.HasSuffix(err.Error(), "is a file") || strings.HasSuffix(err.Error(), "already exists") {
 			writeJsonError(w, r, http.StatusConflict, err)
 		} else {
 			writeJsonError(w, r, http.StatusInternalServerError, err)


### PR DESCRIPTION
# What problem are we solving?
Filer API returns `500 Internal server error` status code if path/dir already exists. It should return 4XX client error.


# How are we solving the problem?
If error message has suffix `already exists`, `409 Conflict` will be returned


# How is the PR tested?
PR is tested manually as I am not able to find related test cases. `weed` binary is generated using `go build ./weed` and empty storage started using below commands.

```
./weed master -mdir="." -ip=localhost
./weed volume -max=100 -mserver="localhost:9333" -dir="./data"
./weed filer -ip=localhost -port=8888 -master=localhost:9333
```
Then API is tested with help of `curl`.

```
> curl -vvv -X POST "http://localhost:8888/foo/"
*   Trying 127.0.0.1:8888...
* Connected to localhost (127.0.0.1) port 8888 (#0)
> POST /foo/ HTTP/1.1
> Host: localhost:8888
> User-Agent: curl/7.81.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 201 Created
< Content-Type: application/json
< Server: SeaweedFS Filer 30GB 3.43
< Date: Wed, 08 Mar 2023 12:00:24 GMT
< Content-Length: 14
< 
* Connection #0 to host localhost left intact
{"name":"foo"}% 

> curl -vvv -X POST "http://localhost:8888/foo/"

*   Trying 127.0.0.1:8888...
* Connected to localhost (127.0.0.1) port 8888 (#0)
> POST /foo/ HTTP/1.1
> Host: localhost:8888
> User-Agent: curl/7.81.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 409 Conflict
< Content-Type: application/json
< Server: SeaweedFS Filer 30GB 3.43
< Date: Wed, 08 Mar 2023 12:00:27 GMT
< Content-Length: 35
< 
* Connection #0 to host localhost left intact
{"error":"dir /foo already exists"}% 
```

There are multiple places where error is returned with message having suffix `already exists`. 
```
> grep -irn 'already exists' weed/

weed/filer/redis3/ItemList.go:94:	// case 1: the name already exists as one leading key in the batch
weed/filer/filer.go:194:			glog.V(3).Infof("EEXIST: entry %s already exists", entry.FullPath)
weed/filer/filer.go:195:			return fmt.Errorf("EEXIST: entry %s already exists", entry.FullPath)
weed/s3api/bucket_metadata.go:174:	//check if already exists
grep: weed/weed: binary file matches
weed/server/volume_grpc_copy.go:33:		glog.V(0).Infof("volume %d already exists. deleted before copying...", req.VolumeId)
weed/server/volume_grpc_tier_upload.go:48:			return fmt.Errorf("destination %s already exists", req.DestinationBackendName)
weed/server/filer_server_handlers_write_autochunk.go:318:		replyerr = fmt.Errorf("dir %s already exists", path)
weed/server/volume_grpc_tier_download.go:32:	// check whether the local .dat already exists
weed/storage/store.go:163:		return fmt.Errorf("Volume Id %d already exists!", vid)
weed/mount/weedfs_xattr.go:66://	the attribute already exists.  To modify these semantics, one of
weed/mount/weedfs_rename.go:61:              newpath already exists.
weed/util/skiplist/name_list.go:69:	// case 1: the name already exists as one leading key in the batch

```

I haven't tested all such occurances except one mentioned in #4270. But IMO even other places also 409 makes sense if 500 is being returned. So even though  `already exists` suffix could cover broader scenarios, it should not be an issue. 


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
