### PR TITLE
Add variabilisation of RBAC

### DIFF
--- a/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
@@ -46,7 +46,9 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.global.imagePullSecrets }}
       {{- end }}
+      {{- if .Values.global.createClusterRole }}
       serviceAccountName: seaweedfs-rw-sa #hack for delete pod master after migration
+      {{- end }}
       terminationGracePeriodSeconds: 60
       {{- if .Values.filer.priorityClassName }}
       priorityClassName: {{ .Values.filer.priorityClassName | quote }}

--- a/k8s/charts/seaweedfs/templates/service-account.yaml
+++ b/k8s/charts/seaweedfs/templates/service-account.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.createClusterRole }}
 #hack for delete pod master after migration
 ---
 kind: ClusterRole
@@ -27,3 +28,4 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: seaweedfs-rw-cr
+{{- end }}

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -1,6 +1,7 @@
 # Available parameters and their default values for the SeaweedFS chart.
 
 global:
+  createClusterRole: true
   registry: ""
   repository: ""
   imageName: chrislusf/seaweedfs


### PR DESCRIPTION
# What problem are we solving?
Sometimes, when deploying the Helm Chart to a specific namespace inside a Kubernetes Cluster that is shared accross many teams, you don't have the rights as a user to access ClusterRole and ClusterRoleBinding globally.

# How are we solving the problem?
In order to bypass this limitation, we can use the default service account in the namespace, and disable the service-account part of the deployment.

# How is the PR tested?
This PR is tested in a live kubernetes environment without rights access to ClusterRole and ClusterRoleBinding.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
