### PR TITLE
added healthz endpoint to filer

### DIFF
--- a/weed/server/filer_server.go
+++ b/weed/server/filer_server.go
@@ -157,6 +157,7 @@ func NewFilerServer(defaultMux, readonlyMux *http.ServeMux, option *FilerOption)
 
 	handleStaticResources(defaultMux)
 	if !option.DisableHttp {
+		defaultMux.HandleFunc("/healthz", fs.filerHealthzHandler)
 		defaultMux.HandleFunc("/", fs.filerHandler)
 	}
 	if defaultMux != readonlyMux {

--- a/weed/server/filer_server_handlers.go
+++ b/weed/server/filer_server_handlers.go
@@ -179,3 +179,8 @@ func (fs *FilerServer) maybeCheckJwtAuthorization(r *http.Request, isWrite bool)
 		return true
 	}
 }
+
+func (fs *FilerServer) filerHealthzHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Server", "SeaweedFS Filer "+util.VERSION)
+	w.WriteHeader(http.StatusOK)
+}


### PR DESCRIPTION
# What problem are we solving?
As described in this [issue](https://github.com/seaweedfs/seaweedfs/issues/4891), we want to enable all security options via the helm chart.
Section 1 from the issue was solved in this [MR](https://github.com/seaweedfs/seaweedfs/pull/4894) by providing configuration for jwt signing to all supported servers.
This MR solves section 2 - where the `liveness` and `readiness` probes fails on `filer` when jwt read jwt signing is enabled.


# How are we solving the problem?
Added a `healthz` endpoint to filer which doesn't require any jwt authentication, similar to an endpoint on the volume server,  for the purposes of health checks.


# How is the PR tested?
Checked with jwt signing applied to that liveness doesn't fail. 


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.