### PR TITLE
fix write volume over size MaxPossibleVolumeSize

### DIFF
--- a/weed/storage/needle/needle_write.go
+++ b/weed/storage/needle/needle_write.go
@@ -127,7 +127,7 @@ func (n *Needle) Append(w backend.BackendStorageFile, version Version) (offset u
 		err = fmt.Errorf("Cannot Read Current Volume Position: %v", e)
 		return
 	}
-	if offset >= MaxPossibleVolumeSize && n.Size.IsValid() {
+	if offset >= MaxPossibleVolumeSize && len(n.Data) != 0 {
 		err = fmt.Errorf("Volume Size %d Exceeded %d", offset, MaxPossibleVolumeSize)
 		return
 	}

--- a/weed/storage/volume_write.go
+++ b/weed/storage/volume_write.go
@@ -107,15 +107,8 @@ func (v *Volume) asyncRequestAppend(request *needle.AsyncRequest) {
 
 func (v *Volume) syncWrite(n *needle.Needle, checkCookie bool) (offset uint64, size Size, isUnchanged bool, err error) {
 	// glog.V(4).Infof("writing needle %s", needle.NewFileIdFromNeedle(v.Id, n).String())
-	actualSize := needle.GetActualSize(Size(len(n.Data)), v.Version())
-
 	v.dataFileAccessLock.Lock()
 	defer v.dataFileAccessLock.Unlock()
-
-	if MaxPossibleVolumeSize < v.nm.ContentSize()+uint64(actualSize) {
-		err = fmt.Errorf("volume size limit %d exceeded! current size is %d", MaxPossibleVolumeSize, v.nm.ContentSize())
-		return
-	}
 
 	return v.doWriteRequest(n, checkCookie)
 }
@@ -193,17 +186,11 @@ func (v *Volume) doWriteRequest(n *needle.Needle, checkCookie bool) (offset uint
 
 func (v *Volume) syncDelete(n *needle.Needle) (Size, error) {
 	// glog.V(4).Infof("delete needle %s", needle.NewFileIdFromNeedle(v.Id, n).String())
-	actualSize := needle.GetActualSize(0, v.Version())
 	v.dataFileAccessLock.Lock()
 	defer v.dataFileAccessLock.Unlock()
 
 	if v.nm == nil {
 		return 0, nil
-	}
-
-	if MaxPossibleVolumeSize < v.nm.ContentSize()+uint64(actualSize) {
-		err := fmt.Errorf("volume size limit %d exceeded! current size is %d", MaxPossibleVolumeSize, v.nm.ContentSize())
-		return 0, err
 	}
 
 	return v.doDeleteRequest(n)


### PR DESCRIPTION
# What problem are we solving?
volume over size MaxPossibleVolumeSize
https://github.com/seaweedfs/seaweedfs/issues/5182


# How are we solving the problem?
1. when write, n.Size is not init yet before prepareWriteBuf, so n.Size.IsValid()  alaways false!
2. v.nm.ContentSize() only have write data use size not include delete use size, so if volume has many delete ops(n) before full, more than n*32 bytes can also write to volume, even volume true offset is large than MaxPossibleVolumeSize


# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
