### PR TITLE
chore: filer healthz handler check filer store

### DIFF
--- a/weed/server/filer_server.go
+++ b/weed/server/filer_server.go
@@ -171,6 +171,7 @@ func NewFilerServer(defaultMux, readonlyMux *http.ServeMux, option *FilerOption)
 	}
 	if defaultMux != readonlyMux {
 		handleStaticResources(readonlyMux)
+		readonlyMux.HandleFunc("/healthz", fs.filerHealthzHandler)
 		readonlyMux.HandleFunc("/", fs.readonlyFilerHandler)
 	}
 

--- a/weed/server/filer_server_handlers.go
+++ b/weed/server/filer_server_handlers.go
@@ -1,6 +1,7 @@
 package weed_server
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"os"
@@ -9,7 +10,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/glog"
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/security"
 	"github.com/seaweedfs/seaweedfs/weed/util"
 
@@ -220,5 +223,9 @@ func (fs *FilerServer) maybeCheckJwtAuthorization(r *http.Request, isWrite bool)
 
 func (fs *FilerServer) filerHealthzHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Server", "SeaweedFS Filer "+util.VERSION)
+	if _, err := fs.filer.Store.FindEntry(context.Background(), filer.TopicsDir); err != nil && err != filer_pb.ErrNotFound {
+		glog.Warningf("filerHealthzHandler FindEntry: %+v", err)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}
 	w.WriteHeader(http.StatusOK)
 }

--- a/weed/server/filer_server_handlers.go
+++ b/weed/server/filer_server_handlers.go
@@ -226,6 +226,7 @@ func (fs *FilerServer) filerHealthzHandler(w http.ResponseWriter, r *http.Reques
 	if _, err := fs.filer.Store.FindEntry(context.Background(), filer.TopicsDir); err != nil && err != filer_pb.ErrNotFound {
 		glog.Warningf("filerHealthzHandler FindEntry: %+v", err)
 		w.WriteHeader(http.StatusServiceUnavailable)
+	} else {
+		w.WriteHeader(http.StatusOK)
 	}
-	w.WriteHeader(http.StatusOK)
 }


### PR DESCRIPTION
# What problem are we solving?

Check the storage life

# How are we solving the problem?

 filer healthz handler check filer store

# How is the PR tested?

localy
```
make server
curl -v http://127.0.0.1:8888/healthz
*   Trying 127.0.0.1:8888...
* Connected to 127.0.0.1 (127.0.0.1) port 8888
> GET /healthz HTTP/1.1
> Host: 127.0.0.1:8888
> User-Agent: curl/8.4.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Server: SeaweedFS Filer 30GB 3.62
< Date: Wed, 17 Jan 2024 10:04:23 GMT
< Content-Length: 0

```

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
