### PR TITLE
Add a way to use a JWT sent in an HTTP only cookie

### DIFF
--- a/weed/security/jwt.go
+++ b/weed/security/jwt.go
@@ -83,6 +83,14 @@ func GetJwt(r *http.Request) EncodedJwt {
 		}
 	}
 
+	// Get token from http only cookie
+	if tokenStr == "" {
+		token, err := r.Cookie("AT")
+		if err == nil {
+			tokenStr = token.Value
+		}
+	}
+
 	return EncodedJwt(tokenStr)
 }
 


### PR DESCRIPTION
If a JWT is not included in the Authorization header or a query string, attempt to get a JWT from an HTTP only cookie.

# What problem are we solving?

**The problem**

The Filer can receive and parse a JWT from an `Authorization: Bearer` header and from a query string, but not from an HTTP only cookie. 

**Why would the JWT be in an HTTP only cookie?**

A JWT would be in an HTTP only cookie when using a web client that receives JWTs from a server configured to send the JWT back to the client in an HTTP only cookie for security reasons. When a server sets an HTTP only cookie on a response, the browser then begins to send the cookie with each subsequent request. The JavaScript code run in the browser cannot access the JWT for security reasons, making the traditional method of appending the JWT to the Authorization header impossible.

**End result**

This change allows the Filer to retrieve the JWT from a cookie present on a request. 

# How are we solving the problem?

After the JWT is not found on either the header or the query string, we check to see if the JWT is present on a cookie labeled "AT" which stands for Access Token. If the JWT is present in said cookie, it is treated the same way as if it was found in the header or query string. 

# How is the PR tested?

I tested this new function on my local machine and it worked with JWTs required for reads and writes. I have a secondary server writing the cookies to a response, where the browser client who made the request stores the cookies and passes them to SeaweedFS. 

# Notes

Feel free to change the title of the cookie. This is only what made sense to me and seemed to follow practices I've seen elsewhere, but not everywhere.

# Checks
- [ ] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
