### PR TITLE
Fix not being executed commands in admin scripts.

### DIFF
--- a/weed/server/master_server.go
+++ b/weed/server/master_server.go
@@ -319,8 +319,8 @@ func processEachCmd(reg *regexp.Regexp, line string, commandEnv *shell.CommandEn
 	cmd := strings.ToLower(cmds[0])
 
 	for _, c := range shell.Commands {
-		if c.Name() == cmd {
-			glog.V(0).Infof("executing: %s %v", cmd, args)
+		if strings.ToLower(c.Name()) == cmd {
+			glog.V(0).Infof("executing: %s %v", c.Name(), args)
 			if err := c.Do(args, commandEnv, os.Stdout); err != nil {
 				glog.V(0).Infof("error: %v", err)
 			}


### PR DESCRIPTION
fix #3718

# What problem are we solving?
In maintenance scripts, some commands like 'volume.delete Empty -quietFor=24h -force' is not executed


# How are we solving the problem?
Solve the problem of lowercase.


# How is the PR tested?
master.toml
```
# Put this file to one of the location, with descending priority
#    ./master.toml
#    $HOME/.seaweedfs/master.toml
#    /etc/seaweedfs/master.toml
# this file is read by master

[master.maintenance]
# periodically run these scripts are the same as running them from 'weed shell'
scripts = """
  lock
  volume.deleteEmpty -quietFor=24h -force
  volume.balance -force
  volume.fix.replication
  s3.clean.uploads -timeAgo=24h
  unlock
"""
sleep_minutes = 1          # sleep minutes between each script execution
```


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
