### PR TITLE
avoid overwriting non-nil uploadReaderToChunks.uploadErr with nil value

### DIFF
--- a/weed/server/filer_server_handlers_write_upload.go
+++ b/weed/server/filer_server_handlers_write_upload.go
@@ -70,9 +70,13 @@ func (fs *FilerServer) uploadReaderToChunks(w http.ResponseWriter, r *http.Reque
 		if err != nil || dataSize == 0 {
 			bufPool.Put(bytesBuffer)
 			<-bytesBufferLimitChan
-			uploadErrLock.Lock()
-			uploadErr = err
-			uploadErrLock.Unlock()
+			if err != nil {
+				uploadErrLock.Lock()
+				if uploadErr == nil {
+					uploadErr = err
+				}
+				uploadErrLock.Unlock()
+			}
 			break
 		}
 		if chunkOffset == 0 && !isAppend {


### PR DESCRIPTION
# What problem are we solving?
The wrong http status code may be returned when an error occurs

when `err == nil && dataSize == 0 && uploadErr != nil`

as L74 will unexpectedly overwrite a non-nil `uploadErr` with a `nil` value

By the way, L73-L75 is not consistent with L102-L106

# How are we solving the problem?
-   only change `uploadErr` when `err != nil`
-   only change `uploadErr` when `uploadErr == nil`


# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
