### PR TITLE
mount: add retry for read only case

### DIFF
--- a/weed/operation/upload_content.go
+++ b/weed/operation/upload_content.go
@@ -121,7 +121,8 @@ func UploadWithRetry(filerClient filer_pb.FilerClient, assignRequest *filer_pb.A
 			return true
 		})
 	} else {
-		err = util.UploadRetry("uploadWithRetry", doUploadFunc)
+		uploadErrList := []string{"transport", "is read only"}
+		err = util.MultiRetry("uploadWithRetry", uploadErrList, doUploadFunc)
 	}
 
 	return

--- a/weed/operation/upload_content.go
+++ b/weed/operation/upload_content.go
@@ -5,11 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/seaweedfs/seaweedfs/weed/glog"
-	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
-	"github.com/seaweedfs/seaweedfs/weed/security"
-	"github.com/seaweedfs/seaweedfs/weed/stats"
-	"github.com/seaweedfs/seaweedfs/weed/util"
 	"io"
 	"mime"
 	"mime/multipart"
@@ -19,6 +14,12 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/glog"
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/security"
+	"github.com/seaweedfs/seaweedfs/weed/stats"
+	"github.com/seaweedfs/seaweedfs/weed/util"
 )
 
 type UploadOption struct {
@@ -120,7 +121,7 @@ func UploadWithRetry(filerClient filer_pb.FilerClient, assignRequest *filer_pb.A
 			return true
 		})
 	} else {
-		err = util.Retry("uploadWithRetry", doUploadFunc)
+		err = util.UploadRetry("uploadWithRetry", doUploadFunc)
 	}
 
 	return

--- a/weed/util/retry.go
+++ b/weed/util/retry.go
@@ -32,7 +32,7 @@ func Retry(name string, job func() error) (err error) {
 	return err
 }
 
-func UploadRetry(name string, job func() error) (err error) {
+func MultiRetry(name string, errList []string, job func() error) (err error) {
 	waitTime := time.Second
 	hasErr := false
 	for waitTime < RetryWaitTime {
@@ -43,7 +43,7 @@ func UploadRetry(name string, job func() error) (err error) {
 			}
 			break
 		}
-		if strings.Contains(err.Error(), "transport") || strings.Contains(err.Error(), "is read only") {
+		if containErr(err.Error(), errList) {
 			hasErr = true
 			glog.V(0).Infof("retry %s: err: %v", name, err)
 		} else {
@@ -84,4 +84,13 @@ func Nvl(values ...string) string {
 		}
 	}
 	return ""
+}
+
+func containErr(err string, errList []string) bool {
+	for _, e := range errList {
+		if strings.Contains(err, e) {
+			return true
+		}
+	}
+	return false
 }

--- a/weed/util/retry.go
+++ b/weed/util/retry.go
@@ -23,7 +23,27 @@ func Retry(name string, job func() error) (err error) {
 		if strings.Contains(err.Error(), "transport") {
 			hasErr = true
 			glog.V(0).Infof("retry %s: err: %v", name, err)
-		} else if name == "uploadWithRetry" && strings.Contains(err.Error(), "is read only") {
+		} else {
+			break
+		}
+		time.Sleep(waitTime)
+		waitTime += waitTime / 2
+	}
+	return err
+}
+
+func UploadRetry(name string, job func() error) (err error) {
+	waitTime := time.Second
+	hasErr := false
+	for waitTime < RetryWaitTime {
+		err = job()
+		if err == nil {
+			if hasErr {
+				glog.V(0).Infof("retry %s successfully", name)
+			}
+			break
+		}
+		if strings.Contains(err.Error(), "transport") || strings.Contains(err.Error(), "is read only") {
 			hasErr = true
 			glog.V(0).Infof("retry %s: err: %v", name, err)
 		} else {

--- a/weed/util/retry.go
+++ b/weed/util/retry.go
@@ -23,6 +23,9 @@ func Retry(name string, job func() error) (err error) {
 		if strings.Contains(err.Error(), "transport") {
 			hasErr = true
 			glog.V(0).Infof("retry %s: err: %v", name, err)
+		} else if name == "uploadWithRetry" && strings.Contains(err.Error(), "is read only") {
+			hasErr = true
+			glog.V(0).Infof("retry %s: err: %v", name, err)
 		} else {
 			break
 		}


### PR DESCRIPTION
# What problem are we solving?

When the disk space corresponding to a volume server is less than "minfreespace" (default 1%), "isDiskSpaceLow" will be set to true, and all volumes corresponding to the node are read only.

However, it takes 5 seconds for the volume to become read only until the master perceives "read only" through the heartbeat information. During this period, if the master allocates fid to the volume on this node, the write will fail.

According to my analysis, #4381 ， #3628 , #3345 failed to write because of this reason.


# How are we solving the problem?
We add retry to mount for this situation, so that the master can assign fids to other nodes to avoid write failures.


# How is the PR tested?

env: more than 4 volume server nodes, ReplicaPlacement=002

When writing data through mount, use large files to fill up the disk corresponding to a volume server. At this time, all volumes on the node are read only. At this time, the mount will retry, and the write will succeed after the master assigns the fid to other nodes.


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
