### PR TITLE
avoid delete collection on fs.mv

### DIFF
--- a/weed/filer/filer_delete_entry.go
+++ b/weed/filer/filer_delete_entry.go
@@ -51,7 +51,9 @@ func (f *Filer) DeleteEntryMetaAndData(ctx context.Context, p util.FullPath, isR
 
 	if shouldDeleteChunks {
 		if isDeleteCollection {
-			f.doDeleteCollection(entry.Name())
+			if err := f.doDeleteCollection(entry.Name()); err != nil {
+				glog.Infof("failed delete collection %s: %v", entry.Name(), err)
+			}
 		} else {
 			f.DirectDeleteChunks(entry.GetChunks())
 		}

--- a/weed/filer/filer_delete_entry.go
+++ b/weed/filer/filer_delete_entry.go
@@ -49,13 +49,12 @@ func (f *Filer) DeleteEntryMetaAndData(ctx context.Context, p util.FullPath, isR
 		return fmt.Errorf("delete file %s: %v", p, err)
 	}
 
-	if shouldDeleteChunks && !isDeleteCollection {
-		f.DirectDeleteChunks(entry.GetChunks())
-	}
-
-	if isDeleteCollection {
-		collectionName := entry.Name()
-		f.doDeleteCollection(collectionName)
+	if shouldDeleteChunks {
+		if isDeleteCollection {
+			f.doDeleteCollection(entry.Name())
+		} else {
+			f.DirectDeleteChunks(entry.GetChunks())
+		}
 	}
 
 	return nil


### PR DESCRIPTION
# What problem are we solving?

```
> fs.mv /buckets/test /test
move: /buckets/test => /test
error: rpc error: code = Unknown desc = /buckets/test move error: fail to move /buckets/test => /test: delete file /buckets/test: filer store delete: delete /buckets/test: Error 1213 (40001): Deadlock found when trying to get lock; try restarting transaction
```

# How are we solving the problem?

skip delete collection

# How is the PR tested?

localy

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
