### PR TITLE
Fix filer.backup local sink to propagate file mode changes

### DIFF
--- a/weed/replication/sink/localsink/local_sink.go
+++ b/weed/replication/sink/localsink/local_sink.go
@@ -90,11 +90,23 @@ func (localsink *LocalSink) CreateEntry(key string, entry *filer_pb.Entry, signa
 		return os.Mkdir(key, os.FileMode(entry.Attributes.FileMode))
 	}
 
-	dstFile, err := os.OpenFile(util.ToShortFileName(key), os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(entry.Attributes.FileMode))
+	mode := os.FileMode(entry.Attributes.FileMode)
+	dstFile, err := os.OpenFile(util.ToShortFileName(key), os.O_RDWR|os.O_CREATE|os.O_TRUNC, mode)
 	if err != nil {
 		return err
 	}
 	defer dstFile.Close()
+
+	fi, err := dstFile.Stat()
+	if err != nil {
+		return err
+	}
+	if fi.Mode() != mode {
+		glog.V(4).Infof("Modify file mode: %o -> %o", fi.Mode(), mode)
+		if err := dstFile.Chmod(mode); err != nil {
+			return err
+		}
+	}
 
 	writeFunc := func(data []byte) error {
 		_, writeErr := dstFile.Write(data)


### PR DESCRIPTION
# What problem are we solving?
When using filer.backup to sync a seaweedfs directory to a local directory, I find that the file mode is not synchronized.


# How are we solving the problem?
Chmod()ing the file as needed when synchronizing.


# How is the PR tested?
Ran it manually and noticed that when I set the executable bit on a file that has already been backed up, the backup is correctly updated with the executable bit.


# Checks
- [N/A - cannot find an existing unit test] I have added unit tests if possible.
- [N/A] I will add related wiki document changes and link to this PR after merging.
