### PR TITLE
Update helm_chart_release.yml - run helm chart release on push to master on changes to k8s/chart files

### DIFF
--- a/.github/workflows/helm_chart_release.yml
+++ b/.github/workflows/helm_chart_release.yml
@@ -1,8 +1,10 @@
 name: "helm: publish charts"
 on:
   push:
-    tags: 
-      - '*'
+    branches:
+      - master
+    paths:
+      - "k8s/charts/**"
 
 permissions:
   contents: write


### PR DESCRIPTION
# What problem are we solving?

When updates are done to the helm chart that are distinct from a release of SeaweedFS itself, the helm chart is not released because the GitHub Workflow only runs when someone tags a branch. 

# How are we solving the problem?

This changes the helm chart release to run on any push to the `master` branch in the `k8s/charts` directory. It will no longer run on tagging, as you need to bump the helm chart version every time you release anyway, so tagging wouldn't have worked for a release unless the chart version directory was updated

# How is the PR tested?

I created a PR on my fork to merge this `patch-1` branch into the `master` branch on my fork: https://github.com/jessebot/seaweedfs/pull/1

After merging that, I created and merged this PR: https://github.com/jessebot/seaweedfs/pull/2

The second PR just updates a small comment in the values.yaml for the helm chart and also the chart version is bumped by a patch. Then, I merge the PR and check if the release has happened, and it did. I verified it worked by running:

```console
$ helm repo add seaweedfs https://jessebot.github.io/seaweedfs/helm
"seaweedfs" has been added to your repositories

$ helm show chart seaweedfs/seaweedfs
apiVersion: v1
appVersion: "3.59"
description: SeaweedFS
name: seaweedfs
version: 3.59.2
```

Version `3.59.2` matches the change I made here: 
https://github.com/jessebot/seaweedfs/pull/2/files?diff=unified&w=0#diff-c1a68b11f62c437872b9f7de591b7b2ea31cd79a49c65b52cf7ad612c00a33ccR5

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
