### PR TITLE
verify content-md5 in header

### DIFF
--- a/weed/server/filer_server_handlers_write_autochunk.go
+++ b/weed/server/filer_server_handlers_write_autochunk.go
@@ -99,6 +99,11 @@ func (fs *FilerServer) doPostAutoChunk(ctx context.Context, w http.ResponseWrite
 	}
 
 	md5bytes = md5Hash.Sum(nil)
+	headerMd5 := r.Header.Get("Content-Md5")
+	if headerMd5 != "" && !(util.Base64Encode(md5bytes) == headerMd5 || fmt.Sprintf("%x", md5bytes) == headerMd5) {
+		fs.filer.DeleteChunks(fileChunks)
+		return nil, nil, errors.New("The Content-Md5 you specified did not match what we received.")
+	}
 	filerResult, replyerr = fs.saveMetaData(ctx, r, fileName, contentType, so, md5bytes, fileChunks, chunkOffset, smallContent)
 	if replyerr != nil {
 		fs.filer.DeleteChunks(fileChunks)
@@ -121,6 +126,11 @@ func (fs *FilerServer) doPutAutoChunk(ctx context.Context, w http.ResponseWriter
 	}
 
 	md5bytes = md5Hash.Sum(nil)
+	headerMd5 := r.Header.Get("Content-Md5")
+	if headerMd5 != "" && !(util.Base64Encode(md5bytes) == headerMd5 || fmt.Sprintf("%x", md5bytes) == headerMd5) {
+		fs.filer.DeleteChunks(fileChunks)
+		return nil, nil, errors.New("The Content-Md5 you specified did not match what we received.")
+	}
 	filerResult, replyerr = fs.saveMetaData(ctx, r, fileName, contentType, so, md5bytes, fileChunks, chunkOffset, smallContent)
 	if replyerr != nil {
 		fs.filer.DeleteChunks(fileChunks)

--- a/weed/server/filer_server_handlers_write_autochunk.go
+++ b/weed/server/filer_server_handlers_write_autochunk.go
@@ -3,6 +3,7 @@ package weed_server
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	//"github.com/seaweedfs/seaweedfs/weed/s3api"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"


### PR DESCRIPTION
if upload content by s3 client and set content-md5 in header,then will verify recived and saved content,if not equal delete thos chunks

# What problem are we solving?
while set content-md5 in request header using aws s3 go client to upload files,weedfs not check the md5.


# How are we solving the problem?
after saved content to volume and got the md5bytes ,if not equal ,delete thoes chunks



# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
