### PR TITLE
s3 fix get list of dir object key with slash suffix

### DIFF
--- a/weed/s3api/s3api_objects_list_handlers.go
+++ b/weed/s3api/s3api_objects_list_handlers.go
@@ -325,7 +325,6 @@ func (s3a *S3ApiServer) doListFilerEntries(client filer_pb.SeaweedFilerClient, d
 	}
 	if cursor.prefixEndsOnDelimiter {
 		request.Limit = uint32(1)
-		cursor.prefixEndsOnDelimiter = false
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -352,6 +351,13 @@ func (s3a *S3ApiServer) doListFilerEntries(client filer_pb.SeaweedFilerClient, d
 		}
 		entry := resp.Entry
 		nextMarker = entry.Name
+		if cursor.prefixEndsOnDelimiter {
+			if entry.Name == prefix && entry.IsDirectory {
+				cursor.prefixEndsOnDelimiter = false
+			} else {
+				continue
+			}
+		}
 		if entry.IsDirectory {
 			// glog.V(4).Infof("List Dir Entries %s, file: %s, maxKeys %d", dir, entry.Name, cursor.maxKeys)
 			if entry.Name == s3_constants.MultipartUploadsFolder { // FIXME no need to apply to all directories. this extra also affects maxKeys


### PR DESCRIPTION
# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/3086


# How are we solving the problem?

https://github.com/seaweedfs/seaweedfs/issues/3086


# How is the PR tested?
with slash
```
aws --endpoint-url http://127.0.0.1:8333 s3api list-objects-v2 --bucket nextcloudext --prefix "Proverka/" | jq '.Contents[] | .Key'
"Proverka/"
"Proverka/File"
"Proverka/File001"
"Proverka/File002"
"Proverka/File003"
"Proverka/File004"
"Proverka/File005"
```
without slash

```
aws --endpoint-url http://127.0.0.1:8333 s3api list-objects-v2 --bucket nextcloudext --prefix "Proverka" | jq '.Contents[] | .Key'
"Proverka/"
"Proverka/File"
"Proverka/File001"
"Proverka/File002"
"Proverka/File003"
"Proverka/File004"
"Proverka/File005"
"Proverka0"
"Proverka001/"
"Proverka1/"
"Proverka2/"
"Proverka3/"
"Proverka4/"
```

empty for entry file and not entry not eq prefix

```
aws --endpoint-url http://127.0.0.1:8333 s3api list-objects-v2 --bucket nextcloudext --prefix "Proverka0/"
aws --endpoint-url http://127.0.0.1:8333 s3api list-objects-v2 --bucket nextcloudext --prefix "Proverk/"
```

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
