### PR TITLE
Fix large file chunks deleted by mistake

### DIFF
--- a/weed/mount/weedfs_xattr.go
+++ b/weed/mount/weedfs_xattr.go
@@ -1,11 +1,12 @@
 package mount
 
 import (
-	"github.com/hanwen/go-fuse/v2/fuse"
-	sys "golang.org/x/sys/unix"
 	"runtime"
 	"strings"
 	"syscall"
+
+	"github.com/hanwen/go-fuse/v2/fuse"
+	sys "golang.org/x/sys/unix"
 )
 
 const (
@@ -129,6 +130,11 @@ func (wfs *WFS) SetXAttr(cancel <-chan struct{}, input *fuse.SetXAttrIn, attr st
 		fallthrough
 	default:
 		entry.Extended[XATTR_PREFIX+attr] = data
+	}
+
+	if fh != nil {
+		fh.dirtyMetadata = true
+		return fuse.OK
 	}
 
 	return wfs.saveEntry(path, entry)

--- a/weed/server/filer_grpc_server.go
+++ b/weed/server/filer_grpc_server.go
@@ -3,11 +3,12 @@ package weed_server
 import (
 	"context"
 	"fmt"
-	"github.com/seaweedfs/seaweedfs/weed/cluster"
 	"os"
 	"path/filepath"
 	"strconv"
 	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/cluster"
 
 	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/glog"
@@ -157,7 +158,7 @@ func (fs *FilerServer) CreateEntry(ctx context.Context, req *filer_pb.CreateEntr
 	createErr := fs.filer.CreateEntry(ctx, newEntry, req.OExcl, req.IsFromOtherCluster, req.Signatures, req.SkipCheckParentDirectory)
 
 	if createErr == nil {
-		fs.filer.DeleteChunks(garbage)
+		fs.filer.DeleteChunksNotRecursive(garbage)
 	} else {
 		glog.V(3).Infof("CreateEntry %s: %v", filepath.Join(req.Directory, req.Entry.Name), createErr)
 		resp.Error = createErr.Error()
@@ -189,7 +190,7 @@ func (fs *FilerServer) UpdateEntry(ctx context.Context, req *filer_pb.UpdateEntr
 	}
 
 	if err = fs.filer.UpdateEntry(ctx, entry, newEntry); err == nil {
-		fs.filer.DeleteChunks(garbage)
+		fs.filer.DeleteChunksNotRecursive(garbage)
 
 		fs.filer.NotifyUpdateEvent(ctx, entry, newEntry, true, req.IsFromOtherCluster, req.Signatures)
 


### PR DESCRIPTION
# What problem are we solving?
Fix #4677 

# Analysis
The problem is caused by manifest.

If the file has two xattr, then mount will trigger saveEntry twice, and  twice (fs *FilerServer) UpdateEntry. With the last (fs *FilerServer) CreateEntry, the file will do 3 manifest operations.

Then CreateEntry and UpdateEntry will judge the previous manifest chunks as garbage, and  fs.filer.DeleteChunks(garbage) will delete the data by mistake.


# How are we solving the problem?

1:  Use DeleteChunksNotRecursive instead of DeleteChunks to clear garbage。

2:  SetXAttr does not call saveEntry when writing data to the file (fh!=nil)



# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
