### PR TITLE
Support https/tls for weed filer/mount

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -268,7 +268,6 @@ require (
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/putdotio/go-putio/putio v0.0.0-20200123120452-16d982cac2b8 // indirect
 	github.com/rclone/ftp v0.0.0-20230327202000-dadc1f64e87d // indirect
-	github.com/rdleal/intervalst v0.0.0-20221028215511-a098aa0d2cb8 // indirect
 	github.com/rfjakob/eme v1.1.2 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect

--- a/unmaintained/repeated_vacuum/repeated_vacuum.go
+++ b/unmaintained/repeated_vacuum/repeated_vacuum.go
@@ -3,10 +3,11 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"log"
 	"math/rand"
 	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb"
 
 	"google.golang.org/grpc"
 
@@ -33,7 +34,7 @@ func main() {
 	go func() {
 		for {
 			println("vacuum threshold", *garbageThreshold)
-			_, _, err := util.Get(fmt.Sprintf("http://%s/vol/vacuum?garbageThreshold=%f", pb.ServerAddress(*master).ToHttpAddress(), *garbageThreshold))
+			_, _, err := util.Get(fmt.Sprintf("%s%s/vol/vacuum?garbageThreshold=%f", util.HttpScheme("client"), pb.ServerAddress(*master).ToHttpAddress(), *garbageThreshold))
 			if err != nil {
 				log.Fatalf("vacuum: %v", err)
 			}
@@ -64,7 +65,7 @@ func genFile(grpcDialOption grpc.DialOption, i int) (*operation.AssignResult, st
 	data := make([]byte, 1024)
 	rand.Read(data)
 
-	targetUrl := fmt.Sprintf("http://%s/%s", assignResult.Url, assignResult.Fid)
+	targetUrl := fmt.Sprintf("%s%s/%s", util.HttpScheme("client"), assignResult.Url, assignResult.Fid)
 
 	uploadOption := &operation.UploadOption{
 		UploadUrl:         targetUrl,

--- a/weed/command/benchmark.go
+++ b/weed/command/benchmark.go
@@ -3,7 +3,6 @@ package command
 import (
 	"bufio"
 	"fmt"
-	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"io"
 	"math"
 	"math/rand"
@@ -13,6 +12,8 @@ import (
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb"
 
 	"google.golang.org/grpc"
 
@@ -212,7 +213,7 @@ func writeFiles(idChan chan int, fileIdLineChan chan string, s *stat) {
 				if isSecure {
 					jwtAuthorization = operation.LookupJwt(b.masterClient.GetMaster(), b.grpcDialOption, df.fp.Fid)
 				}
-				if e := util.Delete(fmt.Sprintf("http://%s/%s", df.fp.Server, df.fp.Fid), string(jwtAuthorization)); e == nil {
+				if e := util.Delete(fmt.Sprintf("%s%s/%s", util.HttpScheme("client"), df.fp.Server, df.fp.Fid), string(jwtAuthorization)); e == nil {
 					s.completed++
 				} else {
 					s.failed++

--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"github.com/spf13/viper"
 	"net"
 	"net/http"
 	"os"
@@ -303,6 +304,12 @@ func (fo *FilerOptions) startFiler() {
 	go grpcS.Serve(grpcL)
 
 	httpS := &http.Server{Handler: defaultMux}
+
+	if viper.GetString("https.filer.ca") != "" {
+		clientCertFile := viper.GetString("https.filer.ca")
+		httpS.TLSConfig = security.LoadClientTLSHTTP(clientCertFile)
+	}
+
 	if runtime.GOOS != "windows" {
 		localSocket := *fo.localSocket
 		if localSocket == "" {

--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"fmt"
-	"github.com/spf13/viper"
 	"net"
 	"net/http"
 	"os"
@@ -10,6 +9,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/spf13/viper"
 
 	"google.golang.org/grpc/reflection"
 
@@ -305,7 +306,7 @@ func (fo *FilerOptions) startFiler() {
 
 	httpS := &http.Server{Handler: defaultMux}
 
-	if viper.GetString("https.filer.ca") != "" {
+	if util.HttpUseTls("filer") {
 		clientCertFile := viper.GetString("https.filer.ca")
 		httpS.TLSConfig = security.LoadClientTLSHTTP(clientCertFile)
 	}

--- a/weed/command/filer_cat.go
+++ b/weed/command/filer_cat.go
@@ -3,14 +3,15 @@ package command
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
 	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/wdclient"
 	"google.golang.org/grpc"
-	"net/url"
-	"os"
-	"strings"
 
 	"github.com/seaweedfs/seaweedfs/weed/security"
 	"github.com/seaweedfs/seaweedfs/weed/util"
@@ -38,7 +39,7 @@ func (fco *FilerCatOptions) GetLookupFileIdFunction() wdclient.LookupFileIdFunct
 		}
 		locations := resp.LocationsMap[vid]
 		for _, loc := range locations.Locations {
-			targetUrls = append(targetUrls, fmt.Sprintf("http://%s/%s", loc.Url, fileId))
+			targetUrls = append(targetUrls, fmt.Sprintf("%s%s/%s", util.HttpScheme("filer"), loc.Url, fileId))
 		}
 		return
 	}

--- a/weed/command/filer_copy.go
+++ b/weed/command/filer_copy.go
@@ -360,7 +360,7 @@ func (worker *FileCopyWorker) uploadFileAsOne(task FileCopyTask, f *os.File) err
 				PairMap:           nil,
 			},
 			func(host, fileId string) string {
-				return fmt.Sprintf("http://%s/%s", host, fileId)
+				return fmt.Sprintf("%s%s/%s", util.HttpScheme("filer"), host, fileId)
 			},
 			util.NewBytesReader(data),
 		)
@@ -394,7 +394,7 @@ func (worker *FileCopyWorker) uploadFileAsOne(task FileCopyTask, f *os.File) err
 		}
 		return nil
 	}); err != nil {
-		return fmt.Errorf("upload data %v to http://%s%s%s: %v\n", fileName, worker.filerAddress.ToHttpAddress(), task.destinationUrlPath, fileName, err)
+		return fmt.Errorf("upload data %v to %s%s%s%s: %v\n", fileName, util.HttpScheme("filer"), worker.filerAddress.ToHttpAddress(), task.destinationUrlPath, fileName, err)
 	}
 
 	return nil
@@ -439,7 +439,7 @@ func (worker *FileCopyWorker) uploadFileInChunks(task FileCopyTask, f *os.File, 
 					PairMap:           nil,
 				},
 				func(host, fileId string) string {
-					return fmt.Sprintf("http://%s/%s", host, fileId)
+					return fmt.Sprintf("%s%s/%s", util.HttpScheme("filer"), host, fileId)
 				},
 				io.NewSectionReader(f, i*chunkSize, chunkSize),
 			)
@@ -505,10 +505,10 @@ func (worker *FileCopyWorker) uploadFileInChunks(task FileCopyTask, f *os.File, 
 		}
 		return nil
 	}); err != nil {
-		return fmt.Errorf("upload data %v to http://%s%s%s: %v\n", fileName, worker.filerAddress.ToHttpAddress(), task.destinationUrlPath, fileName, err)
+		return fmt.Errorf("upload data %v to %s%s%s%s: %v\n", fileName, util.HttpScheme("filer"), worker.filerAddress.ToHttpAddress(), task.destinationUrlPath, fileName, err)
 	}
 
-	fmt.Printf("copied %s => http://%s%s%s\n", f.Name(), worker.filerAddress.ToHttpAddress(), task.destinationUrlPath, fileName)
+	fmt.Printf("copied %s => %s%s%s%s\n", f.Name(), util.HttpScheme("filer"), worker.filerAddress.ToHttpAddress(), task.destinationUrlPath, fileName)
 
 	return nil
 }
@@ -552,7 +552,7 @@ func (worker *FileCopyWorker) saveDataAsChunk(reader io.Reader, name string, off
 			PairMap:           nil,
 		},
 		func(host, fileId string) string {
-			return fmt.Sprintf("http://%s/%s", host, fileId)
+			return fmt.Sprintf("%s%s/%s", util.HttpScheme("filer"), host, fileId)
 		},
 		reader,
 	)

--- a/weed/filer/filer_notify_append.go
+++ b/weed/filer/filer_notify_append.go
@@ -3,7 +3,6 @@ package filer
 import (
 	"context"
 	"fmt"
-	"github.com/spf13/viper"
 	"os"
 	"time"
 
@@ -50,7 +49,6 @@ func (f *Filer) appendToFile(targetFile string, data []byte) error {
 }
 
 func (f *Filer) assignAndUpload(targetFile string, data []byte) (*operation.AssignResult, *operation.UploadResult, error) {
-	util.LoadConfiguration("security", false)
 	// assign a volume location
 	rule := f.FilerConf.MatchStorageRule(targetFile)
 	assignRequest := &operation.VolumeAssignRequest{
@@ -69,12 +67,7 @@ func (f *Filer) assignAndUpload(targetFile string, data []byte) (*operation.Assi
 	}
 
 	// upload data
-	var targetUrl string
-	if viper.GetString("https.client.ca") != "" {
-		targetUrl = "https://" + assignResult.Url + "/" + assignResult.Fid
-	} else {
-		targetUrl = "http://" + assignResult.Url + "/" + assignResult.Fid
-	}
+	targetUrl := util.HttpScheme("filer") + assignResult.Url + "/" + assignResult.Fid
 	uploadOption := &operation.UploadOption{
 		UploadUrl:         targetUrl,
 		Filename:          "",

--- a/weed/filer/filer_notify_append.go
+++ b/weed/filer/filer_notify_append.go
@@ -3,6 +3,7 @@ package filer
 import (
 	"context"
 	"fmt"
+	"github.com/spf13/viper"
 	"os"
 	"time"
 
@@ -49,6 +50,7 @@ func (f *Filer) appendToFile(targetFile string, data []byte) error {
 }
 
 func (f *Filer) assignAndUpload(targetFile string, data []byte) (*operation.AssignResult, *operation.UploadResult, error) {
+	util.LoadConfiguration("security", false)
 	// assign a volume location
 	rule := f.FilerConf.MatchStorageRule(targetFile)
 	assignRequest := &operation.VolumeAssignRequest{
@@ -67,7 +69,12 @@ func (f *Filer) assignAndUpload(targetFile string, data []byte) (*operation.Assi
 	}
 
 	// upload data
-	targetUrl := "http://" + assignResult.Url + "/" + assignResult.Fid
+	var targetUrl string
+	if viper.GetString("https.client.ca") != "" {
+		targetUrl = "https://" + assignResult.Url + "/" + assignResult.Fid
+	} else {
+		targetUrl = "http://" + assignResult.Url + "/" + assignResult.Fid
+	}
 	uploadOption := &operation.UploadOption{
 		UploadUrl:         targetUrl,
 		Filename:          "",

--- a/weed/filer/reader_at.go
+++ b/weed/filer/reader_at.go
@@ -3,7 +3,6 @@ package filer
 import (
 	"context"
 	"fmt"
-	"github.com/spf13/viper"
 	"io"
 	"math/rand"
 	"sync"
@@ -70,12 +69,7 @@ func LookupFn(filerClient filer_pb.FilerClient) wdclient.LookupFileIdFunctionTyp
 		var sameDcTargetUrls, otherTargetUrls []string
 		for _, loc := range locations.Locations {
 			volumeServerAddress := filerClient.AdjustedUrl(loc)
-			var targetUrl string
-			if viper.GetString("https.client.ca") != "" {
-				targetUrl = fmt.Sprintf("https://%s/%s", volumeServerAddress, fileId)
-			} else {
-				targetUrl = fmt.Sprintf("http://%s/%s", volumeServerAddress, fileId)
-			}
+			targetUrl := fmt.Sprintf("%s%s/%s", util.HttpScheme("filer"), volumeServerAddress, fileId)
 			if fcDataCenter == "" || fcDataCenter != loc.DataCenter {
 				otherTargetUrls = append(otherTargetUrls, targetUrl)
 			} else {

--- a/weed/iamapi/iamapi_management_handlers.go
+++ b/weed/iamapi/iamapi_management_handlers.go
@@ -21,14 +21,16 @@ import (
 )
 
 const (
-	charsetUpper           = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-	charset                = charsetUpper + "abcdefghijklmnopqrstuvwxyz/"
-	policyDocumentVersion  = "2012-10-17"
-	StatementActionAdmin   = "*"
-	StatementActionWrite   = "Put*"
-	StatementActionRead    = "Get*"
-	StatementActionList    = "List*"
-	StatementActionTagging = "Tagging*"
+	charsetUpper            = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	charset                 = charsetUpper + "abcdefghijklmnopqrstuvwxyz/"
+	policyDocumentVersion   = "2012-10-17"
+	StatementActionAdmin    = "*"
+	StatementActionWrite    = "Put*"
+	StatementActionWriteAcp = "PutBucketAcl"
+	StatementActionRead     = "Get*"
+	StatementActionReadAcp  = "GetBucketAcl"
+	StatementActionList     = "List*"
+	StatementActionTagging  = "Tagging*"
 )
 
 var (
@@ -44,8 +46,12 @@ func MapToStatementAction(action string) string {
 		return s3_constants.ACTION_ADMIN
 	case StatementActionWrite:
 		return s3_constants.ACTION_WRITE
+	case StatementActionWriteAcp:
+		return s3_constants.ACTION_WRITE_ACP
 	case StatementActionRead:
 		return s3_constants.ACTION_READ
+	case StatementActionReadAcp:
+		return s3_constants.ACTION_READ_ACP
 	case StatementActionList:
 		return s3_constants.ACTION_LIST
 	case StatementActionTagging:
@@ -61,8 +67,12 @@ func MapToIdentitiesAction(action string) string {
 		return StatementActionAdmin
 	case s3_constants.ACTION_WRITE:
 		return StatementActionWrite
+	case s3_constants.ACTION_WRITE_ACP:
+		return StatementActionWriteAcp
 	case s3_constants.ACTION_READ:
 		return StatementActionRead
+	case s3_constants.ACTION_READ_ACP:
+		return StatementActionReadAcp
 	case s3_constants.ACTION_LIST:
 		return StatementActionList
 	case s3_constants.ACTION_TAGGING:

--- a/weed/mount/weedfs.go
+++ b/weed/mount/weedfs.go
@@ -2,7 +2,6 @@ package mount
 
 import (
 	"context"
-	"github.com/spf13/viper"
 	"math/rand"
 	"os"
 	"path"
@@ -183,11 +182,7 @@ func (wfs *WFS) maybeLoadEntry(fullpath util.FullPath) (*filer_pb.Entry, fuse.St
 func (wfs *WFS) LookupFn() wdclient.LookupFileIdFunctionType {
 	if wfs.option.VolumeServerAccess == "filerProxy" {
 		return func(fileId string) (targetUrls []string, err error) {
-			if viper.GetString("https.client.ca") != "" {
-				return []string{"https://" + wfs.getCurrentFiler().ToHttpAddress() + "/?proxyChunkId=" + fileId}, nil
-			} else {
-				return []string{"http://" + wfs.getCurrentFiler().ToHttpAddress() + "/?proxyChunkId=" + fileId}, nil
-			}
+			return []string{util.HttpScheme("filer") + wfs.getCurrentFiler().ToHttpAddress() + "/?proxyChunkId=" + fileId}, nil
 		}
 	}
 	return filer.LookupFn(wfs)

--- a/weed/mount/weedfs.go
+++ b/weed/mount/weedfs.go
@@ -2,6 +2,7 @@ package mount
 
 import (
 	"context"
+	"github.com/spf13/viper"
 	"math/rand"
 	"os"
 	"path"
@@ -182,7 +183,11 @@ func (wfs *WFS) maybeLoadEntry(fullpath util.FullPath) (*filer_pb.Entry, fuse.St
 func (wfs *WFS) LookupFn() wdclient.LookupFileIdFunctionType {
 	if wfs.option.VolumeServerAccess == "filerProxy" {
 		return func(fileId string) (targetUrls []string, err error) {
-			return []string{"http://" + wfs.getCurrentFiler().ToHttpAddress() + "/?proxyChunkId=" + fileId}, nil
+			if viper.GetString("https.client.ca") != "" {
+				return []string{"https://" + wfs.getCurrentFiler().ToHttpAddress() + "/?proxyChunkId=" + fileId}, nil
+			} else {
+				return []string{"http://" + wfs.getCurrentFiler().ToHttpAddress() + "/?proxyChunkId=" + fileId}, nil
+			}
 		}
 	}
 	return filer.LookupFn(wfs)

--- a/weed/mount/weedfs_write.go
+++ b/weed/mount/weedfs_write.go
@@ -2,7 +2,6 @@ package mount
 
 import (
 	"fmt"
-	"github.com/spf13/viper"
 	"io"
 
 	"github.com/seaweedfs/seaweedfs/weed/filer"
@@ -36,17 +35,9 @@ func (wfs *WFS) saveDataAsChunk(fullPath util.FullPath) filer.SaveDataAsChunkFun
 				PairMap:           nil,
 			},
 			func(host, fileId string) string {
-				var fileUrl string
-				if viper.GetString("https.client.ca") != "" {
-					fileUrl = fmt.Sprintf("https://%s/%s", host, fileId)
-					if wfs.option.VolumeServerAccess == "filerProxy" {
-						fileUrl = fmt.Sprintf("https://%s/?proxyChunkId=%s", wfs.getCurrentFiler(), fileId)
-					}
-				} else {
-					fileUrl = fmt.Sprintf("http://%s/%s", host, fileId)
-					if wfs.option.VolumeServerAccess == "filerProxy" {
-						fileUrl = fmt.Sprintf("http://%s/?proxyChunkId=%s", wfs.getCurrentFiler(), fileId)
-					}
+				fileUrl := fmt.Sprintf("%s%s/%s", util.HttpScheme("filer"), host, fileId)
+				if wfs.option.VolumeServerAccess == "filerProxy" {
+					fileUrl = fmt.Sprintf("%s%s/?proxyChunkId=%s", util.HttpScheme("filer"), wfs.getCurrentFiler(), fileId)
 				}
 				return fileUrl
 			},

--- a/weed/operation/lookup.go
+++ b/weed/operation/lookup.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/seaweedfs/seaweedfs/weed/pb"
-	"github.com/seaweedfs/seaweedfs/weed/util"
-	"github.com/spf13/viper"
-	"google.golang.org/grpc"
 	"math/rand"
 	"strings"
 	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+	"google.golang.org/grpc"
 
 	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
 )
@@ -53,12 +53,7 @@ func LookupFileId(masterFn GetMasterFn, grpcDialOption grpc.DialOption, fileId s
 	if len(lookup.Locations) == 0 {
 		return "", jwt, errors.New("File Not Found")
 	}
-	util.LoadConfiguration("security", false)
-	if viper.GetString("https.client.key") != "" {
-		return "https://" + lookup.Locations[rand.Intn(len(lookup.Locations))].Url + "/" + fileId, lookup.Jwt, nil
-	} else {
-		return "http://" + lookup.Locations[rand.Intn(len(lookup.Locations))].Url + "/" + fileId, lookup.Jwt, nil
-	}
+	return util.HttpScheme("client") + lookup.Locations[rand.Intn(len(lookup.Locations))].Url + "/" + fileId, lookup.Jwt, nil
 }
 
 func LookupVolumeId(masterFn GetMasterFn, grpcDialOption grpc.DialOption, vid string) (*LookupResult, error) {

--- a/weed/operation/lookup.go
+++ b/weed/operation/lookup.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"github.com/seaweedfs/seaweedfs/weed/pb"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 	"math/rand"
 	"strings"
@@ -51,7 +53,12 @@ func LookupFileId(masterFn GetMasterFn, grpcDialOption grpc.DialOption, fileId s
 	if len(lookup.Locations) == 0 {
 		return "", jwt, errors.New("File Not Found")
 	}
-	return "http://" + lookup.Locations[rand.Intn(len(lookup.Locations))].Url + "/" + fileId, lookup.Jwt, nil
+	util.LoadConfiguration("security", false)
+	if viper.GetString("https.client.key") != "" {
+		return "https://" + lookup.Locations[rand.Intn(len(lookup.Locations))].Url + "/" + fileId, lookup.Jwt, nil
+	} else {
+		return "http://" + lookup.Locations[rand.Intn(len(lookup.Locations))].Url + "/" + fileId, lookup.Jwt, nil
+	}
 }
 
 func LookupVolumeId(masterFn GetMasterFn, grpcDialOption grpc.DialOption, vid string) (*LookupResult, error) {

--- a/weed/operation/submit.go
+++ b/weed/operation/submit.go
@@ -1,7 +1,6 @@
 package operation
 
 import (
-	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"io"
 	"mime"
 	"net/url"
@@ -9,6 +8,9 @@ import (
 	"path"
 	"strconv"
 	"strings"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb"
+	"github.com/seaweedfs/seaweedfs/weed/util"
 
 	"google.golang.org/grpc"
 
@@ -120,7 +122,7 @@ func newFilePart(fullPathFilename string) (ret FilePart, err error) {
 }
 
 func (fi FilePart) Upload(maxMB int, masterFn GetMasterFn, usePublicUrl bool, jwt security.EncodedJwt, grpcDialOption grpc.DialOption) (retSize uint32, err error) {
-	fileUrl := "http://" + fi.Server + "/" + fi.Fid
+	fileUrl := util.HttpScheme("client") + fi.Server + "/" + fi.Fid
 	if fi.ModTime != 0 {
 		fileUrl += "?ts=" + strconv.Itoa(int(fi.ModTime))
 	}
@@ -178,9 +180,9 @@ func (fi FilePart) Upload(maxMB int, masterFn GetMasterFn, usePublicUrl bool, jw
 					id += "_" + strconv.FormatInt(i, 10)
 				}
 			}
-			fileUrl := "http://" + ret.Url + "/" + id
+			fileUrl := util.HttpScheme("client") + ret.Url + "/" + id
 			if usePublicUrl {
-				fileUrl = "http://" + ret.PublicUrl + "/" + id
+				fileUrl = util.HttpScheme("client") + ret.PublicUrl + "/" + id
 			}
 			count, e := upload_one_chunk(
 				baseName+"-"+strconv.FormatInt(i+1, 10),

--- a/weed/operation/upload_content.go
+++ b/weed/operation/upload_content.go
@@ -6,7 +6,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/spf13/viper"
 	"io"
 	"mime"
 	"mime/multipart"
@@ -16,6 +15,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/spf13/viper"
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
@@ -72,16 +73,7 @@ var (
 )
 
 func init() {
-	util.LoadConfiguration("security", false)
-	HttpClient = &http.Client{Transport: &http.Transport{
-		DialContext: (&net.Dialer{
-			Timeout:   10 * time.Second,
-			KeepAlive: 10 * time.Second,
-		}).DialContext,
-		MaxIdleConns:        1024,
-		MaxIdleConnsPerHost: 1024,
-	}}
-	if viper.GetString("https.client.key") != "" {
+	if util.HttpUseTls("client") {
 		clientCert := viper.GetString("https.client.cert")
 		clientCertKey := viper.GetString("https.client.key")
 
@@ -101,6 +93,15 @@ func init() {
 				// not needed, will take certs from host
 				//	RootCAs:      caCertPool
 			},
+		}}
+	} else {
+		HttpClient = &http.Client{Transport: &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout:   10 * time.Second,
+				KeepAlive: 10 * time.Second,
+			}).DialContext,
+			MaxIdleConns:        1024,
+			MaxIdleConnsPerHost: 1024,
 		}}
 	}
 }

--- a/weed/pb/server_address.go
+++ b/weed/pb/server_address.go
@@ -2,12 +2,12 @@ package pb
 
 import (
 	"fmt"
-	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
-	"github.com/seaweedfs/seaweedfs/weed/util"
-	"github.com/spf13/viper"
 	"net"
 	"strconv"
 	"strings"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
+	"github.com/seaweedfs/seaweedfs/weed/util"
 )
 
 type ServerAddress string
@@ -163,15 +163,9 @@ func FromAddressStrings(strings []string) []ServerAddress {
 }
 
 func ParseUrl(input string) (address ServerAddress, path string, err error) {
-	util.LoadConfiguration("security", false)
-	if viper.GetString("https.client.key") != "" {
-		if !strings.HasPrefix(input, "https://") {
-			return "", "", fmt.Errorf("url %s needs prefix 'https://'", input)
-		}
-	} else {
-		if !strings.HasPrefix(input, "http://") {
-			return "", "", fmt.Errorf("url %s needs prefix 'http://'", input)
-		}
+	scheme := util.HttpScheme("client")
+	if !strings.HasPrefix(input, scheme) {
+		return "", "", fmt.Errorf("url %s needs prefix '%s'", input, scheme)
 	}
 	input = input[7:]
 	pathSeparatorIndex := strings.Index(input, "/")

--- a/weed/pb/server_address.go
+++ b/weed/pb/server_address.go
@@ -163,6 +163,7 @@ func FromAddressStrings(strings []string) []ServerAddress {
 }
 
 func ParseUrl(input string) (address ServerAddress, path string, err error) {
+	util.LoadConfiguration("security", false)
 	if viper.GetString("https.client.key") != "" {
 		if !strings.HasPrefix(input, "https://") {
 			return "", "", fmt.Errorf("url %s needs prefix 'https://'", input)

--- a/weed/pb/server_address.go
+++ b/weed/pb/server_address.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
 	"github.com/seaweedfs/seaweedfs/weed/util"
+	"github.com/spf13/viper"
 	"net"
 	"strconv"
 	"strings"
@@ -162,8 +163,14 @@ func FromAddressStrings(strings []string) []ServerAddress {
 }
 
 func ParseUrl(input string) (address ServerAddress, path string, err error) {
-	if !strings.HasPrefix(input, "http://") {
-		return "", "", fmt.Errorf("url %s needs prefix 'http://'", input)
+	if viper.GetString("https.client.key") != "" {
+		if !strings.HasPrefix(input, "https://") {
+			return "", "", fmt.Errorf("url %s needs prefix 'https://'", input)
+		}
+	} else {
+		if !strings.HasPrefix(input, "http://") {
+			return "", "", fmt.Errorf("url %s needs prefix 'http://'", input)
+		}
 	}
 	input = input[7:]
 	pathSeparatorIndex := strings.Index(input, "/")

--- a/weed/replication/sink/filersink/fetch_write.go
+++ b/weed/replication/sink/filersink/fetch_write.go
@@ -2,11 +2,12 @@ package filersink
 
 import (
 	"fmt"
-	"github.com/schollz/progressbar/v3"
-	"github.com/seaweedfs/seaweedfs/weed/util"
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/schollz/progressbar/v3"
+	"github.com/seaweedfs/seaweedfs/weed/util"
 
 	"google.golang.org/grpc"
 
@@ -109,9 +110,9 @@ func (fs *FilerSink) fetchAndWrite(sourceChunk *filer_pb.FileChunk, path string)
 			PairMap:           nil,
 		},
 		func(host, fileId string) string {
-			fileUrl := fmt.Sprintf("http://%s/%s", host, fileId)
+			fileUrl := fmt.Sprintf("%s%s/%s", util.HttpScheme("volume"), host, fileId)
 			if fs.writeChunkByFiler {
-				fileUrl = fmt.Sprintf("http://%s/?proxyChunkId=%s", fs.address, fileId)
+				fileUrl = fmt.Sprintf("%s%s/?proxyChunkId=%s", util.HttpScheme("volume"), fs.address, fileId)
 			}
 			glog.V(4).Infof("replicating %s to %s header:%+v", filename, fileUrl, header)
 			return fileUrl

--- a/weed/replication/source/filer_source.go
+++ b/weed/replication/source/filer_source.go
@@ -88,7 +88,7 @@ func (fs *FilerSource) LookupFileId(part string) (fileUrls []string, err error) 
 
 	if !fs.proxyByFiler {
 		for _, loc := range locations.Locations {
-			fileUrl := fmt.Sprintf("http://%s/%s?readDeleted=true", loc.Url, part)
+			fileUrl := fmt.Sprintf("%s%s/%s?readDeleted=true", util.HttpScheme("volume"), loc.Url, part)
 			// Prefer same data center
 			if fs.dataCenter != "" && fs.dataCenter == loc.DataCenter {
 				fileUrls = append([]string{fileUrl}, fileUrls...)
@@ -97,7 +97,7 @@ func (fs *FilerSource) LookupFileId(part string) (fileUrls []string, err error) 
 			}
 		}
 	} else {
-		fileUrls = append(fileUrls, fmt.Sprintf("http://%s/?proxyChunkId=%s", fs.address, part))
+		fileUrls = append(fileUrls, fmt.Sprintf("%s%s/?proxyChunkId=%s", util.HttpScheme("volume"), fs.address, part))
 	}
 
 	return
@@ -106,7 +106,7 @@ func (fs *FilerSource) LookupFileId(part string) (fileUrls []string, err error) 
 func (fs *FilerSource) ReadPart(fileId string) (filename string, header http.Header, resp *http.Response, err error) {
 
 	if fs.proxyByFiler {
-		return util.DownloadFile("http://"+fs.address+"/?proxyChunkId="+fileId, "")
+		return util.DownloadFile(util.HttpScheme("volume")+fs.address+"/?proxyChunkId="+fileId, "")
 	}
 
 	fileUrls, err := fs.LookupFileId(fileId)

--- a/weed/s3api/auth_credentials_test.go
+++ b/weed/s3api/auth_credentials_test.go
@@ -89,10 +89,13 @@ func TestCanDo(t *testing.T) {
 		Actions: []Action{
 			"Read:bucket1",
 			"Write:bucket1/*",
+			"WriteAcp:bucket1",
 		},
 	}
 	assert.Equal(t, true, ident2.canDo(ACTION_READ, "bucket1", "/a/b/c/d.txt"))
 	assert.Equal(t, true, ident2.canDo(ACTION_WRITE, "bucket1", "/a/b/c/d.txt"))
+	assert.Equal(t, true, ident2.canDo(ACTION_WRITE_ACP, "bucket1", ""))
+	assert.Equal(t, false, ident2.canDo(ACTION_READ_ACP, "bucket1", ""))
 	assert.Equal(t, false, ident2.canDo(ACTION_LIST, "bucket1", "/a/b/c/d.txt"))
 
 	// across buckets
@@ -106,15 +109,18 @@ func TestCanDo(t *testing.T) {
 	assert.Equal(t, true, ident3.canDo(ACTION_READ, "bucket1", "/a/b/c/d.txt"))
 	assert.Equal(t, true, ident3.canDo(ACTION_WRITE, "bucket1", "/a/b/c/d.txt"))
 	assert.Equal(t, false, ident3.canDo(ACTION_LIST, "bucket1", "/a/b/other/some"))
+	assert.Equal(t, false, ident3.canDo(ACTION_WRITE_ACP, "bucket1", ""))
 
 	// partial buckets
 	ident4 := &Identity{
 		Name: "anything",
 		Actions: []Action{
 			"Read:special_*",
+			"ReadAcp:special_*",
 		},
 	}
 	assert.Equal(t, true, ident4.canDo(ACTION_READ, "special_bucket", "/a/b/c/d.txt"))
+	assert.Equal(t, true, ident4.canDo(ACTION_READ_ACP, "special_bucket", ""))
 	assert.Equal(t, false, ident4.canDo(ACTION_READ, "bucket1", "/a/b/c/d.txt"))
 
 	// admin buckets
@@ -125,7 +131,9 @@ func TestCanDo(t *testing.T) {
 		},
 	}
 	assert.Equal(t, true, ident5.canDo(ACTION_READ, "special_bucket", "/a/b/c/d.txt"))
+	assert.Equal(t, true, ident5.canDo(ACTION_READ_ACP, "special_bucket", ""))
 	assert.Equal(t, true, ident5.canDo(ACTION_WRITE, "special_bucket", "/a/b/c/d.txt"))
+	assert.Equal(t, true, ident5.canDo(ACTION_WRITE_ACP, "special_bucket", ""))
 
 	// anonymous buckets
 	ident6 := &Identity{

--- a/weed/s3api/s3_constants/s3_actions.go
+++ b/weed/s3api/s3_constants/s3_actions.go
@@ -1,11 +1,13 @@
 package s3_constants
 
 const (
-	ACTION_READ    = "Read"
-	ACTION_WRITE   = "Write"
-	ACTION_ADMIN   = "Admin"
-	ACTION_TAGGING = "Tagging"
-	ACTION_LIST    = "List"
+	ACTION_READ      = "Read"
+	ACTION_READ_ACP  = "ReadAcp"
+	ACTION_WRITE     = "Write"
+	ACTION_WRITE_ACP = "WriteAcp"
+	ACTION_ADMIN     = "Admin"
+	ACTION_TAGGING   = "Tagging"
+	ACTION_LIST      = "List"
 
 	SeaweedStorageDestinationHeader = "x-seaweedfs-destination"
 	MultipartUploadsFolder          = ".uploads"

--- a/weed/s3api/s3_constants/s3_config.go
+++ b/weed/s3api/s3_constants/s3_config.go
@@ -7,7 +7,7 @@ import (
 var (
 	CircuitBreakerConfigDir  = "/etc/s3"
 	CircuitBreakerConfigFile = "circuit_breaker.json"
-	AllowedActions           = []string{ACTION_READ, ACTION_WRITE, ACTION_LIST, ACTION_TAGGING, ACTION_ADMIN}
+	AllowedActions           = []string{ACTION_READ, ACTION_READ_ACP, ACTION_WRITE, ACTION_WRITE_ACP, ACTION_LIST, ACTION_TAGGING, ACTION_ADMIN}
 	LimitTypeCount           = "Count"
 	LimitTypeBytes           = "MB"
 	Separator                = ":"

--- a/weed/s3api/s3api_object_copy_handlers.go
+++ b/weed/s3api/s3api_object_copy_handlers.go
@@ -2,15 +2,16 @@ package s3api
 
 import (
 	"fmt"
-	"github.com/seaweedfs/seaweedfs/weed/glog"
-	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
-	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
-	"modernc.org/strutil"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/glog"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
+	"modernc.org/strutil"
 
 	"github.com/seaweedfs/seaweedfs/weed/util"
 )
@@ -81,9 +82,9 @@ func (s3a *S3ApiServer) CopyObjectHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	dstUrl := fmt.Sprintf("http://%s%s/%s%s",
+	dstUrl := fmt.Sprintf("%s%s%s/%s%s", util.HttpScheme("s3"),
 		s3a.option.Filer.ToHttpAddress(), s3a.option.BucketsPath, dstBucket, urlEscapeObject(dstObject))
-	srcUrl := fmt.Sprintf("http://%s%s/%s%s",
+	srcUrl := fmt.Sprintf("%s%s%s/%s%s", util.HttpScheme("s3"),
 		s3a.option.Filer.ToHttpAddress(), s3a.option.BucketsPath, srcBucket, urlEscapeObject(srcObject))
 
 	_, _, resp, err := util.DownloadFile(srcUrl, s3a.maybeGetFilerJwtAuthorizationToken(false))
@@ -170,9 +171,9 @@ func (s3a *S3ApiServer) CopyObjectPartHandler(w http.ResponseWriter, r *http.Req
 
 	rangeHeader := r.Header.Get("x-amz-copy-source-range")
 
-	dstUrl := fmt.Sprintf("http://%s%s/%s/%04d.part",
+	dstUrl := fmt.Sprintf("%s%s%s/%s/%04d.part", util.HttpScheme("s3"),
 		s3a.option.Filer.ToHttpAddress(), s3a.genUploadsFolder(dstBucket), uploadID, partID)
-	srcUrl := fmt.Sprintf("http://%s%s/%s%s",
+	srcUrl := fmt.Sprintf("%s%s%s/%s%s", util.HttpScheme("s3"),
 		s3a.option.Filer.ToHttpAddress(), s3a.option.BucketsPath, srcBucket, urlEscapeObject(srcObject))
 
 	resp, dataReader, err := util.ReadUrlAsReaderCloser(srcUrl, s3a.maybeGetFilerJwtAuthorizationToken(false), rangeHeader)

--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -166,7 +166,7 @@ func removeDuplicateSlashes(object string) string {
 
 func (s3a *S3ApiServer) toFilerUrl(bucket, object string) string {
 	object = urlPathEscape(removeDuplicateSlashes(object))
-	destUrl := fmt.Sprintf("http://%s%s/%s%s",
+	destUrl := fmt.Sprintf("%s%s%s/%s%s", util.HttpScheme("s3"),
 		s3a.option.Filer.ToHttpAddress(), s3a.option.BucketsPath, bucket, object)
 	return destUrl
 }

--- a/weed/s3api/s3api_object_multipart_handlers.go
+++ b/weed/s3api/s3api_object_multipart_handlers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
 	weed_server "github.com/seaweedfs/seaweedfs/weed/server"
+	"github.com/seaweedfs/seaweedfs/weed/util"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -247,7 +248,7 @@ func (s3a *S3ApiServer) PutObjectPartHandler(w http.ResponseWriter, r *http.Requ
 
 	glog.V(2).Infof("PutObjectPartHandler %s %s %04d", bucket, uploadID, partID)
 
-	uploadUrl := fmt.Sprintf("http://%s%s/%s/%04d.part",
+	uploadUrl := fmt.Sprintf("%s%s%s/%s/%04d.part", util.HttpScheme("s3"),
 		s3a.option.Filer.ToHttpAddress(), s3a.genUploadsFolder(bucket), uploadID, partID)
 
 	if partID == 1 && r.Header.Get("Content-Type") == "" {

--- a/weed/s3api/s3api_server.go
+++ b/weed/s3api/s3api_server.go
@@ -147,7 +147,7 @@ func (s3a *S3ApiServer) registerRouter(router *mux.Router) {
 		bucket.Methods("DELETE").Path("/{object:.+}").HandlerFunc(track(s3a.iam.Auth(s3a.cb.Limit(s3a.DeleteObjectTaggingHandler, ACTION_TAGGING)), "DELETE")).Queries("tagging", "")
 
 		// PutObjectACL
-		bucket.Methods("PUT").Path("/{object:.+}").HandlerFunc(track(s3a.iam.Auth(s3a.cb.Limit(s3a.PutObjectAclHandler, ACTION_WRITE)), "PUT")).Queries("acl", "")
+		bucket.Methods("PUT").Path("/{object:.+}").HandlerFunc(track(s3a.iam.Auth(s3a.cb.Limit(s3a.PutObjectAclHandler, ACTION_WRITE_ACP)), "PUT")).Queries("acl", "")
 		// PutObjectRetention
 		bucket.Methods("PUT").Path("/{object:.+}").HandlerFunc(track(s3a.iam.Auth(s3a.cb.Limit(s3a.PutObjectRetentionHandler, ACTION_WRITE)), "PUT")).Queries("retention", "")
 		// PutObjectLegalHold
@@ -156,7 +156,7 @@ func (s3a *S3ApiServer) registerRouter(router *mux.Router) {
 		bucket.Methods("PUT").Path("/{object:.+}").HandlerFunc(track(s3a.iam.Auth(s3a.cb.Limit(s3a.PutObjectLockConfigurationHandler, ACTION_WRITE)), "PUT")).Queries("object-lock", "")
 
 		// GetObjectACL
-		bucket.Methods("GET").Path("/{object:.+}").HandlerFunc(track(s3a.iam.Auth(s3a.cb.Limit(s3a.GetObjectAclHandler, ACTION_READ)), "GET")).Queries("acl", "")
+		bucket.Methods("GET").Path("/{object:.+}").HandlerFunc(track(s3a.iam.Auth(s3a.cb.Limit(s3a.GetObjectAclHandler, ACTION_READ_ACP)), "GET")).Queries("acl", "")
 
 		// objects with query
 
@@ -183,9 +183,9 @@ func (s3a *S3ApiServer) registerRouter(router *mux.Router) {
 		bucket.Methods("POST").HandlerFunc(track(s3a.iam.Auth(s3a.cb.Limit(s3a.DeleteMultipleObjectsHandler, ACTION_WRITE)), "DELETE")).Queries("delete", "")
 
 		// GetBucketACL
-		bucket.Methods("GET").HandlerFunc(track(s3a.iam.Auth(s3a.cb.Limit(s3a.GetBucketAclHandler, ACTION_READ)), "GET")).Queries("acl", "")
+		bucket.Methods("GET").HandlerFunc(track(s3a.iam.Auth(s3a.cb.Limit(s3a.GetBucketAclHandler, ACTION_READ_ACP)), "GET")).Queries("acl", "")
 		// PutBucketACL
-		bucket.Methods("PUT").HandlerFunc(track(s3a.iam.Auth(s3a.cb.Limit(s3a.PutBucketAclHandler, ACTION_WRITE)), "PUT")).Queries("acl", "")
+		bucket.Methods("PUT").HandlerFunc(track(s3a.iam.Auth(s3a.cb.Limit(s3a.PutBucketAclHandler, ACTION_WRITE_ACP)), "PUT")).Queries("acl", "")
 
 		// GetBucketPolicy
 		bucket.Methods("GET").HandlerFunc(track(s3a.iam.Auth(s3a.cb.Limit(s3a.GetBucketPolicyHandler, ACTION_READ)), "GET")).Queries("policy", "")

--- a/weed/server/common.go
+++ b/weed/server/common.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 	"io"
 	"io/fs"
 	"mime/multipart"
@@ -17,6 +16,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 
 	"google.golang.org/grpc"
 
@@ -164,7 +165,7 @@ func submitForClientHandler(w http.ResponseWriter, r *http.Request, masterFn ope
 		return
 	}
 
-	url := "http://" + assignResult.Url + "/" + assignResult.Fid
+	url := util.HttpScheme("filer") + assignResult.Url + "/" + assignResult.Fid
 	if pu.ModifiedTime != 0 {
 		url = url + "?ts=" + strconv.FormatUint(pu.ModifiedTime, 10)
 	}

--- a/weed/server/filer_grpc_server.go
+++ b/weed/server/filer_grpc_server.go
@@ -131,7 +131,7 @@ func (fs *FilerServer) lookupFileId(fileId string) (targetUrls []string, err err
 		return nil, fmt.Errorf("not found volume %d in %s", fid.VolumeId, fileId)
 	}
 	for _, loc := range locations {
-		targetUrls = append(targetUrls, fmt.Sprintf("http://%s/%s", loc.Url, fileId))
+		targetUrls = append(targetUrls, fmt.Sprintf("%s%s/%s", util.HttpScheme("filer"), loc.Url, fileId))
 	}
 	return
 }

--- a/weed/server/filer_server_handlers_write.go
+++ b/weed/server/filer_server_handlers_write.go
@@ -60,7 +60,7 @@ func (fs *FilerServer) assignNewFileInfo(so *operation.StorageOption) (fileId, u
 			}
 		}
 	}
-	urlLocation = "http://" + assignUrl + "/" + assignResult.Fid
+	urlLocation = util.HttpScheme("filer") + assignUrl + "/" + assignResult.Fid
 	if so.Fsync {
 		urlLocation += "?fsync=true"
 	}

--- a/weed/server/master_server.go
+++ b/weed/server/master_server.go
@@ -233,10 +233,10 @@ func (ms *MasterServer) proxyToLeader(f http.HandlerFunc) http.HandlerFunc {
 
 		ms.boundedLeaderChan <- 1
 		defer func() { <-ms.boundedLeaderChan }()
-		targetUrl, err := url.Parse("http://" + raftServerLeader)
+		targetUrl, err := url.Parse(util.HttpScheme("master") + raftServerLeader)
 		if err != nil {
 			writeJsonError(w, r, http.StatusInternalServerError,
-				fmt.Errorf("Leader URL http://%s Parse Error: %v", raftServerLeader, err))
+				fmt.Errorf("Leader URL %s%s Parse Error: %v", util.HttpScheme("master"), raftServerLeader, err))
 			return
 		}
 

--- a/weed/server/volume_grpc_remote.go
+++ b/weed/server/volume_grpc_remote.go
@@ -3,14 +3,16 @@ package weed_server
 import (
 	"context"
 	"fmt"
+	"sync"
+	"time"
+
 	"github.com/seaweedfs/seaweedfs/weed/operation"
 	"github.com/seaweedfs/seaweedfs/weed/pb/volume_server_pb"
 	"github.com/seaweedfs/seaweedfs/weed/remote_storage"
 	"github.com/seaweedfs/seaweedfs/weed/security"
 	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
 	"github.com/seaweedfs/seaweedfs/weed/storage/types"
-	"sync"
-	"time"
+	"github.com/seaweedfs/seaweedfs/weed/util"
 )
 
 func (vs *VolumeServer) FetchAndWriteNeedle(ctx context.Context, req *volume_server_pb.FetchAndWriteNeedleRequest) (resp *volume_server_pb.FetchAndWriteNeedleResponse, err error) {
@@ -62,7 +64,7 @@ func (vs *VolumeServer) FetchAndWriteNeedle(ctx context.Context, req *volume_ser
 			go func(targetVolumeServer string) {
 				defer wg.Done()
 				uploadOption := &operation.UploadOption{
-					UploadUrl:         fmt.Sprintf("http://%s/%s?type=replicate", targetVolumeServer, fileId.String()),
+					UploadUrl:         fmt.Sprintf("%s%s/%s?type=replicate", util.HttpScheme("volume"), targetVolumeServer, fileId.String()),
 					Filename:          "",
 					Cipher:            false,
 					IsInputCompressed: false,

--- a/weed/server/webdav_server.go
+++ b/weed/server/webdav_server.go
@@ -403,7 +403,7 @@ func (f *WebDavFile) saveDataAsChunk(reader io.Reader, name string, offset int64
 			PairMap:           nil,
 		},
 		func(host, fileId string) string {
-			return fmt.Sprintf("http://%s/%s", host, fileId)
+			return fmt.Sprintf("%s%s/%s", util.HttpScheme("filer"), host, fileId)
 		},
 		reader,
 	)

--- a/weed/shell/command_fs_meta_save.go
+++ b/weed/shell/command_fs_meta_save.go
@@ -3,7 +3,6 @@ package shell
 import (
 	"flag"
 	"fmt"
-	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"io"
 	"os"
 	"path/filepath"
@@ -11,6 +10,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/filer"
 
 	"google.golang.org/protobuf/proto"
 
@@ -105,7 +106,7 @@ func (c *commandFsMetaSave) Do(args []string, commandEnv *CommandEnv, writer io.
 	})
 
 	if err == nil {
-		fmt.Fprintf(writer, "meta data for http://%s%s is saved to %s\n", commandEnv.option.FilerAddress.ToHttpAddress(), path, fileName)
+		fmt.Fprintf(writer, "meta data for %s%s%s is saved to %s\n", util.HttpScheme("client"), commandEnv.option.FilerAddress.ToHttpAddress(), path, fileName)
 	}
 
 	return err

--- a/weed/shell/command_s3_clean_uploads.go
+++ b/weed/shell/command_s3_clean_uploads.go
@@ -87,7 +87,7 @@ func (c *commandS3CleanUploads) cleanupUploads(commandEnv *CommandEnv, writer io
 	}
 
 	for _, staleUpload := range staleUploads {
-		deleteUrl := fmt.Sprintf("http://%s%s/%s?recursive=true&ignoreRecursiveError=true", commandEnv.option.FilerAddress.ToHttpAddress(), uploadsDir, staleUpload)
+		deleteUrl := fmt.Sprintf("%s%s%s/%s?recursive=true&ignoreRecursiveError=true", util.HttpScheme("s3"), commandEnv.option.FilerAddress.ToHttpAddress(), uploadsDir, staleUpload)
 		fmt.Fprintf(writer, "purge %s\n", deleteUrl)
 
 		err = util.Delete(deleteUrl, string(encodedJwt))

--- a/weed/shell/command_volume_fsck.go
+++ b/weed/shell/command_volume_fsck.go
@@ -19,6 +19,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/storage/needle_map"
 	"github.com/seaweedfs/seaweedfs/weed/storage/types"
 	"github.com/seaweedfs/seaweedfs/weed/util"
+	"github.com/spf13/viper"
 	"io"
 	"math"
 	"net/http"
@@ -515,11 +516,20 @@ func (c *commandVolumeFsck) oneVolumeFileIdsCheckOneVolume(dataNodeId string, vo
 func (c *commandVolumeFsck) httpDelete(path util.FullPath) {
 	req, err := http.NewRequest(http.MethodDelete, "", nil)
 
-	req.URL = &url.URL{
-		Scheme: "http",
-		Host:   c.env.option.FilerAddress.ToHttpAddress(),
-		Path:   string(path),
+	if viper.GetString("https.client.key") != "" {
+		req.URL = &url.URL{
+			Scheme: "https",
+			Host:   c.env.option.FilerAddress.ToHttpAddress(),
+			Path:   string(path),
+		}
+	} else {
+		req.URL = &url.URL{
+			Scheme: "http",
+			Host:   c.env.option.FilerAddress.ToHttpAddress(),
+			Path:   string(path),
+		}
 	}
+
 	if *c.verbose {
 		fmt.Fprintf(c.writer, "full HTTP delete request to be sent: %v\n", req)
 	}

--- a/weed/shell/command_volume_fsck.go
+++ b/weed/shell/command_volume_fsck.go
@@ -7,6 +7,18 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/operation"
 	"github.com/seaweedfs/seaweedfs/weed/pb"
@@ -19,18 +31,6 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/storage/needle_map"
 	"github.com/seaweedfs/seaweedfs/weed/storage/types"
 	"github.com/seaweedfs/seaweedfs/weed/util"
-	"github.com/spf13/viper"
-	"io"
-	"math"
-	"net/http"
-	"net/url"
-	"os"
-	"path"
-	"path/filepath"
-	"strconv"
-	"strings"
-	"sync"
-	"time"
 )
 
 func init() {
@@ -516,20 +516,11 @@ func (c *commandVolumeFsck) oneVolumeFileIdsCheckOneVolume(dataNodeId string, vo
 func (c *commandVolumeFsck) httpDelete(path util.FullPath) {
 	req, err := http.NewRequest(http.MethodDelete, "", nil)
 
-	if viper.GetString("https.client.key") != "" {
-		req.URL = &url.URL{
-			Scheme: "https",
-			Host:   c.env.option.FilerAddress.ToHttpAddress(),
-			Path:   string(path),
-		}
-	} else {
-		req.URL = &url.URL{
-			Scheme: "http",
-			Host:   c.env.option.FilerAddress.ToHttpAddress(),
-			Path:   string(path),
-		}
+	req.URL = &url.URL{
+		Scheme: util.HttpScheme("volume"),
+		Host:   c.env.option.FilerAddress.ToHttpAddress(),
+		Path:   string(path),
 	}
-
 	if *c.verbose {
 		fmt.Fprintf(c.writer, "full HTTP delete request to be sent: %v\n", req)
 	}

--- a/weed/topology/store_replicate.go
+++ b/weed/topology/store_replicate.go
@@ -4,13 +4,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/spf13/viper"
-	"google.golang.org/grpc"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
+
+	"google.golang.org/grpc"
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/operation"
@@ -61,16 +61,9 @@ func ReplicatedWrite(masterFn operation.GetMasterFn, grpcDialOption grpc.DialOpt
 		start := time.Now()
 		err = DistributedOperation(remoteLocations, func(location operation.Location) error {
 			u := url.URL{
-				Scheme: "http",
+				Scheme: util.HttpScheme("volume"),
 				Host:   location.Url,
 				Path:   r.URL.Path,
-			}
-			if viper.GetString("https.client.key") != "" {
-				u = url.URL{
-					Scheme: "https",
-					Host:   location.Url,
-					Path:   r.URL.Path,
-				}
 			}
 			q := url.Values{
 				"type": {"replicate"},
@@ -149,7 +142,7 @@ func ReplicatedDelete(masterFn operation.GetMasterFn, grpcDialOption grpc.DialOp
 
 	if len(remoteLocations) > 0 { //send to other replica locations
 		if err = DistributedOperation(remoteLocations, func(location operation.Location) error {
-			return util.Delete("http://"+location.Url+r.URL.Path+"?type=replicate", string(jwt))
+			return util.Delete(util.HttpScheme("volume")+location.Url+r.URL.Path+"?type=replicate", string(jwt))
 		}); err != nil {
 			size = 0
 		}

--- a/weed/topology/store_replicate.go
+++ b/weed/topology/store_replicate.go
@@ -61,7 +61,8 @@ func ReplicatedWrite(masterFn operation.GetMasterFn, grpcDialOption grpc.DialOpt
 		start := time.Now()
 		err = DistributedOperation(remoteLocations, func(location operation.Location) error {
 			u := url.URL{
-				Scheme: util.HttpScheme("volume"),
+				//Scheme: util.HttpScheme("volume"),
+				Scheme: "https",
 				Host:   location.Url,
 				Path:   r.URL.Path,
 			}

--- a/weed/topology/store_replicate.go
+++ b/weed/topology/store_replicate.go
@@ -57,10 +57,11 @@ func ReplicatedWrite(masterFn operation.GetMasterFn, grpcDialOption grpc.DialOpt
 	}
 
 	if len(remoteLocations) > 0 { //send to other replica locations
+		util.LoadConfiguration("security", false)
 		start := time.Now()
 		err = DistributedOperation(remoteLocations, func(location operation.Location) error {
 			u := url.URL{
-				Scheme: "https",
+				Scheme: "http",
 				Host:   location.Url,
 				Path:   r.URL.Path,
 			}

--- a/weed/topology/store_replicate.go
+++ b/weed/topology/store_replicate.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 	"net/http"
 	"net/url"
@@ -59,9 +60,16 @@ func ReplicatedWrite(masterFn operation.GetMasterFn, grpcDialOption grpc.DialOpt
 		start := time.Now()
 		err = DistributedOperation(remoteLocations, func(location operation.Location) error {
 			u := url.URL{
-				Scheme: "http",
+				Scheme: "https",
 				Host:   location.Url,
 				Path:   r.URL.Path,
+			}
+			if viper.GetString("https.client.key") != "" {
+				u = url.URL{
+					Scheme: "https",
+					Host:   location.Url,
+					Path:   r.URL.Path,
+				}
 			}
 			q := url.Values{
 				"type": {"replicate"},

--- a/weed/util/constants.go
+++ b/weed/util/constants.go
@@ -11,5 +11,5 @@ var (
 )
 
 func Version() string {
-	return VERSION + " " + COMMIT
+	return VERSION + " " + "NICE" + COMMIT
 }

--- a/weed/util/http_tls.go
+++ b/weed/util/http_tls.go
@@ -1,0 +1,20 @@
+package util
+
+import (
+	"github.com/spf13/viper"
+)
+
+func HttpScheme(part string) string {
+	// todo: could make part-specific lookup (filer/volume/master/client)
+	LoadConfiguration("security", false)
+	if viper.GetString("https.client.ca") != "" {
+		return "https://"
+	}
+
+	return "http://"
+}
+
+func HttpUseTls(part string) bool {
+	// todo: could make part-specific lookup (filer/volume/master/client)
+	return viper.GetString("https.client.ca") != ""
+}

--- a/weed/util/http_tls.go
+++ b/weed/util/http_tls.go
@@ -16,5 +16,6 @@ func HttpScheme(part string) string {
 
 func HttpUseTls(part string) bool {
 	// todo: could make part-specific lookup (filer/volume/master/client)
+	LoadConfiguration("security", false)
 	return viper.GetString("https.client.ca") != ""
 }

--- a/weed/util/http_util.go
+++ b/weed/util/http_util.go
@@ -6,13 +6,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/seaweedfs/seaweedfs/weed/glog"
-	"github.com/seaweedfs/seaweedfs/weed/util/mem"
-	"github.com/spf13/viper"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/seaweedfs/seaweedfs/weed/glog"
+	"github.com/seaweedfs/seaweedfs/weed/util/mem"
+	"github.com/spf13/viper"
 )
 
 var (
@@ -21,12 +22,11 @@ var (
 )
 
 func init() {
-	LoadConfiguration("security", false)
 	Transport = &http.Transport{
 		MaxIdleConns:        1024,
 		MaxIdleConnsPerHost: 1024,
 	}
-	if viper.GetString("https.client.key") != "" {
+	if HttpUseTls("client") {
 		clientCert := viper.GetString("https.client.cert")
 		clientCertKey := viper.GetString("https.client.key")
 
@@ -241,11 +241,7 @@ func NormalizeUrl(url string) string {
 	if strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://") {
 		return url
 	}
-	if viper.GetString("https.client.key") != "" {
-		return "https://" + url
-	} else {
-		return "http://" + url
-	}
+	return HttpScheme("client") + url
 }
 
 func ReadUrl(fileUrl string, cipherKey []byte, isContentCompressed bool, isFullChunk bool, offset int64, size int, buf []byte) (int64, error) {

--- a/weed/util/parse.go
+++ b/weed/util/parse.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"github.com/spf13/viper"
 	"net/url"
 	"strconv"
 	"strings"
@@ -29,8 +30,16 @@ func ParseUint64(text string, defaultValue uint64) uint64 {
 }
 
 func ParseFilerUrl(entryPath string) (filerServer string, filerPort int64, path string, err error) {
-	if !strings.HasPrefix(entryPath, "http://") && !strings.HasPrefix(entryPath, "https://") {
-		entryPath = "http://" + entryPath
+	LoadConfiguration("security", false)
+
+	if viper.GetString("https.client.key") != "" {
+		if !strings.HasPrefix(entryPath, "http://") && !strings.HasPrefix(entryPath, "https://") {
+			entryPath = "https://" + entryPath
+		}
+	} else {
+		if !strings.HasPrefix(entryPath, "http://") && !strings.HasPrefix(entryPath, "https://") {
+			entryPath = "http://" + entryPath
+		}
 	}
 
 	var u *url.URL

--- a/weed/util/parse.go
+++ b/weed/util/parse.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"fmt"
-	"github.com/spf13/viper"
 	"net/url"
 	"strconv"
 	"strings"
@@ -30,16 +29,8 @@ func ParseUint64(text string, defaultValue uint64) uint64 {
 }
 
 func ParseFilerUrl(entryPath string) (filerServer string, filerPort int64, path string, err error) {
-	LoadConfiguration("security", false)
-
-	if viper.GetString("https.client.key") != "" {
-		if !strings.HasPrefix(entryPath, "http://") && !strings.HasPrefix(entryPath, "https://") {
-			entryPath = "https://" + entryPath
-		}
-	} else {
-		if !strings.HasPrefix(entryPath, "http://") && !strings.HasPrefix(entryPath, "https://") {
-			entryPath = "http://" + entryPath
-		}
+	if !strings.HasPrefix(entryPath, "http://") && !strings.HasPrefix(entryPath, "https://") {
+		entryPath = HttpScheme("filer") + entryPath
 	}
 
 	var u *url.URL

--- a/weed/wdclient/masterclient.go
+++ b/weed/wdclient/masterclient.go
@@ -77,7 +77,7 @@ func (mc *MasterClient) LookupFileIdWithFallback(fileId string) (fullUrls []stri
 					DataCenter: vidLoc.DataCenter,
 				}
 				mc.vidMap.addLocation(uint32(vid), loc)
-				httpUrl := "http://" + loc.Url + "/" + fileId
+				httpUrl := util.HttpScheme("client") + loc.Url + "/" + fileId
 				// Prefer same data center
 				if mc.DataCenter != "" && mc.DataCenter == loc.DataCenter {
 					fullUrls = append([]string{httpUrl}, fullUrls...)

--- a/weed/wdclient/vid_map.go
+++ b/weed/wdclient/vid_map.go
@@ -3,12 +3,14 @@ package wdclient
 import (
 	"errors"
 	"fmt"
-	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"math/rand"
 	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb"
+	"github.com/seaweedfs/seaweedfs/weed/util"
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 )
@@ -109,7 +111,8 @@ func (vc *vidMap) LookupFileId(fileId string) (fullUrls []string, err error) {
 		return nil, lookupError
 	}
 	for _, serverUrl := range serverUrls {
-		fullUrls = append(fullUrls, "http://"+serverUrl+"/"+fileId)
+		fullUrls = append(fullUrls, util.HttpScheme("client")+serverUrl+"/"+fileId)
+
 	}
 	return
 }


### PR DESCRIPTION
# What problem are we solving?

We trie to implement https/tls for weed filer/mount

See issue here #https://github.com/seaweedfs/seaweedfs/issues/4835

For quicktesting -> single file (few MB) seems to work with write and reads. (no leftover http/1 connections)
If we test some bigger files (few 100MB), it fails with error, seems like an chunk problem?

`fatal error: concurrent map iteration and map write`  (there is also a very long stack trace if needed)


As additional info -> PR is quick and dirty, and not prepared for master, only for testing purpose.
