### PR TITLE
remove duplicate `fileCount` query

### DIFF
--- a/weed/storage/volume.go
+++ b/weed/storage/volume.go
@@ -306,7 +306,6 @@ func (v *Volume) collectStatus() (maxFileKey types.NeedleId, datFileSize int64, 
 	fileCount = uint64(v.nm.FileCount())
 	deletedCount = uint64(v.nm.DeletedCount())
 	deletedSize = v.nm.DeletedSize()
-	fileCount = uint64(v.nm.FileCount())
 
 	return
 }


### PR DESCRIPTION
# What problem are we solving?
duplicate code: L306, L309 have the same `fileCount` query code


# How are we solving the problem?
delete L309


# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
