### PR TITLE
Improve the performance of prefix list after fix #4668

### DIFF
--- a/weed/filer/filerstore_wrapper.go
+++ b/weed/filer/filerstore_wrapper.go
@@ -303,7 +303,7 @@ func (fsw *FilerStoreWrapper) prefixFilterEntries(ctx context.Context, dirPath u
 				}
 			}
 		}
-		if count < limit && lastFileName <= prefix && len(notPrefixed) == int(limit) {
+		if count < limit && lastFileName <= prefix {
 			notPrefixed = notPrefixed[:0]
 			lastFileName, err = actualStore.ListDirectoryEntries(ctx, dirPath, lastFileName, false, limit, func(entry *Entry) bool {
 				notPrefixed = append(notPrefixed, entry)

--- a/weed/filer/filerstore_wrapper.go
+++ b/weed/filer/filerstore_wrapper.go
@@ -282,8 +282,8 @@ func (fsw *FilerStoreWrapper) prefixFilterEntries(ctx context.Context, dirPath u
 	}
 
 	var notPrefixed []*Entry
-	fetchLimit := int64(500)
-	lastFileName, err = actualStore.ListDirectoryEntries(ctx, dirPath, startFileName, includeStartFile, fetchLimit, func(entry *Entry) bool {
+	const FetchLimit int64 = 500
+	lastFileName, err = actualStore.ListDirectoryEntries(ctx, dirPath, startFileName, includeStartFile, FetchLimit, func(entry *Entry) bool {
 		notPrefixed = append(notPrefixed, entry)
 		return true
 	})
@@ -306,7 +306,7 @@ func (fsw *FilerStoreWrapper) prefixFilterEntries(ctx context.Context, dirPath u
 		}
 		if count < limit && lastFileName <= prefix {
 			notPrefixed = notPrefixed[:0]
-			lastFileName, err = actualStore.ListDirectoryEntries(ctx, dirPath, lastFileName, false, fetchLimit, func(entry *Entry) bool {
+			lastFileName, err = actualStore.ListDirectoryEntries(ctx, dirPath, lastFileName, false, FetchLimit, func(entry *Entry) bool {
 				notPrefixed = append(notPrefixed, entry)
 				return true
 			})

--- a/weed/filer/filerstore_wrapper.go
+++ b/weed/filer/filerstore_wrapper.go
@@ -282,7 +282,8 @@ func (fsw *FilerStoreWrapper) prefixFilterEntries(ctx context.Context, dirPath u
 	}
 
 	var notPrefixed []*Entry
-	lastFileName, err = actualStore.ListDirectoryEntries(ctx, dirPath, startFileName, includeStartFile, limit, func(entry *Entry) bool {
+	fetchLimit := int64(500)
+	lastFileName, err = actualStore.ListDirectoryEntries(ctx, dirPath, startFileName, includeStartFile, fetchLimit, func(entry *Entry) bool {
 		notPrefixed = append(notPrefixed, entry)
 		return true
 	})
@@ -305,7 +306,7 @@ func (fsw *FilerStoreWrapper) prefixFilterEntries(ctx context.Context, dirPath u
 		}
 		if count < limit && lastFileName <= prefix {
 			notPrefixed = notPrefixed[:0]
-			lastFileName, err = actualStore.ListDirectoryEntries(ctx, dirPath, lastFileName, false, limit, func(entry *Entry) bool {
+			lastFileName, err = actualStore.ListDirectoryEntries(ctx, dirPath, lastFileName, false, fetchLimit, func(entry *Entry) bool {
 				notPrefixed = append(notPrefixed, entry)
 				return true
 			})


### PR DESCRIPTION
# What problem are we solving?

after remove compare in pr #4924 , the loop will fetch some objects based on the limit parameter, when limit parameter 
When the limit parameter is set too low and the number of objects is too large, it can cause performance issues.

# How are we solving the problem?

The limit parameter only focuses on the number of results and should not affect the number of entries obtained each time. Modify the List operation of prefixFilterEntries to get a fixed number (500) of entries each time to improve performance. 

# How is the PR tested?

all test passed

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
