### PR TITLE
feat: Add datasource as variable

### DIFF
--- a/other/metrics/grafana_seaweedfs.json
+++ b/other/metrics/grafana_seaweedfs.json
@@ -2452,7 +2452,27 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
   },
   "time": {
     "from": "now-3h",

--- a/other/metrics/grafana_seaweedfs_heartbeat.json
+++ b/other/metrics/grafana_seaweedfs_heartbeat.json
@@ -1895,7 +1895,27 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "selected": true,
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
   },
   "time": {
     "from": "now-5m",

--- a/other/metrics/grafana_seaweedfs_k8s.json
+++ b/other/metrics/grafana_seaweedfs_k8s.json
@@ -2179,8 +2179,8 @@
       {
         "current": {
           "selected": true,
-          "text": "clickhouse-prom",
-          "value": "clickhouse-prom"
+          "text": "default",
+          "value": "default"
         },
         "hide": 0,
         "includeAll": false,


### PR DESCRIPTION
# What problem are we solving?
When importing the dashboards to modern Grafana instances, if the variable `DS_PROMETHEUS` is not present as `templating` variables, it's not able to recognize the datasource from `__inputs` field


# How are we solving the problem?
Adding it as templating variable solves the problem


# How is the PR tested?
Importing the dashboard json file, directly


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
