### PR TITLE
Always include volumes in statefulsets

### DIFF
--- a/k8s/charts/seaweedfs/templates/_helpers.tpl
+++ b/k8s/charts/seaweedfs/templates/_helpers.tpl
@@ -122,19 +122,6 @@ Inject extra environment vars in the format key:value, if populated
 {{- end -}}
 {{- end -}}
 
-{{/* check if any Volume HostPath exists */}}
-{{- define "volume.hostpath_exists" -}}
-{{- if or (or (eq .Values.volume.data.type "hostPath") (and (eq .Values.volume.idx.type "hostPath") .Values.volume.dir_idx )) (eq .Values.volume.logs.type "hostPath") -}}
-{{- printf "true" -}}
-{{- else -}}
-{{- if or .Values.global.enableSecurity .Values.volume.extraVolumes -}}
-{{- printf "true" -}}
-{{- else -}}
-{{- printf "" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
 {{/* check if any Filer PVC exists */}}
 {{- define "filer.pvc_exists" -}}
 {{- if or (eq .Values.filer.data.type "persistentVolumeClaim") (eq .Values.filer.logs.type "persistentVolumeClaim") -}}
@@ -144,40 +131,9 @@ Inject extra environment vars in the format key:value, if populated
 {{- end -}}
 {{- end -}}
 
-{{/* check if any Filer HostPath exists */}}
-{{- define "filer.hostpath_exists" -}}
-{{- if or (eq .Values.filer.data.type "hostPath") (eq .Values.filer.logs.type "hostPath") -}}
-{{- printf "true" -}}
-{{- else -}}
-{{- printf "" -}}
-{{- end -}}
-{{- end -}}
-
 {{/* check if any Master PVC exists */}}
 {{- define "master.pvc_exists" -}}
 {{- if or (eq .Values.master.data.type "persistentVolumeClaim") (eq .Values.master.logs.type "persistentVolumeClaim") -}}
-{{- printf "true" -}}
-{{- else -}}
-{{- printf "" -}}
-{{- end -}}
-{{- end -}}
-
-{{/* check if any Master HostPath exists */}}
-{{- define "master.hostpath_exists" -}}
-{{- if or (eq .Values.master.data.type "hostPath") (eq .Values.master.logs.type "hostPath") -}}
-{{- printf "true" -}}
-{{- else -}}
-{{- if or .Values.global.enableSecurity .Values.volume.extraVolumes -}}
-{{- printf "true" -}}
-{{- else -}}
-{{- printf "" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
-{{/* check if any Master existingClaim is defined */}}
-{{- define "master.existing_claims" -}}
-{{- if or (eq .Values.master.data.type "existingClaim") (eq .Values.master.logs.type "existingClaim") -}}
 {{- printf "true" -}}
 {{- else -}}
 {{- printf "" -}}

--- a/k8s/charts/seaweedfs/templates/master-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/master-statefulset.yaml
@@ -212,9 +212,6 @@ spec:
           resources:
             {{ tpl .Values.master.resources . | nindent 12 | trim }}
           {{- end }}
-      {{- $hostpath_exists := include "master.hostpath_exists" . -}}
-      {{- $existing_claims := include "master.existing_claims" . -}}
-      {{- if or ($hostpath_exists) ($existing_claims) }}
       volumes:
         {{- if eq .Values.master.logs.type "hostPath" }}
         - name: seaweedfs-master-log-volume
@@ -262,7 +259,6 @@ spec:
             secretName: {{ template "seaweedfs.name" . }}-client-cert
         {{- end }}
         {{ tpl .Values.master.extraVolumes . | indent 8 | trim }}
-      {{- end }}
       {{- if .Values.master.nodeSelector }}
       nodeSelector:
         {{ tpl .Values.master.nodeSelector . | indent 8 | trim }}

--- a/k8s/charts/seaweedfs/templates/volume-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/volume-statefulset.yaml
@@ -218,8 +218,6 @@ spec:
           resources:
             {{ tpl .Values.volume.resources . | nindent 12 | trim }}
           {{- end }}
-      {{- $hostpath_exists := include "volume.hostpath_exists" . -}}
-      {{- if $hostpath_exists }}
       volumes:
         {{- if eq .Values.volume.data.type "hostPath" }}
         - name: data
@@ -276,7 +274,6 @@ spec:
         {{- end }}
       {{- if .Values.volume.extraVolumes }}
         {{ tpl .Values.volume.extraVolumes . | indent 8 | trim }}
-      {{- end }}
       {{- end }}
       {{- if .Values.volume.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
# What problem are we solving?

When both `master.data.type` and `master.logs.type` is `persistentVolumeClaim`, deployment of the Helm chart fails:

```
create Pod seaweedfs-master-0 in StatefulSet seaweedfs-master failed error: Pod "seaweedfs-master-0" is invalid: spec.containers[0].volumeMounts[1].name: Not found: "master-config"
```

This is due to a condition that omits the entire volumes section in this case:

https://github.com/seaweedfs/seaweedfs/blob/d5d9fbb8aa5e86f2b866e25f58bf36a7a989478d/k8s/charts/seaweedfs/templates/master-statefulset.yaml#L217C20-L217C20

The issue was introduced by #4797, as it did not take into account this condition.

# How are we solving the problem?

I removed the conditions entirely, including the ones for volume-statefulset. They also interfere with a bunch of other options (`extraVolumes`, `enableSecurity`).

# How is the PR tested?

For the default configuration (using hostPath volumes), deployment works before and after my changes. For a configuration that uses PVCs instead, deployments fail before and work after. 

An example values.yaml to trigger the bug:

```
seaweedfs:
  master:
    data:
      type: persistentVolumeClaim
    logs:
      type: persistentVolumeClaim
```

# Checks

I am unsure if these are relevant for this PR.

- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.

