### PR TITLE
Feat: etcd filer store keys should have customizable prefix

### DIFF
--- a/weed/command/scaffold/filer.toml
+++ b/weed/command/scaffold/filer.toml
@@ -264,6 +264,7 @@ enabled = false
 servers = "localhost:2379"
 username = ""
 password = ""
+key_prefix = "seaweedfs."
 timeout = "3s"
 
 [mongodb]

--- a/weed/filer/etcd/etcd_store_kv.go
+++ b/weed/filer/etcd/etcd_store_kv.go
@@ -8,7 +8,7 @@ import (
 
 func (store *EtcdStore) KvPut(ctx context.Context, key []byte, value []byte) (err error) {
 
-	_, err = store.client.Put(ctx, string(key), string(value))
+	_, err = store.client.Put(ctx, store.etcdKeyPrefix + string(key), string(value))
 
 	if err != nil {
 		return fmt.Errorf("kv put: %v", err)
@@ -19,7 +19,7 @@ func (store *EtcdStore) KvPut(ctx context.Context, key []byte, value []byte) (er
 
 func (store *EtcdStore) KvGet(ctx context.Context, key []byte) (value []byte, err error) {
 
-	resp, err := store.client.Get(ctx, string(key))
+	resp, err := store.client.Get(ctx, store.etcdKeyPrefix + string(key))
 
 	if err != nil {
 		return nil, fmt.Errorf("kv get: %v", err)
@@ -34,7 +34,7 @@ func (store *EtcdStore) KvGet(ctx context.Context, key []byte) (value []byte, er
 
 func (store *EtcdStore) KvDelete(ctx context.Context, key []byte) (err error) {
 
-	_, err = store.client.Delete(ctx, string(key))
+	_, err = store.client.Delete(ctx, store.etcdKeyPrefix + string(key))
 
 	if err != nil {
 		return fmt.Errorf("kv delete: %v", err)


### PR DESCRIPTION
An etcd cluster is not necessarily only dedicated to seaweedfs. This security enhancement adds a customizable key_prefix option to the etcd filer store. This will allow an etcd cluster administrator to limit the seaweedfs etcd user to only read/write a subset of keys under the key_prefix, instead of all keys on the etcd cluster.

# What problem are we solving?

Now that the seaweedfs etcd user can be authenticated by the etcd cluster, the seaweedfs etcd user should not have access to all keys on etcd cluster.

# How are we solving the problem?

By adding a customizable key_prefix.
This means that the etcd cluster administrator can restrict the seaweedfs etcd user to read/write operations for keys under this key_prefix.
 

# How is the PR tested?

By specifying the key_prefix in the filer.toml, and restricting the seaweedfs etcd user to the "seaweedfs." prefix, and seaweedfs were able to read/write the required keys/metadata as normal.


# Checks
- [ ] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
