### PR TITLE
helm: allow setting master.toml config

### DIFF
--- a/k8s/charts/seaweedfs/templates/master-configmap.yaml
+++ b/k8s/charts/seaweedfs/templates/master-configmap.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.master.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "seaweedfs.name" . }}-master-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+data:
+  master.toml: |-
+    {{ .Values.master.config | nindent 4 }}
+{{- end }}

--- a/k8s/charts/seaweedfs/templates/master-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/master-statefulset.yaml
@@ -142,6 +142,10 @@ spec:
             - name: seaweedfs-master-log-volume
               mountPath: "/logs/"
             {{- end }}
+            - name: master-config
+              readOnly: true
+              mountPath: /etc/seaweedfs/master.toml
+              subPath: master.toml
             {{- if .Values.global.enableSecurity }}
             - name: security-config
               readOnly: true
@@ -212,6 +216,9 @@ spec:
             path: {{ .Values.master.data.hostPathPrefix }}/seaweed-master/
             type: DirectoryOrCreate
         {{- end }}
+        - name: master-config
+          configMap:
+            name: {{ template "seaweedfs.name" . }}-master-config
         {{- if .Values.global.enableSecurity }}
         - name: security-config
           configMap:

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -62,6 +62,10 @@ master:
   # Disable http request, only gRpc operations are allowed
   disableHttp: false
 
+  config: |-
+    # Enter any extra configuration for master.toml here.
+    # It may be be a multi-line string.
+
   # can use ANY storage-class , example with local-path-provisioner
   #  data:
   #    type: "persistentVolumeClaim"


### PR DESCRIPTION
# What problem are we solving?

Following my question in https://github.com/seaweedfs/seaweedfs/discussions/4796, I think that it would be a good idea if it was possible to set the contents of `master.toml` from the helm chart. This would have helped me avoid any undocument env variable parsing quirks.

# How are we solving the problem?

Expose `master.config` in values, which can be a multi-line string that will be mounted at `/etc/seaweed/master.toml`.

I based most of the code on the other configmap, `security.toml`.

# How is the PR tested?

I ran the following:
```
git checkout master
helm template test . > output.yaml
git add output.yaml
git checkout aviau/master-config
helm template test . > output.yaml
git diff
```

This is the result:
```
diff --git a/k8s/charts/seaweedfs/output.yaml b/k8s/charts/seaweedfs/output.yaml
index ff0044732..15181f612 100644
--- a/k8s/charts/seaweedfs/output.yaml
+++ b/k8s/charts/seaweedfs/output.yaml
@@ -11,6 +11,23 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/instance: test
 ---
+# Source: seaweedfs/templates/master-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: seaweedfs-master-config
+  namespace: default
+  labels:
+    app.kubernetes.io/name: seaweedfs
+    helm.sh/chart: seaweedfs-3.55
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/instance: test
+data:
+  master.toml: |-
+
+    # Enter any extra configuration for master.toml here.
+    # It may be be a multi-line string.
+---
 # Source: seaweedfs/templates/service-account.yaml
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -468,6 +485,10 @@ spec:
               mountPath: /data
             - name: seaweedfs-master-log-volume
               mountPath: "/logs/"
+            - name: master-config
+              readOnly: true
+              mountPath: /etc/seaweedfs/master.toml
+              subPath: master.toml

           ports:
             - containerPort: 9333
@@ -503,6 +524,9 @@ spec:
           hostPath:
             path: /ssd/seaweed-master/
             type: DirectoryOrCreate
+        - name: master-config
+          configMap:
+            name: seaweedfs-master-config
```

I must admit that I didn't apply the result in a fully working test env, but my k8s-fu tends to indicate the output is correct :)

# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
