### PR TITLE
Update helm_ci.yml - add `ct` flag `--target-branch ${{ github.event.repository.default_branch }}`

### DIFF
--- a/.github/workflows/helm_ci.yml
+++ b/.github/workflows/helm_ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --chart-dirs k8s/charts)
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }} --chart-dirs k8s/charts)
           if [[ -n "$changed" ]]; then
             echo "::set-output name=changed::true"
           fi

--- a/.github/workflows/helm_ci.yml
+++ b/.github/workflows/helm_ci.yml
@@ -42,10 +42,10 @@ jobs:
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint --all --validate-maintainers=false --chart-dirs k8s/charts
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }} --all --validate-maintainers=false --chart-dirs k8s/charts
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.8.0
 
       - name: Run chart-testing (install)
-        run: ct install --all --chart-dirs k8s/charts
+        run: ct install --target-branch ${{ github.event.repository.default_branch }} --all --chart-dirs k8s/charts


### PR DESCRIPTION
# What problem are we solving?
Right now, there's no check in ci to make sure that the Version in Chart.yaml for the seaweedfs helm chart has been bumped.

# How are we solving the problem?
This adds the `--target-branch` flag to the `ct` `list-changed`,`lint`, and `install` commands we run for the helm chart. This will validate the chart against the previous version of the chart for things such as the chart version.

# How is the PR tested?
We use it in the community nextcloud/helm chart:
https://github.com/nextcloud/helm/blob/main/.github/workflows/lint-test.yaml

If the chart version isn't bumped, it will error like [this](https://github.com/nextcloud/helm/actions/runs/7045807982/job/19244291477#step:7:37):

```logtalk
Linting chart "nextcloud => (version: \"4.5.3\", path: \"charts/nextcloud\")"
Checking chart "nextcloud => (version: \"4.5.3\", path: \"charts/nextcloud\")" for a version bump...
Old chart version: 4.5.4
Error: failed linting charts: failed processing charts
New chart version: 4.5.3

------------------------------------------------------------------------------------------------------------------------
 ✖︎ nextcloud => (version: "4.5.3", path: "charts/nextcloud") > chart version not ok. Needs a version bump! 
------------------------------------------------------------------------------------------------------------------------
failed linting charts: failed processing charts
Error: Process completed with exit code 1.
```

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
