### PR TITLE
Update network.go since To16 converts the IP address ip up to a 16-byte representation. If ip is not an IP address (it is the wrong length), To16 returns nil.

### DIFF
--- a/weed/util/network.go
+++ b/weed/util/network.go
@@ -15,18 +15,13 @@ func DetectedHostAddress() string {
 		return ""
 	}
 
-	if v4Address := selectIpV4(netInterfaces, true); v4Address != "" {
+	if v4Address := selectIpV4(netInterfaces); v4Address != "" {
 		return v4Address
-	}
-
-	if v6Address := selectIpV4(netInterfaces, false); v6Address != "" {
-		return v6Address
 	}
 
 	return "localhost"
 }
-
-func selectIpV4(netInterfaces []net.Interface, isIpV4 bool) string {
+func selectIpV4(netInterfaces []net.Interface) string {
 	for _, netInterface := range netInterfaces {
 		if (netInterface.Flags & net.FlagUp) == 0 {
 			continue
@@ -38,15 +33,9 @@ func selectIpV4(netInterfaces []net.Interface, isIpV4 bool) string {
 
 		for _, a := range addrs {
 			if ipNet, ok := a.(*net.IPNet); ok && !ipNet.IP.IsLoopback() {
-				if isIpV4 {
-					if ipNet.IP.To4() != nil {
-						return ipNet.IP.String()
-					}
-				} else {
 					if ipNet.IP.To16() != nil {
 						return ipNet.IP.String()
 					}
-				}
 			}
 		}
 	}


### PR DESCRIPTION
# What problem are we solving?
Optimizing Network code performance


# How are we solving the problem?
To16 also works for ipv4 addresses as referenced in the go documentation: https://pkg.go.dev/net. The referenced change removes a variable and an accompanying check for IPV4/6, improving performance.


# How is the PR tested?
The code should pass the existing network tests.


# Checks
- [ ] I have added unit tests if possible.
- [X] I will add related wiki document changes and link to this PR after merging.
