### PR TITLE
[s3] optimization iam lookup for reducing algorithm complexity

### DIFF
--- a/weed/s3api/auth_credentials_test.go
+++ b/weed/s3api/auth_credentials_test.go
@@ -126,6 +126,15 @@ func TestCanDo(t *testing.T) {
 	}
 	assert.Equal(t, true, ident5.canDo(ACTION_READ, "special_bucket", "/a/b/c/d.txt"))
 	assert.Equal(t, true, ident5.canDo(ACTION_WRITE, "special_bucket", "/a/b/c/d.txt"))
+
+	// anonymous buckets
+	ident6 := &Identity{
+		Name: "anonymous",
+		Actions: []Action{
+			"Read",
+		},
+	}
+	assert.Equal(t, true, ident6.canDo(ACTION_READ, "anything_bucket", "/a/b/c/d.txt"))
 }
 
 type LoadS3ApiConfigurationTestCase struct {

--- a/weed/s3api/auto_signature_v4_test.go
+++ b/weed/s3api/auto_signature_v4_test.go
@@ -8,8 +8,8 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
+	"github.com/seaweedfs/seaweedfs/weed/pb/iam_pb"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 	"io"
 	"net/http"
 	"net/url"
@@ -60,22 +60,24 @@ func TestIsRequestPresignedSignatureV4(t *testing.T) {
 
 // Tests is requested authenticated function, tests replies for s3 errors.
 func TestIsReqAuthenticated(t *testing.T) {
-	option := S3ApiServerOption{
-		GrpcDialOption: grpc.WithTransportCredentials(insecure.NewCredentials()),
+	iam := &IdentityAccessManagement{
+		hashes:       make(map[string]*sync.Pool),
+		hashCounters: make(map[string]*int32),
 	}
-	iam := NewIdentityAccessManagement(&option)
-	iam.identities = []*Identity{
-		{
-			Name: "someone",
-			Credentials: []*Credential{
-				{
-					AccessKey: "access_key_1",
-					SecretKey: "secret_key_1",
+	_ = iam.loadS3ApiConfiguration(&iam_pb.S3ApiConfiguration{
+		Identities: []*iam_pb.Identity{
+			{
+				Name: "someone",
+				Credentials: []*iam_pb.Credential{
+					{
+						AccessKey: "access_key_1",
+						SecretKey: "secret_key_1",
+					},
 				},
+				Actions: []string{},
 			},
-			Actions: nil,
 		},
-	}
+	})
 
 	// List of test cases for validating http request authentication.
 	testCases := []struct {
@@ -97,24 +99,58 @@ func TestIsReqAuthenticated(t *testing.T) {
 	}
 }
 
-func TestCheckAdminRequestAuthType(t *testing.T) {
-	option := S3ApiServerOption{
-		GrpcDialOption: grpc.WithTransportCredentials(insecure.NewCredentials()),
+func TestCheckaAnonymousRequestAuthType(t *testing.T) {
+	iam := &IdentityAccessManagement{
+		hashes:       make(map[string]*sync.Pool),
+		hashCounters: make(map[string]*int32),
 	}
-	iam := NewIdentityAccessManagement(&option)
-	iam.identities = []*Identity{
-		{
-			Name: "someone",
-			Credentials: []*Credential{
-				{
-					AccessKey: "access_key_1",
-					SecretKey: "secret_key_1",
-				},
+	_ = iam.loadS3ApiConfiguration(&iam_pb.S3ApiConfiguration{
+		Identities: []*iam_pb.Identity{
+			{
+				Name:    "anonymous",
+				Actions: []string{s3_constants.ACTION_READ},
 			},
-			Actions: nil,
 		},
+	})
+	testCases := []struct {
+		Request *http.Request
+		ErrCode s3err.ErrorCode
+		Action  Action
+	}{
+		{Request: mustNewRequest("GET", "http://127.0.0.1:9000/bucket", 0, nil, t), ErrCode: s3err.ErrNone, Action: s3_constants.ACTION_READ},
+		{Request: mustNewRequest("PUT", "http://127.0.0.1:9000/bucket", 0, nil, t), ErrCode: s3err.ErrAccessDenied, Action: s3_constants.ACTION_WRITE},
+	}
+	for i, testCase := range testCases {
+		_, s3Error := iam.authRequest(testCase.Request, testCase.Action)
+		if s3Error != testCase.ErrCode {
+			t.Errorf("Test %d: Unexpected s3error returned wanted %d, got %d", i, testCase.ErrCode, s3Error)
+		}
+		if testCase.Request.Header.Get(s3_constants.AmzAuthType) != "Anonymous" {
+			t.Errorf("Test %d: Unexpected AuthType returned wanted %s, got %s", i, "Anonymous", testCase.Request.Header.Get(s3_constants.AmzAuthType))
+		}
 	}
 
+}
+
+func TestCheckAdminRequestAuthType(t *testing.T) {
+	iam := &IdentityAccessManagement{
+		hashes:       make(map[string]*sync.Pool),
+		hashCounters: make(map[string]*int32),
+	}
+	_ = iam.loadS3ApiConfiguration(&iam_pb.S3ApiConfiguration{
+		Identities: []*iam_pb.Identity{
+			{
+				Name: "someone",
+				Credentials: []*iam_pb.Credential{
+					{
+						AccessKey: "access_key_1",
+						SecretKey: "secret_key_1",
+					},
+				},
+				Actions: []string{},
+			},
+		},
+	})
 	testCases := []struct {
 		Request *http.Request
 		ErrCode s3err.ErrorCode


### PR DESCRIPTION
https://github.com/seaweedfs/seaweedfs/issues/4519

# What problem are we solving?

optimization iam lookup for reducing algorithm complexity  O(n) -> O(1) 

# How are we solving the problem?

created additional structures

# How is the PR tested?

```
go test -v  | grep -e Anony -e TestCanDo
=== RUN   TestCanDo
--- PASS: TestCanDo (0.00s)
=== RUN   TestCheckaAnonymousRequestAuthType
--- PASS: TestCheckaAnonymousRequestAuthType (0.00s)
```

# Checks
- [ yes] I have added unit tests if possible.
- [ no ] I will add related wiki document changes and link to this PR after merging.
