### PR TITLE
Set allowed origins in config

### DIFF
--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -258,7 +258,7 @@ func (fo *FilerOptions) startFiler() {
 		ShowUIDirectoryDelete: *fo.showUIDirectoryDelete,
 		DownloadMaxBytesPs:    int64(*fo.downloadMaxMBps) * 1024 * 1024,
 		DiskType:              *fo.diskType,
-		AllowedOrigins:        *fo.allowedOrigins,
+		AllowedOrigins:        strings.Split(*fo.allowedOrigins, ","),
 	})
 	if nfs_err != nil {
 		glog.Fatalf("Filer startup error: %v", nfs_err)

--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -61,6 +61,7 @@ type FilerOptions struct {
 	showUIDirectoryDelete   *bool
 	downloadMaxMBps         *int
 	diskType                *string
+	allowedOrigins          *string
 }
 
 func init() {
@@ -91,6 +92,7 @@ func init() {
 	f.showUIDirectoryDelete = cmdFiler.Flag.Bool("ui.deleteDir", true, "enable filer UI show delete directory button")
 	f.downloadMaxMBps = cmdFiler.Flag.Int("downloadMaxMBps", 0, "download max speed for each download request, in MB per second")
 	f.diskType = cmdFiler.Flag.String("disk", "", "[hdd|ssd|<tag>] hard drive or solid state drive or any tag")
+	f.allowedOrigins = cmdFiler.Flag.String("allowedOrigins", "*", "comma separated list of allowed origins")
 
 	// start s3 on filer
 	filerStartS3 = cmdFiler.Flag.Bool("s3", false, "whether to start S3 gateway")
@@ -229,6 +231,9 @@ func (fo *FilerOptions) startFiler() {
 	if *fo.bindIp == "" {
 		*fo.bindIp = *fo.ip
 	}
+	if *fo.allowedOrigins == "" {
+		*fo.allowedOrigins = "*"
+	}
 
 	defaultLevelDbDirectory := util.ResolvePath(*fo.defaultLevelDbDirectory + "/filerldb2")
 
@@ -253,6 +258,7 @@ func (fo *FilerOptions) startFiler() {
 		ShowUIDirectoryDelete: *fo.showUIDirectoryDelete,
 		DownloadMaxBytesPs:    int64(*fo.downloadMaxMBps) * 1024 * 1024,
 		DiskType:              *fo.diskType,
+		AllowedOrigins:        *fo.allowedOrigins,
 	})
 	if nfs_err != nil {
 		glog.Fatalf("Filer startup error: %v", nfs_err)

--- a/weed/command/s3.go
+++ b/weed/command/s3.go
@@ -42,6 +42,7 @@ type S3Options struct {
 	portGrpc                  *int
 	config                    *string
 	domainName                *string
+	allowedOrigins            *string
 	tlsPrivateKey             *string
 	tlsCertificate            *string
 	tlsCACertificate          *string
@@ -64,6 +65,7 @@ func init() {
 	s3StandaloneOptions.portHttps = cmdS3.Flag.Int("port.https", 0, "s3 server https listen port")
 	s3StandaloneOptions.portGrpc = cmdS3.Flag.Int("port.grpc", 0, "s3 server grpc listen port")
 	s3StandaloneOptions.domainName = cmdS3.Flag.String("domainName", "", "suffix of the host name in comma separated list, {bucket}.{domainName}")
+	s3StandaloneOptions.allowedOrigins = cmdS3.Flag.String("allowedOrigins", "*", "comma separated list of allowed origins")
 	s3StandaloneOptions.dataCenter = cmdS3.Flag.String("dataCenter", "", "prefer to read and write to volumes in this data center")
 	s3StandaloneOptions.config = cmdS3.Flag.String("config", "", "path to the config file")
 	s3StandaloneOptions.auditLogConfig = cmdS3.Flag.String("auditLogConfig", "", "path to the audit log config file")
@@ -220,6 +222,7 @@ func (s3opt *S3Options) startS3Server() bool {
 		Port:                      *s3opt.port,
 		Config:                    *s3opt.config,
 		DomainName:                *s3opt.domainName,
+		AllowedOrigins:            *s3opt.allowedOrigins,
 		BucketsPath:               filerBucketsPath,
 		GrpcDialOption:            grpcDialOption,
 		AllowEmptyFolder:          *s3opt.allowEmptyFolder,

--- a/weed/command/s3.go
+++ b/weed/command/s3.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
@@ -222,7 +223,7 @@ func (s3opt *S3Options) startS3Server() bool {
 		Port:                      *s3opt.port,
 		Config:                    *s3opt.config,
 		DomainName:                *s3opt.domainName,
-		AllowedOrigins:            *s3opt.allowedOrigins,
+		AllowedOrigins:            strings.Split(*s3opt.allowedOrigins, ","),
 		BucketsPath:               filerBucketsPath,
 		GrpcDialOption:            grpcDialOption,
 		AllowEmptyFolder:          *s3opt.allowEmptyFolder,

--- a/weed/command/scaffold/security.toml
+++ b/weed/command/scaffold/security.toml
@@ -4,9 +4,9 @@
 #    /etc/seaweedfs/security.toml
 # this file is read by master, volume server, and filer
 
-# comma separated origins allowed to make requests to the filer. Should be in this format:
-# https://domain.com, or http://localhost:port
-[filer.allowed_origins]
+# comma separated origins allowed to make requests to the filer and s3 gateway. 
+# enter in this format: https://domain.com, or http://localhost:port
+[cors.allowed_origins]
 values = "*"
 
 # this jwt signing key is read by master and volume server, and it is used for write operations:

--- a/weed/command/scaffold/security.toml
+++ b/weed/command/scaffold/security.toml
@@ -4,6 +4,11 @@
 #    /etc/seaweedfs/security.toml
 # this file is read by master, volume server, and filer
 
+# comma separated origins allowed to make requests to the filer. Should be in this format:
+# https://domain.com, or http://localhost:port
+[filer.allowed_origins]
+values = "*"
+
 # this jwt signing key is read by master and volume server, and it is used for write operations:
 # - the Master server generates the JWT, which can be used to write a certain file on a volume server
 # - the Volume server validates the JWT on writing

--- a/weed/command/server.go
+++ b/weed/command/server.go
@@ -240,6 +240,9 @@ func runServer(cmd *Command, args []string) bool {
 	webdavOptions.filer = &filerAddress
 	mqBrokerOptions.filerGroup = filerOptions.filerGroup
 
+	filerOptions.allowedOrigins = f.allowedOrigins
+	s3Options.allowedOrigins = f.allowedOrigins
+
 	go stats_collect.StartMetricsServer(*serverBindIp, *serverMetricsHttpPort)
 
 	folders := strings.Split(*volumeDataFolders, ",")

--- a/weed/command/server.go
+++ b/weed/command/server.go
@@ -106,6 +106,7 @@ func init() {
 	filerOptions.port = cmdServer.Flag.Int("filer.port", 8888, "filer server http listen port")
 	filerOptions.portGrpc = cmdServer.Flag.Int("filer.port.grpc", 0, "filer server grpc listen port")
 	filerOptions.publicPort = cmdServer.Flag.Int("filer.port.public", 0, "filer server public http listen port")
+	filerOptions.allowedOrigins = cmdServer.Flag.String("filer.allowedOrigins", "*", "comma separated list of allowed origins")
 	filerOptions.defaultReplicaPlacement = cmdServer.Flag.String("filer.defaultReplicaPlacement", "", "default replication type. If not specified, use master setting.")
 	filerOptions.disableDirListing = cmdServer.Flag.Bool("filer.disableDirListing", false, "turn off directory listing")
 	filerOptions.maxMB = cmdServer.Flag.Int("filer.maxMB", 4, "split files larger than the limit")
@@ -142,6 +143,7 @@ func init() {
 	s3Options.portHttps = cmdServer.Flag.Int("s3.port.https", 0, "s3 server https listen port")
 	s3Options.portGrpc = cmdServer.Flag.Int("s3.port.grpc", 0, "s3 server grpc listen port")
 	s3Options.domainName = cmdServer.Flag.String("s3.domainName", "", "suffix of the host name in comma separated list, {bucket}.{domainName}")
+	s3Options.allowedOrigins = cmdServer.Flag.String("s3.allowedOrigins", "*", "comma separated list of allowed origins")
 	s3Options.tlsPrivateKey = cmdServer.Flag.String("s3.key.file", "", "path to the TLS private key file")
 	s3Options.tlsCertificate = cmdServer.Flag.String("s3.cert.file", "", "path to the TLS certificate file")
 	s3Options.tlsCACertificate = cmdServer.Flag.String("s3.cacert.file", "", "path to the TLS CA certificate file")
@@ -239,9 +241,6 @@ func runServer(cmd *Command, args []string) bool {
 	iamOptions.filer = &filerAddress
 	webdavOptions.filer = &filerAddress
 	mqBrokerOptions.filerGroup = filerOptions.filerGroup
-
-	filerOptions.allowedOrigins = f.allowedOrigins
-	s3Options.allowedOrigins = f.allowedOrigins
 
 	go stats_collect.StartMetricsServer(*serverBindIp, *serverMetricsHttpPort)
 

--- a/weed/filer/filer.go
+++ b/weed/filer/filer.go
@@ -3,11 +3,12 @@ package filer
 import (
 	"context"
 	"fmt"
-	"github.com/seaweedfs/seaweedfs/weed/cluster/lock_manager"
 	"os"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/cluster/lock_manager"
 
 	"github.com/seaweedfs/seaweedfs/weed/cluster"
 	"github.com/seaweedfs/seaweedfs/weed/pb"

--- a/weed/s3api/s3api_handlers.go
+++ b/weed/s3api/s3api_handlers.go
@@ -40,6 +40,10 @@ func writeSuccessResponseEmpty(w http.ResponseWriter, r *http.Request) {
 	s3err.WriteEmptyResponse(w, r, http.StatusOK)
 }
 
+func writeFailureResponse(w http.ResponseWriter, r *http.Request, errCode s3err.ErrorCode) {
+	s3err.WriteErrorResponse(w, r, errCode)
+}
+
 func validateContentMd5(h http.Header) ([]byte, error) {
 	md5B64, ok := h["Content-Md5"]
 	if ok {

--- a/weed/s3api/s3api_server.go
+++ b/weed/s3api/s3api_server.go
@@ -3,14 +3,15 @@ package s3api
 import (
 	"context"
 	"fmt"
-	"github.com/seaweedfs/seaweedfs/weed/filer"
-	"github.com/seaweedfs/seaweedfs/weed/glog"
-	"github.com/seaweedfs/seaweedfs/weed/pb/s3_pb"
-	"github.com/seaweedfs/seaweedfs/weed/util/grace"
 	"net"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/filer"
+	"github.com/seaweedfs/seaweedfs/weed/glog"
+	"github.com/seaweedfs/seaweedfs/weed/pb/s3_pb"
+	"github.com/seaweedfs/seaweedfs/weed/util/grace"
 
 	"github.com/gorilla/mux"
 	"github.com/seaweedfs/seaweedfs/weed/pb"
@@ -26,6 +27,7 @@ type S3ApiServerOption struct {
 	Port                      int
 	Config                    string
 	DomainName                string
+	AllowedOrigins            string
 	BucketsPath               string
 	GrpcDialOption            grpc.DialOption
 	AllowEmptyFolder          bool
@@ -103,7 +105,7 @@ func (s3a *S3ApiServer) registerRouter(router *mux.Router) {
 
 	apiRouter.Methods("OPTIONS").HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Origin", s3a.option.AllowedOrigins)
 			w.Header().Set("Access-Control-Expose-Headers", "*")
 			w.Header().Set("Access-Control-Allow-Methods", "*")
 			w.Header().Set("Access-Control-Allow-Headers", "*")

--- a/weed/security/jwt.go
+++ b/weed/security/jwt.go
@@ -83,6 +83,14 @@ func GetJwt(r *http.Request) EncodedJwt {
 		}
 	}
 
+	// Get token from http only cookie
+	if tokenStr == "" {
+		token, err := r.Cookie("AT")
+		if err == nil {
+			tokenStr = token.Value
+		}
+	}
+
 	return EncodedJwt(tokenStr)
 }
 

--- a/weed/server/filer_server.go
+++ b/weed/server/filer_server.go
@@ -109,10 +109,10 @@ func NewFilerServer(defaultMux, readonlyMux *http.ServeMux, option *FilerOption)
 	v.SetDefault("jwt.filer_signing.read.expires_after_seconds", 60)
 	readExpiresAfterSec := v.GetInt("jwt.filer_signing.read.expires_after_seconds")
 
-	v.SetDefault("filer.allowed_origins.values", "*")
+	v.SetDefault("cors.allowed_origins.values", "*")
 
 	if (option.AllowedOrigins == nil) || (len(option.AllowedOrigins) == 0) {
-		allowedOrigins := v.GetString("filer.allowed_origins.values")
+		allowedOrigins := v.GetString("cors.allowed_origins.values")
 		domains := strings.Split(allowedOrigins, ",")
 		option.AllowedOrigins = domains
 	}

--- a/weed/server/filer_server.go
+++ b/weed/server/filer_server.go
@@ -112,7 +112,6 @@ func NewFilerServer(defaultMux, readonlyMux *http.ServeMux, option *FilerOption)
 	allowedOrigins := v.GetString("filer.allowed_origins.values")
 
 	option.AllowedOrigins = allowedOrigins
-	os.Stdout.WriteString("---------- Allowed origins: " + option.AllowedOrigins + "\n")
 
 	fs = &FilerServer{
 		option:                option,

--- a/weed/server/filer_server.go
+++ b/weed/server/filer_server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -70,7 +71,7 @@ type FilerOption struct {
 	ShowUIDirectoryDelete bool
 	DownloadMaxBytesPs    int64
 	DiskType              string
-	AllowedOrigins        string
+	AllowedOrigins        []string
 }
 
 type FilerServer struct {
@@ -109,9 +110,12 @@ func NewFilerServer(defaultMux, readonlyMux *http.ServeMux, option *FilerOption)
 	readExpiresAfterSec := v.GetInt("jwt.filer_signing.read.expires_after_seconds")
 
 	v.SetDefault("filer.allowed_origins.values", "*")
-	allowedOrigins := v.GetString("filer.allowed_origins.values")
 
-	option.AllowedOrigins = allowedOrigins
+	if (option.AllowedOrigins == nil) || (len(option.AllowedOrigins) == 0) {
+		allowedOrigins := v.GetString("filer.allowed_origins.values")
+		domains := strings.Split(allowedOrigins, ",")
+		option.AllowedOrigins = domains
+	}
 
 	fs = &FilerServer{
 		option:                option,

--- a/weed/server/filer_server.go
+++ b/weed/server/filer_server.go
@@ -70,6 +70,7 @@ type FilerOption struct {
 	ShowUIDirectoryDelete bool
 	DownloadMaxBytesPs    int64
 	DiskType              string
+	AllowedOrigins        string
 }
 
 type FilerServer struct {
@@ -106,6 +107,12 @@ func NewFilerServer(defaultMux, readonlyMux *http.ServeMux, option *FilerOption)
 	readSigningKey := v.GetString("jwt.filer_signing.read.key")
 	v.SetDefault("jwt.filer_signing.read.expires_after_seconds", 60)
 	readExpiresAfterSec := v.GetInt("jwt.filer_signing.read.expires_after_seconds")
+
+	v.SetDefault("filer.allowed_origins.values", "*")
+	allowedOrigins := v.GetString("filer.allowed_origins.values")
+
+	option.AllowedOrigins = allowedOrigins
+	os.Stdout.WriteString("---------- Allowed origins: " + option.AllowedOrigins + "\n")
 
 	fs = &FilerServer{
 		option:                option,

--- a/weed/server/filer_server_handlers.go
+++ b/weed/server/filer_server_handlers.go
@@ -18,7 +18,7 @@ func (fs *FilerServer) filerHandler(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
 
 	if r.Header.Get("Origin") != "" {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Origin", fs.option.AllowedOrigins)
 		w.Header().Set("Access-Control-Expose-Headers", "*")
 		w.Header().Set("Access-Control-Allow-Headers", "*")
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
@@ -26,7 +26,7 @@ func (fs *FilerServer) filerHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if r.Method == "OPTIONS" {
-		OptionsHandler(w, r, false)
+		OptionsHandler(w, r, false, fs.option.AllowedOrigins)
 		return
 	}
 
@@ -111,7 +111,7 @@ func (fs *FilerServer) readonlyFilerHandler(w http.ResponseWriter, r *http.Reque
 	}()
 	// We handle OPTIONS first because it never should be authenticated
 	if r.Method == "OPTIONS" {
-		OptionsHandler(w, r, true)
+		OptionsHandler(w, r, true, fs.option.AllowedOrigins)
 		return
 	}
 
@@ -130,14 +130,14 @@ func (fs *FilerServer) readonlyFilerHandler(w http.ResponseWriter, r *http.Reque
 	}
 }
 
-func OptionsHandler(w http.ResponseWriter, r *http.Request, isReadOnly bool) {
+func OptionsHandler(w http.ResponseWriter, r *http.Request, isReadOnly bool, allowedOrigins string) {
 	if isReadOnly {
 		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
 	} else {
 		w.Header().Set("Access-Control-Allow-Methods", "PUT, POST, GET, DELETE, OPTIONS")
 		w.Header().Set("Access-Control-Expose-Headers", "*")
 	}
-	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Origin", allowedOrigins)
 	w.Header().Set("Access-Control-Allow-Headers", "*")
 	w.Header().Set("Access-Control-Allow-Credentials", "true")
 }

--- a/weed/server/filer_server_handlers.go
+++ b/weed/server/filer_server_handlers.go
@@ -20,15 +20,19 @@ func (fs *FilerServer) filerHandler(w http.ResponseWriter, r *http.Request) {
 
 	origin := r.Header.Get("Origin")
 	if origin != "" {
-		originFound := false
-		for _, allowedOrigin := range fs.option.AllowedOrigins {
-			if origin == allowedOrigin {
-				originFound = true
+		if fs.option.AllowedOrigins == nil || len(fs.option.AllowedOrigins) == 0 || fs.option.AllowedOrigins[0] == "*" {
+			origin = "*"
+		} else {
+			originFound := false
+			for _, allowedOrigin := range fs.option.AllowedOrigins {
+				if origin == allowedOrigin {
+					originFound = true
+				}
 			}
-		}
-		if !originFound {
-			writeJsonError(w, r, http.StatusForbidden, errors.New("origin not allowed"))
-			return
+			if !originFound {
+				writeJsonError(w, r, http.StatusForbidden, errors.New("origin not allowed"))
+				return
+			}
 		}
 
 		w.Header().Set("Access-Control-Allow-Origin", origin)
@@ -116,15 +120,19 @@ func (fs *FilerServer) readonlyFilerHandler(w http.ResponseWriter, r *http.Reque
 
 	origin := r.Header.Get("Origin")
 	if origin != "" {
-		originFound := false
-		for _, allowedOrigin := range fs.option.AllowedOrigins {
-			if origin == allowedOrigin {
-				originFound = true
+		if fs.option.AllowedOrigins == nil || len(fs.option.AllowedOrigins) == 0 || fs.option.AllowedOrigins[0] == "*" {
+			origin = "*"
+		} else {
+			originFound := false
+			for _, allowedOrigin := range fs.option.AllowedOrigins {
+				if origin == allowedOrigin {
+					originFound = true
+				}
 			}
-		}
-		if !originFound {
-			writeJsonError(w, r, http.StatusForbidden, errors.New("origin not allowed"))
-			return
+			if !originFound {
+				writeJsonError(w, r, http.StatusForbidden, errors.New("origin not allowed"))
+				return
+			}
 		}
 
 		w.Header().Set("Access-Control-Allow-Origin", origin)


### PR DESCRIPTION
# What problem are we solving?

When making a request to a server at a different domain from a browser, the browser will impose a set of restrictions known as CORS. When making a request with credentials from a browser to a server on a different domain, the server with a different domain cannot accept the credentials in the usual way. The usual way is to use the header "Access-Control-Allow-Credentials" with value true. The browser fails the request when the "Access-Control-Allow-Origin" header has a value of *(wildcard). If the value of "Access-Control-Allow-Origin" is set to a specific domain, the browser will let the request through.

This issue appears when making a request to the Filer or S3 Gateway from a web client with credentials included. This happens when the client needs to send HTTP-only cookies to SeaweedFS, a use case addressed in this pull: #5077. 

# How are we solving the problem?

I added a way to specify allowed domains(plural) in the security.toml file and through a command line flag `-allowedDomains`. The default value is still "*". The value set in the configuration file or command line flag adjust the value of the "Access-Control-Allow-Origin" header.

The domains are split by comma in the code and added as a list of type string. When the Filer or S3 Gateway receive a request, we check for the "Domain" header the browser will include. If the header is not empty, we compare the value to the domains added to the config. If there is a match, we return the matched value to give the browser the "go ahead" and respond to the request. If the domain is not found(no match), the request will fail with a status code of 503(Resource Forbidden). If no configuration is changed and the command line flag is not set, the default value is used, and requests that do not include credentials will go through as usual. 

**These changes apply to the Filer and S3 gateway**.

# How is the PR tested?

Tested on my local machine with a web client. I tested with the default value, with the localhost domain in the security.conf, and using the command line flag

# Checks
- [ ] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
