### PR TITLE
The filer does not set defaultReplication to the defaultReplication o…

### DIFF
--- a/weed/server/filer_server.go
+++ b/weed/server/filer_server.go
@@ -195,9 +195,6 @@ func (fs *FilerServer) checkWithMaster() {
 					return fmt.Errorf("get master %s configuration: %v", master, err)
 				}
 				fs.metricsAddress, fs.metricsIntervalSec = resp.MetricsAddress, int(resp.MetricsIntervalSeconds)
-				if fs.option.DefaultReplication == "" {
-					fs.option.DefaultReplication = resp.DefaultReplication
-				}
 				return nil
 			})
 			if readErr == nil {


### PR DESCRIPTION
# What problem are we solving?

When the defaultReplication option of the master is modified and all master nodes are restarted, the defaultReplication will not take effect (because the filer Keep the previous defaultReplication setting from the master)

# How are we solving the problem?

When the defaultReplication of the filer is not set, do not set the defaultReplication to the defaultReplication of the master (it is not necessary, because if the filer is not set, the configuration of the master will be used when calling Assign)

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
