### PR TITLE
[helm] fix: use metricsPort correctly

### DIFF
--- a/k8s/charts/seaweedfs/templates/master-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/master-statefulset.yaml
@@ -126,9 +126,9 @@ spec:
               {{- if .Values.master.metricsIntervalSec }}
               -metrics.intervalSeconds={{ .Values.master.metricsIntervalSec }} \
               {{- end }}
+              {{- end }}
               {{- else if .Values.master.metricsPort }}
               -metricsPort={{ .Values.master.metricsPort }} \
-              {{- end }}
               {{- end }}
               -volumeSizeLimitMB={{ .Values.master.volumeSizeLimitMB }} \
               {{- if .Values.master.disableHttp }}

--- a/k8s/charts/seaweedfs/templates/volume-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/volume-statefulset.yaml
@@ -185,7 +185,7 @@ spec:
             - containerPort: {{ .Values.volume.port }}
               name: swfs-vol
             {{- if .Values.volume.metricsPort }}
-            - containerPort: {{ .Values.filer.metricsPort }}
+            - containerPort: {{ .Values.volume.metricsPort }}
               name: metrics
             {{- end }}
             - containerPort: {{ .Values.volume.grpcPort }}


### PR DESCRIPTION
# What problem are we solving?

The volume server has an incorrect metricsPort configuration(`containerPort: {{ .Values.filer.metricsPort }}`), and the master's metricsPort configuration is also problematic when `global.monitoring.enabled=false`.


# How are we solving the problem?
fix charts templates


# How is the PR tested?
 PR is tested by performing a local Helm lint test


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
