### PR TITLE
Fix: helm: remove deprecated values that caused helm template error for post install hook

### DIFF
--- a/k8s/charts/seaweedfs/Chart.yaml
+++ b/k8s/charts/seaweedfs/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: SeaweedFS
 name: seaweedfs
 appVersion: "3.59"
-version: 3.59.4
+version: 3.60.0

--- a/k8s/charts/seaweedfs/templates/post-install-bucket-hook.yaml
+++ b/k8s/charts/seaweedfs/templates/post-install-bucket-hook.yaml
@@ -80,9 +80,6 @@ spec:
           {{- end }}
           - containerPort: {{ .Values.master.grpcPort }}
             #name: swfs-master-grpc
-        {{- if .Values.master.readinessProbe.enabled }}
-    {{- $hostpath_exists := include "master.hostpath_exists" . -}}
-    {{- $existing_claims := include "master.existing_claims" . -}}
     {{- if .Values.filer.s3.enableAuth }}
       volumes:
         - name: config-users
@@ -93,8 +90,7 @@ spec:
             {{- else }}
             secretName: seaweedfs-s3-secret
             {{- end }}
-        {{- end }}
-{{- end }}
-{{- end }}
-{{- end }}
-{{- end }}
+    {{- end }}{{/** if .Values.filer.s3.enableAuth **/}}
+{{- end }}{{/** if .Values.master.enabled **/}}
+{{- end }}{{/** if .Values.filer.s3.enabled **/}}
+{{- end }}{{/** if .Values.filer.s3.createBuckets **/}}


### PR DESCRIPTION
# What problem are we solving?

This fixes #5107 where there was a templating error in the bucket creation job, due to removed named templates (`master.hostpath_exists` and `master.existing_claims`) which you can see [here](https://github.com/seaweedfs/seaweedfs/pull/5081/files#diff-6cbd4f7b20a68ffff3c0a6d9364c83eefab404de24666459d1cf2bfc3ecfecdcL165) in #5081.

# How are we solving the problem?

I removed the named templates from the `post-install-bucket-hook.yaml`.

Please merge this PR, https://github.com/seaweedfs/seaweedfs/pull/5106, first so we get better checks. edit: it's been merged already :)

This also bumps the chart version.

# How is the PR tested?

```console
helm template . --values test-values.yaml
```

where test-values.yaml is exactly the same as values.yaml except that `filer.s3.createBucket` is set like:

```yaml
filer:
  s3:
    createBuckets:
      - name: bucket-a
        anonymousRead: false
```

It should print the full template with this error on when using the `master` branch:

> Error: template: seaweedfs/templates/post-install-bucket-hook.yaml:84:28: executing "seaweedfs/templates/post-install-bucket-hook.yaml" at <include "master.hostpath_exists" .>: error calling include: template: no template "master.hostpath_exists" associated with template "gotpl"

And it should print no error on my fork's fix branch here.

<details>
<summary>Example of the <code>post-install-bucket-hook.yaml</code> file rendered from my fix branch</summary>

```yaml
---
# Source: seaweedfs/templates/post-install-bucket-hook.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: "release-name-bucket-hook"
  labels:
    app.kubernetes.io/managed-by: "Helm"
    app.kubernetes.io/instance: "release-name"
  annotations:
    "helm.sh/hook": post-install
    "helm.sh/hook-weight": "-5"
    "helm.sh/hook-delete-policy": hook-succeeded
spec:
  template:
    metadata:
      name: "release-name"
      labels:
        app.kubernetes.io/managed-by: "Helm"
        app.kubernetes.io/instance: "release-name"
    spec:
      restartPolicy: Never
      containers:
      - name: post-install-job
        image: chrislusf/seaweedfs:3.59
        env:
          - name: WEED_CLUSTER_DEFAULT
            value: "sw"
          - name: WEED_CLUSTER_SW_MASTER
            value: "seaweedfs-master.argocd:9333"
          - name: WEED_CLUSTER_SW_FILER
            value: "seaweedfs-filer-client.argocd:8888"
          - name: POD_IP
            valueFrom:
              fieldRef:
                fieldPath: status.podIP
          - name: POD_NAME
            valueFrom:
              fieldRef:
                fieldPath: metadata.name
          - name: NAMESPACE
            valueFrom:
              fieldRef:
                fieldPath: metadata.namespace
          - name: SEAWEEDFS_FULLNAME
            value: "seaweedfs"
        command:
          - "/bin/sh"
          - "-ec"
          - |
            exec /bin/echo \
            "s3.bucket.create --name bucket-a" |\
            /usr/bin/weed shell
        volumeMounts:
          - name: config-users
            mountPath: /etc/sw
            readOnly: true
        ports:
          - containerPort: 9333
            name: swfs-master
          - containerPort: 19333
            #name: swfs-master-grpc
      volumes:
        - name: config-users
          secret:
            defaultMode: 420
            secretName: seaweedfs-s3-secret
```

</details>

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
