### PR TITLE
fix: k8s-chart-helm master metrics scraping

### DIFF
--- a/k8s/charts/seaweedfs/templates/master-servicemonitor.yaml
+++ b/k8s/charts/seaweedfs/templates/master-servicemonitor.yaml
@@ -18,7 +18,7 @@ spec:
       scrapeTimeout: 5s
   selector:
     matchLabels:
-      app: {{ template "seaweedfs.name" . }}
-      component: master
+      app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+      app.kubernetes.io/component: master
 {{- end }}
 {{- end }}

--- a/k8s/charts/seaweedfs/templates/master-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/master-statefulset.yaml
@@ -127,7 +127,8 @@ spec:
               -metrics.intervalSeconds={{ .Values.master.metricsIntervalSec }} \
               {{- end }}
               {{- end }}
-              {{- else if .Values.master.metricsPort }}
+              {{- end }}
+              {{- if .Values.master.metricsPort }}
               -metricsPort={{ .Values.master.metricsPort }} \
               {{- end }}
               -volumeSizeLimitMB={{ .Values.master.volumeSizeLimitMB }} \


### PR DESCRIPTION
# What problem are we solving?

master pods metrics were not scraped by prometheus:
- missing `metricsPort` option
- and incorrect service monitor matching labels

# How is the PR tested?

- manually tested in my how deployment ! can do more ?


