### PR TITLE
weed/storage/erasure_coding: Error Handling Fixes

### DIFF
--- a/weed/storage/erasure_coding/ec_encoder.go
+++ b/weed/storage/erasure_coding/ec_encoder.go
@@ -79,7 +79,7 @@ func generateEcFiles(baseFileName string, bufferSize int, largeBlockSize int64, 
 	}
 
 	glog.V(0).Infof("encodeDatFile %s.dat size:%d", baseFileName, fi.Size())
-	err = encodeDatFile(fi.Size(), err, baseFileName, bufferSize, largeBlockSize, file, smallBlockSize)
+	err = encodeDatFile(fi.Size(), baseFileName, bufferSize, largeBlockSize, file, smallBlockSize)
 	if err != nil {
 		return fmt.Errorf("encodeDatFile: %v", err)
 	}
@@ -195,7 +195,7 @@ func encodeDataOneBatch(file *os.File, enc reedsolomon.Encoder, startOffset, blo
 	return nil
 }
 
-func encodeDatFile(remainingSize int64, err error, baseFileName string, bufferSize int, largeBlockSize int64, file *os.File, smallBlockSize int64) error {
+func encodeDatFile(remainingSize int64, baseFileName string, bufferSize int, largeBlockSize int64, file *os.File, smallBlockSize int64) error {
 
 	var processedSize int64
 

--- a/weed/storage/erasure_coding/ec_test.go
+++ b/weed/storage/erasure_coding/ec_test.go
@@ -43,10 +43,10 @@ func TestEncodingDecoding(t *testing.T) {
 
 func validateFiles(baseFileName string) error {
 	nm, err := readNeedleMap(baseFileName)
-	defer nm.Close()
 	if err != nil {
 		return fmt.Errorf("readNeedleMap: %v", err)
 	}
+	defer nm.Close()
 
 	datFile, err := os.OpenFile(baseFileName+".dat", os.O_RDONLY, 0)
 	if err != nil {

--- a/weed/storage/erasure_coding/ec_test.go
+++ b/weed/storage/erasure_coding/ec_test.go
@@ -60,6 +60,9 @@ func validateFiles(baseFileName string) error {
 	}
 
 	ecFiles, err := openEcFiles(baseFileName, true)
+	if err != nil {
+		return fmt.Errorf("error opening ec files: %w", err)
+	}
 	defer closeEcFiles(ecFiles)
 
 	err = nm.AscendingVisit(func(value needle_map.NeedleValue) error {


### PR DESCRIPTION
This fixes three error handling issues in `weed/storage/erasure_encoding`.

An `err` was being passed into `encodeDatFile()` that was never used. I removed it.

An `err` variable in the tests was being dropped.

A deferred `Close()` was being used before an error was checked.

