### PR TITLE
fix(chart): use filer data PVC correctly

### DIFF
--- a/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
@@ -175,7 +175,7 @@ spec:
             - mountPath: /etc/sw
               name: config-users
               readOnly: true
-            {{- if (or .Values.filer.enablePVC (eq .Values.filer.data.type "hostPath")) }}
+            {{- if (or .Values.filer.enablePVC (or (eq .Values.filer.data.type "hostPath") (eq .Values.filer.data.type "persistentVolumeClaim"))) }}
             - name: data-filer
               mountPath: /data
             {{- end }}


### PR DESCRIPTION
Follow-up to #4384

... Not sure if there's other related lurking bugs related to this ongoing `enablePVC -> data.*.type` transition. What's the plan on that? Maybe better to carry it out sooner rather than later ;) (I'm offering to do the work!)