### PR TITLE
Fix Helm chart enableSecurity flag

### DIFF
--- a/k8s/charts/seaweedfs/templates/ca-cert.yaml
+++ b/k8s/charts/seaweedfs/templates/ca-cert.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.enableSecurity }}
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1{{ if .Values.global.certificates.alphacrds }}alpha1{{ end }}
 kind: Certificate
 metadata:
   name: {{ template "seaweedfs.name" . }}-ca-cert

--- a/k8s/charts/seaweedfs/templates/cert-caissuer.yaml
+++ b/k8s/charts/seaweedfs/templates/cert-caissuer.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.global.enableSecurity }}
+apiVersion: cert-manager.io/v1{{ if .Values.global.certificates.alphacrds }}alpha1{{ end }}
+kind: Issuer
+metadata:
+  name: {{ template "seaweedfs.name" . }}-ca-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  ca:
+    secretName: {{ template "seaweedfs.name" . }}-ca-cert
+{{- end }}

--- a/k8s/charts/seaweedfs/templates/cert-clusterissuer.yaml
+++ b/k8s/charts/seaweedfs/templates/cert-clusterissuer.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.enableSecurity }}
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1{{ if .Values.global.certificates.alphacrds }}alpha1{{ end }}
 kind: ClusterIssuer
 metadata:
   name: {{ template "seaweedfs.name" . }}-clusterissuer

--- a/k8s/charts/seaweedfs/templates/client-cert.yaml
+++ b/k8s/charts/seaweedfs/templates/client-cert.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.enableSecurity }}
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1{{ if .Values.global.certificates.alphacrds }}alpha1{{ end }}
 kind: Certificate
 metadata:
   name: {{ template "seaweedfs.name" . }}-client-cert
@@ -7,10 +7,11 @@ metadata:
 spec:
   secretName: {{ template "seaweedfs.name" . }}-client-cert
   issuerRef:
-    name: {{ template "seaweedfs.name" . }}-clusterissuer
-    kind: ClusterIssuer
+    name: {{ template "seaweedfs.name" . }}-ca-issuer
+    kind: Issuer
   commonName: {{ .Values.certificates.commonName }}
-  organization:
+  subject:
+    organizations:
     - "SeaweedFS CA"
   dnsNames:
     - '*.{{ .Release.Namespace }}'
@@ -26,8 +27,9 @@ spec:
     - {{ . }}
     {{- end }}
 {{- end }}
-  keyAlgorithm: {{ .Values.certificates.keyAlgorithm }}
-  keySize: {{ .Values.certificates.keySize }}
+  privateKey:
+    algorithm: {{ .Values.certificates.keyAlgorithm }}
+    size: {{ .Values.certificates.keySize }}
   duration: {{ .Values.certificates.duration }}
   renewBefore: {{ .Values.certificates.renewBefore }}
 {{- end }}

--- a/k8s/charts/seaweedfs/templates/filer-cert.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-cert.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.enableSecurity }}
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1{{ if .Values.global.certificates.alphacrds }}alpha1{{ end }}
 kind: Certificate
 metadata:
   name: {{ template "seaweedfs.name" . }}-filer-cert
@@ -7,10 +7,11 @@ metadata:
 spec:
   secretName: {{ template "seaweedfs.name" . }}-filer-cert
   issuerRef:
-    name: {{ template "seaweedfs.name" . }}-clusterissuer
-    kind: ClusterIssuer
+    name: {{ template "seaweedfs.name" . }}-ca-issuer
+    kind: Issuer
   commonName: {{ .Values.certificates.commonName }}
-  organization:
+  subject:
+    organizations:
     - "SeaweedFS CA"
   dnsNames:
     - '*.{{ .Release.Namespace }}'
@@ -26,8 +27,9 @@ spec:
     - {{ . }}
     {{- end }}
 {{- end }}
-  keyAlgorithm: {{ .Values.certificates.keyAlgorithm }}
-  keySize: {{ .Values.certificates.keySize }}
+  privateKey:
+    algorithm: {{ .Values.certificates.keyAlgorithm }}
+    size: {{ .Values.certificates.keySize }}
   duration: {{ .Values.certificates.duration }}
   renewBefore: {{ .Values.certificates.renewBefore }}
 {{- end }}

--- a/k8s/charts/seaweedfs/templates/master-cert.yaml
+++ b/k8s/charts/seaweedfs/templates/master-cert.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.enableSecurity }}
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1{{ if .Values.global.certificates.alphacrds }}alpha1{{ end }}
 kind: Certificate
 metadata:
   name: {{ template "seaweedfs.name" . }}-master-cert
@@ -7,10 +7,11 @@ metadata:
 spec:
   secretName: {{ template "seaweedfs.name" . }}-master-cert
   issuerRef:
-    name: {{ template "seaweedfs.name" . }}-clusterissuer
-    kind: ClusterIssuer
+    name: {{ template "seaweedfs.name" . }}-ca-issuer
+    kind: Issuer
   commonName: {{ .Values.certificates.commonName }}
-  organization:
+  subject:
+    organizations:
     - "SeaweedFS CA"
   dnsNames:
     - '*.{{ .Release.Namespace }}'
@@ -26,8 +27,9 @@ spec:
     - {{ . }}
     {{- end }}
 {{- end }}
-  keyAlgorithm: {{ .Values.certificates.keyAlgorithm }}
-  keySize: {{ .Values.certificates.keySize }}
+  privateKey:
+    algorithm: {{ .Values.certificates.keyAlgorithm }}
+    size: {{ .Values.certificates.keySize }}
   duration: {{ .Values.certificates.duration }}
   renewBefore: {{ .Values.certificates.renewBefore }}
 {{- end }}

--- a/k8s/charts/seaweedfs/templates/volume-cert.yaml
+++ b/k8s/charts/seaweedfs/templates/volume-cert.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.enableSecurity }}
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1{{ if .Values.global.certificates.alphacrds }}alpha1{{ end }}
 kind: Certificate
 metadata:
   name: {{ template "seaweedfs.name" . }}-volume-cert
@@ -7,10 +7,11 @@ metadata:
 spec:
   secretName: {{ template "seaweedfs.name" . }}-volume-cert
   issuerRef:
-    name: {{ template "seaweedfs.name" . }}-clusterissuer
-    kind: ClusterIssuer
+    name: {{ template "seaweedfs.name" . }}-ca-issuer
+    kind: Issuer
   commonName: {{ .Values.certificates.commonName }}
-  organization:
+  subject:
+    organizations:
     - "SeaweedFS CA"
   dnsNames:
     - '*.{{ .Release.Namespace }}'
@@ -26,8 +27,9 @@ spec:
     - {{ . }}
     {{- end }}
 {{- end }}
-  keyAlgorithm: {{ .Values.certificates.keyAlgorithm }}
-  keySize: {{ .Values.certificates.keySize }}
+  privateKey:
+    algorithm: {{ .Values.certificates.keyAlgorithm }}
+    size: {{ .Values.certificates.keySize }}
   duration: {{ .Values.certificates.duration }}
   renewBefore: {{ .Values.certificates.renewBefore }}
 {{- end }}

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -9,6 +9,8 @@ global:
   restartPolicy: Always
   loggingLevel: 1
   enableSecurity: false
+  certificates:
+    alphacrds: false
   monitoring:
     enabled: false
     gatewayHost: null


### PR DESCRIPTION
- Add parameter for whether to use v1alpha cert-manager CRDs, default off.
- Use self-signed Issuer only for the initial CA certificates, create a new Issuer that uses the generated CA certificate and use that for all the others

# What problem are we solving?
The enableSecurity flag in the Helm chart doesn't work. In particular:

- it creates certificates using the older v1alpha cert-manager Cards which have been superseded for years.
- The certificates are all self signed, instead of self signing the CA certificate and using that certificate to sign everything else.


# How are we solving the problem?
- Add a values.yaml flag to use the old CRDs, off by default.
- Create a new issuer that uses the generated CA certificate.
- Adjust certificate resources to use slightly different format (TODO: retain the old format when using new Cards)


# How is the PR tested?
- Has been running in my cluster for a few months.


# Checks
- [N/A] I have added unit tests if possible.
- [N/A] I will add related wiki document changes and link to this PR after merging.
