### PR TITLE
fix: guard whiteList for file id handle on master

### DIFF
--- a/weed/server/master_server.go
+++ b/weed/server/master_server.go
@@ -145,7 +145,7 @@ func NewMasterServer(r *mux.Router, option *MasterOption, peers map[string]pb.Se
 			r.HandleFunc("/stats/counter", ms.guard.WhiteList(statsCounterHandler))
 			r.HandleFunc("/stats/memory", ms.guard.WhiteList(statsMemoryHandler))
 		*/
-		r.HandleFunc("/{fileId}", ms.redirectHandler)
+		r.HandleFunc("/{fileId}", ms.guard.WhiteList(ms.redirectHandler))
 	}
 
 	ms.Topo.StartRefreshWritableVolumes(


### PR DESCRIPTION
# What problem are we solving?

With whitelist restrictions configured, one handle with a file ID is available for requests from other IPs
```
I1117 04:35:54.641257 common.go:75 response method:GET URL:/sitemap.xml with httpStatus:404 and JSON:{"error":"volume id sitemap.xml not found: Unknown volume id sitemap.xml"}
```

# How are we solving the problem?

add grant whiteList for `{fileId}` handler

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
