### PR TITLE
Fixing a service deployment bug

### DIFF
--- a/k8s/charts/seaweedfs/templates/filer-service.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-service.yaml
@@ -20,6 +20,12 @@ spec:
     port: {{ .Values.filer.grpcPort }}
     targetPort: {{ .Values.filer.grpcPort }}
     protocol: TCP
+  {{- if .Values.filer.s3.enabled }}
+  - name: "swfs-s3"
+    port: {{ .Values.filer.s3.port }}
+    targetPort: {{ .Values.filer.s3.port }}
+    protocol: TCP
+  {{- end }}
   {{- if .Values.filer.metricsPort }}
   - name: "metrics"
     port: {{ .Values.filer.metricsPort }}


### PR DESCRIPTION
When trying to deploy the filer statefulset with s3 baked in, the proper service port is not opened like it is for the separate s3 deployment. Added a conditional check to see if .Values.filer.s3.enabled, and added the port

# What problem are we solving?

When Values.filer.s3.enabled is true, the filer service does not expose the port

# How are we solving the problem?

Added a conditional check to see if .Values.filer.s3.enabled, and added the port

# How is the PR tested?

Tested the helm deployment service creation

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
