### PR TITLE
chore: fix typos in scaffold help output

### DIFF
--- a/weed/command/scaffold.go
+++ b/weed/command/scaffold.go
@@ -21,9 +21,9 @@ var cmdScaffold = &Command{
 	For example, the filer.toml mysql password can be overwritten by environment variable
 		export WEED_MYSQL_PASSWORD=some_password
 	Environment variable rules:
-		* Prefix the variable name with "WEED_"
-		* Uppercase the reset of variable name.
-		* Replace '.' with '_'
+		* Prefix the variable name with "WEED_".
+		* Uppercase the rest of the variable name.
+		* Replace '.' with '_'.
 
   `,
 }


### PR DESCRIPTION
# What problem are we solving?
Minor typos in `weed scaffold --help` output.


# How are we solving the problem?


# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
