### PR TITLE
Fix -raftHashicorp and -raftBootstrap flag propagation.

### DIFF
--- a/weed/command/server.go
+++ b/weed/command/server.go
@@ -97,6 +97,7 @@ func init() {
 	masterOptions.metricsIntervalSec = cmdServer.Flag.Int("master.metrics.intervalSeconds", 15, "Prometheus push interval in seconds")
 	masterOptions.raftResumeState = cmdServer.Flag.Bool("master.resumeState", false, "resume previous state on start master server")
 	masterOptions.raftHashicorp = cmdServer.Flag.Bool("master.raftHashicorp", false, "use hashicorp raft")
+	masterOptions.raftBootstrap = cmdMaster.Flag.Bool("master.raftBootstrap", false, "Whether to bootstrap the Raft cluster")
 	masterOptions.heartbeatInterval = cmdServer.Flag.Duration("master.heartbeatInterval", 300*time.Millisecond, "heartbeat interval of master servers, and will be randomly multiplied by [1, 1.25)")
 	masterOptions.electionTimeout = cmdServer.Flag.Duration("master.electionTimeout", 10*time.Second, "election timeout of master servers")
 


### PR DESCRIPTION
`weed server` was not correctly propagating
`-master.raftHashicorp` and `-master.raftBootstrap` flags when starting the master server.

Related to #4307

# What problem are we solving?

Propagating the following flags to the master server from the server command:
* -raftHashicorp
* -raftBootstrap

# How are we solving the problem?

* Using the `masterOption` argument in `startMaster()` rather than global options.
* Exposing `-master.raftBootstrap` as a server command flag.

# How is the PR tested?

* Ran all unit tests and verified they passed.
* Ran master command to verify no change in behavior.
* Ran server command and verified the Hashicorp Raft server is used when the
  `-master.raftBootstrap` flag is specified.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
