### PR TITLE
Enable support for Restic-based tools (K8up, Velero) to perform backup and restore operations

### DIFF
--- a/k8s/charts/seaweedfs/templates/_helpers.tpl
+++ b/k8s/charts/seaweedfs/templates/_helpers.tpl
@@ -118,7 +118,7 @@ Inject extra environment vars in the format key:value, if populated
 {{- if or (or (eq .Values.volume.data.type "persistentVolumeClaim") (and (eq .Values.volume.idx.type "persistentVolumeClaim") .Values.volume.dir_idx )) (eq .Values.volume.logs.type "persistentVolumeClaim") -}}
 {{- printf "true" -}}
 {{- else -}}
-{{- printf "false" -}}
+{{- printf "" -}}
 {{- end -}}
 {{- end -}}
 
@@ -130,7 +130,7 @@ Inject extra environment vars in the format key:value, if populated
 {{- if or .Values.global.enableSecurity .Values.volume.extraVolumes -}}
 {{- printf "true" -}}
 {{- else -}}
-{{- printf "false" -}}
+{{- printf "" -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
@@ -140,7 +140,7 @@ Inject extra environment vars in the format key:value, if populated
 {{- if or (eq .Values.filer.data.type "persistentVolumeClaim") (eq .Values.filer.logs.type "persistentVolumeClaim") -}}
 {{- printf "true" -}}
 {{- else -}}
-{{- printf "false" -}}
+{{- printf "" -}}
 {{- end -}}
 {{- end -}}
 
@@ -149,7 +149,7 @@ Inject extra environment vars in the format key:value, if populated
 {{- if or (eq .Values.filer.data.type "hostPath") (eq .Values.filer.logs.type "hostPath") -}}
 {{- printf "true" -}}
 {{- else -}}
-{{- printf "false" -}}
+{{- printf "" -}}
 {{- end -}}
 {{- end -}}
 
@@ -158,7 +158,7 @@ Inject extra environment vars in the format key:value, if populated
 {{- if or (eq .Values.master.data.type "persistentVolumeClaim") (eq .Values.master.logs.type "persistentVolumeClaim") -}}
 {{- printf "true" -}}
 {{- else -}}
-{{- printf "false" -}}
+{{- printf "" -}}
 {{- end -}}
 {{- end -}}
 
@@ -170,7 +170,7 @@ Inject extra environment vars in the format key:value, if populated
 {{- if or .Values.global.enableSecurity .Values.volume.extraVolumes -}}
 {{- printf "true" -}}
 {{- else -}}
-{{- printf "false" -}}
+{{- printf "" -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
@@ -180,7 +180,7 @@ Inject extra environment vars in the format key:value, if populated
 {{- if or (not (empty .Values.volume.dir_idx )) (not (empty .Values.volume.initContainers )) -}}
 {{- printf "true" -}}
 {{- else -}}
-{{- printf "false" -}}
+{{- printf "" -}}
 {{- end -}}
 {{- end -}}
 

--- a/k8s/charts/seaweedfs/templates/_helpers.tpl
+++ b/k8s/charts/seaweedfs/templates/_helpers.tpl
@@ -175,6 +175,15 @@ Inject extra environment vars in the format key:value, if populated
 {{- end -}}
 {{- end -}}
 
+{{/* check if any Master existingClaim is defined */}}
+{{- define "master.existing_claims" -}}
+{{- if or (eq .Values.master.data.type "existingClaim") (eq .Values.master.logs.type "existingClaim") -}}
+{{- printf "true" -}}
+{{- else -}}
+{{- printf "" -}}
+{{- end -}}
+{{- end -}}
+
 {{/* check if any InitContainers exist for Volumes */}}
 {{- define "volume.initContainers_exists" -}}
 {{- if or (not (empty .Values.volume.dir_idx )) (not (empty .Values.volume.initContainers )) -}}

--- a/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
@@ -335,6 +335,10 @@ spec:
     {{- if eq .Values.filer.data.type "persistentVolumeClaim"}}
     - metadata:
         name: data-filer
+        {{- with .Values.filer.data.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       spec:
         accessModes: [ "ReadWriteOnce" ]
         storageClassName: {{ .Values.filer.data.storageClass }}
@@ -345,6 +349,10 @@ spec:
     {{- if eq .Values.filer.logs.type "persistentVolumeClaim"}}
     - metadata:
         name: seaweedfs-filer-log-volume
+        {{- with .Values.filer.logs.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       spec:
         accessModes: [ "ReadWriteOnce" ]
         storageClassName: {{ .Values.filer.logs.storageClass }}

--- a/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
@@ -314,7 +314,7 @@ spec:
       nodeSelector:
         {{ tpl .Values.filer.nodeSelector . | indent 8 | trim }}
       {{- end }}
-  {{- if .Values.filer.enablePVC }}
+  {{- if and (.Values.filer.enablePVC) (eq .Values.filer.data.type "persistentVolumeClaim") }}
   # DEPRECATION: Deprecate in favor of filer.data section below
   volumeClaimTemplates:
   - metadata:
@@ -332,7 +332,7 @@ spec:
   {{- $pvc_exists := include "filer.pvc_exists" . -}}
   {{- if $pvc_exists }}
   volumeClaimTemplates:
-    {{- if eq .Values.filer.data.type "persistentVolumeClaim"}}
+    {{- if eq .Values.filer.data.type "persistentVolumeClaim" }}
     - metadata:
         name: data-filer
         {{- with .Values.filer.data.annotations }}
@@ -346,7 +346,7 @@ spec:
           requests:
             storage: {{ .Values.filer.data.size }}
     {{- end }}
-    {{- if eq .Values.filer.logs.type "persistentVolumeClaim"}}
+    {{- if eq .Values.filer.logs.type "persistentVolumeClaim" }}
     - metadata:
         name: seaweedfs-filer-log-volume
         {{- with .Values.filer.logs.annotations }}

--- a/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
@@ -266,11 +266,21 @@ spec:
             path: {{ .Values.filer.logs.hostPathPrefix }}/logs/seaweedfs/filer
             type: DirectoryOrCreate
         {{- end }}
+        {{- if eq .Values.filer.logs.type "existingClaim" }}
+        - name: seaweedfs-filer-log-volume
+          persistentVolumeClaim:
+            claimName: {{ .Values.filer.logs.claimName }}
+        {{- end }}
         {{- if eq .Values.filer.data.type "hostPath" }}
         - name: data-filer
           hostPath:
             path: {{ .Values.filer.data.hostPathPrefix }}/filer_store
             type: DirectoryOrCreate
+        {{- end }}
+        {{- if eq .Values.filer.data.type "existingClaim" }}
+        - name: data-filer
+          persistentVolumeClaim:
+            claimName: {{ .Values.filer.data.claimName }}
         {{- end }}
         - name: db-schema-config-volume
           configMap:

--- a/k8s/charts/seaweedfs/templates/master-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/master-statefulset.yaml
@@ -213,7 +213,8 @@ spec:
             {{ tpl .Values.master.resources . | nindent 12 | trim }}
           {{- end }}
       {{- $hostpath_exists := include "master.hostpath_exists" . -}}
-      {{- if $hostpath_exists }}
+      {{- $existing_claims := include "master.existing_claims" . -}}
+      {{- if or ($hostpath_exists) ($existing_claims) }}
       volumes:
         {{- if eq .Values.master.logs.type "hostPath" }}
         - name: seaweedfs-master-log-volume
@@ -221,11 +222,21 @@ spec:
             path: {{ .Values.master.logs.hostPathPrefix }}/logs/seaweedfs/master
             type: DirectoryOrCreate
         {{- end }}
+        {{- if eq .Values.master.logs.type "existingClaim" }}
+        - name: logs
+          persistentVolumeClaim:
+            claimName: {{ .Values.master.logs.claimName }} 
+        {{- end }}
         {{- if eq .Values.master.data.type "hostPath" }}
         - name: data-{{ .Release.Namespace }}
           hostPath:
             path: {{ .Values.master.data.hostPathPrefix }}/seaweed-master/
             type: DirectoryOrCreate
+        {{- end }}
+        {{- if eq .Values.master.data.type "existingClaim" }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.master.data.claimName }} 
         {{- end }}
         - name: master-config
           configMap:

--- a/k8s/charts/seaweedfs/templates/master-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/master-statefulset.yaml
@@ -223,7 +223,7 @@ spec:
             type: DirectoryOrCreate
         {{- end }}
         {{- if eq .Values.master.logs.type "existingClaim" }}
-        - name: logs
+        - name: seaweedfs-master-log-volume
           persistentVolumeClaim:
             claimName: {{ .Values.master.logs.claimName }} 
         {{- end }}
@@ -234,7 +234,7 @@ spec:
             type: DirectoryOrCreate
         {{- end }}
         {{- if eq .Values.master.data.type "existingClaim" }}
-        - name: data
+        - name: data-{{ .Release.Namespace }}
           persistentVolumeClaim:
             claimName: {{ .Values.master.data.claimName }} 
         {{- end }}

--- a/k8s/charts/seaweedfs/templates/master-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/master-statefulset.yaml
@@ -273,6 +273,10 @@ spec:
     {{- if eq .Values.master.data.type "persistentVolumeClaim"}}
     - metadata:
         name: data-{{ .Release.Namespace }}
+        {{- with .Values.master.data.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       spec:
         accessModes: [ "ReadWriteOnce" ]
         storageClassName: {{ .Values.master.data.storageClass }}
@@ -283,6 +287,10 @@ spec:
     {{- if eq .Values.master.logs.type "persistentVolumeClaim"}}
     - metadata:
         name: seaweedfs-master-log-volume
+        {{- with .Values.master.logs.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       spec:
         accessModes: [ "ReadWriteOnce" ]
         storageClassName: {{ .Values.master.logs.storageClass }}

--- a/k8s/charts/seaweedfs/templates/volume-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/volume-statefulset.yaml
@@ -227,17 +227,32 @@ spec:
             path: {{ .Values.volume.data.hostPathPrefix }}/object_store/
             type: DirectoryOrCreate
         {{- end }}
+        {{- if eq .Values.volume.data.type "existingClaim" }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.volume.data.claimName }} 
+        {{- end }}
         {{- if and (eq .Values.volume.idx.type "hostPath") .Values.volume.dir_idx }}
         - name: idx
           hostPath:
             path: {{ .Values.volume.idx.hostPathPrefix }}/seaweedfs-volume-idx/
             type: DirectoryOrCreate
         {{- end }}
+        {{- if eq .Values.volume.idx.type "existingClaim" }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.volume.idx.claimName }} 
+        {{- end }}
         {{- if eq .Values.volume.logs.type "hostPath" }}
         - name: logs
           hostPath:
             path: {{ .Values.volume.logs.hostPathPrefix }}/logs/seaweedfs/volume
             type: DirectoryOrCreate
+        {{- end }}
+        {{- if eq .Values.volume.logs.type "existingClaim" }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.volume.data.claimName }} 
         {{- end }}
         {{- if .Values.global.enableSecurity }}
         - name: security-config

--- a/k8s/charts/seaweedfs/templates/volume-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/volume-statefulset.yaml
@@ -239,7 +239,7 @@ spec:
             type: DirectoryOrCreate
         {{- end }}
         {{- if eq .Values.volume.idx.type "existingClaim" }}
-        - name: data
+        - name: idx
           persistentVolumeClaim:
             claimName: {{ .Values.volume.idx.claimName }} 
         {{- end }}
@@ -250,7 +250,7 @@ spec:
             type: DirectoryOrCreate
         {{- end }}
         {{- if eq .Values.volume.logs.type "existingClaim" }}
-        - name: data
+        - name: logs
           persistentVolumeClaim:
             claimName: {{ .Values.volume.data.claimName }} 
         {{- end }}

--- a/k8s/charts/seaweedfs/templates/volume-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/volume-statefulset.yaml
@@ -288,6 +288,10 @@ spec:
     {{- if eq .Values.volume.data.type "persistentVolumeClaim"}}
     - metadata:
         name: data
+        {{- with .Values.volume.data.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       spec:
         accessModes: [ "ReadWriteOnce" ]
         storageClassName: {{ .Values.volume.data.storageClass }}
@@ -298,6 +302,10 @@ spec:
     {{- if and (eq .Values.volume.idx.type "persistentVolumeClaim") .Values.volume.dir_idx }}
     - metadata:
         name: idx
+        {{- with .Values.volume.idx.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       spec:
         accessModes: [ "ReadWriteOnce" ]
         storageClassName: {{ .Values.volume.idx.storageClass }}
@@ -308,6 +316,10 @@ spec:
     {{- if eq .Values.volume.logs.type "persistentVolumeClaim" }}
     - metadata:
         name: logs
+        {{- with .Values.volume.logs.annotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       spec:
         accessModes: [ "ReadWriteOnce" ]
         storageClassName: {{ .Values.volume.logs.storageClass }}

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -77,6 +77,12 @@ master:
   #    type: "persistentVolumeClaim"
   #    size: "24Ti"
   #    storageClass: "local-path-provisioner"
+  #
+  # You may also spacify an existing claim:
+  #  data:
+  #    type: "existingClaim"
+  #    claimName: "my-pvc"
+
   data:
     type: "hostPath"
     size: ""
@@ -222,6 +228,12 @@ volume:
 #    type: "persistentVolumeClaim"
 #    size: "24Ti"
 #    storageClass: "local-path-provisioner"
+#
+# You may also spacify an existing claim:
+#  data:
+#    type: "existingClaim"
+#    claimName: "my-pvc"
+
   data:
     type: "hostPath"
     size: ""
@@ -391,6 +403,11 @@ filer:
   #    type: "persistentVolumeClaim"
   #    size: "24Ti"
   #    storageClass: "local-path-provisioner"
+  #
+  # You may also spacify an existing claim:
+  #  data:
+  #    type: "existingClaim"
+  #    claimName: "my-pvc"
   data:
     type: "hostPath"
     size: ""

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -78,7 +78,7 @@ master:
   #    type: "persistentVolumeClaim"
   #    size: "24Ti"
   #    storageClass: "local-path-provisioner"
-  #    annotations: 
+  #    annotations:
   #      "key": "value"
   #
   # You may also spacify an existing claim:
@@ -231,7 +231,7 @@ volume:
   #    type: "persistentVolumeClaim"
   #    size: "24Ti"
   #    storageClass: "local-path-provisioner"
-  #    annotations: 
+  #    annotations:
   #      "key": "value"
   #
   # You may also spacify an existing claim:
@@ -408,7 +408,7 @@ filer:
   #    type: "persistentVolumeClaim"
   #    size: "24Ti"
   #    storageClass: "local-path-provisioner"
-  #    annotations: 
+  #    annotations:
   #      "key": "value"
   #
   # You may also spacify an existing claim:

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -72,17 +72,19 @@ master:
     # Enter any extra configuration for master.toml here.
     # It may be be a multi-line string.
 
-  # can use ANY storage-class , example with local-path-provisioner
+  # You may use ANY storage-class, example with local-path-provisioner
+  # Annotations are optional.
   #  data:
   #    type: "persistentVolumeClaim"
   #    size: "24Ti"
   #    storageClass: "local-path-provisioner"
+  #    annotations: 
+  #      "key": "value"
   #
   # You may also spacify an existing claim:
   #  data:
   #    type: "existingClaim"
   #    claimName: "my-pvc"
-
   data:
     type: "hostPath"
     size: ""
@@ -223,16 +225,19 @@ volume:
   # minimum free disk space(in percents). If free disk space lower this value - all volumes marks as ReadOnly
   minFreeSpacePercent: 7
 
-# can use ANY storage-class , example with local-path-provisioner
-#  data:
-#    type: "persistentVolumeClaim"
-#    size: "24Ti"
-#    storageClass: "local-path-provisioner"
-#
-# You may also spacify an existing claim:
-#  data:
-#    type: "existingClaim"
-#    claimName: "my-pvc"
+  # You may use ANY storage-class, example with local-path-provisioner
+  # Annotations are optional.
+  #  data:
+  #    type: "persistentVolumeClaim"
+  #    size: "24Ti"
+  #    storageClass: "local-path-provisioner"
+  #    annotations: 
+  #      "key": "value"
+  #
+  # You may also spacify an existing claim:
+  #  data:
+  #    type: "existingClaim"
+  #    claimName: "my-pvc"
 
   data:
     type: "hostPath"
@@ -397,12 +402,14 @@ filer:
   storage: 25Gi
   # storageClass is the class of storage which defaults to null (the Kube cluster will pick the default).
   storageClass: null
-
-  # can use ANY storage-class , example with local-path-provisioner
+  # You may use ANY storage-class, example with local-path-provisioner
+  # Annotations are optional.
   #  data:
   #    type: "persistentVolumeClaim"
   #    size: "24Ti"
   #    storageClass: "local-path-provisioner"
+  #    annotations: 
+  #      "key": "value"
   #
   # You may also spacify an existing claim:
   #  data:


### PR DESCRIPTION
# What problem are we solving?

As an administrator, I would like to create backups of S3 data stored in SeaweedFS to  external media or a storage provider for long-term archival and compliance purposes. I would also like to restore the backups to a live state in the event of an audit, system failure, or security incident.

# How are we solving the problem?

By adding support for initializing SeaweedFS using existing volume claims, and adding annotation to `VolumeClaimTemplates` we can enable [Restic](https://restic.readthedocs.io/en/stable/010_introduction.html)-based backup tools like [Velero](https://velero.io/) and [K8up](https://k8up.io/k8up/2.7/index.html) to conduct automated backups and restoration of SeaweedFS data.


# How is the PR tested?

The full process is documented here: [s3-backups.md](https://github.com/small-hack/argocd-apps/blob/eso-helm-chart-test/alpha/seaweedfs/backups/s3-backups.md) for reproducibility and will be added to the wiki upon approval. below is a summary:

1. Create a new kubernetes cluster using K3s
2. Install SeaweedFS as a local S3 provider
5. Install K8up and backup the 3 SeaweedFS PVCs to Backblaze B2.
6. Uninstall SeaweedFS  and delete its PVCs
7. Create PVCs and restore them from backups using  K8up 
8. Re-install SeaweedFS using existing claims and retrieve data


A more involved postgres cluster recovery is also documented here: [backups.md](https://github.com/small-hack/argocd-apps/blob/eso-helm-chart-test/alpha/seaweedfs/backups/backups.md) 

# Checks
- [ ] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
