### PR TITLE
Remote gateway options bug fix

### DIFF
--- a/weed/command/filer_remote_gateway_buckets.go
+++ b/weed/command/filer_remote_gateway_buckets.go
@@ -224,7 +224,7 @@ func (option *RemoteGatewayOptions) makeBucketedEventProcessor(filerSource *sour
 			if writeErr != nil {
 				return writeErr
 			}
-			return updateLocalEntry(&remoteSyncOptions, message.NewParentPath, message.NewEntry, remoteEntry)
+			return updateLocalEntry(&remoteGatewayOptions, message.NewParentPath, message.NewEntry, remoteEntry)
 		}
 		if filer_pb.IsDelete(resp) {
 			if resp.Directory == option.bucketsDir {
@@ -288,7 +288,7 @@ func (option *RemoteGatewayOptions) makeBucketedEventProcessor(filerSource *sour
 						if writeErr != nil {
 							return writeErr
 						}
-						return updateLocalEntry(&remoteSyncOptions, message.NewParentPath, message.NewEntry, remoteEntry)
+						return updateLocalEntry(&remoteGatewayOptions, message.NewParentPath, message.NewEntry, remoteEntry)
 					}
 				}
 			}
@@ -325,7 +325,7 @@ func (option *RemoteGatewayOptions) makeBucketedEventProcessor(filerSource *sour
 				if writeErr != nil {
 					return writeErr
 				}
-				return updateLocalEntry(&remoteSyncOptions, message.NewParentPath, message.NewEntry, remoteEntry)
+				return updateLocalEntry(&remoteGatewayOptions, message.NewParentPath, message.NewEntry, remoteEntry)
 			}
 		}
 

--- a/weed/filer/remote_mapping.go
+++ b/weed/filer/remote_mapping.go
@@ -15,9 +15,11 @@ func ReadMountMappings(grpcDialOption grpc.DialOption, filerAddress pb.ServerAdd
 		oldContent, readErr = ReadInsideFiler(client, DirectoryEtcRemote, REMOTE_STORAGE_MOUNT_FILE)
 		return readErr
 	}); readErr != nil {
-		return nil, readErr
+		if readErr != filer_pb.ErrNotFound {
+			return nil, fmt.Errorf("read existing mapping: %v", readErr)
+		}
+		oldContent = nil
 	}
-
 	mappings, readErr = UnmarshalRemoteStorageMappings(oldContent)
 	if readErr != nil {
 		return nil, fmt.Errorf("unmarshal mappings: %v", readErr)


### PR DESCRIPTION
# What problem are we solving?
I encountered the issue when i was trying to have a `filer.remote.gateway` instance for async backup.
The problem is that when you set filer address in `filer.remote.gateway` `-filer` flag, It won't use the filer address and encounters error while trying to write to the filer. Actually it uses RemoteSyncOptions instead of RemoteGatewayOptions. So because RemoteSyncOptions have default values it will use localhost:8888 as filer address and will ignore the actual filer address.

# How are we solving the problem?
By changing `filer_remote_gateway_buckets.go` file to use `RemoteGatewayOptions` instead of `RemoteSyncOptions` 

# How is the PR tested?
Locally on docker compose


# Checks
No need for editing wiki