### PR TITLE
Helm chart jwt signing configuration

### DIFF
--- a/k8s/charts/seaweedfs/templates/security-configmap.yaml
+++ b/k8s/charts/seaweedfs/templates/security-configmap.yaml
@@ -13,10 +13,38 @@ data:
   security.toml: |-
     # this file is read by master, volume server, and filer
 
+    {{- if .Values.global.securityConfig.jwtSigning.volumeWrite }}
     # the jwt signing key is read by master and volume server
     # a jwt expires in 10 seconds
     [jwt.signing]
     key = "{{ randAlphaNum 10 | b64enc }}"
+    {{- end }}
+
+    {{- if .Values.global.securityConfig.jwtSigning.volumeRead }}
+    # this jwt signing key is read by master and volume server, and it is used for read operations:
+    # - the Master server generates the JWT, which can be used to read a certain file on a volume server
+    # - the Volume server validates the JWT on reading
+    [jwt.signing.read]
+    key = "{{ randAlphaNum 10 | b64enc }}"
+    {{- end }}
+
+    {{- if .Values.global.securityConfig.jwtSigning.filerWrite }}
+    # If this JWT key is configured, Filer only accepts writes over HTTP if they are signed with this JWT:
+    # - f.e. the S3 API Shim generates the JWT
+    # - the Filer server validates the JWT on writing
+    # the jwt defaults to expire after 10 seconds.
+    [jwt.filer_signing]
+    key = "{{ randAlphaNum 10 | b64enc }}"
+    {{- end }}
+
+    {{- if .Values.global.securityConfig.jwtSigning.filerRead }}
+    # If this JWT key is configured, Filer only accepts reads over HTTP if they are signed with this JWT:
+    # - f.e. the S3 API Shim generates the JWT
+    # - the Filer server validates the JWT on writing
+    # the jwt defaults to expire after 10 seconds.
+    [jwt.filer_signing.read]
+    key = "{{ randAlphaNum 10 | b64enc }}"
+    {{- end }}
 
     # all grpc tls authentications are mutual
     # the values for the following ca, cert, and key are paths to the PERM files.

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -13,8 +13,8 @@ global:
   securityConfig:
     jwtSigning:
       volumeWrite: true
-      volumeRead: true
-      filerWrite: true
+      volumeRead: false
+      filerWrite: false
       filerRead: false
   certificates:
     alphacrds: false

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -10,6 +10,12 @@ global:
   restartPolicy: Always
   loggingLevel: 1
   enableSecurity: false
+  securityConfig:
+    jwtSigning:
+      volumeWrite: true
+      volumeRead: true
+      filerWrite: true
+      filerRead: false
   certificates:
     alphacrds: false
   monitoring:


### PR DESCRIPTION
# What problem are we solving?
As described in this [issue](https://github.com/seaweedfs/seaweedfs/issues/4891) - currently when deploying using the repo helm chart, there is no option to customize the `security.toml`. More specifically we need to enable jwt signing for all supported options. Currently only volume write is enforced, we want to enforce it also for volume read and filer read and write.


# How are we solving the problem?
Adding configuration to the `values.yaml` for each jwt signing option will enable to customize this behavior for any supported option.
Default configuration in `values.yaml` is keeping current behavior where only volume write is enforced OOTB (all other new values are `false`). This way it doesn't introduce any change in current behavior, but only expands it.

# How is the PR tested?
Changed different config values and verified file content is changed accordingly. 


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
