### PR TITLE
Wrong default value for volume.ressource

### DIFF
--- a/k8s/charts/seaweedfs/Chart.yaml
+++ b/k8s/charts/seaweedfs/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: SeaweedFS
 name: seaweedfs
 appVersion: "3.56"
-version: "3.56"
+version: "3.57"

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -280,7 +280,7 @@ volume:
   # should map directly to the value of the resources field for a PodSpec,
   # formatted as a multi-line string. By default no direct resource request
   # is made.
-  resources: {}
+  resources: null
 
   # Toleration Settings for server pods
   # This should be a multi-line string matching the Toleration array


### PR DESCRIPTION
# What problem are we solving?


https://github.com/seaweedfs/seaweedfs/blob/0bb97709d41b1be4c74f01dcc65aac6d5f88bd16/k8s/charts/seaweedfs/values.yaml#L283

Getting  : 

aleopold@aleopold:~/desktop/helm/charts/qalita$ helm lint -f values.yaml .
coalesce.go:220: warning: cannot overwrite table with non table for qalita.seaweedfs.volume.resources (map[])
coalesce.go:220: warning: cannot overwrite table with non table for qalita.seaweedfs.volume.resources (map[])
coalesce.go:220: warning: cannot overwrite table with non table for qalita.seaweedfs.volume.resources (map[])
coalesce.go:220: warning: cannot overwrite table with non table for qalita.seaweedfs.volume.resources (map[])

when values are : 

```yaml
seaweedfs:
  volume:
    resources: |
      requests:
        memory: "100Mi"
        cpu: "50m"
...
```

# How are we solving the problem?

Please replace to : 

```yaml
resources: null
```


# How is the PR tested?

Github Actions and helm lint

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
