### PR TITLE
Add time to first byte metric for s3

### DIFF
--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -355,6 +355,7 @@ func (s3a *S3ApiServer) doDeleteEmptyDirectories(client filer_pb.SeaweedFilerCli
 func (s3a *S3ApiServer) proxyToFiler(w http.ResponseWriter, r *http.Request, destUrl string, isWrite bool, responseFn func(proxyResponse *http.Response, w http.ResponseWriter) (statusCode int)) {
 
 	glog.V(3).Infof("s3 proxying %s to %s", r.Method, destUrl)
+	start := time.Now()
 
 	proxyReq, err := http.NewRequest(r.Method, destUrl, r.Body)
 
@@ -404,12 +405,12 @@ func (s3a *S3ApiServer) proxyToFiler(w http.ResponseWriter, r *http.Request, des
 			return
 		}
 	}
-
 	if resp.StatusCode == http.StatusNotFound {
 		s3err.WriteErrorResponse(w, r, s3err.ErrNoSuchKey)
 		return
 	}
 
+	TimeToFirstByte(r.Method, start, r)
 	if resp.Header.Get(s3_constants.X_SeaweedFS_Header_Directory_Key) == "true" {
 		responseStatusCode := responseFn(resp, w)
 		s3err.PostLog(r, responseStatusCode, s3err.ErrNone)

--- a/weed/s3api/stats.go
+++ b/weed/s3api/stats.go
@@ -46,5 +46,5 @@ func track(f http.HandlerFunc, action string) http.HandlerFunc {
 
 func TimeToFirstByte(action string, start time.Time, r *http.Request) {
 	bucket, _ := s3_constants.GetBucketAndObject(r)
-	stats_collect.S3TimeToFirstByteHistogram.WithLabelValues(action, bucket).Observe(time.Since(start).Seconds())
+	stats_collect.S3TimeToFirstByteHistogram.WithLabelValues(action, bucket).Observe(float64(time.Since(start).Milliseconds()))
 }

--- a/weed/s3api/stats.go
+++ b/weed/s3api/stats.go
@@ -43,3 +43,8 @@ func track(f http.HandlerFunc, action string) http.HandlerFunc {
 		stats_collect.S3RequestCounter.WithLabelValues(action, strconv.Itoa(recorder.Status), bucket).Inc()
 	}
 }
+
+func TimeToFirstByte(action string, start time.Time, r *http.Request) {
+	bucket, _ := s3_constants.GetBucketAndObject(r)
+	stats_collect.S3TimeToFirstByteHistogram.WithLabelValues(action, bucket).Observe(time.Since(start).Seconds())
+}

--- a/weed/stats/metrics.go
+++ b/weed/stats/metrics.go
@@ -230,9 +230,9 @@ var (
 		prometheus.HistogramOpts{
 			Namespace: Namespace,
 			Subsystem: "s3",
-			Name:      "time_to_first_byte_seconds",
+			Name:      "time_to_first_byte_millisecond",
 			Help:      "Bucketed histogram of s3 time to first byte request processing time.",
-			Buckets:   prometheus.ExponentialBuckets(0.0001, 2, 24),
+			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 27),
 		}, []string{"type", "bucket"})
 
 )

--- a/weed/stats/metrics.go
+++ b/weed/stats/metrics.go
@@ -226,6 +226,15 @@ var (
 			Help:      "Bucketed histogram of s3 request processing time.",
 			Buckets:   prometheus.ExponentialBuckets(0.0001, 2, 24),
 		}, []string{"type", "bucket"})
+	S3TimeToFirstByteHistogram = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: Namespace,
+			Subsystem: "s3",
+			Name:      "time_to_first_byte_seconds",
+			Help:      "Bucketed histogram of s3 time to first byte request processing time.",
+			Buckets:   prometheus.ExponentialBuckets(0.0001, 2, 24),
+		}, []string{"type", "bucket"})
+
 )
 
 func init() {
@@ -258,6 +267,7 @@ func init() {
 
 	Gather.MustRegister(S3RequestCounter)
 	Gather.MustRegister(S3RequestHistogram)
+	Gather.MustRegister(S3TimeToFirstByteHistogram)
 }
 
 func LoopPushingMetric(name, instance, addr string, intervalSeconds int) {


### PR DESCRIPTION
# What problem are we solving?
Lack of time to first byte metric for s3


# How are we solving the problem?
Add a histogram metric for s3 time to first byte and observe it when filer returns response



# How is the PR tested?
Simple write and read to s3 interface and observing `SeaweedFS_s3_time_to_first_byte_seconds_bucket` metric


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
