### PR TITLE
[filerstore] mysql falls back to update only if error contains  msg "duplicate entry"

### DIFF
--- a/weed/filer/abstract_sql/abstract_sql_store.go
+++ b/weed/filer/abstract_sql/abstract_sql_store.go
@@ -161,31 +161,24 @@ func (store *AbstractSqlStore) InsertEntry(ctx context.Context, entry *filer.Ent
 	if len(entry.GetChunks()) > filer.CountEntryChunksForGzip {
 		meta = util.MaybeGzipData(meta)
 	}
-
+	sqlInsert := "insert"
 	res, err := db.ExecContext(ctx, store.GetSqlInsert(bucket), util.HashStringToLong(dir), name, dir, meta)
-	if err == nil {
-		return
+	if err != nil && strings.Contains(strings.ToLower(err.Error()), "duplicate entry") {
+		// now the insert failed possibly due to duplication constraints
+		sqlInsert = "falls back to update"
+		glog.V(1).Infof("insert %s %s: %v", entry.FullPath, sqlInsert, err)
+		res, err = db.ExecContext(ctx, store.GetSqlUpdate(bucket), meta, util.HashStringToLong(dir), name, dir)
 	}
-
-	if !strings.Contains(strings.ToLower(err.Error()), "duplicate") {
-		// return fmt.Errorf("insert: %s", err)
-		// skip this since the error can be in a different language
-	}
-
-	// now the insert failed possibly due to duplication constraints
-	glog.V(1).Infof("insert %s falls back to update: %v", entry.FullPath, err)
-
-	res, err = db.ExecContext(ctx, store.GetSqlUpdate(bucket), meta, util.HashStringToLong(dir), name, dir)
 	if err != nil {
-		return fmt.Errorf("upsert %s: %s", entry.FullPath, err)
+		return fmt.Errorf("%s %s: %s", sqlInsert, entry.FullPath, err)
 	}
 
 	_, err = res.RowsAffected()
 	if err != nil {
-		return fmt.Errorf("upsert %s but no rows affected: %s", entry.FullPath, err)
+		return fmt.Errorf("%s %s but no rows affected: %s", sqlInsert, entry.FullPath, err)
 	}
-	return nil
 
+	return nil
 }
 
 func (store *AbstractSqlStore) UpdateEntry(ctx context.Context, entry *filer.Entry) (err error) {


### PR DESCRIPTION
https://github.com/seaweedfs/seaweedfs/issues/5062

# What problem are we solving?

Reducing chaos when inserting rows

# How are we solving the problem?

falls back to update only if error contains  msg "duplicate entry"

# How is the PR tested?

localy

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
