### PR TITLE
Unix Socket listener for S3 server

### DIFF
--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -105,6 +105,7 @@ func init() {
 	filerS3Options.auditLogConfig = cmdFiler.Flag.String("s3.auditLogConfig", "", "path to the audit log config file")
 	filerS3Options.allowEmptyFolder = cmdFiler.Flag.Bool("s3.allowEmptyFolder", true, "allow empty folders")
 	filerS3Options.allowDeleteBucketNotEmpty = cmdFiler.Flag.Bool("s3.allowDeleteBucketNotEmpty", true, "allow recursive deleting all entries along with bucket")
+	filerS3Options.localSocket = cmdFiler.Flag.String("s3.localSocket", "", "default to /tmp/seaweedfs-s3-<port>.sock")
 
 	// start webdav on filer
 	filerStartWebDav = cmdFiler.Flag.Bool("webdav", false, "whether to start webdav gateway")

--- a/weed/command/server.go
+++ b/weed/command/server.go
@@ -147,6 +147,7 @@ func init() {
 	s3Options.auditLogConfig = cmdServer.Flag.String("s3.auditLogConfig", "", "path to the audit log config file")
 	s3Options.allowEmptyFolder = cmdServer.Flag.Bool("s3.allowEmptyFolder", true, "allow empty folders")
 	s3Options.allowDeleteBucketNotEmpty = cmdServer.Flag.Bool("s3.allowDeleteBucketNotEmpty", true, "allow recursive deleting all entries along with bucket")
+	s3Options.localSocket = cmdServer.Flag.String("s3.localSocket", "", "default to /tmp/seaweedfs-s3-<port>.sock")
 
 	iamOptions.port = cmdServer.Flag.Int("iam.port", 8111, "iam server http listen port")
 


### PR DESCRIPTION
# What problem are we solving?
As it suggested by wiki, S3 servers commonly running behind a reverse-proxy server like nginx and  currently the connection between the two established using OS loop-back.
Unix socket are proven to be more efficient and robust than lo and using them alongside tcp port listening can help busy servers.
 
# How are we solving the problem?
Basically I copy-pasted your previous commit about [adding Unix domain sockets to filer server](https://github.com/seaweedfs/seaweedfs/commit/da3d330616663e1c843514bd7a7a2c1833bf42d1)  with required changes.

# How is the PR tested?
I built the project and spin up an instance and test the connection between nginx & s3 server.
Unix socket listening on `/tmp/seaweedfs-s3-%port%.sock` by default.


# Checks
- [ ] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
