### PR TITLE
Fix missing VersionConfiguration node in get-bucket-versioning response

### DIFF
--- a/weed/s3api/s3api_bucket_handlers.go
+++ b/weed/s3api/s3api_bucket_handlers.go
@@ -545,10 +545,9 @@ func (s3a *S3ApiServer) GetBucketVersioningHandler(w http.ResponseWriter, r *htt
 		return
 	}
 
-	result := &s3.PutBucketVersioningInput{
+	s3err.WriteAwsXMLResponse(w, r, http.StatusOK, &s3.PutBucketVersioningInput{
 		VersioningConfiguration: &s3.VersioningConfiguration{
 			Status: aws.String(s3.BucketVersioningStatusSuspended),
 		},
-	}
-	s3err.WriteAwsXMLResponse(w, r, http.StatusOK, result)
+	})
 }

--- a/weed/s3api/s3api_bucket_handlers.go
+++ b/weed/s3api/s3api_bucket_handlers.go
@@ -545,8 +545,10 @@ func (s3a *S3ApiServer) GetBucketVersioningHandler(w http.ResponseWriter, r *htt
 		return
 	}
 
-	result := &s3.VersioningConfiguration{}
-	result.SetStatus(s3.BucketVersioningStatusSuspended)
-
+	result := &s3.PutBucketVersioningInput{
+		VersioningConfiguration: &s3.VersioningConfiguration{
+			Status: aws.String(s3.BucketVersioningStatusSuspended),
+		},
+	}
 	s3err.WriteAwsXMLResponse(w, r, http.StatusOK, result)
 }


### PR DESCRIPTION
# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/5155

# How are we solving the problem?

https://github.com/seaweedfs/seaweedfs/issues/5155

# How is the PR tested?

locally
```
aws --endpoint-url http://127.0.0.1:8000 s3api get-bucket-versioning --bucket test --debug
2024-01-04 01:11:38,946 - MainThread - urllib3.connectionpool - DEBUG - http://127.0.0.1:8000 "GET /test?versioning HTTP/1.1" 200 125
2024-01-04 01:11:38,947 - MainThread - botocore.parsers - DEBUG - Response headers: {'Accept-Ranges': 'bytes', 'Content-Length': '125', 'Content-Type': 'application/xml', 'Server': 'SeaweedFS S3', 'X-Amz-Request-Id': '1704312698946573000', 'Date': 'Wed, 03 Jan 2024 20:11:38 GMT'}
2024-01-04 01:11:38,947 - MainThread - botocore.parsers - DEBUG - Response body:
b'<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status>Suspended</Status></VersioningConfiguration>'
2024-01-04 01:11:38,949 - MainThread - botocore.hooks - DEBUG - Event needs-retry.s3.GetBucketVersioning: calling handler <bound method RetryHandler.needs_retry of <botocore.retries.standard.RetryHandler object at 0x112becf90>>
2024-01-04 01:11:38,950 - MainThread - botocore.retries.standard - DEBUG - Not retrying request.
2024-01-04 01:11:38,950 - MainThread - botocore.hooks - DEBUG - Event needs-retry.s3.GetBucketVersioning: calling handler <bound method S3RegionRedirectorv2.redirect_from_error of <botocore.utils.S3RegionRedirectorv2 object at 0x112bec350>>
2024-01-04 01:11:38,950 - MainThread - botocore.hooks - DEBUG - Event after-call.s3.GetBucketVersioning: calling handler <function enhance_error_msg at 0x112252de0>
2024-01-04 01:11:38,950 - MainThread - botocore.hooks - DEBUG - Event after-call.s3.GetBucketVersioning: calling handler <bound method RetryQuotaChecker.release_retry_quota of <botocore.retries.standard.RetryQuotaChecker object at 0x112bebf90>>
2024-01-04 01:11:38,950 - MainThread - awscli.formatter - DEBUG - RequestId: 1704312698946573000
{
    "Status": "Suspended"
}
```


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
