### PR TITLE
[helm] fix log to stderr and default host for ingress

### DIFF
--- a/k8s/charts/seaweedfs/templates/ingress.yaml
+++ b/k8s/charts/seaweedfs/templates/ingress.yaml
@@ -17,8 +17,7 @@ spec:
   tls:
     {{ .Values.filer.ingress.tls | default list | toYaml | nindent 6}}
   rules:
-  - host: {{ .Values.filer.ingress.host }}
-    http:
+  - http:
       paths:
       - path: /sw-filer/?(.*)
         pathType: ImplementationSpecific
@@ -32,6 +31,9 @@ spec:
 {{- else }}
           serviceName: {{ template "seaweedfs.name" . }}-filer
           servicePort: {{ .Values.filer.port }}
+{{- end }}
+{{- if .Values.filer.ingress.host }}
+    host: {{ .Values.filer.ingress.host }}
 {{- end }}
 {{- end }}
 ---
@@ -52,8 +54,7 @@ metadata:
 spec:
   ingressClassName: {{ .Values.master.ingress.className | quote }}
   rules:
-  - host: {{ .Values.master.ingress.host }}
-    http:
+  - http:
       paths:
       - path: /sw-master/?(.*)
         pathType: ImplementationSpecific
@@ -67,5 +68,8 @@ spec:
 {{- else }}
           serviceName: {{ template "seaweedfs.name" . }}-master
           servicePort: {{ .Values.master.port }}
+{{- end }}
+{{- if .Values.filer.ingress.host }}
+    host: {{ .Values.master.ingress.host }}
 {{- end }}
 {{- end }}

--- a/k8s/charts/seaweedfs/templates/s3-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/s3-deployment.yaml
@@ -107,8 +107,10 @@ spec:
               {{- end }}
               -filer={{ template "seaweedfs.name" . }}-filer-client.{{ .Release.Namespace }}:{{ .Values.filer.port }}
           volumeMounts:
+            {{- if eq .Values.s3.logs.type "hostPath" }}
             - name: logs
               mountPath: "/logs/"
+            {{- end }}
             - mountPath: /etc/sw
               name: config-users
               readOnly: true

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -127,6 +127,7 @@ master:
   ingress:
     enabled: false
     className: "nginx"
+    # host: false for "*" hostname
     host: "master.seaweedfs.local"
     annotations:
       nginx.ingress.kubernetes.io/auth-type: "basic"
@@ -375,6 +376,7 @@ filer:
   ingress:
     enabled: false
     className: "nginx"
+    # host: false for "*" hostname
     host: "seaweedfs.cluster.local"
     annotations:
       nginx.ingress.kubernetes.io/backend-protocol: GRPC


### PR DESCRIPTION
# What problem are we solving?
1 - for testing it is useful to be able to not specify a host for ingress, in which case it will become the default host
2 - a separate instance for s3 contains an error when logging to stderr
# How are we solving the problem?
1 - remove host from ingress
2 - additional if for logging for stderr
# How is the PR tested?
local
# Checks
- [x] I have added unit tests if possible.
- [] I will add related wiki document changes and link to this PR after merging.
