### PR TITLE
Fix s3 api object list with params max-keys and prefix

### DIFF
--- a/weed/filer/filerstore_wrapper.go
+++ b/weed/filer/filerstore_wrapper.go
@@ -292,10 +292,8 @@ func (fsw *FilerStoreWrapper) prefixFilterEntries(ctx context.Context, dirPath u
 
 	count := int64(0)
 	for count < limit && len(notPrefixed) > 0 {
-		var isLastItemHasPrefix bool
 		for _, entry := range notPrefixed {
 			if strings.HasPrefix(entry.Name(), prefix) {
-				isLastItemHasPrefix = true
 				count++
 				if !eachEntryFunc(entry) {
 					return
@@ -303,11 +301,9 @@ func (fsw *FilerStoreWrapper) prefixFilterEntries(ctx context.Context, dirPath u
 				if count >= limit {
 					break
 				}
-			} else {
-				isLastItemHasPrefix = false
 			}
 		}
-		if count < limit && isLastItemHasPrefix && len(notPrefixed) == int(limit) {
+		if count < limit && lastFileName <= prefix && len(notPrefixed) == int(limit) {
 			notPrefixed = notPrefixed[:0]
 			lastFileName, err = actualStore.ListDirectoryEntries(ctx, dirPath, lastFileName, false, limit, func(entry *Entry) bool {
 				notPrefixed = append(notPrefixed, entry)


### PR DESCRIPTION
# What problem are we solving?

redis as filer store, suppose bucket have objects:

```text
demo_v1
demo_v10
demo_v11
demo_v12
demo_v2
demo_v20
```

when request s3api list objects with params max-keys and prefix, like `http://localhost:8333/test?max-keys=2&prefix=demo_v2`, we got 0 result. Because the item's rank in redis is bigger than the max-keys.

# How are we solving the problem?

drop `isLastItemHasPrefix`, compare the prefix and lastFileName directly.

# How is the PR tested?

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
