### PR TITLE
[helm] add possibility to use array for imagePullSecrets

### DIFF
--- a/k8s/charts/seaweedfs/templates/_helpers.tpl
+++ b/k8s/charts/seaweedfs/templates/_helpers.tpl
@@ -183,3 +183,18 @@ Inject extra environment vars in the format key:value, if populated
 {{- printf "false" -}}
 {{- end -}}
 {{- end -}}
+
+{{/* Return the proper imagePullSecrets */}}
+{{- define "seaweedfs.imagePullSecrets" -}}
+{{- if .Values.global.imagePullSecrets }}
+{{- if kindIs "string" .Values.global.imagePullSecrets }}
+imagePullSecrets:
+  - name: {{ .Values.global.imagePullSecrets }}
+{{- else }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
@@ -42,10 +42,7 @@ spec:
       tolerations:
         {{ tpl .Values.filer.tolerations . | nindent 8 | trim }}
       {{- end }}
-      {{- if .Values.global.imagePullSecrets }}
-      imagePullSecrets:
-        - name: {{ .Values.global.imagePullSecrets }}
-      {{- end }}
+      {{- include "seaweedfs.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.global.createClusterRole }}
       serviceAccountName: seaweedfs-rw-sa #hack for delete pod master after migration
       {{- end }}

--- a/k8s/charts/seaweedfs/templates/master-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/master-statefulset.yaml
@@ -42,10 +42,7 @@ spec:
       tolerations:
         {{ tpl .Values.master.tolerations . | nindent 8 | trim }}
       {{- end }}
-      {{- if .Values.global.imagePullSecrets }}
-      imagePullSecrets:
-        - name: {{ .Values.global.imagePullSecrets }}
-      {{- end }}
+      {{- include "seaweedfs.imagePullSecrets" . | nindent 6 }}
       terminationGracePeriodSeconds: 60
       {{- if .Values.master.priorityClassName }}
       priorityClassName: {{ .Values.master.priorityClassName | quote }}

--- a/k8s/charts/seaweedfs/templates/s3-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/s3-deployment.yaml
@@ -30,10 +30,7 @@ spec:
       tolerations:
         {{ tpl .Values.s3.tolerations . | nindent 8 | trim }}
       {{- end }}
-      {{- if .Values.global.imagePullSecrets }}
-      imagePullSecrets:
-        - name: {{ .Values.global.imagePullSecrets }}
-      {{- end }}
+      {{- include "seaweedfs.imagePullSecrets" . | nindent 6 }}
       terminationGracePeriodSeconds: 10
       {{- if .Values.s3.priorityClassName }}
       priorityClassName: {{ .Values.s3.priorityClassName | quote }}

--- a/k8s/charts/seaweedfs/templates/volume-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/volume-statefulset.yaml
@@ -36,10 +36,7 @@ spec:
       tolerations:
         {{ tpl .Values.volume.tolerations . | nindent 8 | trim }}
       {{- end }}
-      {{- if .Values.global.imagePullSecrets }}
-      imagePullSecrets:
-        - name: {{ .Values.global.imagePullSecrets }}
-      {{- end }}
+      {{- include "seaweedfs.imagePullSecrets" . | nindent 6 }}
       terminationGracePeriodSeconds: 150
       {{- if .Values.volume.priorityClassName }}
       priorityClassName: {{ .Values.volume.priorityClassName | quote }}


### PR DESCRIPTION
# What problem are we solving?

Current parameter global.imagePullSecrets is a string, but will be good to able to specify array for it. A lot of community charts using "global.imagePullSecrets" parameter as a list and we can't override "global" parameters per subchart so I'm suggesting this solution.

# How are we solving the problem?

I added additional helper function for that which is returns proper imagePullSecrets section:
- if global.imagePullSecrets parameter is a string it returns imagePullSecrets with single element (for backward compatibility);
- Otherwise it expects list and generates imagePullSecrets section with element for each list element;

# How is the PR tested?

Manually tested with:
- default parameters
- with global.imagePullSecrets overrided to string
- with global.imagePullSecrets overrided to list

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
