### PR TITLE
fix(chart): use hostpath filer persistence when deprecated enablePVC is unset

### DIFF
--- a/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
@@ -175,7 +175,7 @@ spec:
             - mountPath: /etc/sw
               name: config-users
               readOnly: true
-            {{- if .Values.filer.enablePVC }}
+            {{- if (or .Values.filer.enablePVC (eq .Values.filer.data.type "hostPath")) }}
             - name: data-filer
               mountPath: /data
             {{- end }}


### PR DESCRIPTION
If hostPath is used for filer persistence and the deprecated `enablePVC` option is left false, the filer storage is not persistent.