### PR TITLE
Add deleted bytes to total_disk_size

### DIFF
--- a/weed/storage/store.go
+++ b/weed/storage/store.go
@@ -251,6 +251,7 @@ func (s *Store) CollectHeartbeat() *master_pb.Heartbeat {
 	maxVolumeCounts := make(map[string]uint32)
 	var maxFileKey NeedleId
 	collectionVolumeSize := make(map[string]int64)
+	collectionVolumeDeletedBytes := make(map[string]int64)
 	collectionVolumeReadOnlyCount := make(map[string]map[string]uint8)
 	for _, location := range s.Locations {
 		var deleteVids []needle.VolumeId
@@ -283,9 +284,11 @@ func (s *Store) CollectHeartbeat() *master_pb.Heartbeat {
 
 			if _, exist := collectionVolumeSize[v.Collection]; !exist {
 				collectionVolumeSize[v.Collection] = 0
+				collectionVolumeDeletedBytes[v.Collection] = 0
 			}
 			if !shouldDeleteVolume {
 				collectionVolumeSize[v.Collection] += int64(volumeMessage.Size)
+				collectionVolumeDeletedBytes[v.Collection] += int64(volumeMessage.DeletedByteCount)
 			} else {
 				collectionVolumeSize[v.Collection] -= int64(volumeMessage.Size)
 				if collectionVolumeSize[v.Collection] <= 0 {
@@ -340,6 +343,10 @@ func (s *Store) CollectHeartbeat() *master_pb.Heartbeat {
 
 	for col, size := range collectionVolumeSize {
 		stats.VolumeServerDiskSizeGauge.WithLabelValues(col, "normal").Set(float64(size))
+	}
+
+	for col, deletedBytes := range collectionVolumeDeletedBytes{
+		stats.VolumeServerDiskSizeGauge.WithLabelValues(col, "deleted_bytes").Set(float64(deletedBytes))
 	}
 
 	for col, types := range collectionVolumeReadOnlyCount {


### PR DESCRIPTION
# What problem are we solving?
`total_disk_size` is only shows actual disk size but there is no metric for deleted bytes
So we can't get find out what is size of collection content without deleted bytes
So I'm adding deleted bytes as a metric

But I have two questions:
1- should I add collectionVolumeDeletedBytes to `else` too? I didn't understand what is shouldDeleteVolume
```go
if !shouldDeleteVolume {                                                              
	collectionVolumeSize[v.Collection] += int64(volumeMessage.Size)                     
	collectionVolumeDeletedBytes[v.Collection] += int64(volumeMessage.DeletedByteCount) 
} else {                                                                              
	collectionVolumeSize[v.Collection] -= int64(volumeMessage.Size)                     
	if collectionVolumeSize[v.Collection] <= 0 {                                        
		delete(collectionVolumeSize, v.Collection)                                        
	}                                                                                   
}                                                                                     
```
2- Should I use  `type` label, or use another label, or create a new metric?


# How are we solving the problem?
Calculating deleted bytes when volume server is calculating `total_disk_size`


# How is the PR tested?
```bash
$ go run weed/weed.go server -ip.bind 0.0.0.0 -volume.max 0 -master.volumeSizeLimitMB=100 -dir=/tmp/x  -filer -s3 -metricsPort 9327
$ warp mixed --insecure --host localhost:8333 --noclear  --obj.size 1KiB --concurrent 10 --noprefix --bucket test
$ echo "collection.list" | weed shell
> collection:""	volumeCount:7	size:12765064	fileCount:4	deletedBytes:0	deletion:0
collection:"test"	volumeCount:7	size:63147104	fileCount:58517	deletedBytes:20013732	deletion:18876
Total 2 collections.
$ curl -s  localhost:9327/metrics | grep "total_disk_size"
# HELP SeaweedFS_volumeServer_total_disk_size Actual disk size used by volumes.
# TYPE SeaweedFS_volumeServer_total_disk_size gauge
SeaweedFS_volumeServer_total_disk_size{collection="",type="deleted_bytes"} 0
SeaweedFS_volumeServer_total_disk_size{collection="",type="normal"} 1.3924672e+07
SeaweedFS_volumeServer_total_disk_size{collection="test",type="deleted_bytes"} 2.0013732e+07
SeaweedFS_volumeServer_total_disk_size{collection="test",type="normal"} 6.3147104e+07
```
both metrics and `collection.list` shows 20013732 (2.0013732e+07) as deleted_bytes


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
