### PR TITLE
fix isMisplaced() in command_volume_fix_replication.go

### DIFF
--- a/weed/shell/command_volume_fix_replication.go
+++ b/weed/shell/command_volume_fix_replication.go
@@ -572,12 +572,12 @@ func isMisplaced(replicas []*VolumeReplica, replicaPlacement *super_block.Replic
 
 	for i := 0; i < len(replicas); i++ {
 		others := otherThan(replicas, i)
-		if satisfyReplicaPlacement(replicaPlacement, others, *replicas[i].location) {
-			return false
+		if !satisfyReplicaPlacement(replicaPlacement, others, *replicas[i].location) {
+			return true
 		}
 	}
 
-	return true
+	return false
 
 }
 


### PR DESCRIPTION
# What problem are we solving?

A volume ID is considered to be misplaced only if **all** the replicas don't meet the configured replica placement setting.
It should be considered misplaced even if only one of the replicas is in in the wrong place.

fixes #4836 