### PR TITLE
Helm chart fixes:

### DIFF
--- a/k8s/charts/seaweedfs/templates/ingress.yaml
+++ b/k8s/charts/seaweedfs/templates/ingress.yaml
@@ -14,8 +14,11 @@ metadata:
     {{ omit .Values.filer.ingress.annotations "kubernetes.io/ingress.class" | toYaml | nindent 4 }}
 spec:
   ingressClassName: {{ .Values.filer.ingress.className | quote }}
+  tls:
+    {{ .Values.filer.ingress.tls | default list | toYaml | nindent 6}}
   rules:
-  - http:
+  - host: {{ .Values.filer.ingress.host }}
+    http:
       paths:
       - path: /sw-filer/?(.*)
         pathType: ImplementationSpecific

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -124,6 +124,7 @@ master:
   ingress:
     enabled: false
     className: "nginx"
+    host: "master.seaweedfs.local"
     annotations:
       nginx.ingress.kubernetes.io/auth-type: "basic"
       nginx.ingress.kubernetes.io/auth-secret: "default/ingress-basic-auth-secret"
@@ -371,7 +372,9 @@ filer:
   ingress:
     enabled: false
     className: "nginx"
+    host: "seaweedfs.cluster.local"
     annotations:
+      nginx.ingress.kubernetes.io/backend-protocol: GRPC
       nginx.ingress.kubernetes.io/auth-type: "basic"
       nginx.ingress.kubernetes.io/auth-secret: "default/ingress-basic-auth-secret"
       nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required - SW-Filer'


### PR DESCRIPTION
- Allow TLS and Host name to be specified in values.yaml

# What problem are we solving?
The ingress right now isn't really usable because the host name is hard coded and you can't configure TLS.


# How are we solving the problem?
This patch allows configuring TLS and hostnames for the ingress resources using values.yaml.


# How is the PR tested?
You guessed it, locally in my cluster.


# Checks
- [N/A] I have added unit tests if possible.
- [Yes] I will add related wiki document changes and link to this PR after merging.
