### PR TITLE
Add secret support for filer environment variables.

### DIFF
--- a/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
@@ -88,7 +88,12 @@ spec:
             {{- if .Values.filer.extraEnvironmentVars }}
             {{- range $key, $value := .Values.filer.extraEnvironmentVars }}
             - name: {{ $key }}
+            {{- if kindIs "string" $value }}
               value: {{ $value | quote }}
+            {{- else }}
+              valueFrom:
+                {{ toYaml $value | nindent 16 | trim }}
+            {{- end -}}
             {{- end }}
             {{- end }}
             {{- if .Values.global.extraEnvironmentVars }}


### PR DESCRIPTION
Instead of providing a literal value as a string, you can provide the contents of valueFrom as a map.

# What problem are we solving?
Especially since the filer can only really be configured by environment variables, it's very common to want to have some of the values (like database passwords) in a secret.


# How are we solving the problem?
Allow the user to supply a map instead of a string for an environment variable value. If they do, we put it under valueFrom.

This seemed like the best backwards compatible way of doing this.

Of course in the future it might be better to add proper configuration for the filer storage backend instead of hard coding memsql and having to override it. But this is a first step.


# How is the PR tested?
Run locally in my cluster


# Checks
- [N/A] I have added unit tests if possible.
- [N/A] I will add related wiki document changes and link to this PR after merging.
