### PR TITLE
fix bugs:  seaweedfs master ingress host  configuration do not work

### DIFF
--- a/k8s/charts/seaweedfs/templates/ingress.yaml
+++ b/k8s/charts/seaweedfs/templates/ingress.yaml
@@ -52,7 +52,8 @@ metadata:
 spec:
   ingressClassName: {{ .Values.master.ingress.className | quote }}
   rules:
-  - http:
+  - host: {{ .Values.master.ingress.host }}
+    http:
       paths:
       - path: /sw-master/?(.*)
         pathType: ImplementationSpecific


### PR DESCRIPTION
# What problem are we solving?
seaweedfs master ingress host  configuration do not work


# How are we solving the problem?

the same as filer ingress， add  a host filed of master ingress

# How is the PR tested?

tested


# Checks
- [X ] I have added unit tests if possible.
- [X ] I will add related wiki document changes and link to this PR after merging.
