### PR TITLE
Enable multiple disks per volume server. Also streamline the use of /logs & /idx

### DIFF
--- a/k8s/charts/seaweedfs/templates/_helpers.tpl
+++ b/k8s/charts/seaweedfs/templates/_helpers.tpl
@@ -142,7 +142,7 @@ Inject extra environment vars in the format key:value, if populated
 
 {{/* check if any InitContainers exist for Volumes */}}
 {{- define "volume.initContainers_exists" -}}
-{{- if or (not (empty .Values.volume.dir_idx )) (not (empty .Values.volume.initContainers )) -}}
+{{- if or (not (empty .Values.volume.idx )) (not (empty .Values.volume.initContainers )) -}}
 {{- printf "true" -}}
 {{- else -}}
 {{- printf "" -}}

--- a/k8s/charts/seaweedfs/templates/volume-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/volume-statefulset.yaml
@@ -64,8 +64,10 @@ spec:
           volumeMounts:
             - name: idx
               mountPath: {{ .Values.volume.idx.name }}
-            - name: data
-              mountPath: {{ .Values.volume.dir }}
+          {{- range $dir :=  .Values.volume.dataDirs }} 
+            - name: {{ $dir.name }}
+              mountPath: /{{ $dir.name }}
+          {{- end }}
         {{- end }}
         {{- if .Values.volume.initContainers }}
         {{ tpl .Values.volume.initContainers . | nindent 8 | trim }}

--- a/k8s/charts/seaweedfs/templates/volume-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/volume-statefulset.yaml
@@ -55,15 +55,15 @@ spec:
       {{- $initContainers_exists := include "volume.initContainers_exists" . -}}
       {{- if $initContainers_exists }}
       initContainers:
-        {{- if .Values.volume.dir_idx }}
+        {{- if .Values.volume.idx }}
         - name: seaweedfs-vol-move-idx
           image: {{ template "volume.image" . }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}
           command: [ '/bin/sh', '-c' ]
-          args: [ 'if ls {{ .Values.volume.dir }}/*.idx >/dev/null 2>&1; then mv {{ .Values.volume.dir }}/*.idx {{ .Values.volume.dir_idx }}/; fi;' ]
+          args: [ 'ls {{range $dir :=  .Values.volume.dataDirs }}/{{$dir.name}}/*.idx {{end}} && xargs -I {} mv {} /idx/' ]
           volumeMounts:
             - name: idx
-              mountPath: {{ .Values.volume.dir_idx }}
+              mountPath: {{ .Values.volume.idx.name }}
             - name: data
               mountPath: {{ .Values.volume.dir }}
         {{- end }}
@@ -101,7 +101,7 @@ spec:
             - "-ec"
             - |
               exec /usr/bin/weed \
-                {{- if eq .Values.volume.logs.type "hostPath" }}
+                {{- if .Values.volume.logs }}
                 -logdir=/logs \
                 {{- else }}
                 -logtostderr=true \
@@ -116,11 +116,11 @@ spec:
                 {{- if .Values.volume.metricsPort }}
                 -metricsPort={{ .Values.volume.metricsPort }} \
                 {{- end }}
-                -dir={{ .Values.volume.dir }} \
-                {{- if .Values.volume.dir_idx }}
-                -dir.idx={{ .Values.volume.dir_idx }} \
+                -dir {{range $index, $dir :=  .Values.volume.dataDirs }}{{if ne $index 0}},{{end}}/{{$dir.name}}{{end}} \
+                {{- if .Values.volume.idx }}
+                -dir.idx= /idx \
                 {{- end }}
-                -max={{ .Values.volume.maxVolumes }} \
+                -max {{range $index, $dir :=  .Values.volume.dataDirs }}{{if ne $index 0}},{{end}}{{$dir.maxVolumes}}{{end}} \
                 {{- if .Values.volume.rack }}
                 -rack={{ .Values.volume.rack }} \
                 {{- end }}
@@ -149,15 +149,17 @@ spec:
                 -compactionMBps={{ .Values.volume.compactionMBps }} \
                 -mserver={{ range $index := until (.Values.master.replicas | int) }}${SEAWEEDFS_FULLNAME}-master-{{ $index }}.${SEAWEEDFS_FULLNAME}-master.{{ $.Release.Namespace }}:{{ $.Values.master.port }}{{ if lt $index (sub ($.Values.master.replicas | int) 1) }},{{ end }}{{ end }}
           volumeMounts:
-            - name: data
-              mountPath: "{{ .Values.volume.dir }}/"
-            {{- if .Values.volume.dir_idx }}
-            - name: idx
-              mountPath: "{{ .Values.volume.dir_idx }}/"
+            {{- range $dir := .Values.volume.dataDirs }}
+            - name: {{ $dir.name }}
+              mountPath: "/{{ $dir.name }}/"
             {{- end }}
-            {{- if eq .Values.volume.logs.type "hostPath" }}
+            {{- if .Values.volume.logs }}
             - name: logs
               mountPath: "/logs/"
+            {{- end }}
+            {{- if .Values.volume.idx }}
+            - name: idx
+              mountPath: "/idx/"
             {{- end }}
             {{- if .Values.global.enableSecurity }}
             - name: security-config
@@ -222,40 +224,51 @@ spec:
       {{- include "common.tplvalues.render" (dict "value" .Values.volume.sidecars "context" $) | nindent 8 }}
       {{- end }}
       volumes:
-        {{- if eq .Values.volume.data.type "hostPath" }}
-        - name: data
+
+     {{- range $dir := .Values.volume.dataDirs }}
+
+      {{- if eq $dir.type "hostPath" }}
+        - name: {{ $dir.name }}
           hostPath:
-            path: {{ .Values.volume.data.hostPathPrefix }}/object_store/
+            path: {{ $dir.hostPathPrefix }}/object_store/
             type: DirectoryOrCreate
-        {{- end }}
-        {{- if eq .Values.volume.data.type "existingClaim" }}
-        - name: data
+      {{- end }}
+      {{- if eq $dir.type "existingClaim" }}
+        - name: {{ $dir.name }}
           persistentVolumeClaim:
-            claimName: {{ .Values.volume.data.claimName }} 
-        {{- end }}
-        {{- if and (eq .Values.volume.idx.type "hostPath") .Values.volume.dir_idx }}
+            claimName: {{ $dir.claimName }} 
+      {{- end }}
+
+     {{- end }}
+
+     {{- if .Values.volume.idx }}
+       {{- if eq .Values.volume.idx.type "hostPath" }}
         - name: idx
           hostPath:
             path: {{ .Values.volume.idx.hostPathPrefix }}/seaweedfs-volume-idx/
             type: DirectoryOrCreate
-        {{- end }}
-        {{- if eq .Values.volume.idx.type "existingClaim" }}
+       {{- end }}
+       {{- if eq .Values.volume.idx.type "existingClaim" }}
         - name: idx
           persistentVolumeClaim:
             claimName: {{ .Values.volume.idx.claimName }} 
-        {{- end }}
-        {{- if eq .Values.volume.logs.type "hostPath" }}
+       {{- end }}
+     {{- end }}
+
+     {{- if .Values.volume.logs }}
+       {{- if eq .Values.volume.logs.type "hostPath" }}
         - name: logs
           hostPath:
             path: {{ .Values.volume.logs.hostPathPrefix }}/logs/seaweedfs/volume
             type: DirectoryOrCreate
-        {{- end }}
-        {{- if eq .Values.volume.logs.type "existingClaim" }}
+       {{- end }}
+       {{- if eq .Values.volume.logs.type "existingClaim" }}
         - name: logs
           persistentVolumeClaim:
-            claimName: {{ .Values.volume.data.claimName }} 
-        {{- end }}
-        {{- if .Values.global.enableSecurity }}
+            claimName: {{ .Values.volume.logs.claimName }} 
+       {{- end }}
+     {{- end }}
+     {{- if .Values.global.enableSecurity }}
         - name: security-config
           configMap:
             name: {{ template "seaweedfs.name" . }}-security-config
@@ -274,7 +287,7 @@ spec:
         - name: client-cert
           secret:
             secretName: {{ template "seaweedfs.name" . }}-client-cert
-        {{- end }}
+      {{- end }}
       {{- if .Values.volume.extraVolumes }}
         {{ tpl .Values.volume.extraVolumes . | indent 8 | trim }}
       {{- end }}
@@ -282,24 +295,25 @@ spec:
       nodeSelector:
         {{ tpl .Values.volume.nodeSelector . | indent 8 | trim }}
       {{- end }}
-  {{- $pvc_exists := include "volume.pvc_exists" . -}}
-  {{- if $pvc_exists }}
   volumeClaimTemplates:
-    {{- if eq .Values.volume.data.type "persistentVolumeClaim"}}
+    {{- range $dir := .Values.volume.dataDirs }}
+    {{- if eq $dir.type "persistentVolumeClaim" }}
     - metadata:
-        name: data
-        {{- with .Values.volume.data.annotations }}
+        name: {{ $dir.name }}
+        {{- with $dir.annotations }}
         annotations:
           {{- toYaml . | nindent 10 }}
         {{- end }}
       spec:
         accessModes: [ "ReadWriteOnce" ]
-        storageClassName: {{ .Values.volume.data.storageClass }}
+        storageClassName: {{ $dir.storageClass }}
         resources:
           requests:
-            storage: {{ .Values.volume.data.size }}
+            storage: {{ $dir.size }}
     {{- end }}
-    {{- if and (eq .Values.volume.idx.type "persistentVolumeClaim") .Values.volume.dir_idx }}
+    {{- end }}
+
+    {{- if and .Values.volume.idx (eq .Values.volume.idx.type "persistentVolumeClaim") }}
     - metadata:
         name: idx
         {{- with .Values.volume.idx.annotations }}
@@ -313,7 +327,7 @@ spec:
           requests:
             storage: {{ .Values.volume.idx.size }}
     {{- end }}
-    {{- if eq .Values.volume.logs.type "persistentVolumeClaim" }}
+    {{- if and .Values.volume.logs (eq .Values.volume.logs.type "persistentVolumeClaim") }}
     - metadata:
         name: logs
         {{- with .Values.volume.logs.annotations }}
@@ -327,5 +341,4 @@ spec:
           requests:
             storage: {{ .Values.volume.logs.size }}
     {{- end }}
-      {{- end }}
-{{- end }}
+    {{- end }}

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -270,7 +270,6 @@ volume:
 
 
   idx:
-    name: idx
     type: "hostPath"
     size: ""
     storageClass: ""

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -89,7 +89,6 @@ master:
   #    claimName: "my-pvc"
   data:
     type: "hostPath"
-    size: ""
     storageClass: ""
     hostPathPrefix: /ssd
 
@@ -239,31 +238,44 @@ volume:
   # minimum free disk space(in percents). If free disk space lower this value - all volumes marks as ReadOnly
   minFreeSpacePercent: 7
 
-  # You may use ANY storage-class, example with local-path-provisioner
+  # For each data disk you may use ANY storage-class, example with local-path-provisioner
   # Annotations are optional.
-  #  data:
-  #    type: "persistentVolumeClaim"
-  #    size: "24Ti"
-  #    storageClass: "local-path-provisioner"
-  #    annotations:
+  #  dataDirs:
+  #   - name: data:
+  #     type: "persistentVolumeClaim"
+  #     size: "24Ti"
+  #     storageClass: "local-path-provisioner"
+  #     annotations:
   #      "key": "value"
+  #     maxVolumes: 0
   #
   # You may also spacify an existing claim:
-  #  data:
-  #    type: "existingClaim"
-  #    claimName: "my-pvc"
+  #    - name: data
+  #      type: "existingClaim"
+  #      claimName: "my-pvc"
+  #     maxVolumes: 0
 
-  data:
-    type: "hostPath"
-    size: ""
-    storageClass: ""
-    hostPathPrefix: /storage
+
+  dataDirs:
+   - name: data1
+     type: "hostPath"
+     hostPathPrefix: /ssd
+     maxVolumes: 0   # If set to zero on non-windows OS, the limit will be auto configured. (default "7")
+
+   #- name: data2
+   #  type: "persistentVolumeClaim"
+   #  storageClass: "yourClassNameOfChoice"
+   #  size: "800Gi"
+   #  maxVolumes: 0
+
 
   idx:
+    name: idx
     type: "hostPath"
     size: ""
     storageClass: ""
     hostPathPrefix: /ssd
+
 
   logs:
     type: "hostPath"
@@ -274,14 +286,6 @@ volume:
   # limit background compaction or copying speed in mega bytes per second
   compactionMBps: "50"
 
-  # Directories to store data files. dir[,dir]... (default "/tmp")
-  dir: "/data"
-  # Directories to store index files. dir[,dir]... (default is the same as "dir")
-  dir_idx: null
-
-  # Maximum numbers of volumes, count[,count]...
-  # If set to zero on non-windows OS, the limit will be auto configured. (default "7")
-  maxVolumes: "0"
 
   # Volume server's rack name
   rack: null


### PR DESCRIPTION
# What problem are we solving?

While weed can have multiple disks passed as a parameter, this is not currently possible with the 
current Helm Chart. This PR solves essentially this. 

This is a problem because the only option to extend the cluster storage capacity is to either 
-  add a new node and install a new volume server  on it
-  add a new instance of the volume server on the same node (changing the antiafinity rule) 

Both options feels awkward/suboptimal when "weed" allows to manage multiple disk on one instance

# How are we solving the problem?

- change of structures for data

The `data` property for `Values.volume` becomes `dataDirs` and is now an array.

- Changes in `templates/volume-statefulset.yaml`

  - We basically loop over `dataDirs` to make sure we create the appropriate `volumes` and `persistenVolumeClaims" needed.

  - `maxVolumes` is derived as well from the `dataDirs` and use accordingly (it needs to be speicifed in the for each dataDir entry) 


- Not 100% linked to the main feature but in there too:

   - We simplified the management of the idx folder removing the use of dir_idx in the process and made sure 
   the volume is mounted
   - For logs volume: we make sure it is mounted not matter the type
   
# How is the PR tested?

Manually only by using different combinaison of volume type for dataDirs, logs and idx. 

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
