### PR TITLE
add ingress for seaweedfs s3

### DIFF
--- a/k8s/charts/seaweedfs/templates/s3-ingress.yaml
+++ b/k8s/charts/seaweedfs/templates/s3-ingress.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.s3.ingress.enabled }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: ingress-{{ template "seaweedfs.name" . }}-s3
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.s3.ingress.annotations }}
+  annotations:
+    {{ tpl .Values.s3.ingress.annotations . | nindent 4 | trim }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: s3
+spec:
+  ingressClassName: {{ .Values.s3.ingress.className | quote }}
+  tls:
+    {{ .Values.s3.ingress.tls | default list | toYaml | nindent 6}}
+  rules:
+  - http:
+      paths:
+      - path: /
+        pathType: ImplementationSpecific
+        backend:
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+          service:
+            name: {{ template "seaweedfs.name" . }}-s3
+            port:
+              number: {{ .Values.s3.port }}
+              #name:
+{{- else }}
+          serviceName: {{ template "seaweedfs.name" . }}-s3
+          servicePort: {{ .Values.s3.port }}
+{{- end }}
+{{- if .Values.s3.ingress.host }}
+    host: {{ .Values.s3.ingress.host }}
+{{- end }}
+{{- end }}

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -621,6 +621,12 @@ s3:
     failureThreshold: 100
     timeoutSeconds: 10
 
+  ingress:
+    enabled: false
+    className: "nginx"
+    # host: false for "*" hostname
+    host: "seaweedfs.cluster.local"
+
 certificates:
   commonName: "SeaweedFS CA"
   ipAddresses: []


### PR DESCRIPTION
# What problem are we solving?
It is necessary to be able to raise a separate Ingress for the seaweedfs-s3 service

# How are we solving the problem?

Add separate ingress in helm chart

# How is the PR tested?

helm lint/helm test in CI

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
