### PR TITLE
remove compare to fix #4668 issue

### DIFF
--- a/weed/filer/filerstore_wrapper.go
+++ b/weed/filer/filerstore_wrapper.go
@@ -303,7 +303,7 @@ func (fsw *FilerStoreWrapper) prefixFilterEntries(ctx context.Context, dirPath u
 				}
 			}
 		}
-		if count < limit && lastFileName <= prefix && len(notPrefixed) == int(limit) {
+		if count < limit && lastFileName <= prefix {
 			notPrefixed = notPrefixed[:0]
 			lastFileName, err = actualStore.ListDirectoryEntries(ctx, dirPath, lastFileName, false, limit, func(entry *Entry) bool {
 				notPrefixed = append(notPrefixed, entry)


### PR DESCRIPTION
# What problem are we solving?

#4668 the S3 api list file error when function [ListDirectoryPrefixedEntries](https://github.com/seaweedfs/seaweedfs/blob/f24c7e803f0a14d35e2bb40a2ed838c80b8cf2e8/weed/filer/redis3/universal_redis_store.go#L135C64-L135C64) of filer store is not implemented and the parent directory have more than two directory and the sort of directory name is before the listed directory

example when using filer store like cassandra(ListDirectoryPrefixedEntries not implemented) :
myseaweedfs/test/ has only two object
myseaweedfs/test/config
myseaweedfs/test/keys/

mc ls myseaweedfs/test/keys can list file under keys directory
myseaweedfs/test/ has three directory

myseaweedfs/test/config
myseaweedfs/test/data/
myseaweedfs/test/keys/

mc ls myseaweedfs/test/keys can not list file under keys directory

```shell
root@af1718fe2359:/go/src# mc mb my/test
Bucket created successfully `my/test`.
root@af1718fe2359:/go/src# mc cp 123 my/test/keys/
 0 B / ? ━┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉━━root@af1718fe2359:/go/src# mc ls my/test
[2023-10-18 14:28:42 UTC]     0B keys/
root@af1718fe2359:/go/src# mc ls my/test/
[2023-10-18 14:28:44 UTC]     0B keys/
root@af1718fe2359:/go/src# mc ls my/test/keys
[2023-10-18 14:28:37 UTC]     0B STANDARD 123
root@af1718fe2359:/go/src# mc ls my/test/keys/
[2023-10-18 14:28:37 UTC]     0B STANDARD 123
root@af1718fe2359:/go/src# mc cp 123 my/test/data/
 0 B / ? 
root@af1718fe2359:/go/src# mc ls my/test/     
[2023-10-18 14:28:37 UTC]     0B data/
[2023-10-18 14:28:37 UTC]     0B keys/
root@af1718fe2359:/go/src# 
root@af1718fe2359:/go/src# mc ls my/test/keys/
[2023-10-18 14:28:37 UTC]     0B STANDARD 123
root@af1718fe2359:/go/src# mc cp aaa my/test/
 0 B / ? 
root@af1718fe2359:/go/src# mc ls my/test/keys/
root@af1718fe2359:/go/src# mc rm my/test/123
Removed `my/test/123`.
root@af1718fe2359:/go/src# mc ls my/test/keys/
[2023-10-18 14:28:37 UTC]     0B STANDARD 123
root@af1718fe2359:/go/src# 
root@af1718fe2359:/go/src# touch aaa
root@af1718fe2359:/go/src# mc cp aaa my/test/
 0 B / ? ━┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉┉━━
root@af1718fe2359:/go/src# mc ls my/test/
[2023-10-18 14:35:40 UTC]     0B STANDARD aaa
[2023-10-18 14:35:43 UTC]     0B data/
[2023-10-18 14:35:43 UTC]     0B keys/
root@af1718fe2359:/go/src# mc ls my/test/keys/
root@af1718fe2359:/go/src#( return nothing)
root@af1718fe2359:/go/src# mc rm my/test/aaa
Removed `my/test/aaa`.
root@af1718fe2359:/go/src# mc ls my/test/keys/
[2023-10-18 14:28:37 UTC]     0B STANDARD 123
```

# How are we solving the problem?

remove a compare len(notPrefixed) == int(limit)  in
https://github.com/seaweedfs/seaweedfs/blob/117fbba5bf1947a280376e688d24b3a9b1c589c9/weed/filer/filerstore_wrapper.go#L306
which is commit in https://github.com/seaweedfs/seaweedfs/commit/4ee0a6f47bda39887750480a729d0732a64a079d#

# How is the PR tested?

all test passed 
and after that I am currently refining the unit testing in this scenario.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
