### PR TITLE
improve k8s probes templating in helm chart

### DIFF
--- a/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
@@ -224,26 +224,30 @@ spec:
               name: metrics
             - containerPort: {{ .Values.filer.grpcPort }}
               #name: swfs-filer-grpc
+          {{- if .Values.filer.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: /
+              path: {{ .Values.filer.readinessProbe.httpGet.path }}
               port: {{ .Values.filer.port }}
-              scheme: HTTP
-            initialDelaySeconds: 10
-            periodSeconds: 15
-            successThreshold: 1
-            failureThreshold: 100
-            timeoutSeconds: 10
+              scheme: {{ .Values.filer.readinessProbe.scheme }}
+            initialDelaySeconds: {{ .Values.filer.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.filer.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.filer.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.filer.readinessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.filer.readinessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.filer.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: /
+              path: {{ .Values.filer.livenessProbe.httpGet.path }}
               port: {{ .Values.filer.port }}
-              scheme: HTTP
-            initialDelaySeconds: 20
-            periodSeconds: 30
-            successThreshold: 1
-            failureThreshold: 5
-            timeoutSeconds: 10
+              scheme: {{ .Values.filer.livenessProbe.scheme }}
+            initialDelaySeconds: {{ .Values.filer.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.filer.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.filer.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.filer.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.filer.livenessProbe.timeoutSeconds }}
+          {{- end }}
           {{- if .Values.filer.resources }}
           resources:
             {{ tpl .Values.filer.resources . | nindent 12 | trim }}

--- a/k8s/charts/seaweedfs/templates/master-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/master-statefulset.yaml
@@ -177,26 +177,30 @@ spec:
             {{- end }}
             - containerPort: {{ .Values.master.grpcPort }}
               #name: swfs-master-grpc
+          {{- if .Values.master.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: /cluster/status
+              path: {{ .Values.master.readinessProbe.httpGet.path }}
               port: {{ .Values.master.port }}
-              scheme: HTTP
-            initialDelaySeconds: 10
-            periodSeconds: 45
-            successThreshold: 2
-            failureThreshold: 100
-            timeoutSeconds: 10
+              scheme: {{ .Values.master.readinessProbe.scheme }}
+            initialDelaySeconds: {{ .Values.master.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.master.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.master.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.master.readinessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.master.readinessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.master.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: /cluster/status
+              path: {{ .Values.master.livenessProbe.httpGet.path }}
               port: {{ .Values.master.port }}
-              scheme: HTTP
-            initialDelaySeconds: 20
-            periodSeconds: 30
-            successThreshold: 1
-            failureThreshold: 4
-            timeoutSeconds: 10
+              scheme: {{ .Values.master.livenessProbe.scheme }}
+            initialDelaySeconds: {{ .Values.master.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.master.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.master.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.master.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.master.livenessProbe.timeoutSeconds }}
+          {{- end }}
           {{- if .Values.master.resources }}
           resources:
             {{ tpl .Values.master.resources . | nindent 12 | trim }}

--- a/k8s/charts/seaweedfs/templates/s3-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/s3-deployment.yaml
@@ -146,26 +146,30 @@ spec:
             - containerPort: {{ .Values.s3.metricsPort }}
               name: "metrics"
             {{- end }}
+          {{- if .Values.s3.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: /status
+              path: {{ .Values.s3.readinessProbe.httpGet.path }}
               port: {{ .Values.s3.port }}
-              scheme: HTTP
-            initialDelaySeconds: 15
-            periodSeconds: 15
-            successThreshold: 1
-            failureThreshold: 100
-            timeoutSeconds: 10
+              scheme: {{ .Values.s3.readinessProbe.scheme }}
+            initialDelaySeconds: {{ .Values.s3.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.s3.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.s3.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.s3.readinessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.s3.readinessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.s3.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: /status
+              path: {{ .Values.s3.livenessProbe.httpGet.path }}
               port: {{ .Values.s3.port }}
-              scheme: HTTP
-            initialDelaySeconds: 20
-            periodSeconds: 60
-            successThreshold: 1
-            failureThreshold: 20
-            timeoutSeconds: 10
+              scheme: {{ .Values.s3.livenessProbe.scheme }}
+            initialDelaySeconds: {{ .Values.s3.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.s3.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.s3.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.s3.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.s3.livenessProbe.timeoutSeconds }}
+          {{- end }}
           {{- if .Values.s3.resources }}
           resources:
             {{ tpl .Values.s3.resources . | nindent 12 | trim }}

--- a/k8s/charts/seaweedfs/templates/volume-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/volume-statefulset.yaml
@@ -183,26 +183,30 @@ spec:
             {{- end }}
             - containerPort: {{ .Values.volume.grpcPort }}
               name: swfs-vol-grpc
+          {{- if .Values.volume.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: /status
+              path: {{ .Values.volume.readinessProbe.httpGet.path }}
               port: {{ .Values.volume.port }}
-              scheme: HTTP
-            initialDelaySeconds: 15
-            periodSeconds: 15
-            successThreshold: 1
-            failureThreshold: 100
-            timeoutSeconds: 30
+              scheme: {{ .Values.volume.readinessProbe.scheme }}
+            initialDelaySeconds: {{ .Values.volume.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.volume.readinessProbe.periodSeconds }}
+            successThreshold: {{ .Values.volume.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.volume.readinessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.volume.readinessProbe.timeoutSeconds }}
+          {{- end }}
+          {{- if .Values.volume.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: /status
+              path: {{ .Values.volume.livenessProbe.httpGet.path }}
               port: {{ .Values.volume.port }}
-              scheme: HTTP
-            initialDelaySeconds: 20
-            periodSeconds: 90
-            successThreshold: 1
-            failureThreshold: 4
-            timeoutSeconds: 30
+              scheme: {{ .Values.volume.livenessProbe.scheme }}
+            initialDelaySeconds: {{ .Values.volume.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.volume.livenessProbe.periodSeconds }}
+            successThreshold: {{ .Values.volume.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.volume.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.volume.livenessProbe.timeoutSeconds }}
+          {{- end }}
           {{- if .Values.volume.resources }}
           resources:
             {{ tpl .Values.volume.resources . | nindent 12 | trim }}

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -160,6 +160,32 @@ master:
     WEED_MASTER_VOLUME_GROWTH_COPY_3: 3
     WEED_MASTER_VOLUME_GROWTH_COPY_OTHER: 1
 
+  # used to configure livenessProbe on master-server containers
+  #
+  livenessProbe:
+    enabled: true
+    httpGet:
+      path: /cluster/status
+      scheme: HTTP
+    initialDelaySeconds: 20
+    periodSeconds: 30
+    successThreshold: 1
+    failureThreshold: 4
+    timeoutSeconds: 10
+
+  # used to configure readinessProbe on master-server containers
+  #
+  readinessProbe:
+    enabled: true
+    httpGet:
+      path: /cluster/status
+      scheme: HTTP
+    initialDelaySeconds: 10
+    periodSeconds: 45
+    successThreshold: 2
+    failureThreshold: 100
+    timeoutSeconds: 10
+
 volume:
   enabled: true
   repository: null
@@ -276,6 +302,32 @@ volume:
   # used to assign a service account.
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
   serviceAccountName: ""
+
+  # used to configure livenessProbe on volume-server containers
+  #
+  livenessProbe:
+    enabled: true
+    httpGet:
+      path: /status
+      scheme: HTTP
+    initialDelaySeconds: 20
+    periodSeconds: 90
+    successThreshold: 1
+    failureThreshold: 4
+    timeoutSeconds: 30
+
+  # used to configure readinessProbe on volume-server containers
+  #
+  readinessProbe:
+    enabled: true
+    httpGet:
+      path: /status
+      scheme: HTTP
+    initialDelaySeconds: 15
+    periodSeconds: 15
+    successThreshold: 1
+    failureThreshold: 100
+    timeoutSeconds: 30
 
 filer:
   enabled: true
@@ -431,6 +483,31 @@ filer:
     # directories under this folder will be automatically creating a separate bucket
     WEED_FILER_BUCKETS_FOLDER: "/buckets"
 
+  # used to configure livenessProbe on filer containers
+  #
+  livenessProbe:
+    enabled: true
+    httpGet:
+      path: /
+      scheme: HTTP
+    initialDelaySeconds: 20
+    periodSeconds: 30
+    successThreshold: 1
+    failureThreshold: 5
+    timeoutSeconds: 10
+
+  # used to configure readinessProbe on filer containers
+  #
+  readinessProbe:
+    enabled: true
+    httpGet:
+      path: /
+      scheme: HTTP
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    successThreshold: 1
+    failureThreshold: 100
+    timeoutSeconds: 10
 
   # secret env variables
   secretExtraEnvironmentVars: []
@@ -517,6 +594,32 @@ s3:
     size: ""
     storageClass: ""
     hostPathPrefix: /storage
+
+  # used to configure livenessProbe on s3 containers
+  #
+  livenessProbe:
+    enabled: true
+    httpGet:
+      path: /status
+      scheme: HTTP
+    initialDelaySeconds: 20
+    periodSeconds: 60
+    successThreshold: 1
+    failureThreshold: 20
+    timeoutSeconds: 10
+
+  # used to configure readinessProbe on s3 containers
+  #
+  readinessProbe:
+    enabled: true
+    httpGet:
+      path: /status
+      scheme: HTTP
+    initialDelaySeconds: 15
+    periodSeconds: 15
+    successThreshold: 1
+    failureThreshold: 100
+    timeoutSeconds: 10
 
 certificates:
   commonName: "SeaweedFS CA"


### PR DESCRIPTION
# What problem are we solving?

User can't customize k8s probes in their clusters via helm chart

# How are we solving the problem?

Take out the hardcoded parameters of k8s probes from the templates in values.yaml

# How is the PR tested?

helm lint/helm template on local computer
