### PR TITLE
fix: weed/storage: dropped error

### DIFF
--- a/weed/storage/store_ec_delete.go
+++ b/weed/storage/store_ec_delete.go
@@ -36,7 +36,9 @@ func (s *Store) DeleteEcShardNeedle(ecVolume *erasure_coding.EcVolume, n *needle
 func (s *Store) doDeleteNeedleFromAtLeastOneRemoteEcShards(ecVolume *erasure_coding.EcVolume, needleId types.NeedleId) error {
 
 	_, _, intervals, err := ecVolume.LocateEcShardNeedle(needleId, ecVolume.Version)
-
+	if err != nil {
+		return err
+	}
 	if len(intervals) == 0 {
 		return erasure_coding.NotFoundError
 	}


### PR DESCRIPTION
This fixes a dropped `err` variable in `weed/storage`.