### PR TITLE
#5230 The 'path' parameter in filer.sync matches any bucket that has the prefix

### DIFF
--- a/weed/command/filer_sync.go
+++ b/weed/command/filer_sync.go
@@ -251,6 +251,13 @@ func doSubscribeFilerMetaChanges(clientId int32, clientEpoch int32, grpcDialOpti
 
 	glog.V(0).Infof("start sync %s(%d) => %s(%d) from %v(%d)", sourceFiler, sourceFilerSignature, targetFiler, targetFilerSignature, time.Unix(0, sourceFilerOffsetTsNs), sourceFilerOffsetTsNs)
 
+	if !strings.HasSuffix(sourcePath, "/") {
+		sourcePath = sourcePath + "/"
+	}
+	if !strings.HasSuffix(targetPath, "/") {
+		targetPath = targetPath + "/"
+	}
+
 	// create filer sink
 	filerSource := &source.FilerSource{}
 	filerSource.DoInitialize(sourceFiler.ToHttpAddress(), sourceFiler.ToGrpcAddress(), sourcePath, sourceReadChunkFromFiler)
@@ -398,7 +405,7 @@ func genProcessFunction(sourcePath string, targetPath string, excludePaths []str
 			return nil
 		}
 
-		if !strings.HasPrefix(resp.Directory, sourcePath) {
+		if !strings.HasPrefix(resp.Directory+"/", sourcePath) {
 			return nil
 		}
 		for _, excludePath := range excludePaths {

--- a/weed/command/filer_sync.go
+++ b/weed/command/filer_sync.go
@@ -251,6 +251,7 @@ func doSubscribeFilerMetaChanges(clientId int32, clientEpoch int32, grpcDialOpti
 
 	glog.V(0).Infof("start sync %s(%d) => %s(%d) from %v(%d)", sourceFiler, sourceFilerSignature, targetFiler, targetFilerSignature, time.Unix(0, sourceFilerOffsetTsNs), sourceFilerOffsetTsNs)
 
+	var orgSourcePath = sourcePath
 	if !strings.HasSuffix(sourcePath, "/") {
 		sourcePath = sourcePath + "/"
 	}
@@ -300,7 +301,7 @@ func doSubscribeFilerMetaChanges(clientId int32, clientEpoch int32, grpcDialOpti
 		lastLogTsNs = now
 		// collect synchronous offset
 		statsCollect.FilerSyncOffsetGauge.WithLabelValues(sourceFiler.String(), targetFiler.String(), clientName, sourcePath).Set(float64(offsetTsNs))
-		return setOffset(grpcDialOption, targetFiler, getSignaturePrefixByPath(sourcePath), sourceFilerSignature, offsetTsNs)
+		return setOffset(grpcDialOption, targetFiler, getSignaturePrefixByPath(orgSourcePath), sourceFilerSignature, offsetTsNs)
 	})
 
 	metadataFollowOption := &pb.MetadataFollowOption{


### PR DESCRIPTION
# What problem are we solving?
#5230


# How are we solving the problem?
This should be considered a quick fix that just works with #5230.  It adds a slash to the end of path without altering `Signature`.
However, I'm not sure this is the right way to do it. Extra care should be taken while dealing with path slashes.


# How is the PR tested?
- using `local-sync-mount-compose.yml` , add ` "-a.debug -b.debug -a.path /buckets/test1 -b.path /buckets/test1 `
- verify `/buckets/test1` is synced normally
- With this patch,  `/buckets/test123` should no longer touched by sync

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
