### PR TITLE
weed/server: remove unneeded err from streamReadOneVolume() signature

### DIFF
--- a/weed/server/volume_grpc_read_all.go
+++ b/weed/server/volume_grpc_read_all.go
@@ -10,14 +10,14 @@ import (
 func (vs *VolumeServer) ReadAllNeedles(req *volume_server_pb.ReadAllNeedlesRequest, stream volume_server_pb.VolumeServer_ReadAllNeedlesServer) (err error) {
 
 	for _, vid := range req.VolumeIds {
-		if err := vs.streamReadOneVolume(needle.VolumeId(vid), stream, err); err != nil {
+		if err := vs.streamReadOneVolume(needle.VolumeId(vid), stream); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (vs *VolumeServer) streamReadOneVolume(vid needle.VolumeId, stream volume_server_pb.VolumeServer_ReadAllNeedlesServer, err error) error {
+func (vs *VolumeServer) streamReadOneVolume(vid needle.VolumeId, stream volume_server_pb.VolumeServer_ReadAllNeedlesServer) error {
 	v := vs.store.GetVolume(vid)
 	if v == nil {
 		return fmt.Errorf("not found volume id %d", vid)
@@ -30,7 +30,5 @@ func (vs *VolumeServer) streamReadOneVolume(vid needle.VolumeId, stream volume_s
 
 	offset := int64(v.SuperBlock.BlockSize())
 
-	err = storage.ScanVolumeFileFrom(v.Version(), v.DataBackend, offset, scanner)
-
-	return err
+	return storage.ScanVolumeFileFrom(v.Version(), v.DataBackend, offset, scanner)
 }


### PR DESCRIPTION
This removes an unneeded `err` variable from `streamReadOneVolume()`.