### PR TITLE
fix key corrupt when fs.configure copy path trie

### DIFF
--- a/weed/filer/filer_conf.go
+++ b/weed/filer/filer_conf.go
@@ -125,7 +125,8 @@ func (fc *FilerConf) DeleteLocationConf(locationPrefix string) {
 		if string(key) == locationPrefix {
 			return true
 		}
-		rules.Put(key, value)
+		key = bytes.Clone(key)
+		_ = rules.Put(key, value)
 		return true
 	})
 	fc.rules = rules


### PR DESCRIPTION
# What problem are we solving?

fix key corrupt when fs.configure copy path trie

# How are we solving the problem?

bytes.copy(key)

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
