### PR TITLE
Removed problematic if statement

### DIFF
--- a/weed/server/filer_server.go
+++ b/weed/server/filer_server.go
@@ -111,11 +111,9 @@ func NewFilerServer(defaultMux, readonlyMux *http.ServeMux, option *FilerOption)
 
 	v.SetDefault("cors.allowed_origins.values", "*")
 
-	if (option.AllowedOrigins == nil) || (len(option.AllowedOrigins) == 0) {
-		allowedOrigins := v.GetString("cors.allowed_origins.values")
-		domains := strings.Split(allowedOrigins, ",")
-		option.AllowedOrigins = domains
-	}
+	allowedOrigins := v.GetString("cors.allowed_origins.values")
+	domains := strings.Split(allowedOrigins, ",")
+	option.AllowedOrigins = domains
 
 	fs = &FilerServer{
 		option:                option,


### PR DESCRIPTION
# What problem are we solving?

The removed if statement was causing the value of option.AllowedOrigins to always be equal to "*". 

# How are we solving the problem?

Removing the if statement that was causing the config values to only be set when the option.AllowedOrigins property is nil or empty. 

Now the values in the config file will be used when present. This allows for people who don't need this feature to not update their security.toml files(same as before).

# How is the PR tested?

I tested on my local machine using a web client that makes requests that fail when SeaweedFS has the wildcard config. Then I adjusted the config values and retried the same requests. The AccessControlAllowOrigin header was successfully changed according to the config in my tests.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
