### PR TITLE
Healthz check for deadlocks

### DIFF
--- a/weed/server/raft_server_handlers.go
+++ b/weed/server/raft_server_handlers.go
@@ -1,9 +1,12 @@
 package weed_server
 
 import (
+	"github.com/cenkalti/backoff/v4"
+	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
 	"net/http"
+	"time"
 )
 
 type ClusterStatusResult struct {
@@ -27,12 +30,24 @@ func (s *RaftServer) StatusHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *RaftServer) HealthzHandler(w http.ResponseWriter, r *http.Request) {
-	_, err := s.topo.Leader()
+	leader, err := s.topo.Leader()
 	if err != nil {
 		w.WriteHeader(http.StatusServiceUnavailable)
-	} else {
-		w.WriteHeader(http.StatusOK)
+		return
 	}
+	if s.serverAddr == leader {
+		expBackoff := backoff.NewExponentialBackOff()
+		expBackoff.InitialInterval = 20 * time.Millisecond
+		expBackoff.MaxInterval = 1 * time.Second
+		expBackoff.MaxElapsedTime = 5 * time.Second
+		isLocked, err := backoff.RetryWithData(s.topo.IsChildLocked, expBackoff)
+		glog.Errorf("HealthzHandler: %+v", err)
+		if isLocked {
+			w.WriteHeader(http.StatusLocked)
+			return
+		}
+	}
+	w.WriteHeader(http.StatusOK)
 }
 
 func (s *RaftServer) StatsRaftHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
# What problem are we solving?

When a deadlock occurs, the leader master server pretends to be alive
https://github.com/seaweedfs/seaweedfs/issues/4522

# How are we solving the problem?

Define a deadlock in the liveness handles, which will allow the container to be restarted with the leader of the master and control will take another

# How is the PR tested?

localy
```
make dev
curl -v -I  http://127.0.0.1:9333/cluster/healthz
*   Trying 127.0.0.1:9333...
* Connected to 127.0.0.1 (127.0.0.1) port 9333 (#0)
> HEAD /cluster/healthz HTTP/1.1
> Host: 127.0.0.1:9333
> User-Agent: curl/7.77.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
HTTP/1.1 200 OK
< Date: Fri, 09 Jun 2023 11:24:46 GMT
Date: Fri, 09 Jun 2023 11:24:46 GMT
```

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
