### PR TITLE
Feat: support username/password authentication for etcd filer store s…

### DIFF
--- a/weed/command/scaffold/filer.toml
+++ b/weed/command/scaffold/filer.toml
@@ -262,6 +262,8 @@ routeByLatency = false
 [etcd]
 enabled = false
 servers = "localhost:2379"
+username = ""
+password = ""
 timeout = "3s"
 
 [mongodb]

--- a/weed/filer/etcd/etcd_store.go
+++ b/weed/filer/etcd/etcd_store.go
@@ -37,15 +37,18 @@ func (store *EtcdStore) Initialize(configuration weed_util.Configuration, prefix
 		servers = "localhost:2379"
 	}
 
+        username := configuration.GetString(prefix + "username")
+        password := configuration.GetString(prefix + "password")
+
 	timeout := configuration.GetString(prefix + "timeout")
 	if timeout == "" {
 		timeout = "3s"
 	}
 
-	return store.initialize(servers, timeout)
+	return store.initialize(servers, username, password, timeout)
 }
 
-func (store *EtcdStore) initialize(servers string, timeout string) (err error) {
+func (store *EtcdStore) initialize(servers string, username string, password string, timeout string) (err error) {
 	glog.Infof("filer store etcd: %s", servers)
 
 	to, err := time.ParseDuration(timeout)
@@ -55,6 +58,8 @@ func (store *EtcdStore) initialize(servers string, timeout string) (err error) {
 
 	store.client, err = clientv3.New(clientv3.Config{
 		Endpoints:   strings.Split(servers, ","),
+		Username:    username,
+		Password:    password,
 		DialTimeout: to,
 	})
 	if err != nil {


### PR DESCRIPTION
…eaweedfs/seaweedfs#4262

# What problem are we solving?

Authenticated access to etcd file store.

# How are we solving the problem?

By providing username/password in the filer.toml config.

# How is the PR tested?

Tested against etcd cluster.

1. When username/password are defined but empty, the etcd client continues to behave as presently, i.e. unauthenticated.

2. When username/password are defined but etcd cluster does not have authentication enabled, we just see a warning but we are successful in establishing a filer store:


	I0515 23:22:27.274216 etcd_store.go:52 filer store etcd: http://10.77.7.239:2379
	{"level":"warn","ts":"2023-05-15T23:22:27.275769Z","logger":"etcd-client","caller":"v3@v3.5.8/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc0005defc0/10.77.7.239:2379","attempt":0,"error":"rpc error: code = FailedPrecondition desc = etcdserver: authentication is not enabled"}
	I0515 23:22:27.276407 filer.go:144 existing filer.store.id = 1144695955
	I0515 23:22:27.276419 configuration.go:28 configured filer store to etcd


3. When etcd authentication is enabled but username/password is empty in the filer.toml file:


	I0515 23:51:51.927440 etcd_store.go:52 filer store etcd: http://10.77.7.239:2379
	{"level":"warn","ts":"2023-05-15T23:51:51.92917Z","logger":"etcd-client","caller":"v3@v3.5.8/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc0005fdc00/10.77.7.239:2379","attempt":0,"error":"rpc error: code = InvalidArgument desc = etcdserver: user name is empty"}


4. When etcd authentication is enabled but the username/password in filer.toml is wrong, we get something like:



	I0515 23:38:12.015732 etcd_store.go:52 filer store etcd: http://10.77.7.239:2379
	{"level":"warn","ts":"2023-05-15T23:38:12.106207Z","logger":"etcd-client","caller":"v3@v3.5.8/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0xc000904c40/10.77.7.239:2379","attempt":0,"error":"rpc error: code = InvalidArgument desc = etcdserver: authentication failed, invalid user ID or password"}
	F0515 23:38:12.106396 configuration.go:25 failed to initialize store for etcd: connect to etcd http://10.77.7.239:2379: etcdserver: authentication failed, invalid user ID or password


5. When etcd authentication is enabled and correct username/password is provided in filer.toml, everything works as expected.

# Checks
- [ ] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
