### PR TITLE
Fix s3 object list 

### DIFF
--- a/weed/s3api/s3api_objects_list_handlers.go
+++ b/weed/s3api/s3api_objects_list_handlers.go
@@ -139,8 +139,8 @@ func (s3a *S3ApiServer) listFilerEntries(bucket string, originalPrefix string, m
 	var doErr error
 	var nextMarker string
 	cursor := &ListingCursor{
-		maxKeys:               maxKeys,
-		prefixEndsOnDelimiter: strings.HasSuffix(originalPrefix, "/") && len(originalMarker) == 0,
+		maxKeys: maxKeys,
+		//prefixEndsOnDelimiter: strings.HasSuffix(originalPrefix, "/") && len(originalMarker) == 0,
 	}
 
 	// check filer
@@ -236,6 +236,7 @@ type ListingCursor struct {
 func normalizePrefixMarker(prefix, marker string) (alignedDir, alignedPrefix, alignedMarker string) {
 	// alignedDir should not end with "/"
 	// alignedDir, alignedPrefix, alignedMarker should only have "/" in middle
+	isDirSuffix := strings.HasSuffix(prefix, "/")
 	if len(marker) == 0 {
 		prefix = strings.Trim(prefix, "/")
 	} else {
@@ -246,7 +247,12 @@ func normalizePrefixMarker(prefix, marker string) (alignedDir, alignedPrefix, al
 		return "", "", marker
 	}
 	if marker == "" {
-		alignedDir, alignedPrefix = toDirAndName(prefix)
+		if isDirSuffix {
+			alignedDir = prefix
+			alignedPrefix = ""
+		} else {
+			alignedDir, alignedPrefix = toDirAndName(prefix)
+		}
 		return
 	}
 	if !strings.HasPrefix(marker, prefix) {


### PR DESCRIPTION
# What problem are we solving?
Only the directories under the bucket can be listed, and the subdirectories cannot be listed


# How are we solving the problem?
Path ending in "/" are considered subpath rather than prefix.


# How is the PR tested?

screenshot:
Level 1 sub directory of the bucket (Consistent result)
<img width="1241" alt="image" src="https://github.com/seaweedfs/seaweedfs/assets/43405321/9300472c-1f8f-4809-8727-500d565c25c8">
![image](https://github.com/seaweedfs/seaweedfs/assets/43405321/92b3bc7d-1391-4119-b66c-09e4464903ac)

Level 2 sub directory of the bucket (Inconsistent result)
<img width="1317" alt="image" src="https://github.com/seaweedfs/seaweedfs/assets/43405321/2215414a-a7ff-4f9f-b3d5-d29fabc864d1">

![image](https://github.com/seaweedfs/seaweedfs/assets/43405321/e5db25c6-4373-48b2-b1dd-c08dbf781015)



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.


