### PR TITLE
[s3acl] Step 0: Put bucket ACL only responds success if the ACL is private.

### DIFF
--- a/docker/compose/s3tests.conf
+++ b/docker/compose/s3tests.conf
@@ -18,10 +18,10 @@ bucket prefix = yournamehere-{random}-
 
 [s3 main]
 # main display_name set in vstart.sh
-display_name = M. Tester
+display_name = s3_tests
 
 # main user_idname set in vstart.sh
-user_id = testid
+user_id = s3_tests
 
 # main email set in vstart.sh
 email = tester@ceph.com

--- a/weed/s3api/s3api_bucket_handlers.go
+++ b/weed/s3api/s3api_bucket_handlers.go
@@ -259,32 +259,54 @@ func (s3a *S3ApiServer) GetBucketAclHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	response := AccessControlPolicy{}
-	for _, ident := range s3a.iam.identities {
-		if len(ident.Credentials) == 0 {
-			continue
-		}
-		for _, action := range ident.Actions {
-			if !action.overBucket(bucket) || action.getPermission() == "" {
-				continue
-			}
-			id := ident.Credentials[0].AccessKey
-			if response.Owner.DisplayName == "" && action.isOwner(bucket) && len(ident.Credentials) > 0 {
-				response.Owner.DisplayName = ident.Name
-				response.Owner.ID = id
-			}
-			response.AccessControlList.Grant = append(response.AccessControlList.Grant, Grant{
-				Grantee: Grantee{
-					ID:          id,
-					DisplayName: ident.Name,
-					Type:        "CanonicalUser",
-					XMLXSI:      "CanonicalUser",
-					XMLNS:       "http://www.w3.org/2001/XMLSchema-instance"},
-				Permission: action.getPermission(),
-			})
-		}
+	identityId := r.Header.Get(s3_constants.AmzIdentityId)
+	response := AccessControlPolicy{
+		Owner: CanonicalUser{
+			ID:          identityId,
+			DisplayName: identityId,
+		},
 	}
+	response.AccessControlList.Grant = append(response.AccessControlList.Grant, Grant{
+		Grantee: Grantee{
+			ID:          identityId,
+			DisplayName: identityId,
+			Type:        "CanonicalUser",
+			XMLXSI:      "CanonicalUser",
+			XMLNS:       "http://www.w3.org/2001/XMLSchema-instance"},
+		Permission: s3.PermissionFullControl,
+	})
 	writeSuccessResponseXML(w, r, response)
+}
+
+// PutBucketAclHandler Put bucket ACL only responds success if the ACL is private.
+// https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketAcl.html //
+func (s3a *S3ApiServer) PutBucketAclHandler(w http.ResponseWriter, r *http.Request) {
+	// collect parameters
+	bucket, _ := s3_constants.GetBucketAndObject(r)
+	glog.V(3).Infof("GetBucketAclHandler %s", bucket)
+
+	if err := s3a.checkBucket(r, bucket); err != s3err.ErrNone {
+		s3err.WriteErrorResponse(w, r, err)
+		return
+	}
+	cannedAcl := r.Header.Get(s3_constants.AmzCannedAcl)
+	switch {
+	case cannedAcl == "":
+		acl := &s3.AccessControlPolicy{}
+		if err := xmlDecoder(r.Body, acl, r.ContentLength); err != nil {
+			glog.Errorf("PutBucketAclHandler: %s", err)
+			s3err.WriteErrorResponse(w, r, s3err.ErrInvalidRequest)
+			return
+		}
+		if len(acl.Grants) == 1 && acl.Grants[0].Permission != nil && *acl.Grants[0].Permission == s3_constants.PermissionFullControl {
+			writeSuccessResponseEmpty(w, r)
+			return
+		}
+	case cannedAcl == s3_constants.CannedAclPrivate:
+		writeSuccessResponseEmpty(w, r)
+		return
+	}
+	s3err.WriteErrorResponse(w, r, s3err.ErrNotImplemented)
 }
 
 // GetBucketLifecycleConfigurationHandler Get Bucket Lifecycle configuration

--- a/weed/s3api/s3api_bucket_handlers.go
+++ b/weed/s3api/s3api_bucket_handlers.go
@@ -283,7 +283,7 @@ func (s3a *S3ApiServer) GetBucketAclHandler(w http.ResponseWriter, r *http.Reque
 func (s3a *S3ApiServer) PutBucketAclHandler(w http.ResponseWriter, r *http.Request) {
 	// collect parameters
 	bucket, _ := s3_constants.GetBucketAndObject(r)
-	glog.V(3).Infof("GetBucketAclHandler %s", bucket)
+	glog.V(3).Infof("PutBucketAclHandler %s", bucket)
 
 	if err := s3a.checkBucket(r, bucket); err != s3err.ErrNone {
 		s3err.WriteErrorResponse(w, r, err)

--- a/weed/s3api/s3api_bucket_skip_handlers.go
+++ b/weed/s3api/s3api_bucket_skip_handlers.go
@@ -41,9 +41,3 @@ func (s3a *S3ApiServer) PutBucketPolicyHandler(w http.ResponseWriter, r *http.Re
 func (s3a *S3ApiServer) DeleteBucketPolicyHandler(w http.ResponseWriter, r *http.Request) {
 	s3err.WriteErrorResponse(w, r, http.StatusNoContent)
 }
-
-// PutBucketAclHandler Put bucket ACL
-// https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketAcl.html
-func (s3a *S3ApiServer) PutBucketAclHandler(w http.ResponseWriter, r *http.Request) {
-	s3err.WriteErrorResponse(w, r, s3err.ErrNotImplemented)
-}


### PR DESCRIPTION
pass tests:
test_bucket_acl_default
test_bucket_acl_canned_private_to_private

https://github.com/seaweedfs/seaweedfs/issues/4519

# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/4259

# How are we solving the problem?

 Put bucket ACL only responds success if the ACL is private.

# How is the PR tested?

```
./weed -v 4 server -s3 -filer -volume.max=0 -master.volumeSizeLimitMB=1024 -volume.preStopSeconds=1 -s3.port=8000 -s3.allowEmptyFolder=falses3.allowDeleteBucketNotEmpty=false -s3.config=./docker/compose/s3.json

S3TEST_CONF=/Users/lebedev/GolandProjects/seaweedfs/docker/compose/s3tests.conf tox -- s3tests_boto3/functional/test_s3.py::test_bucket_acl_default s3tests_boto3/functional/test_s3.py::test_bucket_acl_canned_private_to_private
======================================================== test session starts ========================================================
platform darwin -- Python 3.11.3, pytest-7.3.1, pluggy-1.0.0
cachedir: .tox/py/.pytest_cache
rootdir: /Users/lebedev/GolandProjects/s3-tests
configfile: pytest.ini
collected 2 items                                                                                                                   

s3tests_boto3/functional/test_s3.py ..                                                                                        [100%]

========================================================= warnings summary ==========================================================
.tox/py/lib/python3.11/site-packages/botocore/utils.py:15
  /Users/lebedev/GolandProjects/s3-tests/.tox/py/lib/python3.11/site-packages/botocore/utils.py:15: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    import cgi

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================== 2 passed, 1 warning in 0.42s ====================================================
.pkg: _exit> python /opt/homebrew/Cellar/tox/4.6.0/libexec/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
  py: OK (3.17=setup[2.43]+cmd[0.75] seconds)
  congratulations :) (3.28 seconds)
```

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
