### PR TITLE
helm chart: fix annotations templating for s3.ingress.annotations and document it and s3.ingress.tls in values.yaml

### DIFF
--- a/k8s/charts/seaweedfs/Chart.yaml
+++ b/k8s/charts/seaweedfs/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: SeaweedFS
 name: seaweedfs
 appVersion: "3.59"
-version: 3.59.0
+version: 3.59.1

--- a/k8s/charts/seaweedfs/templates/s3-ingress.yaml
+++ b/k8s/charts/seaweedfs/templates/s3-ingress.yaml
@@ -10,9 +10,9 @@ kind: Ingress
 metadata:
   name: ingress-{{ template "seaweedfs.name" . }}-s3
   namespace: {{ .Release.Namespace }}
-  {{- if .Values.s3.ingress.annotations }}
+  {{- with .Values.s3.ingress.annotations }}
   annotations:
-    {{ tpl .Values.s3.ingress.annotations . | nindent 4 | trim }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
     app.kubernetes.io/name: {{ template "seaweedfs.name" . }}

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -641,6 +641,9 @@ s3:
     className: "nginx"
     # host: false for "*" hostname
     host: "seaweedfs.cluster.local"
+    # additional ingress annotations for the s3 endpoint
+    annotations: []
+    tls: []
 
 certificates:
   commonName: "SeaweedFS CA"


### PR DESCRIPTION
# What problem are we solving?

A templating error for `s3.ingress.annotations` as well as documenting both the `annotations` and `tls` values in values.yaml. Example error when deploying this helm chart as an Application via Argo CD, which inflates the templates with `helm template` and then does a `kubectl apply` on the resulting manifests:

> Failed to load target state: failed to generate manifest for source 1 of 1: rpc error: code = Unknown desc = Manifest generation error (cached): `helm template . --name-template seaweedfs --namespace seaweedfs --kube-version 1.27 --values /tmp/ce2b630b-aeca-4c10-a49a-f232ad7a4712 <api versions removed> --include-crds` failed exit status 1: Error: template: seaweedfs/templates/s3-ingress.yaml:15:18: executing "seaweedfs/templates/s3-ingress.yaml" at <.Values.s3.ingress.annotations>: wrong type for value; expected string; got map[string]interface {} Use --debug flag to render out invalid YAML

# How are we solving the problem?
Using `with` instead of `if` ([`with` functions as an implicit `if`](https://helm.sh/docs/chart_template_guide/control_structures/#modifying-scope-using-with)) to reduce templating code, and removing the `trim` as the value of the parameter is not a string; it's an object.

# How is the PR tested?

A plain `values.yaml`, which I've named `values-test.yaml`, with the following changed:

```diff
@@ -550,7 +550,7 @@ filer:
     auditLogConfig: {}

 s3:
-  enabled: false
+  enabled: true
   repository: null
   imageName: null
   imageTag: null
@@ -637,12 +637,13 @@ s3:
     timeoutSeconds: 10

   ingress:
-    enabled: false
+    enabled: true
     className: "nginx"
     # host: false for "*" hostname
     host: "seaweedfs.cluster.local"
     # additional ingress annotations for the s3 endpoint
-    annotations: []
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt-staging
     tls: []

 certificates:
```

Then, from the cloned repo in the `k8s/charts/seaweedfs` directory I ran:

```bash
helm template . --values values-test.yaml --output-dir testing
cat testing/seaweedfs/templates/s3-ingress.yaml
```

Which shows:

```yaml
---
# Source: seaweedfs/templates/s3-ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: ingress-seaweedfs-s3
  namespace: argocd
  annotations:
    cert-manager.io/cluster-issuer: letsencrypt-staging
  labels:
    app.kubernetes.io/name: seaweedfs
    helm.sh/chart: seaweedfs-3.59.1
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/component: s3
spec:
  ingressClassName: "nginx"
  tls:

      []
  rules:
  - http:
      paths:
      - path: /
        pathType: ImplementationSpecific
        backend:
          service:
            name: seaweedfs-s3
            port:
              number: 8333
              #name:
    host: seaweedfs.cluster.local
```

To reproduce the error we're solving, you can keep the same `values-test.yaml` in place but use the live version of the helm chart to template, you get this error:

> Error: template: seaweedfs/templates/s3-ingress.yaml:15:18: executing "seaweedfs/templates/s3-ingress.yaml" at <.Values.s3.ingress.annotations>: wrong type for value; expected string; got map[string]interface {}

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
