### PR TITLE
Make filer compatible with s3 when handling /buckets/../.. paths (an entry can be both a file and a directory)

### DIFF
--- a/weed/filer/entry.go
+++ b/weed/filer/entry.go
@@ -140,3 +140,16 @@ func maxUint64(x, y uint64) uint64 {
 	}
 	return y
 }
+
+// When Entry.IsDirectory() is true, pass the Mime! = "" to determine whether it is an object file,
+// so if the mime was empty before, the default value is set to "application/octet-stream"
+func (e *Entry) ensureMimeForS3Entry(mime string) {
+	if e.Mime != "" {
+		return
+	}
+	if mime != "" {
+		e.Mime = mime
+	} else {
+		e.Mime = "application/octet-stream"
+	}
+}

--- a/weed/filer/filer.go
+++ b/weed/filer/filer.go
@@ -314,6 +314,7 @@ func (f *Filer) UpdateEntry(ctx context.Context, oldEntry, entry *Entry, updateM
 		if oldEntry.IsDirectory() && !entry.IsDirectory() {
 			if updateModeAndMime {
 				entry.Mode |= oldEntry.Mode
+				entry.ensureMimeForS3Entry("")
 			} else {
 				glog.Errorf("existing %s is a directory", oldEntry.FullPath)
 				return fmt.Errorf("existing %s is a directory", oldEntry.FullPath)
@@ -322,7 +323,7 @@ func (f *Filer) UpdateEntry(ctx context.Context, oldEntry, entry *Entry, updateM
 		if !oldEntry.IsDirectory() && entry.IsDirectory() {
 			if updateModeAndMime {
 				entry.Mode |= oldEntry.Mode
-				entry.Mime = oldEntry.Mime
+				entry.ensureMimeForS3Entry(oldEntry.Mime)
 			} else {
 				glog.Errorf("existing %s is a file", oldEntry.FullPath)
 				return fmt.Errorf("existing %s is a file", oldEntry.FullPath)

--- a/weed/filer/filerstore_wrapper.go
+++ b/weed/filer/filerstore_wrapper.go
@@ -141,10 +141,6 @@ func (fsw *FilerStoreWrapper) UpdateEntry(ctx context.Context, entry *Entry) err
 	}()
 
 	filer_pb.BeforeEntrySerialization(entry.GetChunks())
-	if entry.Mime == "application/octet-stream" {
-		entry.Mime = ""
-	}
-
 	if err := fsw.handleUpdateToHardLinks(ctx, entry); err != nil {
 		return err
 	}

--- a/weed/pb/filer_pb/filer.pb.go
+++ b/weed/pb/filer_pb/filer.pb.go
@@ -357,6 +357,10 @@ func (x *Entry) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
+func (x *Entry) IsS3File() bool {
+	return !x.IsDirectory || (x.Attributes != nil && x.Attributes.Mime != "")
+}
+
 func (*Entry) ProtoMessage() {}
 
 func (x *Entry) ProtoReflect() protoreflect.Message {

--- a/weed/pb/filer_pb/filer.pb.go
+++ b/weed/pb/filer_pb/filer.pb.go
@@ -357,10 +357,6 @@ func (x *Entry) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (x *Entry) IsS3File() bool {
-	return !x.IsDirectory || (x.Attributes != nil && x.Attributes.Mime != "")
-}
-
 func (*Entry) ProtoMessage() {}
 
 func (x *Entry) ProtoReflect() protoreflect.Message {

--- a/weed/s3api/s3api_object_copy_handlers.go
+++ b/weed/s3api/s3api_object_copy_handlers.go
@@ -41,7 +41,7 @@ func (s3a *S3ApiServer) CopyObjectHandler(w http.ResponseWriter, r *http.Request
 		fullPath := util.FullPath(fmt.Sprintf("%s/%s%s", s3a.option.BucketsPath, dstBucket, dstObject))
 		dir, name := fullPath.DirAndName()
 		entry, err := s3a.getEntry(dir, name)
-		if err != nil || entry.IsDirectory {
+		if err != nil || !entry.IsS3File() {
 			s3err.WriteErrorResponse(w, r, s3err.ErrInvalidCopySource)
 			return
 		}
@@ -70,7 +70,7 @@ func (s3a *S3ApiServer) CopyObjectHandler(w http.ResponseWriter, r *http.Request
 	}
 	srcPath := util.FullPath(fmt.Sprintf("%s/%s%s", s3a.option.BucketsPath, srcBucket, srcObject))
 	dir, name := srcPath.DirAndName()
-	if entry, err := s3a.getEntry(dir, name); err != nil || entry.IsDirectory {
+	if entry, err := s3a.getEntry(dir, name); err != nil || !entry.IsS3File() {
 		s3err.WriteErrorResponse(w, r, s3err.ErrInvalidCopySource)
 		return
 	}

--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -127,10 +127,13 @@ func (s3a *S3ApiServer) PutObjectHandler(w http.ResponseWriter, r *http.Request)
 
 func urlEscapeObject(object string) string {
 	t := urlPathEscape(removeDuplicateSlashes(object))
-	if strings.HasPrefix(t, "/") {
-		return t
+	if !strings.HasPrefix(t, "/") {
+		t = "/" + t
 	}
-	return "/" + t
+	if t != "/" && strings.HasSuffix(t, "/") {
+		return strings.Trim(t, "/")
+	}
+	return t
 }
 
 func urlPathEscape(object string) string {

--- a/weed/s3api/s3api_object_handlers_test.go
+++ b/weed/s3api/s3api_object_handlers_test.go
@@ -35,7 +35,7 @@ func TestRemoveDuplicateSlashes(t *testing.T) {
 		{
 			name:           "path with duplicates",
 			path:           "///path//to/object//",
-			expectedResult: "/path/to/object/",
+			expectedResult: "/path/to/object",
 		},
 	}
 

--- a/weed/server/filer_grpc_server.go
+++ b/weed/server/filer_grpc_server.go
@@ -187,7 +187,8 @@ func (fs *FilerServer) UpdateEntry(ctx context.Context, req *filer_pb.UpdateEntr
 		return &filer_pb.UpdateEntryResponse{}, err
 	}
 
-	if err = fs.filer.UpdateEntry(ctx, entry, newEntry); err == nil {
+	isS3EntryPath := fs.filer.IsS3EntryPath(fullpath)
+	if err = fs.filer.UpdateEntry(ctx, entry, newEntry, isS3EntryPath); err == nil {
 		fs.filer.DeleteChunks(garbage)
 
 		fs.filer.NotifyUpdateEvent(ctx, entry, newEntry, true, req.IsFromOtherCluster, req.Signatures)
@@ -285,7 +286,7 @@ func (fs *FilerServer) DeleteEntry(ctx context.Context, req *filer_pb.DeleteEntr
 
 	glog.V(4).Infof("DeleteEntry %v", req)
 
-	err = fs.filer.DeleteEntryMetaAndData(ctx, util.JoinPath(req.Directory, req.Name), req.IsRecursive, req.IgnoreRecursiveError, req.IsDeleteData, req.IsFromOtherCluster, req.Signatures)
+	err = fs.filer.DeleteEntryMetaAndData(ctx, util.JoinPath(req.Directory, req.Name), req.IsRecursive, req.IgnoreRecursiveError, req.IsDeleteData, req.IsFromOtherCluster, req.Signatures, false)
 	resp = &filer_pb.DeleteEntryResponse{}
 	if err != nil && err != filer_pb.ErrNotFound {
 		resp.Error = err.Error()

--- a/weed/server/filer_grpc_server_rename.go
+++ b/weed/server/filer_grpc_server_rename.go
@@ -203,7 +203,7 @@ func (fs *FilerServer) moveSelfEntry(ctx context.Context, stream filer_pb.Seawee
 
 	// delete old entry
 	ctx = context.WithValue(ctx, "OP", "MV")
-	deleteErr := fs.filer.DeleteEntryMetaAndData(ctx, oldPath, false, false, false, false, signatures)
+	deleteErr := fs.filer.DeleteEntryMetaAndData(ctx, oldPath, false, false, false, false, signatures, false)
 	if deleteErr != nil {
 		return deleteErr
 	}

--- a/weed/server/filer_server_handlers_write_autochunk.go
+++ b/weed/server/filer_server_handlers_write_autochunk.go
@@ -143,15 +143,21 @@ func (fs *FilerServer) saveMetaData(ctx context.Context, r *http.Request, fileNa
 
 	// fix the path
 	path := r.URL.Path
-	if strings.HasSuffix(path, "/") {
-		if fileName != "" {
-			path += fileName
+	if fs.filer.IsS3EntryPath(path) {
+		if strings.HasSuffix(path, "/") {
+			path = path[0 : len(path)-1]
 		}
 	} else {
-		if fileName != "" {
-			if possibleDirEntry, findDirErr := fs.filer.FindEntry(ctx, util.FullPath(path)); findDirErr == nil {
-				if possibleDirEntry.IsDirectory() {
-					path += "/" + fileName
+		if strings.HasSuffix(path, "/") {
+			if fileName != "" {
+				path += fileName
+			}
+		} else {
+			if fileName != "" {
+				if possibleDirEntry, findDirErr := fs.filer.FindEntry(ctx, util.FullPath(path)); findDirErr == nil {
+					if possibleDirEntry.IsDirectory() {
+						path += "/" + fileName
+					}
 				}
 			}
 		}


### PR DESCRIPTION
# What problem are we solving?

Due to filer's mandatory compatibility with the path specification of posix, many files (both object files and logical directories in ceph s3) cannot be migrated from ceph to seaweed. 

When migrating these files, a response of 409 (prompt 'existing xxx is a directory' or 'existing xxx is a file') will be generated, which is very frustrating

# How are we solving the problem?

Make filer compatible with s3 when handling /buckets/../.. paths (an entry can be both a file and a directory)

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
