### PR TITLE
Update the solution when a file cannot be located.

### DIFF
--- a/other/java/client/src/main/java/seaweedfs/client/SeaweedRead.java
+++ b/other/java/client/src/main/java/seaweedfs/client/SeaweedRead.java
@@ -69,7 +69,7 @@ public class SeaweedRead {
             if (locations == null || locations.getLocationsCount() == 0) {
                 LOG.error("failed to locate {}", chunkView.fileId);
                 volumeIdCache.clearLocations(volumeId);
-                return 0;
+                throw new IOException("failed to locate file");
             }
 
             int len = readChunkView(filerClient, startOffset, buf, chunkView, locations);


### PR DESCRIPTION
# What problem are we solving?
When a file cannot be located, return 0 maybe not a good solution.
Issues in   #5218 

# How are we solving the problem?
Throw an exception directly when the file cannot be located.
I would like to ask everyone, is it feasible to handle issues by directly throwing an IOException? This is to avoid the risk of falling into an infinite loop when calling the SeaweedInputStream.read method.

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
