### PR TITLE
Update network.go by revisiting #5134

### DIFF
--- a/weed/util/network.go
+++ b/weed/util/network.go
@@ -15,18 +15,14 @@ func DetectedHostAddress() string {
 		return ""
 	}
 
-	if v4Address := selectIpV4(netInterfaces, true); v4Address != "" {
+	if v4Address := selectIpV4(netInterfaces); v4Address != "" {
 		return v4Address
-	}
-
-	if v6Address := selectIpV4(netInterfaces, false); v6Address != "" {
-		return v6Address
 	}
 
 	return "localhost"
 }
 
-func selectIpV4(netInterfaces []net.Interface, isIpV4 bool) string {
+func selectIpV4(netInterfaces []net.Interface) string {
 	for _, netInterface := range netInterfaces {
 		if (netInterface.Flags & net.FlagUp) == 0 {
 			continue
@@ -38,15 +34,9 @@ func selectIpV4(netInterfaces []net.Interface, isIpV4 bool) string {
 
 		for _, a := range addrs {
 			if ipNet, ok := a.(*net.IPNet); ok && !ipNet.IP.IsLoopback() {
-				if isIpV4 {
-					if ipNet.IP.To4() != nil {
+					if ipNet.IP.To4() != nil && ipNet.IP.To16() == nil || ipNet.IP.To16() != nil && ipNet.IP.To4() == nil{
 						return ipNet.IP.String()
 					}
-				} else {
-					if ipNet.IP.To16() != nil {
-						return ipNet.IP.String()
-					}
-				}
 			}
 		}
 	}


### PR DESCRIPTION
From the go source code on potential conflicts in IP Addressing schemes: https://cs.opensource.google/go/go/+/master:src/net/rawconn_unix_test.go
			// There's no guarantee that IP-level socket
			// options work well with dual stack sockets.
			// A simple solution would be to take a look
			// at the bound address to the raw connection
			// and to classify the address family of the
			// underlying socket by the bound address:
			//
			// - When IP.To16() != nil and IP.To4() == nil,
			//   we can assume that the raw connection
			//   consists of an IPv6 socket using only
			//   IPv6 addresses.
			//
			// - When IP.To16() == nil and IP.To4() != nil,
			//   the raw connection consists of an IPv4
			//   socket using only IPv4 addresses.
			//
			// - Otherwise, the raw connection is a dual
			//   stack socket, an IPv6 socket using IPv6
			//   addresses including IPv4-mapped or
			//   IPv4-embedded IPv6 addresses.

# What problem are we solving?



# How are we solving the problem?



# How is the PR tested?



# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
