### PR TITLE
chore: add maxMB option for webdav

### DIFF
--- a/weed/command/server.go
+++ b/weed/command/server.go
@@ -164,6 +164,7 @@ func init() {
 	webdavOptions.tlsCertificate = cmdServer.Flag.String("webdav.cert.file", "", "path to the TLS certificate file")
 	webdavOptions.cacheDir = cmdServer.Flag.String("webdav.cacheDir", os.TempDir(), "local cache directory for file chunks")
 	webdavOptions.cacheSizeMB = cmdServer.Flag.Int64("webdav.cacheCapacityMB", 0, "local cache capacity in MB")
+	webdavOptions.maxMB = cmdServer.Flag.Int("webdav.maxMB", 4, "split files larger than the limit")
 	webdavOptions.filerRootPath = cmdServer.Flag.String("webdav.filer.path", "/", "use this remote path from filer server")
 
 	mqBrokerOptions.port = cmdServer.Flag.Int("mq.broker.port", 17777, "message queue broker gRPC listen port")

--- a/weed/command/webdav.go
+++ b/weed/command/webdav.go
@@ -32,6 +32,7 @@ type WebDavOption struct {
 	tlsCertificate *string
 	cacheDir       *string
 	cacheSizeMB    *int64
+	maxMB          *int
 }
 
 func init() {
@@ -45,6 +46,7 @@ func init() {
 	webDavStandaloneOptions.tlsCertificate = cmdWebDav.Flag.String("cert.file", "", "path to the TLS certificate file")
 	webDavStandaloneOptions.cacheDir = cmdWebDav.Flag.String("cacheDir", os.TempDir(), "local cache directory for file chunks")
 	webDavStandaloneOptions.cacheSizeMB = cmdWebDav.Flag.Int64("cacheCapacityMB", 0, "local cache capacity in MB")
+	webDavStandaloneOptions.maxMB = cmdWebDav.Flag.Int("maxMB", 4, "split files larger than the limit")
 	webDavStandaloneOptions.filerRootPath = cmdWebDav.Flag.String("filer.path", "/", "use this remote path from filer server")
 }
 
@@ -116,6 +118,7 @@ func (wo *WebDavOption) startWebDav() bool {
 		Cipher:         cipher,
 		CacheDir:       util.ResolvePath(*wo.cacheDir),
 		CacheSizeMB:    *wo.cacheSizeMB,
+		MaxMB:          *wo.maxMB,
 	})
 	if webdavServer_err != nil {
 		glog.Fatalf("WebDav Server startup error: %v", webdavServer_err)

--- a/weed/server/webdav_server.go
+++ b/weed/server/webdav_server.go
@@ -38,6 +38,7 @@ type WebDavOption struct {
 	Cipher         bool
 	CacheDir       string
 	CacheSizeMB    int64
+	MaxMB          int
 }
 
 type WebDavServer struct {
@@ -262,7 +263,7 @@ func (fs *WebDavFileSystem) OpenFile(ctx context.Context, fullFilePath string, f
 			fs:          fs,
 			name:        fullFilePath,
 			isDirectory: false,
-			bufWriter:   buffered_writer.NewBufferedWriteCloser(4 * 1024 * 1024),
+			bufWriter:   buffered_writer.NewBufferedWriteCloser(fs.option.MaxMB * 1024 * 1024),
 		}, nil
 	}
 
@@ -278,7 +279,7 @@ func (fs *WebDavFileSystem) OpenFile(ctx context.Context, fullFilePath string, f
 		fs:          fs,
 		name:        fullFilePath,
 		isDirectory: false,
-		bufWriter:   buffered_writer.NewBufferedWriteCloser(4 * 1024 * 1024),
+		bufWriter:   buffered_writer.NewBufferedWriteCloser(fs.option.MaxMB * 1024 * 1024),
 	}, nil
 
 }


### PR DESCRIPTION
# What problem are we solving?

By default, all files sent via the webdav are divided into 4 MB chunks
```
> fs.meta.cat /buckets/webdav/weed-large-disk-20240103-2027-linux-amd64.tar.gz
{
  "name":  "weed-large-disk-20240103-2027-linux-amd64.tar.gz",
  "isDirectory":  false,
  "chunks":  [
    {
      "fileId":  "13,246c035113",
      "offset":  "0",
      "size":  "4193628",
      "modifiedTsNs":  "1704444726306330276",
      "eTag":  "NKVthpvjO2ajrLs0n0Nk8A==",
      "sourceFileId":  "",
      "fid":  {
        "volumeId":  13,
        "fileKey":  "36",
        "cookie":  1812156691
      },
      "sourceFid":  null,
      "cipherKey":  "",
      "isCompressed":  false,
      "isChunkManifest":  false
    },
    {
      "fileId":  "13,26fc0594b9",
      "offset":  "4193628",
      "size":  "4193628",
      "modifiedTsNs":  "1704444726481273482",
      "eTag":  "+5FJ69N8Z7IJRpy5Jmb48w==",
      "sourceFileId":  "",
      "fid":  {
        "volumeId":  13,
        "fileKey":  "38",
        "cookie":  4228224185
      },
      "sourceFid":  null,
      "cipherKey":  "",
      "isCompressed":  false,
      "isChunkManifest":  false
    },
    {
      "fileId":  "14,2857ecad66",
      "offset":  "8387256",
      "size":  "4193580",
      "modifiedTsNs":  "1704444726674774784",
      "eTag":  "b/r2jiPOCDv3DZaodW31Ow==",
      "sourceFileId":  "",
      "fid":  {
        "volumeId":  14,
        "fileKey":  "40",
        "cookie":  1475128678
      },
      "sourceFid":  null,
      "cipherKey":  "",
      "isCompressed":  false,
      "isChunkManifest":  false
    },
    {
      "fileId":  "10,2ac8202573",
      "offset":  "12580836",
      "size":  "4193628",
      "modifiedTsNs":  "1704444726872577175",
      "eTag":  "8QZOrw1BfJpCYmR+oEL/Mg==",
      "sourceFileId":  "",
      "fid":  {
        "volumeId":  10,
        "fileKey":  "42",
        "cookie":  3357549939
      },
      "sourceFid":  null,
      "cipherKey":  "",
      "isCompressed":  false,
      "isChunkManifest":  false
    },
    {
      "fileId":  "9,2cbf8c2a52",
      "offset":  "16774464",
      "size":  "2040941",
      "modifiedTsNs":  "1704444727437906367",
      "eTag":  "pnyzZkFb7QeK+ptINCroeg==",
      "sourceFileId":  "",
      "fid":  {
        "volumeId":  9,
        "fileKey":  "44",
        "cookie":  3213634130
      },
      "sourceFid":  null,
      "cipherKey":  "",
      "isCompressed":  false,
      "isChunkManifest":  false
    }
  ],
  "attributes":  {
    "fileSize":  "18815405",
    "mtime":  "1704444727",
    "fileMode":  438,
    "uid":  985,
    "gid":  985,
    "crtime":  "1704444725",
    "mime":  "",
    "ttlSec":  86400,
    "userName":  "",
    "groupName":  [],
    "symlinkTarget":  "",
    "md5":  "",
    "rdev":  0,
    "inode":  "0"
  },
  "extended":  {},
  "hardLinkId":  "",
  "hardLinkCounter":  0,
  "content":  "",
  "remoteEntry":  null,
  "quota":  "0"
}chunks 5 meta size: 445 gzip:441
```


# How are we solving the problem?

add maxMb option for webdav server

# How is the PR tested?

locally
```
curl -I http://127.0.0.1:7333/weed-large-disk-20240103-2027-linux-amd64.tar.gz
HTTP/1.1 200 OK
Accept-Ranges: bytes
Content-Length: 18815405
Content-Type: application/gzip
Etag: b6a21404afceccfa47fc99897d1fa97d-5
Last-Modified: Fri, 05 Jan 2024 08:52:07 GMT
Date: Fri, 05 Jan 2024 10:39:48 GMT

curl -X DELETE http://127.0.0.1:7333/weed-large-disk-20240103-2027-linux-amd64.tar.gz

curl -T /tmp/weed-large-disk-20240103-2027-linux-amd64.tar.gz http://127.0.0.1:7333/
Created%                                                                                                                                                                                                     

curl -I http://127.0.0.1:7333/weed-large-disk-20240103-2027-linux-amd64.tar.gz       
HTTP/1.1 200 OK
Accept-Ranges: bytes
Content-Length: 18815405
Content-Type: application/gzip
Etag: fc63b87fd56f06fc54155f8a2fdf370d
Last-Modified: Fri, 05 Jan 2024 10:40:12 GMT
Date: Fri, 05 Jan 2024 10:40:19 GMT
```

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
