### PR TITLE
Context path support for UI

### DIFF
--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -58,6 +58,7 @@ type FilerOptions struct {
 	debug                   *bool
 	debugPort               *int
 	localSocket             *string
+	uiContextPath           *string
 	showUIDirectoryDelete   *bool
 	downloadMaxMBps         *int
 	diskType                *string
@@ -73,6 +74,7 @@ func init() {
 	f.port = cmdFiler.Flag.Int("port", 8888, "filer server http listen port")
 	f.portGrpc = cmdFiler.Flag.Int("port.grpc", 0, "filer server grpc listen port")
 	f.publicPort = cmdFiler.Flag.Int("port.readonly", 0, "readonly port opened to public")
+	f.uiContextPath = cmdFiler.Flag.String("ui.contextPath", "", "filer server http context path")
 	f.defaultReplicaPlacement = cmdFiler.Flag.String("defaultReplicaPlacement", "", "default replication type. If not specified, use master setting.")
 	f.disableDirListing = cmdFiler.Flag.Bool("disableDirListing", false, "turn off directory listing")
 	f.maxMB = cmdFiler.Flag.Int("maxMB", 4, "split files larger than the limit")
@@ -247,6 +249,7 @@ func (fo *FilerOptions) startFiler() {
 		DefaultLevelDbDir:     defaultLevelDbDirectory,
 		DisableHttp:           *fo.disableHttp,
 		Host:                  filerAddress,
+		UIContextPath:         *fo.uiContextPath,
 		Cipher:                *fo.cipher,
 		SaveToFilerLimit:      int64(*fo.saveToFilerLimit),
 		ConcurrentUploadLimit: int64(*fo.concurrentUploadLimitMB) * 1024 * 1024,

--- a/weed/command/master.go
+++ b/weed/command/master.go
@@ -56,6 +56,7 @@ type MasterOptions struct {
 	electionTimeout    *time.Duration
 	raftHashicorp      *bool
 	raftBootstrap      *bool
+	uiContextPath      *string
 }
 
 func init() {
@@ -81,6 +82,7 @@ func init() {
 	m.electionTimeout = cmdMaster.Flag.Duration("electionTimeout", 10*time.Second, "election timeout of master servers")
 	m.raftHashicorp = cmdMaster.Flag.Bool("raftHashicorp", false, "use hashicorp raft")
 	m.raftBootstrap = cmdMaster.Flag.Bool("raftBootstrap", false, "Whether to bootstrap the Raft cluster")
+	m.uiContextPath = cmdMaster.Flag.String("ui.contextPath", "", "master server http context path")
 }
 
 var cmdMaster = &Command{
@@ -311,5 +313,6 @@ func (m *MasterOptions) toMasterOption(whiteList []string) *weed_server.MasterOp
 		DisableHttp:             *m.disableHttp,
 		MetricsAddress:          *m.metricsAddress,
 		MetricsIntervalSec:      *m.metricsIntervalSec,
+		UIContextPath:           *m.uiContextPath,
 	}
 }

--- a/weed/command/server.go
+++ b/weed/command/server.go
@@ -114,6 +114,7 @@ func init() {
 	filerOptions.saveToFilerLimit = cmdServer.Flag.Int("filer.saveToFilerLimit", 0, "Small files smaller than this limit can be cached in filer store.")
 	filerOptions.concurrentUploadLimitMB = cmdServer.Flag.Int("filer.concurrentUploadLimitMB", 64, "limit total concurrent upload size")
 	filerOptions.localSocket = cmdServer.Flag.String("filer.localSocket", "", "default to /tmp/seaweedfs-filer-<port>.sock")
+	filerOptions.uiContextPath = cmdServer.Flag.String("filer.ui.contextPath", "", "filer server ui http context path")
 	filerOptions.showUIDirectoryDelete = cmdServer.Flag.Bool("filer.ui.deleteDir", true, "enable filer UI show delete directory button")
 	filerOptions.downloadMaxMBps = cmdServer.Flag.Int("filer.downloadMaxMBps", 0, "download max speed for each download request, in MB per second")
 	filerOptions.diskType = cmdServer.Flag.String("filer.disk", "", "[hdd|ssd|<tag>] hard drive or solid state drive or any tag")

--- a/weed/command/server.go
+++ b/weed/command/server.go
@@ -100,6 +100,7 @@ func init() {
 	masterOptions.raftBootstrap = cmdMaster.Flag.Bool("master.raftBootstrap", false, "Whether to bootstrap the Raft cluster")
 	masterOptions.heartbeatInterval = cmdServer.Flag.Duration("master.heartbeatInterval", 300*time.Millisecond, "heartbeat interval of master servers, and will be randomly multiplied by [1, 1.25)")
 	masterOptions.electionTimeout = cmdServer.Flag.Duration("master.electionTimeout", 10*time.Second, "election timeout of master servers")
+	masterOptions.uiContextPath = cmdServer.Flag.String("master.ui.contextPath", "", "master server ui http context path")
 
 	filerOptions.filerGroup = cmdServer.Flag.String("filer.filerGroup", "", "share metadata with other filers in the same filerGroup")
 	filerOptions.collection = cmdServer.Flag.String("filer.collection", "", "all data will be stored in this collection")

--- a/weed/command/server.go
+++ b/weed/command/server.go
@@ -133,6 +133,7 @@ func init() {
 	serverOptions.v.concurrentUploadLimitMB = cmdServer.Flag.Int("volume.concurrentUploadLimitMB", 64, "limit total concurrent upload size")
 	serverOptions.v.concurrentDownloadLimitMB = cmdServer.Flag.Int("volume.concurrentDownloadLimitMB", 64, "limit total concurrent download size")
 	serverOptions.v.publicUrl = cmdServer.Flag.String("volume.publicUrl", "", "publicly accessible address")
+	serverOptions.v.uiContextPath = cmdServer.Flag.String("volume.ui.contextPath", "", "volume server ui http context path")
 	serverOptions.v.preStopSeconds = cmdServer.Flag.Int("volume.preStopSeconds", 10, "number of seconds between stop send heartbeats and stop volume server")
 	serverOptions.v.pprof = cmdServer.Flag.Bool("volume.pprof", false, "enable pprof http handlers. precludes --memprofile and --cpuprofile")
 	serverOptions.v.idxFolder = cmdServer.Flag.String("volume.dir.idx", "", "directory to store .idx files")

--- a/weed/command/volume.go
+++ b/weed/command/volume.go
@@ -44,6 +44,7 @@ type VolumeServerOptions struct {
 	idxFolder                 *string
 	ip                        *string
 	publicUrl                 *string
+	uiContextPath             *string
 	bindIp                    *string
 	mastersString             *string
 	masters                   []pb.ServerAddress
@@ -78,6 +79,7 @@ func init() {
 	v.publicPort = cmdVolume.Flag.Int("port.public", 0, "port opened to public")
 	v.ip = cmdVolume.Flag.String("ip", util.DetectedHostAddress(), "ip or server name, also used as identifier")
 	v.publicUrl = cmdVolume.Flag.String("publicUrl", "", "Publicly accessible address")
+	v.uiContextPath = cmdVolume.Flag.String("ui.contextPath", "", "volume server http context path")
 	v.bindIp = cmdVolume.Flag.String("ip.bind", "", "ip address to bind to. If empty, default to same as -ip option.")
 	v.mastersString = cmdVolume.Flag.String("mserver", "localhost:9333", "comma-separated master servers")
 	v.preStopSeconds = cmdVolume.Flag.Int("preStopSeconds", 10, "number of seconds between stop send heartbeats and stop volume server")
@@ -237,7 +239,7 @@ func (v VolumeServerOptions) startVolumeServer(volumeFolders, maxVolumeCounts, v
 	}
 
 	volumeServer := weed_server.NewVolumeServer(volumeMux, publicVolumeMux,
-		*v.ip, *v.port, *v.portGrpc, *v.publicUrl,
+		*v.ip, *v.port, *v.portGrpc, *v.publicUrl, *v.uiContextPath,
 		v.folders, v.folderMaxLimits, minFreeSpaces, diskTypes,
 		*v.idxFolder,
 		volumeNeedleMapKind,

--- a/weed/server/common.go
+++ b/weed/server/common.go
@@ -246,6 +246,24 @@ func statsMemoryHandler(w http.ResponseWriter, r *http.Request) {
 	writeJsonQuiet(w, r, http.StatusOK, m)
 }
 
+func muxWithContextPathPrefix(uiContextPath string, mux *http.ServeMux) *http.ServeMux {
+	if len(uiContextPath) == 0 {
+		return mux
+	}
+	newMux := http.NewServeMux()
+	mux.Handle(uiContextPath+"/", http.StripPrefix(uiContextPath, newMux))
+	return newMux
+}
+
+func routerWithContextPathPrefix(uiContextPath string, router *mux.Router) *mux.Router {
+	if len(uiContextPath) == 0 {
+		return router
+	}
+	newRouter := mux.NewRouter()
+	router.PathPrefix(uiContextPath+"/").Handler(http.StripPrefix(uiContextPath, newRouter))
+	return newRouter
+}
+
 var StaticFS fs.FS
 
 func handleStaticResources(defaultMux *http.ServeMux) {

--- a/weed/server/filer_server.go
+++ b/weed/server/filer_server.go
@@ -53,6 +53,7 @@ type FilerOption struct {
 	Masters               *pb.ServerDiscovery
 	FilerGroup            string
 	Collection            string
+	UIContextPath         string
 	DefaultReplication    string
 	DisableDirListing     bool
 	MaxMB                 int

--- a/weed/server/filer_server.go
+++ b/weed/server/filer_server.go
@@ -98,6 +98,13 @@ type FilerServer struct {
 }
 
 func NewFilerServer(defaultMux, readonlyMux *http.ServeMux, option *FilerOption) (fs *FilerServer, err error) {
+	if defaultMux == readonlyMux {
+		defaultMux = muxWithContextPathPrefix(option.UIContextPath, defaultMux)
+		readonlyMux = defaultMux
+	} else {
+		defaultMux = muxWithContextPathPrefix(option.UIContextPath, defaultMux)
+		readonlyMux = muxWithContextPathPrefix(option.UIContextPath, readonlyMux)
+	}
 
 	v := util.GetViper()
 	signingKey := v.GetString("jwt.filer_signing.key")

--- a/weed/server/filer_server_handlers_read_dir.go
+++ b/weed/server/filer_server_handlers_read_dir.go
@@ -56,6 +56,7 @@ func (fs *FilerServer) listDirectoryHandler(w http.ResponseWriter, r *http.Reque
 
 	if r.Header.Get("Accept") == "application/json" {
 		writeJsonQuiet(w, r, http.StatusOK, struct {
+			ContextPath           string
 			Path                  string
 			Entries               interface{}
 			Limit                 int
@@ -63,6 +64,7 @@ func (fs *FilerServer) listDirectoryHandler(w http.ResponseWriter, r *http.Reque
 			ShouldDisplayLoadMore bool
 			EmptyFolder           bool
 		}{
+			fs.option.UIContextPath,
 			path,
 			entries,
 			limit,
@@ -74,6 +76,7 @@ func (fs *FilerServer) listDirectoryHandler(w http.ResponseWriter, r *http.Reque
 	}
 
 	err = ui.StatusTpl.Execute(w, struct {
+		ContextPath           string
 		Path                  string
 		Breadcrumbs           []ui.Breadcrumb
 		Entries               interface{}
@@ -83,6 +86,7 @@ func (fs *FilerServer) listDirectoryHandler(w http.ResponseWriter, r *http.Reque
 		EmptyFolder           bool
 		ShowDirectoryDelete   bool
 	}{
+		fs.option.UIContextPath,
 		path,
 		ui.ToBreadcrumb(path),
 		entries,

--- a/weed/server/filer_ui/filer.html
+++ b/weed/server/filer_ui/filer.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
 <html>
+{{ $contextPath := .ContextPath }}
 <head>
     <title>SeaweedFS Filer</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="/seaweedfsstatic/bootstrap/3.3.1/css/bootstrap.min.css">
+    <link rel="stylesheet" href="{{ $contextPath }}/seaweedfsstatic/bootstrap/3.3.1/css/bootstrap.min.css">
     <style>
         body {
             padding-bottom: 128px;
@@ -81,7 +82,7 @@
 <div class="container">
     <div class="page-header">
         <h1>
-            <a href="https://github.com/seaweedfs/seaweedfs"><img src="/seaweedfsstatic/seaweed50x50.png"></img></a>
+            <a href="https://github.com/seaweedfs/seaweedfs"><img src="{{ $contextPath }}/seaweedfsstatic/seaweed50x50.png"></img></a>
             SeaweedFS Filer
         </h1>
     </div>
@@ -97,7 +98,7 @@
             </div>
             <ol class="breadcrumb">
             {{ range $entry := .Breadcrumbs }}
-            <li><a href="{{ printpath $entry.Link }}">
+            <li><a href="{{ printpath $contextPath $entry.Link }}">
                 {{ $entry.Name }}
             </li></a>
             {{ end }}
@@ -122,11 +123,11 @@
                     <td>
                         {{ if $entry.IsDirectory }}
                         <span class="glyphicon glyphicon-folder-open" aria-hidden="true"></span>&nbsp;
-                        <a href="{{ printpath $path  "/" $entry.Name "/"}}" >
+                        <a href="{{ printpath $contextPath $path  "/" $entry.Name "/"}}" >
                         {{ $entry.Name }}
                         </a>
                         {{ else }}
-                        <a href="{{ printpath $path  "/" $entry.Name }}" >
+                        <a href="{{ printpath $contextPath $path  "/" $entry.Name }}" >
                         {{ $entry.Name }}
                         </a>
                         {{ end }}
@@ -170,7 +171,7 @@
 
     {{ if .ShouldDisplayLoadMore }}
     <div class="row">
-        <a href={{ print .Path "?limit=" .Limit "&lastFileName=" .LastFileName }} >
+        <a href="{{ print $contextPath .Path "?limit=" .Limit "&lastFileName=" .LastFileName }}">
         Load more
         </a>
     </div>
@@ -335,7 +336,7 @@
         if (newName == null || newName == '') {
             return;
         }
-        var url = basePath + encodeURIComponent(newName);
+        var url = "{{ $contextPath }}" + basePath + encodeURIComponent(newName);
         var originPath = basePath + originName;
         url += '?mv.from=' + encodeURIComponent(originPath);
         var xhr = new XMLHttpRequest();
@@ -349,7 +350,7 @@
         if (!confirm('Are you sure to delete ' + path + '?')) {
             return;
         }
-        var url = path;
+        var url = "{{ $contextPath }}" + path;
         if (url.endsWith('/')) {
             url += '?recursive=true';
         }

--- a/weed/server/master_server.go
+++ b/weed/server/master_server.go
@@ -38,6 +38,7 @@ const (
 )
 
 type MasterOption struct {
+	UIContextPath     string
 	Master            pb.ServerAddress
 	MetaFolder        string
 	VolumeSizeLimitMB uint32

--- a/weed/server/master_server.go
+++ b/weed/server/master_server.go
@@ -80,6 +80,7 @@ type MasterServer struct {
 }
 
 func NewMasterServer(r *mux.Router, option *MasterOption, peers map[string]pb.ServerAddress) *MasterServer {
+	r = routerWithContextPathPrefix(option.UIContextPath, r)
 
 	v := util.GetViper()
 	signingKey := v.GetString("jwt.signing.key")

--- a/weed/server/master_server_handlers_ui.go
+++ b/weed/server/master_server_handlers_ui.go
@@ -22,6 +22,7 @@ func (ms *MasterServer) uiStatusHandler(w http.ResponseWriter, r *http.Request) 
 
 	if ms.Topo.RaftServer != nil {
 		args := struct {
+			ContextPath       string
 			Version           string
 			Topology          interface{}
 			RaftServer        raft.Server
@@ -29,6 +30,7 @@ func (ms *MasterServer) uiStatusHandler(w http.ResponseWriter, r *http.Request) 
 			Counters          *stats.ServerStats
 			VolumeSizeLimitMB uint32
 		}{
+			ms.option.UIContextPath,
 			util.Version(),
 			ms.Topo.ToInfo(),
 			ms.Topo.RaftServer,
@@ -39,6 +41,7 @@ func (ms *MasterServer) uiStatusHandler(w http.ResponseWriter, r *http.Request) 
 		ui.StatusTpl.Execute(w, args)
 	} else if ms.Topo.HashicorpRaft != nil {
 		args := struct {
+			ContextPath       string
 			Version           string
 			Topology          interface{}
 			RaftServer        *hashicorpRaft.Raft
@@ -46,6 +49,7 @@ func (ms *MasterServer) uiStatusHandler(w http.ResponseWriter, r *http.Request) 
 			Counters          *stats.ServerStats
 			VolumeSizeLimitMB uint32
 		}{
+			ms.option.UIContextPath,
 			util.Version(),
 			ms.Topo.ToInfo(),
 			ms.Topo.HashicorpRaft,

--- a/weed/server/master_ui/master.html
+++ b/weed/server/master_ui/master.html
@@ -1,14 +1,15 @@
 <!DOCTYPE html>
 <html>
+{{ $contextPath := .ContextPath }}
 <head>
     <title>SeaweedFS {{ .Version }}</title>
-    <link rel="stylesheet" href="/seaweedfsstatic/bootstrap/3.3.1/css/bootstrap.min.css">
+    <link rel="stylesheet" href="{{ $contextPath }}/seaweedfsstatic/bootstrap/3.3.1/css/bootstrap.min.css">
 </head>
 <body>
 <div class="container">
     <div class="page-header">
         <h1>
-            <a href="https://github.com/seaweedfs/seaweedfs"><img src="/seaweedfsstatic/seaweed50x50.png"></img></a>
+            <a href="https://github.com/seaweedfs/seaweedfs"><img src="{{ $contextPath }}/seaweedfsstatic/seaweed50x50.png"></img></a>
             SeaweedFS <small>{{ .Version }}</small>
         </h1>
     </div>

--- a/weed/server/master_ui/masterNewRaft.html
+++ b/weed/server/master_ui/masterNewRaft.html
@@ -1,14 +1,15 @@
 <!DOCTYPE html>
 <html>
+{{ $contextPath := .ContextPath }}
 <head>
     <title>SeaweedFS {{ .Version }}</title>
-    <link rel="stylesheet" href="/seaweedfsstatic/bootstrap/3.3.1/css/bootstrap.min.css">
+    <link rel="stylesheet" href="{{ $contextPath }}/seaweedfsstatic/bootstrap/3.3.1/css/bootstrap.min.css">
 </head>
 <body>
 <div class="container">
     <div class="page-header">
         <h1>
-            <a href="https://github.com/seaweedfs/seaweedfs"><img src="/seaweedfsstatic/seaweed50x50.png"></img></a>
+            <a href="https://github.com/seaweedfs/seaweedfs"><img src="{{ $contextPath }}/seaweedfsstatic/seaweed50x50.png"></img></a>
             SeaweedFS <small>{{ .Version }}</small>
         </h1>
     </div>

--- a/weed/server/volume_server.go
+++ b/weed/server/volume_server.go
@@ -72,6 +72,13 @@ func NewVolumeServer(adminMux, publicMux *http.ServeMux, ip string,
 	readBufferSizeMB int,
 	ldbTimeout int64,
 ) *VolumeServer {
+	if adminMux == publicMux {
+		adminMux = muxWithContextPathPrefix(uiContextPath, adminMux)
+		publicMux = adminMux
+	} else {
+		adminMux = muxWithContextPathPrefix(uiContextPath, adminMux)
+		publicMux = muxWithContextPathPrefix(uiContextPath, publicMux)
+	}
 
 	v := util.GetViper()
 	signingKey := v.GetString("jwt.signing.key")

--- a/weed/server/volume_server.go
+++ b/weed/server/volume_server.go
@@ -33,6 +33,7 @@ type VolumeServer struct {
 
 	SeedMasterNodes []pb.ServerAddress
 	currentMaster   pb.ServerAddress
+	UIContextPath   string
 	pulseSeconds    int
 	dataCenter      string
 	rack            string
@@ -53,7 +54,7 @@ type VolumeServer struct {
 }
 
 func NewVolumeServer(adminMux, publicMux *http.ServeMux, ip string,
-	port int, grpcPort int, publicUrl string,
+	port int, grpcPort int, publicUrl string, uiContextPath string,
 	folders []string, maxCounts []int32, minFreeSpaces []util.MinFreeSpace, diskTypes []types.DiskType,
 	idxFolder string,
 	needleMapKind storage.NeedleMapKind,
@@ -107,7 +108,7 @@ func NewVolumeServer(adminMux, publicMux *http.ServeMux, ip string,
 
 	vs.checkWithMaster()
 
-	vs.store = storage.NewStore(vs.grpcDialOption, ip, port, grpcPort, publicUrl, folders, maxCounts, minFreeSpaces, idxFolder, vs.needleMapKind, diskTypes, ldbTimeout)
+	vs.store = storage.NewStore(vs.grpcDialOption, ip, port, grpcPort, publicUrl, uiContextPath, folders, maxCounts, minFreeSpaces, idxFolder, vs.needleMapKind, diskTypes, ldbTimeout)
 	vs.guard = security.NewGuard(whiteList, signingKey, expiresAfterSec, readSigningKey, readExpiresAfterSec)
 
 	handleStaticResources(adminMux)

--- a/weed/server/volume_server_handlers_ui.go
+++ b/weed/server/volume_server_handlers_ui.go
@@ -35,6 +35,7 @@ func (vs *VolumeServer) uiStatusHandler(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 	args := struct {
+		ContextPath   string
 		Version       string
 		Masters       []pb.ServerAddress
 		Volumes       interface{}
@@ -44,6 +45,7 @@ func (vs *VolumeServer) uiStatusHandler(w http.ResponseWriter, r *http.Request) 
 		Stats         interface{}
 		Counters      *stats.ServerStats
 	}{
+		vs.store.UIContextPath,
 		util.Version(),
 		vs.SeedMasterNodes,
 		normalVolumeInfos,

--- a/weed/server/volume_server_ui/volume.html
+++ b/weed/server/volume_server_ui/volume.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
 <html>
+{{ $contextPath := .ContextPath }}
 <head>
     <title>SeaweedFS {{ .Version }}</title>
-    <link rel="stylesheet" href="/seaweedfsstatic/bootstrap/3.3.1/css/bootstrap.min.css">
-    <script type="text/javascript" src="/seaweedfsstatic/javascript/jquery-3.6.0.min.js"></script>
+    <link rel="stylesheet" href="{{ $contextPath }}/seaweedfsstatic/bootstrap/3.3.1/css/bootstrap.min.css">
+    <script type="text/javascript" src="{{ $contextPath }}/seaweedfsstatic/javascript/jquery-3.6.0.min.js"></script>
     <script type="text/javascript"
-            src="/seaweedfsstatic/javascript/jquery-sparklines/2.1.2/jquery.sparkline.min.js"></script>
+            src="{{ $contextPath }}/seaweedfsstatic/javascript/jquery-sparklines/2.1.2/jquery.sparkline.min.js"></script>
     <script type="text/javascript">
         $(function () {
             var periods = ['second', 'minute', 'hour', 'day'];
@@ -30,7 +31,7 @@
 <div class="container">
     <div class="page-header">
         <h1>
-            <a href="https://github.com/seaweedfs/seaweedfs"><img src="/seaweedfsstatic/seaweed50x50.png"></img></a>
+            <a href="https://github.com/seaweedfs/seaweedfs"><img src="{{ $contextPath }}/seaweedfsstatic/seaweed50x50.png"></img></a>
             SeaweedFS <small>{{ .Version }}</small>
         </h1>
     </div>

--- a/weed/storage/store.go
+++ b/weed/storage/store.go
@@ -62,6 +62,7 @@ type Store struct {
 	Port                int
 	GrpcPort            int
 	PublicUrl           string
+	UIContextPath       string
 	Locations           []*DiskLocation
 	dataCenter          string // optional information, overwriting master setting if exists
 	rack                string // optional information, overwriting master setting if exists
@@ -75,13 +76,13 @@ type Store struct {
 }
 
 func (s *Store) String() (str string) {
-	str = fmt.Sprintf("Ip:%s, Port:%d, GrpcPort:%d PublicUrl:%s, dataCenter:%s, rack:%s, connected:%v, volumeSizeLimit:%d", s.Ip, s.Port, s.GrpcPort, s.PublicUrl, s.dataCenter, s.rack, s.connected, s.GetVolumeSizeLimit())
+	str = fmt.Sprintf("Ip:%s, Port:%d, GrpcPort:%d PublicUrl:%s, UIContextPath:%s, dataCenter:%s, rack:%s, connected:%v, volumeSizeLimit:%d", s.Ip, s.Port, s.GrpcPort, s.PublicUrl, s.UIContextPath, s.dataCenter, s.rack, s.connected, s.GetVolumeSizeLimit())
 	return
 }
 
-func NewStore(grpcDialOption grpc.DialOption, ip string, port int, grpcPort int, publicUrl string, dirnames []string, maxVolumeCounts []int32,
+func NewStore(grpcDialOption grpc.DialOption, ip string, port int, grpcPort int, publicUrl string, uiContextPath string, dirnames []string, maxVolumeCounts []int32,
 	minFreeSpaces []util.MinFreeSpace, idxFolder string, needleMapKind NeedleMapKind, diskTypes []DiskType, ldbTimeout int64) (s *Store) {
-	s = &Store{grpcDialOption: grpcDialOption, Port: port, Ip: ip, GrpcPort: grpcPort, PublicUrl: publicUrl, NeedleMapKind: needleMapKind}
+	s = &Store{grpcDialOption: grpcDialOption, Port: port, Ip: ip, GrpcPort: grpcPort, PublicUrl: publicUrl, UIContextPath: uiContextPath, NeedleMapKind: needleMapKind}
 	s.Locations = make([]*DiskLocation, 0)
 
 	var wg sync.WaitGroup


### PR DESCRIPTION
# What problem are we solving?

Creating subdomains for 3 different UIs may not be possible or feasible for a given project or company. This PR adds optional parameters to serve the filer & master UI's on a context path. Original idea found in this [discussion idea](https://github.com/seaweedfs/seaweedfs/discussions/4013).


# How are we solving the problem?

Adding new configuration items `master.ui.contextPath`, `filer.ui.contextPath` & `volume.ui.contextPath` when run via `weed server` and `ui.contextPath` when servers are run individually.

A new internal context-path variable is used to wrap UI endpoint registration & prefix rendered html documents.


# How is the PR tested?

By hand on a development test server.


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
