### PR TITLE
fix TestMisplacedChecking() and add test-case

### DIFF
--- a/weed/shell/command_volume_fix_replication_test.go
+++ b/weed/shell/command_volume_fix_replication_test.go
@@ -332,7 +332,10 @@ func TestMisplacedChecking(t *testing.T) {
 					location: &location{"dc1", "r1", &master_pb.DataNodeInfo{Id: "dn1"}},
 				},
 				{
-					location: &location{"dc1", "r2", &master_pb.DataNodeInfo{Id: "dn2"}},
+					location: &location{"dc1", "r1", &master_pb.DataNodeInfo{Id: "dn2"}},
+				},
+				{
+					location: &location{"dc1", "r2", &master_pb.DataNodeInfo{Id: "dn3"}},
 				},
 			},
 			expected: false,
@@ -345,10 +348,13 @@ func TestMisplacedChecking(t *testing.T) {
 					location: &location{"dc1", "r1", &master_pb.DataNodeInfo{Id: "dn1"}},
 				},
 				{
-					location: &location{"dc1", "r2", &master_pb.DataNodeInfo{Id: "dn2"}},
+					location: &location{"dc1", "r1", &master_pb.DataNodeInfo{Id: "dn2"}},
+				},
+				{
+					location: &location{"dc2", "r2", &master_pb.DataNodeInfo{Id: "dn3"}},
 				},
 			},
-			expected: false,
+			expected: true,
 		},
 		{
 			name:        "test 100",


### PR DESCRIPTION
# What problem are we solving?

TestMisplacedChecking() is missing "replicas" for some of the tests.

# How are we solving the problem?

I added the missing "replicas" to the test and modified it to cover issue #4836
