### PR TITLE
Remote gateway Bug fix

### DIFF
--- a/weed/filer/remote_mapping.go
+++ b/weed/filer/remote_mapping.go
@@ -15,9 +15,11 @@ func ReadMountMappings(grpcDialOption grpc.DialOption, filerAddress pb.ServerAdd
 		oldContent, readErr = ReadInsideFiler(client, DirectoryEtcRemote, REMOTE_STORAGE_MOUNT_FILE)
 		return readErr
 	}); readErr != nil {
-		return nil, readErr
+		if readErr != filer_pb.ErrNotFound {
+			return nil, fmt.Errorf("read existing mapping: %v", readErr)
+		}
+		oldContent = nil
 	}
-
 	mappings, readErr = UnmarshalRemoteStorageMappings(oldContent)
 	if readErr != nil {
 		return nil, fmt.Errorf("unmarshal mappings: %v", readErr)


### PR DESCRIPTION
 - Remote gateway problem with mappings in filer when they are not present

# What problem are we solving?
So this comes from here: 
https://github.com/seaweedfs/seaweedfs/pull/5054#issuecomment-1848402868

There is a problem with `weed filer.remote.gateway`.
When you have a fresh installation and no mounts, then the mapping config file is not present. So when you try to use `weed filer.remote.gateway` it can't access the mapping file and will encounter an error.
So There was two solutions:
- You can do a dummy mount to mapping file get creates.
- I changed the code to work even when the mapping file is not present.


# How are we solving the problem?

So easy, just adding an if statement to check if the error was `file not found error` then ignores it and set the oldContent to `nil`
This procedure is not from me and is present in `InsertMountMapping` function inside `remote_storage`

Here is the change:
```
readErr != nil {
		if readErr != filer_pb.ErrNotFound {
			return nil, fmt.Errorf("read existing mapping: %v", readErr)
		}
		oldContent = nil
	}
```

Before this change, because the code wasn't able to find the mapping file in fresh installation it was not able to start `filer.remote.gateway`, But now it will make it's content `nil` and continue its work.  The mapping file will be created when `filer.remote.gateway` start its work.

# How is the PR tested?

Local test environment(on docker compose) for backup
Also checked it in kubernetes deployment. 


# Checks
Doesn't need change in wiki