### PR TITLE
allow deleting only older empty  dir without recursion

### DIFF
--- a/weed/s3api/s3api_objects_list_handlers.go
+++ b/weed/s3api/s3api_objects_list_handlers.go
@@ -18,8 +18,6 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
 )
 
-const cutoffTimeNewEmptyDir = 3
-
 type ListBucketResultV2 struct {
 	XMLName               xml.Name      `xml:"http://s3.amazonaws.com/doc/2006-03-01/ ListBucketResult"`
 	Name                  string        `xml:"Name"`
@@ -391,7 +389,7 @@ func (s3a *S3ApiServer) doListFilerEntries(client filer_pb.SeaweedFilerClient, d
 				// println("doListFilerEntries2 nextMarker", nextMarker)
 			} else {
 				var isEmpty bool
-				if !s3a.option.AllowEmptyFolder && !entry.IsDirectoryKeyObject() {
+				if !s3a.option.AllowEmptyFolder && entry.IsOlderDir() {
 					if isEmpty, err = s3a.ensureDirectoryAllEmpty(client, dir, entry.Name); err != nil {
 						glog.Errorf("check empty folder %s: %v", dir, err)
 					}
@@ -447,16 +445,11 @@ func (s3a *S3ApiServer) ensureDirectoryAllEmpty(filerClient filer_pb.SeaweedFile
 	var startFrom string
 	var isExhausted bool
 	var foundEntry bool
-	cutOffTimeAtSec := time.Now().Unix() + cutoffTimeNewEmptyDir
 	for fileCounter == 0 && !isExhausted && err == nil {
 		err = filer_pb.SeaweedList(filerClient, currentDir, "", func(entry *filer_pb.Entry, isLast bool) error {
 			foundEntry = true
-			if entry.IsDirectory {
-				if entry.Attributes != nil && cutOffTimeAtSec >= entry.Attributes.GetCrtime() {
-					fileCounter++
-				} else {
-					subDirs = append(subDirs, entry.Name)
-				}
+			if entry.IsOlderDir() {
+				subDirs = append(subDirs, entry.Name)
 			} else {
 				fileCounter++
 			}
@@ -489,7 +482,7 @@ func (s3a *S3ApiServer) ensureDirectoryAllEmpty(filerClient filer_pb.SeaweedFile
 	}
 
 	glog.V(1).Infof("deleting empty folder %s", currentDir)
-	if err = doDeleteEntry(filerClient, parentDir, name, true, true); err != nil {
+	if err = doDeleteEntry(filerClient, parentDir, name, true, false); err != nil {
 		return
 	}
 


### PR DESCRIPTION
# What problem are we solving?

When write operations are highly concurrent, deletion sometimes deletes files supposedly from empty folders
https://github.com/seaweedfs/seaweedfs/issues/4015

# How are we solving the problem?

Now not only subfolders are checked, but also the folder itself, that it has been created for more than 3 seconds

# How is the PR tested?

```
make dev
s3cmd --no-ssl --host-bucket=127.0.0.1:8333 --host=127.0.0.1:8333 put fileb s3://test/newFolder/subfolder/fileb
s3cmd --no-ssl --host-bucket=127.0.0.1:8333 --host=127.0.0.1:8333 rm s3://test/newFolder/subfolder/fileb
s3cmd --no-ssl --host-bucket=127.0.0.1:8333 --host=127.0.0.1:8333 ls s3://test/
```
localy
```
eaweedfs-filer-1   | I0425 13:14:07.934076 filer_grpc_server.go:40 ListEntries directory:"/buckets/test"  limit:10002
seaweedfs-s3-1      | + ensureDirectoryAllEmpty /buckets/test newFolder
seaweedfs-s3-1      | I0425 13:14:07.935827 s3api_objects_list_handlers.go:440 + isEmpty /buckets/test/newFolder
seaweedfs-s3-1      | I0425 13:14:07.935840 filer_client.go:120 read directory: directory:"/buckets/test/newFolder"  limit:9
seaweedfs-filer-1   | I0425 13:14:07.936346 filer_grpc_server.go:40 ListEntries directory:"/buckets/test/newFolder"  limit:9
seaweedfs-s3-1      | I0425 13:14:07.936771 s3api_objects_list_handlers.go:485 deleting empty folder /buckets/test/newFolder
seaweedfs-s3-1      | I0425 13:14:07.936805 filer_util.go:65 delete entry /buckets/test/newFolder: directory:"/buckets/test"  name:"newFolder"  is_delete_data:true  ignore_recursive_error:true
seaweedfs-filer-1   | I0425 13:14:07.937558 filer_grpc_server.go:286 DeleteEntry directory:"/buckets/test"  name:"newFolder"  is_delete_data:true  ignore_recursive_error:true
seaweedfs-filer-1   | I0425 13:14:07.937863 filer_delete_entry.go:110 deleting directory /buckets/test/newFolder delete chunks: true
seaweedfs-filer-1   | I0425 13:14:07.937939 filer_delete_entry.go:123 deleting entry /buckets/test/newFolder, delete chunks: true
seaweedfs-filer-1   | I0425 13:14:07.939267 filer_grpc_server.go:40 ListEntries directory:"/buckets/test"  startFromFileName:"newFolder"  limit:10001
seaweedfs-s3-1      | I0425 13:14:07.938733 s3api_objects_list_handlers.go:491 - isEmpty /buckets/test/newFolder false
seaweedfs-s3-1      | I0425 13:14:07.941002 error_handler.go:96 status 200 application/xml: <?xml version="1.0" encoding="UTF-8"?>
seaweedfs-s3-1      | <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>test</Name><Prefix></Prefix><Marker></Marker><MaxKeys>10000</MaxKeys><Delimiter>/</Delimiter><IsTruncated>false</IsTruncated><Contents><Key>fakedir/</Key><ETag>&#34;d41d8cd98f00b204e9800998ecf8427e-0&#34;</ETag><Size>0</Size><Owner><ID>0</ID></Owner><StorageClass>STANDARD</StorageClass><LastModified>2023-04-12T09:02:40Z</LastModified></Contents></ListBucketResult>
```

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] 
