### PR TITLE
Fix filer sync set offset

### DIFF
--- a/docker/compose/local-sync-mount-compose.yml
+++ b/docker/compose/local-sync-mount-compose.yml
@@ -3,6 +3,9 @@ services:
   node1:
     image: chrislusf/seaweedfs:local
     command: "server -master -volume -filer"
+    ports:
+      - 8888:8888
+      - 18888:18888
     healthcheck:
       test: [ "CMD", "curl", "--fail", "-I", "http://localhost:9333/cluster/healthz" ]
       interval: 1s
@@ -24,6 +27,7 @@ services:
     image: chrislusf/seaweedfs:local
     ports:
       - 7888:8888
+      - 17888:18888
     command: "server -master -volume -filer"
     healthcheck:
       test: [ "CMD", "curl", "--fail", "-I", "http://localhost:9333/cluster/healthz" ]

--- a/docker/compose/local-sync-mount-compose.yml
+++ b/docker/compose/local-sync-mount-compose.yml
@@ -3,19 +3,50 @@ services:
   node1:
     image: chrislusf/seaweedfs:local
     command: "server -master -volume -filer"
+    healthcheck:
+      test: [ "CMD", "curl", "--fail", "-I", "http://localhost:9333/cluster/healthz" ]
+      interval: 1s
+      start_period: 10s
+      timeout: 30s
   mount1:
     image: chrislusf/seaweedfs:local
     privileged: true
     command: "mount -filer=node1:8888 -dir=/mnt -dirAutoCreate"
+    healthcheck:
+      test: [ "CMD", "curl", "--fail", "-I", "http://node1:8888/" ]
+      interval: 1s
+      start_period: 10s
+      timeout: 30s
+    depends_on:
+      node1:
+        condition: service_healthy
   node2:
     image: chrislusf/seaweedfs:local
     ports:
       - 7888:8888
     command: "server -master -volume -filer"
+    healthcheck:
+      test: [ "CMD", "curl", "--fail", "-I", "http://localhost:9333/cluster/healthz" ]
+      interval: 1s
+      start_period: 10s
+      timeout: 30s
   mount2:
     image: chrislusf/seaweedfs:local
     privileged: true
     command: "mount -filer=node2:8888 -dir=/mnt -dirAutoCreate"
+    healthcheck:
+      test: [ "CMD", "curl", "--fail", "-I", "http://node2:8888/" ]
+      interval: 1s
+      start_period: 10s
+      timeout: 30s
+    depends_on:
+      node2:
+        condition: service_healthy
   sync:
     image: chrislusf/seaweedfs:local
     command: "-v=4 filer.sync -a=node1:8888 -b=node2:8888 -a.debug -b.debug"
+    depends_on:
+      mount1:
+        condition: service_healthy
+      mount2:
+        condition: service_healthy

--- a/weed/command/filer_remote_sync_dir.go
+++ b/weed/command/filer_remote_sync_dir.go
@@ -33,7 +33,8 @@ func followUpdatesAndUploadToRemote(option *RemoteSyncOptions, filerSource *sour
 		return err
 	}
 
-	processor := NewMetadataProcessor(eachEntryFunc, 128)
+	lastOffsetTs := collectLastSyncOffset(option, option.grpcDialOption, pb.ServerAddress(*option.filerAddress), mountedDir, *option.timeAgo)
+	processor := NewMetadataProcessor(eachEntryFunc, 128, lastOffsetTs.UnixNano())
 
 	var lastLogTsNs = time.Now().UnixNano()
 	processEventFnWithOffset := pb.AddOffsetFunc(func(resp *filer_pb.SubscribeMetadataResponse) error {
@@ -50,17 +51,16 @@ func followUpdatesAndUploadToRemote(option *RemoteSyncOptions, filerSource *sour
 		processor.AddSyncJob(resp)
 		return nil
 	}, 3*time.Second, func(counter int64, lastTsNs int64) error {
-		if processor.processedTsWatermark == 0 {
+		offsetTsNs := processor.processedTsWatermark.Load()
+		if offsetTsNs == 0 {
 			return nil
 		}
 		// use processor.processedTsWatermark instead of the lastTsNs from the most recent job
 		now := time.Now().UnixNano()
-		glog.V(0).Infof("remote sync %s progressed to %v %0.2f/sec", *option.filerAddress, time.Unix(0, processor.processedTsWatermark), float64(counter)/(float64(now-lastLogTsNs)/1e9))
+		glog.V(0).Infof("remote sync %s progressed to %v %0.2f/sec", *option.filerAddress, time.Unix(0, offsetTsNs), float64(counter)/(float64(now-lastLogTsNs)/1e9))
 		lastLogTsNs = now
-		return remote_storage.SetSyncOffset(option.grpcDialOption, pb.ServerAddress(*option.filerAddress), mountedDir, processor.processedTsWatermark)
+		return remote_storage.SetSyncOffset(option.grpcDialOption, pb.ServerAddress(*option.filerAddress), mountedDir, offsetTsNs)
 	})
-
-	lastOffsetTs := collectLastSyncOffset(option, option.grpcDialOption, pb.ServerAddress(*option.filerAddress), mountedDir, *option.timeAgo)
 
 	option.clientEpoch++
 

--- a/weed/command/filer_sync.go
+++ b/weed/command/filer_sync.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync/atomic"
 	"time"
 )
 
@@ -50,7 +51,7 @@ type SyncOptions struct {
 	aDoDeleteFiles  *bool
 	bDoDeleteFiles  *bool
 	clientId        int32
-	clientEpoch     int32
+	clientEpoch     atomic.Int32
 }
 
 const (
@@ -150,10 +151,10 @@ func runFilerSynchronize(cmd *Command, args []string) bool {
 			os.Exit(2)
 		}
 		for {
-			syncOptions.clientEpoch++
+			syncOptions.clientEpoch.Add(1)
 			err := doSubscribeFilerMetaChanges(
 				syncOptions.clientId,
-				syncOptions.clientEpoch,
+				syncOptions.clientEpoch.Load(),
 				grpcDialOption,
 				filerA,
 				*syncOptions.aPath,
@@ -188,10 +189,10 @@ func runFilerSynchronize(cmd *Command, args []string) bool {
 		}
 		go func() {
 			for {
-				syncOptions.clientEpoch++
+				syncOptions.clientEpoch.Add(1)
 				err := doSubscribeFilerMetaChanges(
 					syncOptions.clientId,
-					syncOptions.clientEpoch,
+					syncOptions.clientEpoch.Load(),
 					grpcDialOption,
 					filerB,
 					*syncOptions.bPath,
@@ -274,7 +275,7 @@ func doSubscribeFilerMetaChanges(clientId int32, clientEpoch int32, grpcDialOpti
 		glog.Warningf("invalid concurrency value, using default: %d", DefaultConcurrencyLimit)
 		concurrency = DefaultConcurrencyLimit
 	}
-	processor := NewMetadataProcessor(processEventFn, concurrency)
+	processor := NewMetadataProcessor(processEventFn, concurrency, sourceFilerOffsetTsNs)
 
 	var lastLogTsNs = time.Now().UnixNano()
 	var clientName = fmt.Sprintf("syncFrom_%s_To_%s", string(sourceFiler), string(targetFiler))
@@ -282,16 +283,17 @@ func doSubscribeFilerMetaChanges(clientId int32, clientEpoch int32, grpcDialOpti
 		processor.AddSyncJob(resp)
 		return nil
 	}, 3*time.Second, func(counter int64, lastTsNs int64) error {
-		if processor.processedTsWatermark == 0 {
+		offsetTsNs := processor.processedTsWatermark.Load()
+		if offsetTsNs == 0 {
 			return nil
 		}
 		// use processor.processedTsWatermark instead of the lastTsNs from the most recent job
 		now := time.Now().UnixNano()
-		glog.V(0).Infof("sync %s to %s progressed to %v %0.2f/sec", sourceFiler, targetFiler, time.Unix(0, processor.processedTsWatermark), float64(counter)/(float64(now-lastLogTsNs)/1e9))
+		glog.V(0).Infof("sync %s to %s progressed to %v %0.2f/sec", sourceFiler, targetFiler, time.Unix(0, offsetTsNs), float64(counter)/(float64(now-lastLogTsNs)/1e9))
 		lastLogTsNs = now
 		// collect synchronous offset
-		statsCollect.FilerSyncOffsetGauge.WithLabelValues(sourceFiler.String(), targetFiler.String(), clientName, sourcePath).Set(float64(processor.processedTsWatermark))
-		return setOffset(grpcDialOption, targetFiler, getSignaturePrefixByPath(sourcePath), sourceFilerSignature, processor.processedTsWatermark)
+		statsCollect.FilerSyncOffsetGauge.WithLabelValues(sourceFiler.String(), targetFiler.String(), clientName, sourcePath).Set(float64(offsetTsNs))
+		return setOffset(grpcDialOption, targetFiler, getSignaturePrefixByPath(sourcePath), sourceFilerSignature, offsetTsNs)
 	})
 
 	metadataFollowOption := &pb.MetadataFollowOption{


### PR DESCRIPTION
# What problem are we solving?

At the first start, StartTsNs synchronization is not immediately saved in the KV

https://github.com/seaweedfs/seaweedfs/issues/5195
https://github.com/seaweedfs/seaweedfs/issues/5194

sync logs:
```
I0112 11:01:52.291144 filer_sync.go:283 sync 172.23.1.17:8889 to 172.23.1.22:8889 progressed to 2024-01-12 11:01:50.707339332 +0000 UTC 7.82/sec
I0112 11:01:53.668629 filer_sync.go:244 start sync 172.23.1.17:8889(26522631) => 172.23.1.22:8889(714225182) from 2023-12-30 07:32:41.375628109 +0000 UTC(1703921561375628109)
--
I0112 11:37:17.308526 filer_sync.go:283 sync 172.23.1.17:8889 to 172.23.1.22:8889 progressed to 2024-01-12 11:37:12.989976139 +0000 UTC 2.46/sec
I0112 11:37:20.519268 filer_sync.go:244 start sync 172.23.1.17:8889(26522631) => 172.23.1.22:8889(714225182) from 2023-12-30 07:32:41.375628109 +0000 UTC(1703921561375628109)
--
I0112 12:35:44.264373 filer_sync.go:283 sync 172.23.1.17:8889 to 172.23.1.22:8889 progressed to 2024-01-12 12:35:42.444002175 +0000 UTC 3.47/sec
I0112 12:35:49.557259 filer_sync.go:244 start sync 172.23.1.17:8889(26522631) => 172.23.1.22:8889(714225182) from 2023-12-30 07:32:41.375628109 +0000 UTC(1703921561375628109)
```

# How are we solving the problem?

use atomic and on start init OffsetTsNs for metadataProcessor 

# How is the PR tested?

localy
```
CGO_ENABLED=1 go build -race && ./weed -v=4 filer.sync -a=127.0.0.1:8888 -b=127.0.0.1:7888 -a.debug -b.debug
I0112 15:03:39.398966 config.go:46 Reading : Config File "security" Not Found in "[/Users/whitefox/GolandProjects/seaweedfs/weed /Users/whitefox/.seaweedfs /usr/local/etc/seaweedfs /etc/seaweedfs]"
I0112 15:03:39.412076 filer_sync.go:252 start sync 127.0.0.1:8888(1454599209) => 127.0.0.1:7888(84036997) from 2024-01-12 13:38:10.417321424 +0500 +05(1705048690417321424)
I0112 15:03:39.412086 filer_sync.go:252 start sync 127.0.0.1:7888(84036997) => 127.0.0.1:8888(1454599209) from 2024-01-11 19:20:51.38569696 +0500 +05(1704982851385696960)
I0112 15:03:39.418507 filer_sync.go:292 sync 127.0.0.1:8888 to 127.0.0.1:7888 progressed to 2024-01-12 13:38:10.417321424 +0500 +05 158.35/sec
I0112 15:03:39.418700 filer_sync.go:292 sync 127.0.0.1:7888 to 127.0.0.1:8888 progressed to 2024-01-11 19:20:51.38569696 +0500 +05 154.94/sec
I0112 15:03:39.418709 filer_sync.go:394 received directory:"/"  event_notification:{new_entry:{name:"mount2_test_0"  attributes:{mtime:1704983503  file_mode:420  crtime:1704983503  inode:939179574260652823}}  delete_chunks:true  new_parent_path:"/"  signatures:-1621104884  signatures:84036997}  ts_ns:1704983503551078304
I0112 15:03:39.418545 filer_sync.go:394 received directory:"/"  event_notification:{old_entry:{name:"test_lol100"  attributes:{mtime:1705048690  file_mode:420  crtime:1705048690  inode:10257067146898396612}}  new_entry:{name:"test_lol100"  chunks:{size:7  modified_ts_ns:1705048690417299090  e_tag:"niPfm95I3dJAYnNkHZXPkw=="  fid:{volume_id:6  file_key:127  cookie:3537679189}  is_compressed:true}  attributes:{file_size:7  mtime:1705048690  file_mode:420  crtime:1705048690  mime:"text/plain; charset=utf-8"  inode:10257067146898396612}}  delete_chunks:true  new_parent_path:"/"  signatures:1244411091  signatures:1454599209}  ts_ns:1705048690417855174
I0112 15:03:39.418853 filer_sink.go:173 lookup entry: directory:"/"  name:"test_lol100"
I0112 15:03:39.419470 filer_sync.go:394 received directory:"/"  event_notification:{new_entry:{name:"test_lol_new"  attributes:{mtime:1705049157  file_mode:420  crtime:1705049157  inode:13078435918492321563}}  delete_chunks:true  new_parent_path:"/"  signatures:1244411091  signatures:1454599209}  ts_ns:1705049157375177584
I0112 15:03:39.419871 filer_sink.go:120 already replicated /mount2_test_0
I0112 15:03:39.419832 filer_sink.go:189 oldEntry name:"test_lol100"  attributes:{mtime:1705048690  file_mode:420  crtime:1705048690  inode:10257067146898396612}, newEntry name:"test_lol100"  chunks:{size:7  modified_ts_ns:1705048690417299090  e_tag:"niPfm95I3dJAYnNkHZXPkw=="  fid:{volume_id:6  file_key:127  cookie:3537679189}  is_compressed:true}  attributes:{file_size:7  mtime:1705048690  file_mode:420  crtime:1705048690  mime:"text/plain; charset=utf-8"  inode:10257067146898396612}, existingEntry: name:"test_lol100"  attributes:{mtime:1705048690  file_mode:420  crtime:1705048690  inode:10257067146898396612}
I0112 15:03:39.419913 filer_sync.go:394 received directory:"/"  event_notification:{old_entry:{name:"mount2_test_0"  attributes:{mtime:1704983503  file_mode:420  crtime:1704983503  inode:939179574260652823}}  new_entry:{name:"mount2_test_0"  chunks:{size:4  modified_ts_ns:1704983503553342220  e_tag:"WbzDrWd1Vi+EWVPPAWJCJQ=="  fid:{volume_id:4  file_key:24  cookie:3650840817}  is_compressed:true}  attributes:{file_size:4  mtime:1704983503  file_mode:420  crtime:1704983503  mime:"text/plain; charset=utf-8"  inode:939179574260652823}}  delete_chunks:true  new_parent_path:"/"  signatures:-1621104884  signatures:84036997}  ts_ns:1704983503569892762
I0112 15:03:39.420126 filer_sink.go:173 lookup entry: directory:"/"  name:"mount2_test_0"
I0112 15:03:39.420191 filer_sink.go:120 already replicated /test_lol_new
I0112 15:03:39.420226 filer_sync.go:394 received directory:"/"  event_notification:{old_entry:{name:"test_lol_new"  attributes:{mtime:1705049157  file_mode:420  crtime:1705049157  inode:13078435918492321563}}  new_entry:{name:"test_lol_new"  chunks:{size:4  modified_ts_ns:1705049157379179709  e_tag:"WbzDrWd1Vi+EWVPPAWJCJQ=="  fid:{volume_id:3  file_key:129  cookie:204158483}  is_compressed:true}  attributes:{file_size:4  mtime:1705049157  file_mode:420  crtime:1705049157  mime:"text/plain; charset=utf-8"  inode:13078435918492321563}}  delete_chunks:true  new_parent_path:"/"  signatures:1244411091  signatures:1454599209}  ts_ns:1705049157396666334
I0112 15:03:39.420407 filer_sink.go:173 lookup entry: directory:"/"  name:"test_lol_new"
I0112 15:03:39.420884 filer_sink.go:189 oldEntry name:"mount2_test_0"  attributes:{mtime:1704983503  file_mode:420  crtime:1704983503  inode:939179574260652823}, newEntry name:"mount2_test_0"  chunks:{size:4  modified_ts_ns:1704983503553342220  e_tag:"WbzDrWd1Vi+EWVPPAWJCJQ=="  fid:{volume_id:4  file_key:24  cookie:3650840817}  is_compressed:true}  attributes:{file_size:4  mtime:1704983503  file_mode:420  crtime:1704983503  mime:"text/plain; charset=utf-8"  inode:939179574260652823}, existingEntry: name:"mount2_test_0"  attributes:{mtime:1704983503  file_mode:420  crtime:1704983503  inode:939179574260652823}
I0112 15:03:39.421101 filer_sink.go:189 oldEntry name:"test_lol_new"  attributes:{mtime:1705049157  file_mode:420  crtime:1705049157  inode:13078435918492321563}, newEntry name:"test_lol_new"  chunks:{size:4  modified_ts_ns:1705049157379179709  e_tag:"WbzDrWd1Vi+EWVPPAWJCJQ=="  fid:{volume_id:3  file_key:129  cookie:204158483}  is_compressed:true}  attributes:{file_size:4  mtime:1705049157  file_mode:420  crtime:1705049157  mime:"text/plain; charset=utf-8"  inode:13078435918492321563}, existingEntry: name:"test_lol_new"  attributes:{mtime:1705049157  file_mode:420  crtime:1705049157  inode:13078435918492321563}
```

<img width="1180" alt="image" src="https://github.com/seaweedfs/seaweedfs/assets/9497591/50569b5d-6c97-4de4-a817-f0a77ccfb276">


The original cause of the problem is in the upsert request
Update not work https://dbfiddle.uk/6tMKYdu2
<img width="1367" alt="image" src="https://github.com/seaweedfs/seaweedfs/assets/9497591/c0d1fefd-87e8-48a8-9f04-8b826d464a54">
Update work https://dbfiddle.uk/nYQg2ttG
<img width="1380" alt="image" src="https://github.com/seaweedfs/seaweedfs/assets/9497591/27507847-d1c3-4e58-a1fc-a79acffcf0cc">

https://dev.mysql.com/doc/refman/5.7/en/insert-on-duplicate.html
```
upsertQuery = """INSERT INTO `%s` (`dirhash`,`name`,`directory`,`meta`) VALUES (?,?,?,?) ON DUPLICATE KEY UPDATE `meta` = VALUES(`meta`)"""
```

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
