### PR TITLE
weed/operation: fix dropped error

### DIFF
--- a/weed/operation/upload_content.go
+++ b/weed/operation/upload_content.go
@@ -188,6 +188,9 @@ func doUploadData(data []byte, option *UploadOption) (uploadResult *UploadResult
 		} else if !iAmSure && option.MimeType == "" && len(data) > 16*1024 {
 			var compressed []byte
 			compressed, err = util.GzipData(data[0:128])
+			if err != nil {
+				return
+			}
 			shouldGzipNow = len(compressed)*10 < 128*9 // can not compress to less than 90%
 		}
 	}


### PR DESCRIPTION
This fixes a dropped `err` variable in the `weed/operation` package.