### PR TITLE
Update weed fix description

### DIFF
--- a/weed/command/fix.go
+++ b/weed/command/fix.go
@@ -25,7 +25,8 @@ var cmdFix = &Command{
 	UsageLine: "fix [-volumeId=234] [-collection=bigData] /tmp",
 	Short:     "run weed tool fix on files or whole folders to recreate index file(s) if corrupted",
 	Long: `Fix runs the SeaweedFS fix command on dat files or whole folders to re-create the index .idx file.
-  `,
+  You Need to stop the volume server when running this command.
+`,
 }
 
 var (
@@ -42,8 +43,8 @@ type VolumeFileScanner4Fix struct {
 func (scanner *VolumeFileScanner4Fix) VisitSuperBlock(superBlock super_block.SuperBlock) error {
 	scanner.version = superBlock.Version
 	return nil
-
 }
+
 func (scanner *VolumeFileScanner4Fix) ReadNeedleBody() bool {
 	return false
 }
@@ -115,7 +116,6 @@ func runFix(cmd *Command, args []string) bool {
 }
 
 func doFixOneVolume(basepath string, baseFileName string, collection string, volumeId int64) {
-
 	indexFileName := path.Join(basepath, baseFileName+".idx")
 
 	nm := needle_map.NewMemDb()


### PR DESCRIPTION
# What problem are we solving?
https://github.com/seaweedfs/seaweedfs/issues/4743

# How are we solving the problem?
Update `weed fix` description to 
```
Description:
  Fix runs the SeaweedFS fix command on dat files or whole folders to re-create the index .idx file.
  You Need to stop the volume server when running this command.
```


# How is the PR tested?
```shell
$ go run ./weed/weed.go fix --help
Example: weed fix [-volumeId=234] [-collection=bigData] /tmp
Default Usage:
  -collection string
    	an optional volume collection name, if specified only it will be processed
  -ignoreError
    	an optional, if true will be processed despite errors
  -options string
    	a file of command line options, each line in optionName=optionValue format
  -volumeId int
    	an optional volume id, if not 0 (default) only it will be processed
Description:
  Fix runs the SeaweedFS fix command on dat files or whole folders to re-create the index .idx file.
  You Need to stop the volume server when running this command.
```


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
