### PR TITLE
doIsEmpty() return error if v.DataBackend is nil

### DIFF
--- a/weed/storage/volume.go
+++ b/weed/storage/volume.go
@@ -134,16 +134,20 @@ func (v *Volume) ContentSize() uint64 {
 }
 
 func (v *Volume) doIsEmpty() (bool, error) {
-	if v.DataBackend != nil {
+	// check v.DataBackend.GetStat()
+	if v.DataBackend == nil {
+		return false, fmt.Errorf("v.DataBackend is nil")
+	} else {
 		datFileSize, _, e := v.DataBackend.GetStat()
 		if e != nil {
 			glog.V(0).Infof("Failed to read file size %s %v", v.DataBackend.Name(), e)
-			return false, e
+			return false, fmt.Errorf("v.DataBackend.GetStat(): %v", e)
 		}
 		if datFileSize > super_block.SuperBlockSize {
 			return false, nil
 		}
 	}
+	// check v.nm.ContentSize()
 	if v.nm != nil {
 		if v.nm.ContentSize() > 0 {
 			return false, nil


### PR DESCRIPTION
# What problem are we solving?
https://github.com/seaweedfs/seaweedfs/pull/4574#discussion_r1228129815


# How are we solving the problem?
`return false, fmt.Errorf("v.DataBackend is nil")` when `v.DataBackend == nil`


# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
