### PR TITLE
Remove the auth check for volume server reads

### DIFF
--- a/weed/server/volume_server_handlers_read.go
+++ b/weed/server/volume_server_handlers_read.go
@@ -3,7 +3,6 @@ package weed_server
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -31,11 +30,6 @@ var fileNameEscaper = strings.NewReplacer(`\`, `\\`, `"`, `\"`)
 func (vs *VolumeServer) GetOrHeadHandler(w http.ResponseWriter, r *http.Request) {
 	n := new(needle.Needle)
 	vid, fid, filename, ext, _ := parseURLPath(r.URL.Path)
-
-	if !vs.maybeCheckJwtAuthorization(r, vid, fid, false) {
-		writeJsonError(w, r, http.StatusUnauthorized, errors.New("wrong jwt"))
-		return
-	}
 
 	volumeId, err := needle.NewVolumeId(vid)
 	if err != nil {


### PR DESCRIPTION
According to the documentation this shouldn't be authorized. It was breaking reads from the filer.

# What problem are we solving?
Issue [#3352
](https://github.com/seaweedfs/seaweedfs/issues/3352)
The auth check broke the filer being able to read files from the volume server if jwt.signing.key was set in security.toml.

# How are we solving the problem?
Removing the auth check on reads.
