### PR TITLE
S3 TLS credentials Refreshing

### DIFF
--- a/weed/command/s3.go
+++ b/weed/command/s3.go
@@ -2,8 +2,11 @@ package command
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
+	"google.golang.org/grpc/credentials/tls/certprovider"
+	"google.golang.org/grpc/credentials/tls/certprovider/pemfile"
 	"google.golang.org/grpc/reflection"
 	"net/http"
 	"time"
@@ -40,6 +43,7 @@ type S3Options struct {
 	auditLogConfig            *string
 	localFilerSocket          *string
 	dataCenter                *string
+	certProvider              certprovider.Provider
 }
 
 func init() {
@@ -150,6 +154,12 @@ func runS3(cmd *Command, args []string) bool {
 
 }
 
+// GetCertificateWithUpdate Auto refreshing TSL certificate
+func (S3opt *S3Options) GetCertificateWithUpdate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+	certs, err := S3opt.certProvider.KeyMaterial(context.Background())
+	return &certs.Certs[0], err
+}
+
 func (s3opt *S3Options) startS3Server() bool {
 
 	filerAddress := pb.ServerAddress(*s3opt.filer)
@@ -245,15 +255,24 @@ func (s3opt *S3Options) startS3Server() bool {
 	go grpcS.Serve(grpcL)
 
 	if *s3opt.tlsPrivateKey != "" {
+		pemfileOptions := pemfile.Options{
+			CertFile:        *s3opt.tlsCertificate,
+			KeyFile:         *s3opt.tlsPrivateKey,
+			RefreshDuration: security.CredRefreshingInterval,
+		}
+		if s3opt.certProvider, err = pemfile.NewProvider(pemfileOptions); err != nil {
+			glog.Fatalf("pemfile.NewProvider(%v) %v failed: %v", pemfileOptions, err)
+		}
+		httpS.TLSConfig = &tls.Config{GetCertificate: s3opt.GetCertificateWithUpdate}
 		glog.V(0).Infof("Start Seaweed S3 API Server %s at https port %d", util.Version(), *s3opt.port)
 		if s3ApiLocalListener != nil {
 			go func() {
-				if err = httpS.ServeTLS(s3ApiLocalListener, *s3opt.tlsCertificate, *s3opt.tlsPrivateKey); err != nil {
+				if err = httpS.ServeTLS(s3ApiLocalListener, "", ""); err != nil {
 					glog.Fatalf("S3 API Server Fail to serve: %v", err)
 				}
 			}()
 		}
-		if err = httpS.ServeTLS(s3ApiListener, *s3opt.tlsCertificate, *s3opt.tlsPrivateKey); err != nil {
+		if err = httpS.ServeTLS(s3ApiListener, "", ""); err != nil {
 			glog.Fatalf("S3 API Server Fail to serve: %v", err)
 		}
 	} else {

--- a/weed/command/s3.go
+++ b/weed/command/s3.go
@@ -261,7 +261,7 @@ func (s3opt *S3Options) startS3Server() bool {
 			RefreshDuration: security.CredRefreshingInterval,
 		}
 		if s3opt.certProvider, err = pemfile.NewProvider(pemfileOptions); err != nil {
-			glog.Fatalf("pemfile.NewProvider(%v) %v failed: %v", pemfileOptions, err)
+			glog.Fatalf("pemfile.NewProvider(%v) failed: %v", pemfileOptions, err)
 		}
 		httpS.TLSConfig = &tls.Config{GetCertificate: s3opt.GetCertificateWithUpdate}
 		glog.V(0).Infof("Start Seaweed S3 API Server %s at https port %d", util.Version(), *s3opt.port)

--- a/weed/security/tls.go
+++ b/weed/security/tls.go
@@ -16,7 +16,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-const credRefreshingInterval = time.Duration(5) * time.Hour
+const CredRefreshingInterval = time.Duration(5) * time.Hour
 
 type Authenticator struct {
 	AllowedWildcardDomain string
@@ -31,7 +31,10 @@ func LoadServerTLS(config *util.ViperProxy, component string) (grpc.ServerOption
 	serverOptions := pemfile.Options{
 		CertFile:        config.GetString(component + ".cert"),
 		KeyFile:         config.GetString(component + ".key"),
-		RefreshDuration: credRefreshingInterval,
+		RefreshDuration: CredRefreshingInterval,
+	}
+	if serverOptions.CertFile == "" || serverOptions.KeyFile == "" {
+		return nil, nil
 	}
 
 	serverIdentityProvider, err := pemfile.NewProvider(serverOptions)
@@ -42,7 +45,7 @@ func LoadServerTLS(config *util.ViperProxy, component string) (grpc.ServerOption
 
 	serverRootOptions := pemfile.Options{
 		RootFile:        config.GetString("grpc.ca"),
-		RefreshDuration: credRefreshingInterval,
+		RefreshDuration: CredRefreshingInterval,
 	}
 	serverRootProvider, err := pemfile.NewProvider(serverRootOptions)
 	if err != nil {
@@ -99,7 +102,7 @@ func LoadClientTLS(config *util.ViperProxy, component string) grpc.DialOption {
 	clientOptions := pemfile.Options{
 		CertFile:        certFileName,
 		KeyFile:         keyFileName,
-		RefreshDuration: credRefreshingInterval,
+		RefreshDuration: CredRefreshingInterval,
 	}
 	clientProvider, err := pemfile.NewProvider(clientOptions)
 	if err != nil {
@@ -108,7 +111,7 @@ func LoadClientTLS(config *util.ViperProxy, component string) grpc.DialOption {
 	}
 	clientRootOptions := pemfile.Options{
 		RootFile:        config.GetString("grpc.ca"),
-		RefreshDuration: credRefreshingInterval,
+		RefreshDuration: CredRefreshingInterval,
 	}
 	clientRootProvider, err := pemfile.NewProvider(clientRootOptions)
 	if err != nil {


### PR DESCRIPTION
# What problem are we solving?

When deploying k8s, the certificate in accordance with the object, the manager certificate can be reissued quite often, for example, once every 3 months, which requires restarting the application in the pod.
https://github.com/seaweedfs/seaweedfs/pull/4507

```
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  annotations:
    k8s.tochka.com/mutate-hosts: basic, extended
    meta.helm.sh/release-name: fast
    meta.helm.sh/release-namespace: s3
  creationTimestamp: "2023-01-31T06:57:17Z"
  generation: 1
  labels:
    app: fast-api
    app.kubernetes.io/component: api
    app.kubernetes.io/instance: fast
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: seaweedfs
    app.kubernetes.io/version: 3.48-6fdff0b
    helm.sh/chart: seaweedfs-0.4.70
  name: fast-ing
  namespace: s3
  resourceVersion: "2467815081"
  uid: 783ecc46-b8da-4237-a466-96a31c2c2fae
spec:
  commonName: fast-api.s3.stage
  dnsNames:
  - fast-api.s3.svc.cluster.local
  issuerRef:
    kind: ClusterIssuer
    name: vault-issuer
  secretName: fast-ing
status:
  conditions:
  - lastTransitionTime: "2023-01-31T06:57:17Z"
    message: Certificate is up to date and has not expired
    observedGeneration: 1
    reason: Ready
    status: "True"
    type: Ready
  notAfter: "2023-07-22T09:17:20Z"
  notBefore: "2023-04-23T09:16:50Z"
  renewalTime: "2023-06-22T09:17:10Z"
  revision: 2
```

# How are we solving the problem?

In order not to do this, the application itself will re-read the contents of files with a certificate for 5 hours

# How is the PR tested?

localy run
```
make dev
I0526 08:49:12.338476 s3.go:267 Start Seaweed S3 API Server 30GB 3.51  at https port 8333
I0526 08:50:03.926792 s3api_bucket_handlers.go:36 ListBucketsHandler
I0526 08:50:03.928867 filer_client.go:120 read directory: directory:"/buckets" limit:2147483647
I0526 08:50:03.960554 error_handler.go:96 status 200 application/xml: <?xml version="1.0" encoding="UTF-8"?>
<ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName></DisplayName><ID></ID></Owner><Buckets><Bucket><CreationDate>2023-04-12T08:50:42Z</CreationDate><Name>test</Name></Bucket></Buckets></ListAllMyBucketsResult>
```

curl
```
curl -kv https://127.0.0.1:8333/
*   Trying 127.0.0.1:8333...
* Connected to 127.0.0.1 (127.0.0.1) port 8333 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS change cipher, Change cipher spec (1):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / ECDHE-RSA-CHACHA20-POLY1305
* ALPN, server accepted to use h2
* Server certificate:
*  subject: CN=s3.dev
*  start date: May 18 10:45:00 2023 GMT
*  expire date: Nov 18 10:54:18 2024 GMT
*  issuer: CN=SeaweedFS CA
*  SSL certificate verify result: unable to get local issuer certificate (20), continuing anyway.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x11e812e00)
> GET / HTTP/2
> Host: 127.0.0.1:8333
> user-agent: curl/7.77.0
> accept: */*
> 
* Connection state changed (MAX_CONCURRENT_STREAMS == 250)!
< HTTP/2 200 
< accept-ranges: bytes
< content-type: application/xml
< server: SeaweedFS S3
< x-amz-request-id: 1685092371692353219
< content-length: 289
< date: Fri, 26 May 2023 09:12:51 GMT
< 
<?xml version="1.0" encoding="UTF-8"?>
* Connection #0 to host 127.0.0.1 left intact
<ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><DisplayName></DisplayName><ID></ID></Owner><Buckets><Bucket><CreationDate>2023-04-12T08:50:42Z</CreationDate><Name>test</Name></Bucket></Buckets></ListAllMyBucketsResult>M
```
# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
