### PR TITLE
update fuse client log which should output the fh of FileHandle. 

### DIFF
--- a/weed/mount/filehandle.go
+++ b/weed/mount/filehandle.go
@@ -27,7 +27,6 @@ type FileHandle struct {
 	dirtyPages    *PageWriter
 	reader        *filer.ChunkReadAt
 	contentType   string
-	handle        uint64
 	sync.RWMutex
 
 	isDeleted bool

--- a/weed/mount/weedfs_file_sync.go
+++ b/weed/mount/weedfs_file_sync.go
@@ -96,7 +96,7 @@ func (wfs *WFS) doFlush(fh *FileHandle, uid, gid uint32) fuse.Status {
 	fileFullPath := fh.FullPath()
 	dir, name := fileFullPath.DirAndName()
 	// send the data to the OS
-	glog.V(4).Infof("doFlush %s fh %d", fileFullPath, fh.handle)
+	glog.V(4).Infof("doFlush %s fh %d", fileFullPath, fh.fh)
 
 	if !wfs.IsOverQuota {
 		if err := fh.dirtyPages.FlushData(); err != nil {
@@ -177,7 +177,7 @@ func (wfs *WFS) doFlush(fh *FileHandle, uid, gid uint32) fuse.Status {
 	}
 
 	if err != nil {
-		glog.Errorf("%v fh %d flush: %v", fileFullPath, fh.handle, err)
+		glog.Errorf("%v fh %d flush: %v", fileFullPath, fh.fh, err)
 		return fuse.EIO
 	}
 


### PR DESCRIPTION


# What problem are we solving?

the variables handle of FileHandle is invalid


# How are we solving the problem?

update fuse client log which should output the fh of FileHandle. 
the variables handle of FileHandle is useless and delete it.

# How is the PR tested?

write a file, and watch the log

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
