### PR TITLE
Fix: http rename move dir to subdir

### DIFF
--- a/weed/filer/filer_rename.go
+++ b/weed/filer/filer_rename.go
@@ -2,16 +2,23 @@ package filer
 
 import (
 	"fmt"
-	"github.com/seaweedfs/seaweedfs/weed/util"
 	"strings"
+
+	"github.com/seaweedfs/seaweedfs/weed/util"
 )
 
-func (f *Filer) CanRename(source, target util.FullPath) error {
+func (f *Filer) CanRename(source, target util.FullPath, oldName string) error {
+	sourcePath := source.Child(oldName)
+	if strings.HasPrefix(string(target), string(sourcePath)) {
+		return fmt.Errorf("mv: can not move directory to a subdirectory of itself")
+	}
+
 	sourceBucket := f.DetectBucket(source)
 	targetBucket := f.DetectBucket(target)
 	if sourceBucket != targetBucket {
 		return fmt.Errorf("can not move across collection %s => %s", sourceBucket, targetBucket)
 	}
+
 	return nil
 }
 

--- a/weed/server/filer_grpc_server_rename.go
+++ b/weed/server/filer_grpc_server_rename.go
@@ -19,7 +19,7 @@ func (fs *FilerServer) AtomicRenameEntry(ctx context.Context, req *filer_pb.Atom
 	oldParent := util.FullPath(filepath.ToSlash(req.OldDirectory))
 	newParent := util.FullPath(filepath.ToSlash(req.NewDirectory))
 
-	if err := fs.filer.CanRename(oldParent, newParent); err != nil {
+	if err := fs.filer.CanRename(oldParent, newParent, req.OldName); err != nil {
 		return nil, err
 	}
 
@@ -55,7 +55,7 @@ func (fs *FilerServer) StreamRenameEntry(req *filer_pb.StreamRenameEntryRequest,
 	oldParent := util.FullPath(filepath.ToSlash(req.OldDirectory))
 	newParent := util.FullPath(filepath.ToSlash(req.NewDirectory))
 
-	if err := fs.filer.CanRename(oldParent, newParent); err != nil {
+	if err := fs.filer.CanRename(oldParent, newParent, req.OldName); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
# What problem are we solving?
Http api does not prevent parent directory from moving to its subdirectory which can result in filer corruption.

refer to #4045 

# How are we solving the problem?
Add parent-child directory relationship judgment.

# How is the PR tested?
curl -i -X POST 'http://localhost:8888/a/b/?mv.from=/a/' should be failed.


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
