### PR TITLE
Fix twice increase metric counter

### DIFF
--- a/weed/server/volume_server_handlers_read.go
+++ b/weed/server/volume_server_handlers_read.go
@@ -166,7 +166,6 @@ func (vs *VolumeServer) GetOrHeadHandler(w http.ResponseWriter, r *http.Request)
 	}
 	if n.Cookie != cookie {
 		glog.V(0).Infof("request %s with cookie:%x expected:%x from %s agent %s", r.URL.Path, cookie, n.Cookie, r.RemoteAddr, r.UserAgent())
-		stats.VolumeServerRequestCounter.WithLabelValues(stats.ErrorGetNotFound).Inc()
 		NotFound(w)
 		return
 	}


### PR DESCRIPTION
# What problem are we solving?
https://github.com/seaweedfs/seaweedfs/pull/4960#discussion_r1376344671
Looks like VolumeServerRequestCounter increase twice if cookie is not valid

# How are we solving the problem?
delete `stats.VolumeServerRequestCounter.WithLabelValues(stats.ErrorGetNotFound).Inc()`


# How is the PR tested?
Run weed server


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
