### PR TITLE
use env for flags wtih dot in name

### DIFF
--- a/weed/util/fla9/fla9.go
+++ b/weed/util/fla9/fla9.go
@@ -1059,11 +1059,13 @@ func (f *FlagSet) ParseEnv(environ []string) error {
 		}
 
 		envKey := strings.ToUpper(flag.Name)
+
 		if f.envPrefix != "" {
 			envKey = f.envPrefix + "_" + envKey
 		}
 		envKey = strings.Replace(envKey, "-", "_", -1)
-
+		envKey = strings.Replace(envKey, ".", "_", -1)
+		 
 		value, isSet := env[envKey]
 		if !isSet {
 			continue


### PR DESCRIPTION
# What problem are we solving?
Set flags with dot in their name with environment variable like this:
```shell
export PORT_GRPC=9000
```


# How are we solving the problem?
Change `.` to `_` when trying to find flag in environment variables



# How is the PR tested?
With this commands
```shell
export PORT=5000
export PORT_GRPC=5001
export IP_BIND=0.0.0.0
go run ./weed/weed.go master
```


# Checks
- [ ] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
