### PR TITLE
fix: webdav avoid create empty files

### DIFF
--- a/weed/server/webdav_server.go
+++ b/weed/server/webdav_server.go
@@ -236,7 +236,7 @@ func (fs *WebDavFileSystem) OpenFile(ctx context.Context, fullFilePath string, f
 					Name:        name,
 					IsDirectory: perm&os.ModeDir > 0,
 					Attributes: &filer_pb.FuseAttributes{
-						Mtime:    time.Now().Unix(),
+						Mtime:    0,
 						Crtime:   time.Now().Unix(),
 						FileMode: uint32(perm),
 						Uid:      fs.option.Uid,
@@ -423,12 +423,13 @@ func (f *WebDavFile) Write(buf []byte) (int, error) {
 
 	glog.V(2).Infof("WebDavFileSystem.Write %v", f.name)
 
-	dir, _ := util.FullPath(f.name).DirAndName()
+	fullPath := util.FullPath(f.name)
+	dir, _ := fullPath.DirAndName()
 
 	var getErr error
 	ctx := context.Background()
 	if f.entry == nil {
-		f.entry, getErr = filer_pb.GetEntry(f.fs, util.FullPath(f.name))
+		f.entry, getErr = filer_pb.GetEntry(f.fs, fullPath)
 	}
 
 	if f.entry == nil {
@@ -445,6 +446,11 @@ func (f *WebDavFile) Write(buf []byte) (int, error) {
 			chunk, flushErr = f.saveDataAsChunk(util.NewBytesReader(data), f.name, offset, time.Now().UnixNano())
 
 			if flushErr != nil {
+				if f.entry.Attributes.Mtime == 0 {
+					if err := f.fs.removeAll(ctx, f.name); err != nil {
+						glog.Errorf("bufWriter.Flush remove file error: %+v", f.name)
+					}
+				}
 				return fmt.Errorf("%s upload result: %v", f.name, flushErr)
 			}
 


### PR DESCRIPTION
# What problem are we solving?

At the time of restart, the master server may be unavailable due to the selection of a leader and errors may occur during Assign operations. Which lead to the creation of empty files via webdav.
```
curl -T test.pdf http://127.0.0.1:7333/test/
Method Not Allowed


> fs.meta.cat /webdav/test/test.pdf
{
  "name":  "test.pdf",
  "isDirectory":  false,
  "chunks":  [],
  "attributes":  {
    "fileSize":  "0",
    "mtime":  "1704301263",
    "fileMode":  438,
    "uid":  501,
    "gid":  20,
    "crtime":  "1704301263",
    "mime":  "",
    "ttlSec":  0,
    "userName":  "",
    "groupName":  [],
    "symlinkTarget":  "",
    "md5":  "",
    "rdev":  0,
    "inode":  "0"
  },
  "extended":  {},
  "hardLinkId":  "",
  "hardLinkCounter":  0,
  "content":  "",
  "remoteEntry":  null,
  "quota":  "0"
}chunks 0 meta size: 35 gzip:63
```

# How are we solving the problem?

In case of chunk writing errors, deletes metadata about the file

# How is the PR tested?

locally 

logs
```
I0103 22:11:50.900439 filer.go:229 InsertEntry /webdav/test/test.pdf: new entry: test.pdf
I0103 22:11:50.900494 filer.go:250 CreateEntry /webdav/test/test.pdf: created
I0103 22:11:50.900642 webdav_server.go:426 WebDavFileSystem.Write /webdav/test/test.pdf
I0103 22:11:50.900782 filer_grpc_server.go:24 LookupDirectoryEntry /webdav/test/test.pdf
I0103 22:11:50.900915 webdav_server.go:444 WebDavFileSystem.Write entry file_mode:438 uid:501 gid:20 crtime:1704301910
I0103 22:11:50.900959 webdav_server.go:499 WebDavFileSystem.Write /webdav/test/test.pdf: written [0,32768)
I0103 22:11:50.900979 webdav_server.go:426 WebDavFileSystem.Write /webdav/test/test.pdf
I0103 22:11:50.900985 webdav_server.go:444 WebDavFileSystem.Write entry file_size:32768 file_mode:438 uid:501 gid:20 crtime:1704301910
I0103 22:11:50.901019 webdav_server.go:499 WebDavFileSystem.Write /webdav/test/test.pdf: written [32768,65536)
I0103 22:11:50.901035 webdav_server.go:426 WebDavFileSystem.Write /webdav/test/test.pdf
I0103 22:11:50.901039 webdav_server.go:444 WebDavFileSystem.Write entry file_size:65536 file_mode:438 uid:501 gid:20 crtime:1704301910
I0103 22:11:50.901076 webdav_server.go:499 WebDavFileSystem.Write /webdav/test/test.pdf: written [65536,98304)
I0103 22:11:50.901091 webdav_server.go:426 WebDavFileSystem.Write /webdav/test/test.pdf
I0103 22:11:50.901094 webdav_server.go:444 WebDavFileSystem.Write entry file_size:98304 file_mode:438 uid:501 gid:20 crtime:1704301910
I0103 22:11:50.901104 webdav_server.go:499 WebDavFileSystem.Write /webdav/test/test.pdf: written [98304,131072)
I0103 22:11:50.901128 webdav_server.go:426 WebDavFileSystem.Write /webdav/test/test.pdf
I0103 22:11:50.901131 webdav_server.go:444 WebDavFileSystem.Write entry file_size:131072 file_mode:438 uid:501 gid:20 crtime:1704301910
I0103 22:11:50.901191 webdav_server.go:499 WebDavFileSystem.Write /webdav/test/test.pdf: written [131072,163840)
I0103 22:11:50.901204 webdav_server.go:426 WebDavFileSystem.Write /webdav/test/test.pdf
I0103 22:11:50.901207 webdav_server.go:444 WebDavFileSystem.Write entry file_size:163840 file_mode:438 uid:501 gid:20 crtime:1704301910
I0103 22:11:50.901217 webdav_server.go:499 WebDavFileSystem.Write /webdav/test/test.pdf: written [163840,196608)
I0103 22:11:50.901234 webdav_server.go:426 WebDavFileSystem.Write /webdav/test/test.pdf
I0103 22:11:50.901237 webdav_server.go:444 WebDavFileSystem.Write entry file_size:196608 file_mode:438 uid:501 gid:20 crtime:1704301910
I0103 22:11:50.901244 webdav_server.go:499 WebDavFileSystem.Write /webdav/test/test.pdf: written [196608,202218)
I0103 22:11:50.901434 webdav_server.go:628 WebDavFile.Stat /webdav/test/test.pdf
I0103 22:11:50.901587 filer_grpc_server.go:24 LookupDirectoryEntry /webdav/test/test.pdf
I0103 22:11:50.901689 webdav_server.go:508 WebDavFileSystem.Close /webdav/test/test.pdf
I0103 22:11:50.902118 filer_grpc_server.go:318 AssignVolume: rpc error: code = Unknown desc = no free volumes left for {"replication":{},"ttl":{"Count":0,"Unit":0}}
I0103 22:11:50.902228 webdav_server.go:414 upload data /webdav/test/test.pdf: filerGrpcAddress assign volume: assign volume failure count:1 path:"/webdav/test/test.pdf": assign volume: rpc error: code = Unknown desc = no free volumes left for {"replication":{},"ttl":{"Count":0,"Unit":0}}
I0103 22:11:50.902385 filer_grpc_server.go:292 DeleteEntry directory:"/webdav/test" name:"test.pdf" is_delete_data:true signatures:-28504403
I0103 22:11:50.902419 filer_delete_entry.go:124 deleting entry /webdav/test/test.pdf, delete chunks: true
I0103 22:11:51.900039 master_grpc_server_admin.go:93 isLocked 192.168.3.43: 
I0103 22:11:51.900087 master_grpc_server_admin.go:135 LeaseAdminToken 192.168.3.43
```

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
