### PR TITLE
Fix the segfault from not setting s3 https port

### DIFF
--- a/weed/command/server.go
+++ b/weed/command/server.go
@@ -139,6 +139,7 @@ func init() {
 	serverOptions.v.readBufferSizeMB = cmdServer.Flag.Int("volume.readBufferSizeMB", 4, "<experimental> larger values can optimize query performance but will increase some memory usage,Use with hasSlowRead normally")
 
 	s3Options.port = cmdServer.Flag.Int("s3.port", 8333, "s3 server http listen port")
+	s3Options.portHttps = cmdServer.Flag.Int("s3.port.https", 0, "s3 server https listen port")
 	s3Options.portGrpc = cmdServer.Flag.Int("s3.port.grpc", 0, "s3 server grpc listen port")
 	s3Options.domainName = cmdServer.Flag.String("s3.domainName", "", "suffix of the host name in comma separated list, {bucket}.{domainName}")
 	s3Options.tlsPrivateKey = cmdServer.Flag.String("s3.key.file", "", "path to the TLS private key file")


### PR DESCRIPTION
# What problem are we solving?
Changes in 3.53 resulted in a segfaults if launching `weed server -s3` without -s3.port.https, this fixes that. 
See [issues/4627](https://github.com/seaweedfs/seaweedfs/issues/4627)


# How are we solving the problem?
Initialise the value in the server command.


# How is the PR tested?
By running it without setting the -s3.port.https option.


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
