### PR TITLE
fix no more writables volumes while disk free space is sufficient

### DIFF
--- a/weed/topology/node.go
+++ b/weed/topology/node.go
@@ -243,6 +243,7 @@ func (n *NodeImpl) CollectDeadNodeAndFullVolumes(freshThreshHold int64, volumeSi
 	if n.IsRack() {
 		for _, c := range n.Children() {
 			dn := c.(*DataNode) //can not cast n to DataNode
+			dn.RLock()
 			for _, v := range dn.GetVolumes() {
 				if v.Size >= volumeSizeLimit {
 					//fmt.Println("volume",v.Id,"size",v.Size,">",volumeSizeLimit)
@@ -259,6 +260,7 @@ func (n *NodeImpl) CollectDeadNodeAndFullVolumes(freshThreshHold int64, volumeSi
 					}
 				}
 			}
+			dn.RUnlock()
 		}
 	} else {
 		for _, c := range n.Children() {

--- a/weed/topology/topology_vacuum.go
+++ b/weed/topology/topology_vacuum.go
@@ -172,6 +172,21 @@ func (t *Topology) batchVacuumVolumeCommit(grpcDialOption grpc.DialOption, vl *V
 	}
 
 	if isCommitSuccess {
+		//reset all vacuumed volumes size
+		for _, dn := range vacuumLocationList.list {
+			vInfo, err := dn.GetVolumesById(vid)
+			if err != nil {
+				glog.V(0).Infof("get volume info for volume: %d failed %v", vid, err)
+				return false
+			}
+
+			dn.Lock()
+			disk := dn.getOrCreateDisk(vInfo.DiskType)
+			vInfo.Size = 0
+			disk.doAddOrUpdateVolume(vInfo)
+			dn.Unlock()
+		}
+
 		for _, dn := range vacuumLocationList.list {
 			vl.SetVolumeAvailable(dn, vid, isReadOnly)
 		}


### PR DESCRIPTION
# What problem are we solving?
start volume server with  -max=0.

After seaweedfs runs for a period of time, "no more writable volumes" appears. Checking the disk usage we found that there is still a lot of disk left. 


# Analysis

Through the master's api "dir/status", we can see that the number of volumes has reached the maximum value that the system can create.  Some with very small volumes (hundreds of MB) do not appear in the Master's writables.

After observing the log, it is found that after the vacuum is over, the master sets the volume to be writable, but immediately judges that the volume is full and sets it as unwritable.


![image](https://github.com/seaweedfs/seaweedfs/assets/75450248/7b953b82-fe3f-4c90-bc7b-c4e8a127ce26)


It is judged that the reason for this problem is that the volume size obtained by the CollectDeadNodeAndFullVolumes function is obtained through the heartbeat information, which is the old size. This kind of misjudgment is easy to occur if you vacuum a volume whose size exceeds volumeSizeLimitMB.


# How are we solving the problem?

We set the volume size of the vacuumed node to 0 when the garbage collection is complete. In this way, such misjudgment will not occur. When the master receives the next heartbeat message, mark the volume size as the actual value.




# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
