### PR TITLE
fix has changes false if deleted result size eq zero

### DIFF
--- a/weed/shell/command_volume_check_disk.go
+++ b/weed/shell/command_volume_check_disk.go
@@ -286,7 +286,7 @@ func doVolumeCheckDisk(minuend, subtrahend *needle_map.MemDb, source, target *Vo
 			return hasChanges, deleteErr
 		}
 		for _, deleteResult := range deleteResults {
-			if deleteResult.Status == http.StatusAccepted {
+			if deleteResult.Status == http.StatusAccepted && deleteResult.Size > 0 {
 				hasChanges = true
 				return
 			}


### PR DESCRIPTION
https://github.com/seaweedfs/seaweedfs/issues/4171

# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/4171

# How are we solving the problem?

If the file was previously deleted, then the size will return to 0; therefore, there were no changes and there is no need to repeat the cycle.

# How is the PR tested?

dev localy.
```
> volume.check.disk -v -force -syncDeleted -volumeId 5774
Do sync volume 5774 on a.info.FileCount 3082 =! b.info.FileCount 3061) 
load collection serb-default volume 5774 index size 49312 from 192.168.245.255:8080 ...
load collection serb-default volume 5774 index size 48976 from 192.168.245.255:8081 ...
volume 5774 192.168.245.255:8081 has 2853 entries, 192.168.245.255:8080 missed 0 and partially deleted 0 entries
partially deleted needle key: 3060820471988128132, values {Key:2a7a38009a188984 Offset:44905114 Size:0}
volume 5774 192.168.245.255:8080 has 2853 entries, 192.168.245.255:8081 missed 0 and partially deleted 1 entries
delete 5774,2a7a38009a18898400000000 192.168.245.255:8080 => 192.168.245.255:8081
delete 3060820471988128132 192.168.245.255:8080 => 192.168.245.255:8081
delete result hasChanges: file_id:"5774,2a7a38009a18898400000000" status:304, size: 0
```

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
