### PR TITLE
Waiting for writes to complete with acquired lock may lead to deadlock

### DIFF
--- a/weed/mount/page_writer/upload_pipeline.go
+++ b/weed/mount/page_writer/upload_pipeline.go
@@ -147,14 +147,17 @@ func (up *UploadPipeline) MaybeReadDataAt(p []byte, off int64, tsNs int64) (maxS
 }
 
 func (up *UploadPipeline) FlushAll() {
+	up.flushChunks()
+	up.waitForCurrentWritersToComplete()
+}
+
+func (up *UploadPipeline) flushChunks() {
 	up.chunksLock.Lock()
 	defer up.chunksLock.Unlock()
 
 	for logicChunkIndex, memChunk := range up.writableChunks {
 		up.moveToSealed(memChunk, logicChunkIndex)
 	}
-
-	up.waitForCurrentWritersToComplete()
 }
 
 func (up *UploadPipeline) maybeMoveToSealed(memChunk PageChunk, logicChunkIndex LogicChunkIndex) {


### PR DESCRIPTION
Waiting for writes to complete with acquired lock may lead to deadlock, fixes #4952