### PR TITLE
fix: s3tests test_get_object_ifnonematch_good

### DIFF
--- a/weed/server/filer_server_handlers_read.go
+++ b/weed/server/filer_server_handlers_read.go
@@ -67,12 +67,14 @@ func checkPreconditions(w http.ResponseWriter, r *http.Request, entry *filer.Ent
 	ifModifiedSinceHeader := r.Header.Get("If-Modified-Since")
 	if ifNoneMatchETagHeader != "" {
 		if util.CanonicalizeETag(etag) == util.CanonicalizeETag(ifNoneMatchETagHeader) {
+			setEtag(w, etag)
 			w.WriteHeader(http.StatusNotModified)
 			return true
 		}
 	} else if ifModifiedSinceHeader != "" {
 		if t, parseError := time.Parse(http.TimeFormat, ifModifiedSinceHeader); parseError == nil {
 			if !t.Before(entry.Attr.Mtime) {
+				setEtag(w, etag)
 				w.WriteHeader(http.StatusNotModified)
 				return true
 			}
@@ -147,11 +149,11 @@ func (fs *FilerServer) GetOrHeadHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	etag := filer.ETagEntry(entry)
 	if checkPreconditions(w, r, entry) {
 		return
 	}
 
+	etag := filer.ETagEntry(entry)
 	w.Header().Set("Accept-Ranges", "bytes")
 
 	// mime type


### PR DESCRIPTION
# What problem are we solving?

```
____________________ test_get_object_ifmodifiedsince_failed ____________________
    @pytest.mark.fails_on_dbstore
    def test_get_object_ifmodifiedsince_failed():
        bucket_name = get_new_bucket()
        client = get_client()
        client.put_object(Bucket=bucket_name, Key='foo', Body='bar')
        response = client.get_object(Bucket=bucket_name, Key='foo')
        etag = response['ETag']
        last_modified = str(response['LastModified'])
    
        last_modified = last_modified.split('+')[0]
        mtime = datetime.datetime.strptime(last_modified, '%Y-%m-%d %H:%M:%S')
    
        after = mtime + datetime.timedelta(seconds=1)
        after_str = time.strftime("%a, %d %b %Y %H:%M:%S GMT", after.timetuple())
    
        time.sleep(1)
    
        e = assert_raises(ClientError, client.get_object, Bucket=bucket_name, Key='foo', IfModifiedSince=after_str)
        status, error_code = _get_status_and_error_code(e.response)
        assert status == 304
        assert e.response['Error']['Message'] == 'Not Modified'
>       assert e.response['ResponseMetadata']['HTTPHeaders']['etag'] == etag
E       KeyError: 'etag'
s3tests_boto3/functional/test_s3.py:3050: KeyError
```

# How are we solving the problem?


add etag to Headers

# How is the PR tested?

```
S3TEST_CONF=s3tests.conf tox -- s3tests_boto3/functional/test_s3.py::test_get_object_ifnonematch_good s3tests_boto3/functional/test_s3.py::test_get_object_ifmodifiedsince_failed
py: commands[0]> pytest s3tests_boto3/functional/test_s3.py::test_get_object_ifnonematch_good s3tests_boto3/functional/test_s3.py::test_get_object_ifmodifiedsince_failed
================================================================= test session starts ==================================================================
platform darwin -- Python 3.12.1, pytest-7.4.4, pluggy-1.3.0
cachedir: .tox/py/.pytest_cache
rootdir: /Users/whitefox/PycharmProjects/s3-tests
configfile: pytest.ini
collected 2 items                                                                                                                                      

s3tests_boto3/functional/test_s3.py ..                                                                                                           [100%]


============================================================ 2 passed, 24 warnings in 1.96s ============================================================
  py: OK (4.14=setup[2.01]+cmd[2.13] seconds)
  congratulations :) (4.18 seconds)

```

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
