### PR TITLE
Allow override internalTrafficPolicy

### DIFF
--- a/k8s/charts/seaweedfs/templates/s3-service.yaml
+++ b/k8s/charts/seaweedfs/templates/s3-service.yaml
@@ -9,6 +9,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
+  internalTrafficPolicy: {{ .Values.s3.internalTrafficPolicy | default "Cluster" }}
   ports:
   - name: "swfs-s3"
     port: {{ if .Values.s3.enabled }}{{ .Values.s3.port }}{{ else }}{{ .Values.filer.s3.port }}{{ end }}

--- a/k8s/charts/seaweedfs/templates/volume-service.yaml
+++ b/k8s/charts/seaweedfs/templates/volume-service.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   clusterIP: None
+  internalTrafficPolicy: {{ .Values.volume.internalTrafficPolicy | default "Cluster" }
   ports:
   - name: "swfs-volume"
     port: {{ .Values.volume.port }}

--- a/k8s/charts/seaweedfs/templates/volume-service.yaml
+++ b/k8s/charts/seaweedfs/templates/volume-service.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   clusterIP: None
-  internalTrafficPolicy: {{ .Values.volume.internalTrafficPolicy | default "Cluster" }
+  internalTrafficPolicy: {{ .Values.volume.internalTrafficPolicy | default "Cluster" }}
   ports:
   - name: "swfs-volume"
     port: {{ .Values.volume.port }}


### PR DESCRIPTION
# What problem are we solving?
When deploying, one could configure the affinity of filers and volumes so that they are colocated; eg: on any node there can be a) no filer and no volume OR b) one filer pod AND one volume pod. In scenario B, it would make sense than that the filer pod communicates with the volume pod on the same node, and avoid any network hops between nodes. 

# How are we solving the problem?
This is accomplished by setting internalTrafficPolicy to "Local" for the volume service.


# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
