### PR TITLE
ec.decode: mount the collected ec shards

### DIFF
--- a/weed/shell/command_ec_decode.go
+++ b/weed/shell/command_ec_decode.go
@@ -197,6 +197,16 @@ func collectEcShards(commandEnv *CommandEnv, nodeToEcIndexBits map[pb.ServerAddr
 				return fmt.Errorf("copy %d.%v %s => %s : %v\n", vid, needToCopyEcIndexBits.ShardIds(), loc, targetNodeLocation, copyErr)
 			}
 
+			fmt.Printf("mount %d.%v on %s\n", vid, needToCopyEcIndexBits.ShardIds(), targetNodeLocation)
+			_, mountErr := volumeServerClient.VolumeEcShardsMount(context.Background(), &volume_server_pb.VolumeEcShardsMountRequest{
+				VolumeId:   uint32(vid),
+				Collection: collection,
+				ShardIds:   needToCopyEcIndexBits.ToUint32Slice(),
+			})
+			if mountErr != nil {
+				return fmt.Errorf("mount %d.%v on %s : %v\n", vid, needToCopyEcIndexBits.ShardIds(), targetNodeLocation, mountErr)
+			}
+
 			return nil
 		})
 


### PR DESCRIPTION
Thank you for this great project! 


What I use:
+ Software: version 30GB 3.58 d1e83a3b4df0c515d0aeb75dfbc8f398a771a90a linux amd64
+ One machine is used as master/filer/volume-server, and several others as volume-servers only.


# What problem are we solving?

It reports "ec volume x missing shard y" when running ``ec.decode`` subcommand in the weed shell.

After searching the issue list, I find there is already an issue: #4833 

I'm not sure if you can reproduce this issue. Maybe something not properly configured in my cases(?).

Just like the comment in #4833, it can sometimes work after restarting the volume server process, or just run ``kill -s HUP $(pgrep -f "weed volume")`` without restarting the process. But sometimes it doesn't work.

# How are we solving the problem?

```golang
doEcDecode()
  collectEcShards()
    volumeServerClient.VolumeEcShardsCopy()   // (1)
  generateNormalVolume()
    volumeServerClient.VolumeEcShardsToVolume()     
      vs.store.CollectEcShards()      // (2)
      loop the shardFileNames and check if shard missing    // (3)
  mountVolumeAndDeleteEcShards()
    ...
```

This is the trace when running ``ec.decode -volumeId xx`` in the weed shell.

It will copy the ec shard files to a chosen target volume server at (1). And at (2) it will enumerate the shard files from the ``location.ecVolumes`` variable, but the variable doesn't get the shard files just copied in step (1) included.  So it will return an error at step (3).

This can explain why "it mysteriously worked" in #4833. At the first time of running ec.decode, the shard files are copied to the chosen volume server, but it fails in step (3). After restarting the service, these shard files will be loaded by the call of ``loadExistingVolumes``, and if the volume-server is still the target one, it can work properly at the second time.

So I add a change here at step (1) by adding a call of ``volumeServerClient.VolumeEcShardsMount()`` to work around the issue after the shard files get copied.


# How is the PR tested?

I am not sure if it's a proper fix or not. But for now it can work around the issue here in my case.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
