### PR TITLE
Fix s3.clean.uploads

### DIFF
--- a/weed/shell/command_s3_clean_uploads.go
+++ b/weed/shell/command_s3_clean_uploads.go
@@ -3,12 +3,13 @@ package shell
 import (
 	"flag"
 	"fmt"
-	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
-	"github.com/seaweedfs/seaweedfs/weed/security"
-	"github.com/seaweedfs/seaweedfs/weed/util"
 	"io"
 	"math"
 	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
+	"github.com/seaweedfs/seaweedfs/weed/security"
+	"github.com/seaweedfs/seaweedfs/weed/util"
 
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 )
@@ -17,8 +18,7 @@ func init() {
 	Commands = append(Commands, &commandS3CleanUploads{})
 }
 
-type commandS3CleanUploads struct {
-}
+type commandS3CleanUploads struct{}
 
 func (c *commandS3CleanUploads) Name() string {
 	return "s3.clean.uploads"
@@ -34,14 +34,13 @@ func (c *commandS3CleanUploads) Help() string {
 }
 
 func (c *commandS3CleanUploads) Do(args []string, commandEnv *CommandEnv, writer io.Writer) (err error) {
-
 	bucketCommand := flag.NewFlagSet(c.Name(), flag.ContinueOnError)
 	uploadedTimeAgo := bucketCommand.Duration("timeAgo", 24*time.Hour, "created time before now. \"1.5h\" or \"2h45m\". Valid time units are \"m\", \"h\"")
 	if err = bucketCommand.Parse(args); err != nil {
 		return nil
 	}
 
-	signingKey := util.GetViper().GetString("jwt.signing.key")
+	signingKey := util.GetViper().GetString("jwt.filer_signing.key")
 
 	var filerBucketsPath string
 	filerBucketsPath, err = readFilerBucketsPath(commandEnv)
@@ -65,7 +64,6 @@ func (c *commandS3CleanUploads) Do(args []string, commandEnv *CommandEnv, writer
 	}
 
 	return err
-
 }
 
 func (c *commandS3CleanUploads) cleanupUploads(commandEnv *CommandEnv, writer io.Writer, filerBucketsPath string, bucket string, timeAgo time.Duration, signingKey string) error {
@@ -99,5 +97,4 @@ func (c *commandS3CleanUploads) cleanupUploads(commandEnv *CommandEnv, writer io
 	}
 
 	return nil
-
 }


### PR DESCRIPTION
# What problem are we solving?
wrong jwt error in `s3.clean.uploads`  
security.toml:
```toml
[jwt.signing]                      
key = "aaaaaaaaaaaa"           
expires_after_seconds = 30
                                   
[jwt.filer_signing]                
key = "bbbbbbbbbbb"           
expires_after_seconds = 30
```
```
> s3.clean.uploads -timeAgo 0
purge http://192.168.20.70:8888/buckets/test/.uploads/109f4b3c50d7b0df729d299bc6f8e9ef9066971f_19a49cbefa9c47cd8ecdf0f8993d1cdb?recursive=true&ignoreRecursiveError=true
failed cleanup uploads for bucket test: purge /buckets/test/.uploads/109f4b3c50d7b0df729d299bc6f8e9ef9066971f_19a49cbefa9c47cd8ecdf0f8993d1cdb: wrong jwt> 
```




# How are we solving the problem?
`weed shell` is using `jwt.signing.key` for `s3.clean.upload` instead of `jwt.filer_signing.key`


# How is the PR tested?
```
$ go run ./weed/weed.go master
$ go run ./weed/weed.go filer -s3 
$ go run ./weed/weed.go volume
$ dd if=/dev/zero of=test2 bs=1024MB count=1
$ aws --endpoint http://localhost:8333 s3 cp test2  s3://test
terminate aws cli with `SIGKILL`
$ echo "ls -a /buckets/test/.uploads/" | go run ./weed/weed.go shell
109f4b3c50d7b0df729d299bc6f8e9ef9066971f_8bb5348b440a47d9ae6cd9ed76c49995
echo "s3.clean.uploads -timeAgo 0" | go run ./weed/weed.go shell
purge http://192.168.20.70:8888/buckets/test/.uploads/109f4b3c50d7b0df729d299bc6f8e9ef9066971f_8bb5348b440a47d9ae6cd9ed76c49995?recursive=true&ignoreRecursiveError=true
$ echo "ls -a /buckets/test/.uploads/" | go run ./weed/weed.go shell
```


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
