### PR TITLE
 fix: logger place msg

### DIFF
--- a/weed/shell/command_volume_fix_replication.go
+++ b/weed/shell/command_volume_fix_replication.go
@@ -102,7 +102,7 @@ func (c *commandVolumeFixReplication) Do(args []string, commandEnv *CommandEnv, 
 				underReplicatedVolumeIds = append(underReplicatedVolumeIds, vid)
 			case isMisplaced(replicas, replicaPlacement):
 				misplacedVolumeIds = append(misplacedVolumeIds, vid)
-				fmt.Fprintf(writer, "volume %d replication %s is not well placed %+v\n", replica.info.Id, replicaPlacement, replica)
+				fmt.Fprintf(writer, "volume %d replication %s is not well placed %s\n", replica.info.Id, replicaPlacement, replica.location.dataNode.Id)
 			case replicaPlacement.GetCopyCount() < len(replicas):
 				overReplicatedVolumeIds = append(overReplicatedVolumeIds, vid)
 				fmt.Fprintf(writer, "volume %d replication %s, but over replicated %+d\n", replica.info.Id, replicaPlacement, len(replicas))


### PR DESCRIPTION
# What problem are we solving?

 https://github.com/seaweedfs/seaweedfs/issues/4646

the message is not read
```
volume 98510 replication 010 is not well placed &{location:0xc0012940f0 info:0xc0009eec60}
```


# How are we solving the problem?
replace on:
```
volume 98510 replication 010 is not well placed fast-volume-1.s3-fast-volume.service.stagedc.consul:8080
```

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
