### PR TITLE
weed/shell: Fix volume.balance logic

### DIFF
--- a/weed/shell/command_volume_balance.go
+++ b/weed/shell/command_volume_balance.go
@@ -279,7 +279,8 @@ func balanceSelectedVolume(commandEnv *CommandEnv, diskType types.DiskType, volu
 		}
 
 		var fullNode *Node
-		for fullNodeIndex := len(nodesWithCapacity) - 1; fullNodeIndex >= 0; fullNodeIndex-- {
+		var fullNodeIndex int
+		for fullNodeIndex = len(nodesWithCapacity) - 1; fullNodeIndex >= 0; fullNodeIndex-- {
 			fullNode = nodesWithCapacity[fullNodeIndex]
 			if !fullNode.isOneVolumeOnly() {
 				break
@@ -290,9 +291,7 @@ func balanceSelectedVolume(commandEnv *CommandEnv, diskType types.DiskType, volu
 			candidateVolumes = append(candidateVolumes, v)
 		}
 		sortCandidatesFn(candidateVolumes)
-
-		for i := 0; i < len(nodesWithCapacity)-1; i++ {
-			emptyNode := nodesWithCapacity[i]
+		for _, emptyNode := range nodesWithCapacity[:fullNodeIndex] {
 			if !(fullNode.localVolumeRatio(capacityFunc) > idealVolumeRatio && emptyNode.localVolumeNextRatio(capacityFunc) <= idealVolumeRatio) {
 				// no more volume servers with empty slots
 				break

--- a/weed/shell/command_volume_balance.go
+++ b/weed/shell/command_volume_balance.go
@@ -1,6 +1,7 @@
 package shell
 
 import (
+	"cmp"
 	"flag"
 	"fmt"
 	"io"
@@ -244,7 +245,7 @@ func (n *Node) selectVolumes(fn func(v *master_pb.VolumeInformationMessage) bool
 
 func sortWritableVolumes(volumes []*master_pb.VolumeInformationMessage) {
 	slices.SortFunc(volumes, func(a, b *master_pb.VolumeInformationMessage) int {
-		return int(a.Size - b.Size)
+		return cmp.Compare(a.Size, b.Size)
 	})
 }
 
@@ -270,7 +271,7 @@ func balanceSelectedVolume(commandEnv *CommandEnv, diskType types.DiskType, volu
 	for hasMoved {
 		hasMoved = false
 		slices.SortFunc(nodesWithCapacity, func(a, b *Node) int {
-			return int(a.localVolumeRatio(capacityFunc) - b.localVolumeRatio(capacityFunc))
+			return cmp.Compare(a.localVolumeRatio(capacityFunc), b.localVolumeRatio(capacityFunc))
 		})
 		if len(nodesWithCapacity) == 0 {
 			fmt.Printf("no volume server found with capacity for %s", diskType.ReadableString())


### PR DESCRIPTION
# What problem are we solving?

The `volume.balance` command failed to properly balance volumes, because when
it sorted nodes by capacity, it used this comparison function:
    
```golang
func(a, b *Node) int {
  return int(a.localVolumeRatio(capacityFunc) - b.localVolumeRatio(capacityFunc))
})
 ```
    
This doesn't work because `int(-0.1)` is zero, not a negative number, so nodes
were not properly sorted.

# How are we solving the problem?

Make use of `cmp.Compare()` instead, which returns the expected
result. 

# How is the PR tested?

On a SeaweedFS cluster that was imbalanced, I ran `volume.balance`, but it didn't move anything. After applying this PR, I ran it again and this time it moved the volumes properly.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
