### PR TITLE
Pass correct Filer's gRPC port to S3 server.

### DIFF
--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -169,7 +169,7 @@ func runFiler(cmd *Command, args []string) bool {
 
 	go stats_collect.StartMetricsServer(*f.bindIp, *f.metricsHttpPort)
 
-	filerAddress := util.JoinHostPort(*f.ip, *f.port)
+	filerAddress := pb.NewServerAddress(*f.ip, *f.port, *f.portGrpc).String()
 	startDelay := time.Duration(2)
 	if *filerStartS3 {
 		filerS3Options.filer = &filerAddress


### PR DESCRIPTION
Fixes seaweedfs/seaweedfs#4971

# What problem are we solving?
Filer's gRPC port got lost in passing to S3 server.



# How are we solving the problem?
Using another function to build filerAddress.


# How is the PR tested?
go test ./...
Local run.

