### PR TITLE
weed/replication/sub: fix dropped error

### DIFF
--- a/weed/replication/sub/notification_aws_sqs.go
+++ b/weed/replication/sub/notification_aws_sqs.go
@@ -99,7 +99,10 @@ func (k *AwsSqsInput) ReceiveMessage() (key string, message *filer_pb.EventNotif
 	text := *result.Messages[0].Body
 	message = &filer_pb.EventNotification{}
 	err = proto.Unmarshal([]byte(text), message)
-
+	if err != nil {
+		err = fmt.Errorf("unmarshal message from sqs %s: %w", k.queueUrl, err)
+		return
+	}
 	// delete the message
 	_, err = k.svc.DeleteMessage(&sqs.DeleteMessageInput{
 		QueueUrl:      &k.queueUrl,


### PR DESCRIPTION
This fixes a dropped `err` variable in `weed/replication/sub`.