### PR TITLE
fix s3test test_bucket_listv2_delimiter_prefix_ends_with_delimiter

### DIFF
--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -94,12 +94,15 @@ func (s3a *S3ApiServer) PutObjectHandler(w http.ResponseWriter, r *http.Request)
 	defer dataReader.Close()
 
 	objectContentType := r.Header.Get("Content-Type")
-	if strings.HasSuffix(object, "/") && r.ContentLength == 0 {
+	if strings.HasSuffix(object, "/") && r.ContentLength <= 1024 {
 		if err := s3a.mkdir(
 			s3a.option.BucketsPath, bucket+strings.TrimSuffix(object, "/"),
 			func(entry *filer_pb.Entry) {
 				if objectContentType == "" {
 					objectContentType = s3_constants.FolderMimeType
+				}
+				if r.ContentLength > 0 {
+					entry.Content, _ = io.ReadAll(r.Body)
 				}
 				entry.Attributes.Mime = objectContentType
 			}); err != nil {

--- a/weed/s3api/s3api_objects_list_handlers.go
+++ b/weed/s3api/s3api_objects_list_handlers.go
@@ -142,7 +142,7 @@ func (s3a *S3ApiServer) listFilerEntries(bucket string, originalPrefix string, m
 	var nextMarker string
 	cursor := &ListingCursor{
 		maxKeys:               maxKeys,
-		prefixEndsOnDelimiter: strings.HasSuffix(originalPrefix, "/"),
+		prefixEndsOnDelimiter: strings.HasSuffix(originalPrefix, "/") && len(originalMarker) == 0,
 	}
 
 	// check filer
@@ -238,7 +238,11 @@ type ListingCursor struct {
 func normalizePrefixMarker(prefix, marker string) (alignedDir, alignedPrefix, alignedMarker string) {
 	// alignedDir should not end with "/"
 	// alignedDir, alignedPrefix, alignedMarker should only have "/" in middle
-	prefix = strings.Trim(prefix, "/")
+	if len(marker) == 0 {
+		prefix = strings.Trim(prefix, "/")
+	} else {
+		prefix = strings.TrimLeft(prefix, "/")
+	}
 	marker = strings.TrimLeft(marker, "/")
 	if prefix == "" {
 		return "", "", marker


### PR DESCRIPTION
# What problem are we solving?

```
> fs.tree /buckets/yournamehere-8l0wvspgzg423hom-1
yournamehere-oke81c27mfnzwpwt-1
└──asdf
    └──asdf
```

run test
```
>       validate_bucket_listv2(bucket_name, 'asdf/', '/', None, 1000, False, ['asdf/'], [], last=True)

s3tests_boto3/functional/test_s3.py:342: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

bucket_name = 'yournamehere-8l0wvspgzg423hom-1', prefix = 'asdf/', delimiter = '/', continuation_token = None, max_keys = 1000, is_truncated = False, check_objs = ['asdf/']
check_prefixes = [], last = True
    def validate_bucket_listv2(bucket_name, prefix, delimiter, continuation_token, max_keys,
        keys = _get_keys(response)
        prefixes = _get_prefixes(response)
    
>       assert len(keys) == len(check_objs)
E       AssertionError: assert 0 == 1
E        +  where 0 = len([])
E        +  and   1 = len(['asdf/'])

s3tests_boto3/functional/test_s3.py:286: AssertionError
```

# How are we solving the problem?


# How is the PR tested?

```
> fs.tree /buckets/yournamehere-ir3pmbprn9gt03xb-1
yournamehere-oke81c27mfnzwpwt-1
└──asdf
> fs.meta.cat /buckets/yournamehere-ir3pmbprn9gt03xb-1/asdf
{
  "name": "asdf",
  "isDirectory": true,
  "chunks": [],
  "attributes": {
    "fileSize": "0",
    "mtime": "1681322080",
    "fileMode": 2147484159,
    "uid": 0,
    "gid": 0,
    "crtime": "1681322080",
    "mime": "httpd/unix-directory",
    "ttlSec": 0,
    "userName": "",
    "groupName": [],
    "symlinkTarget": "",
    "md5": "",
    "rdev": 0,
    "inode": "0"
  },
  "extended": {},
  "hardLinkId": "",
  "hardLinkCounter": 0,
  "content": "YXNkZi8=",
  "remoteEntry": null,
  "quota": "0"
}chunks 0 meta size: 57 gzip:85
```

check
```
aws --endpoint-url http://127.0.0.1:8000 s3api list-objects-v2 --bucket yournamehere-ir3pmbprn9gt03xb-1 --no-cli-pager --prefix "asdf/" --delimiter '/'
{
    "Contents": [
        {
            "Key": "asdf/",
            "LastModified": "2023-04-12T17:27:33+00:00",
            "ETag": "\"d41d8cd98f00b204e9800998ecf8427e-0\"",
            "Size": 0,
            "StorageClass": "STANDARD",
            "Owner": {
                "ID": "0"
            }
        }
    ]
}
```

s3test:
```
FAILED s3tests_boto3/functional/test_s3.py::test_bucket_listv2_delimiter_basic - botocore.exceptions.ClientError: An error occurred (ExistingObjectIsFile) when calling the PutObject operation: Existing Object is a file.
FAILED s3tests_boto3/functional/test_s3.py::test_bucket_listv2_encoding_basic - AssertionError: assert ['asdf+b'] == ['asdf%2Bb']
FAILED s3tests_boto3/functional/test_s3.py::test_bucket_listv2_fetchowner_defaultempty - assert not 'Owner' in {'ETag': '"82d0f0fa8551de8b7eb5ecb65eae0261"', 'Key': 'foo/bar', 'LastModified': datetime.datetime(2023, 4, 12, 18, 5, 17, tzinfo=tzlocal()), 'Ow...
FAILED s3tests_boto3/functional/test_s3.py::test_bucket_listv2_fetchowner_empty - assert not 'Owner' in {'ETag': '"82d0f0fa8551de8b7eb5ecb65eae0261"', 'Key': 'foo/bar', 'LastModified': datetime.datetime(2023, 4, 12, 18, 5, 17, tzinfo=tzlocal()), 'Ow...
FAILED s3tests_boto3/functional/test_s3.py::test_bucket_listv2_maxkeys_none - assert 10000 == 1000
FAILED s3tests_boto3/functional/test_s3.py::test_bucket_listv2_unordered - AssertionError: ClientError not raised
FAILED s3tests_boto3/functional/test_s3.py::test_bucket_listv2_continuationtoken_empty - KeyError: 'ContinuationToken'
======================================================= 25 failed, 27 passed, 476 deselected, 11 warnings in 19.27s ========================================================
ERROR: InvocationError for command /opt/s3-tests/.tox/py/bin/pytest s3tests_boto3/functional/test_s3.py -m list_objects_v2 (exited with code 1)
_________________________________________________________________________________ summary __________________________________________________________________________________
```
# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
