### PR TITLE
fix: doDeleteFiles deletes files

### DIFF
--- a/weed/command/filer_sync.go
+++ b/weed/command/filer_sync.go
@@ -408,7 +408,7 @@ func genProcessFunction(sourcePath string, targetPath string, excludePaths []str
 		}
 		// handle deletions
 		if filer_pb.IsDelete(resp) {
-			if doDeleteFiles {
+			if !doDeleteFiles {
 				return nil
 			}
 			if !strings.HasPrefix(string(sourceOldKey), sourcePath) {


### PR DESCRIPTION
# What problem are we solving?
if doDeleteFiles is false then the files are deleted 
```
/usr/bin/weed filer.sync -a  192.168.0.1:8889 -b 192.168.0.2:8889 -a.path / -b.path b.doDeleteFiles=false
I0112 10:51:34.052780 filer_sink.go:97 delete entry: /buckets/webdav/2/2/012975d1b383bde2750347ebdd6a5186a00fb9d9.json
```

# How are we solving the problem?

invert login if 

# How is the PR tested?

```
localy
```

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
