### PR TITLE
fix: skip s3 .uploads

### DIFF
--- a/weed/command/filer_sync.go
+++ b/weed/command/filer_sync.go
@@ -11,6 +11,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/replication/sink"
 	"github.com/seaweedfs/seaweedfs/weed/replication/sink/filersink"
 	"github.com/seaweedfs/seaweedfs/weed/replication/source"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 	"github.com/seaweedfs/seaweedfs/weed/security"
 	statsCollect "github.com/seaweedfs/seaweedfs/weed/stats"
 	"github.com/seaweedfs/seaweedfs/weed/util"
@@ -393,7 +394,9 @@ func genProcessFunction(sourcePath string, targetPath string, excludePaths []str
 		if debug {
 			glog.V(0).Infof("received %v", resp)
 		}
-
+		if strings.Contains(resp.Directory, "/"+s3_constants.MultipartUploadsFolder+"/") {
+			return nil
+		}
 		if !strings.HasPrefix(resp.Directory, sourcePath) {
 			return nil
 		}


### PR DESCRIPTION
# What problem are we solving?
#4758 [filer]filer.sync with default concurrency(32) leaves lot of orphans 
- `.uploads` folder is used during s3 multi-part uploads and will be deleted after a successful upload
- During filer.sync, as the real data is referenced by two files (the final file and temp file in .uploads), it will be synced twice

# How are we solving the problem?
skip .uploads folder during sync
@chrislusf  may be it's a better idea not to include `.uploads` folder in system log?

# How is the PR tested?
- add `-s3` param to `local-sync-mount-compose.yml` 
- using the following python code to upload a large(100MB) file to node-1
```
from minio import Minio
from minio.error import S3Error

def main():
    # Create a client with the MinIO server playground, its access key
    # and secret key.
    client = Minio("192.168.207.2:8333",
        access_key="",
        secret_key="",
        secure=False

    )

    # The file to upload, change this path if needed
    source_file = "test.mp4"

    # The destination bucket and filename on the MinIO server
    bucket_name = "test"
    destination_file = "test.mp4"

    # Make the bucket if it doesn't exist.
    found = client.bucket_exists(bucket_name)
    if not found:
        client.make_bucket(bucket_name)
        print("Created bucket", bucket_name)
    else:
        print("Bucket", bucket_name, "already exists")

    # Upload the file, renaming it in the process
    client.fput_object(
        bucket_name, destination_file, source_file,
    )
    print(
        source_file, "successfully uploaded as object",
        destination_file, "to bucket", bucket_name,
    )

if __name__ == "__main__":
    try:
        main()
    except S3Error as exc:
        print("error occurred.", exc)
```
- Verify that the file has been replicated to node-2 successfully and there is no `.uploads` folder created

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
