### PR TITLE
fix: return etag with md5 in webdav responses

### DIFF
--- a/weed/server/webdav_server.go
+++ b/weed/server/webdav_server.go
@@ -96,6 +96,7 @@ type FileInfo struct {
 	size         int64
 	mode         os.FileMode
 	modifiedTime time.Time
+	etag         string
 	isDirectory  bool
 }
 
@@ -105,6 +106,10 @@ func (fi *FileInfo) Mode() os.FileMode  { return fi.mode }
 func (fi *FileInfo) ModTime() time.Time { return fi.modifiedTime }
 func (fi *FileInfo) IsDir() bool        { return fi.isDirectory }
 func (fi *FileInfo) Sys() interface{}   { return nil }
+
+func (fi *FileInfo) ETag(ctx context.Context) (string, error) {
+	return fi.etag, nil
+}
 
 type WebDavFile struct {
 	fs               *WebDavFileSystem
@@ -369,6 +374,7 @@ func (fs *WebDavFileSystem) stat(ctx context.Context, fullFilePath string) (os.F
 	fi.name = string(fullpath)
 	fi.mode = os.FileMode(entry.Attributes.FileMode)
 	fi.modifiedTime = time.Unix(entry.Attributes.Mtime, 0)
+	fi.etag = filer.ETag(entry)
 	fi.isDirectory = entry.IsDirectory
 
 	if fi.name == "/" {

--- a/weed/server/wrapped_webdav_fs.go
+++ b/weed/server/wrapped_webdav_fs.go
@@ -95,3 +95,11 @@ func (w wrappedFileInfo) Name() string {
 	name := w.FileInfo.Name()
 	return strings.TrimPrefix(name, *w.subFolder)
 }
+
+func (w wrappedFileInfo) ETag(ctx context.Context) (string, error) {
+	etag, _ := w.FileInfo.(webdav.ETager).ETag(ctx)
+	if len(etag) == 0 {
+		return etag, webdav.ErrNotImplemented
+	}
+	return etag, nil
+}


### PR DESCRIPTION
# What problem are we solving?

Pass ETag in webdav responses is not implemented

# How are we solving the problem?

Added Etag function

# How is the PR tested?

locally
```
curl -I http://127.0.0.1:7333/test.pdf
HTTP/1.1 200 OK
Accept-Ranges: bytes
Content-Length: 202218
Content-Type: application/pdf
Etag: dd2de77517aa4534fa285899ae8a257a
Last-Modified: Wed, 03 Jan 2024 13:12:57 GMT
Date: Wed, 03 Jan 2024 13:17:35 GMT

md5 test.pdf              
MD5 (test.pdf) = dd2de77517aa4534fa285899ae8a257a
```

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
