### PR TITLE
s3 fix get fake dir object key

### DIFF
--- a/weed/s3api/s3_constants/s3_actions.go
+++ b/weed/s3api/s3_constants/s3_actions.go
@@ -9,4 +9,5 @@ const (
 
 	SeaweedStorageDestinationHeader = "x-seaweedfs-destination"
 	MultipartUploadsFolder          = ".uploads"
+	FolderMimeType                  = "httpd/unix-directory"
 )

--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -99,7 +99,7 @@ func (s3a *S3ApiServer) PutObjectHandler(w http.ResponseWriter, r *http.Request)
 			s3a.option.BucketsPath, bucket+strings.TrimSuffix(object, "/"),
 			func(entry *filer_pb.Entry) {
 				if objectContentType == "" {
-					objectContentType = "httpd/unix-directory"
+					objectContentType = s3_constants.FolderMimeType
 				}
 				entry.Attributes.Mime = objectContentType
 			}); err != nil {

--- a/weed/server/filer_server_handlers_read.go
+++ b/weed/server/filer_server_handlers_read.go
@@ -127,7 +127,7 @@ func (fs *FilerServer) GetOrHeadHandler(w http.ResponseWriter, r *http.Request) 
 		w.Header().Set(s3_constants.X_SeaweedFS_Header_Directory_Key, "true")
 	}
 
-	if isForDirectory {
+	if isForDirectory && entry.Attr.Mime != s3_constants.FolderMimeType {
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}

--- a/weed/server/filer_server_handlers_read.go
+++ b/weed/server/filer_server_handlers_read.go
@@ -15,8 +15,6 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/exp/slices"
-
 	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/images"
@@ -120,7 +118,8 @@ func (fs *FilerServer) GetOrHeadHandler(w http.ResponseWriter, r *http.Request) 
 			writeJsonQuiet(w, r, http.StatusOK, entry)
 			return
 		}
-		if slices.Contains([]string{"httpd/unix-directory", ""}, entry.Attr.Mime) {
+		if entry.Attr.Mime == "" || (entry.Attr.Mime == s3_constants.FolderMimeType && r.Header.Get(s3_constants.AmzIdentityId) == "") {
+			// return index of directory for non s3 gateway
 			fs.listDirectoryHandler(w, r)
 			return
 		}


### PR DESCRIPTION
# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/3086


# How are we solving the problem?

https://github.com/seaweedfs/seaweedfs/issues/3086


# How is the PR tested?

```
aws --endpoint-url http://127.0.0.1:8333 s3api head-object --bucket nextcloudext --key "rootFolder"
{
    "AcceptRanges": "bytes",
    "LastModified": "2023-04-11T09:25:13+00:00",
    "ContentLength": 0,
    "ETag": "\"d41d8cd98f00b204e9800998ecf8427e-0\"",
    "ContentDisposition": "inline; filename=\"rootFolder\"",
    "ContentType": "httpd/unix-directory",
    "Metadata": {}
}
```
and
```
aws --endpoint-url http://127.0.0.1:8333 s3api head-object --bucket nextcloudext --key "rootFolder/"
{
    "AcceptRanges": "bytes",
    "LastModified": "2023-04-11T09:25:13+00:00",
    "ContentLength": 0,
    "ETag": "\"d41d8cd98f00b204e9800998ecf8427e-0\"",
    "ContentDisposition": "inline; filename=\"rootFolder\"",
    "ContentType": "httpd/unix-directory",
    "Metadata": {}
}
```


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
