### PR TITLE
fix: clean metric MasterReplicaPlacementMismatch for unregister volume

### DIFF
--- a/weed/topology/topology.go
+++ b/weed/topology/topology.go
@@ -19,6 +19,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
 	"github.com/seaweedfs/seaweedfs/weed/sequence"
+	"github.com/seaweedfs/seaweedfs/weed/stats"
 	"github.com/seaweedfs/seaweedfs/weed/storage"
 	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
 	"github.com/seaweedfs/seaweedfs/weed/storage/super_block"
@@ -273,6 +274,9 @@ func (t *Topology) RegisterVolumeLayout(v storage.VolumeInfo, dn *DataNode) {
 }
 func (t *Topology) UnRegisterVolumeLayout(v storage.VolumeInfo, dn *DataNode) {
 	glog.Infof("removing volume info: %+v from %v", v, dn.id)
+	if v.ReplicaPlacement.GetCopyCount() > 1 {
+		stats.MasterReplicaPlacementMismatch.WithLabelValues(v.Collection, v.Id.String()).Set(0)
+	}
 	diskType := types.ToDiskType(v.DiskType)
 	volumeLayout := t.GetVolumeLayout(v.Collection, v.ReplicaPlacement, v.Ttl, diskType)
 	volumeLayout.UnRegisterVolume(&v, dn)


### PR DESCRIPTION
# What problem are we solving?

Metrics show SeaweedFS_master_replica_placement_mismatch count 1
```

SeaweedFS_master_replica_placement_mismatch{alias="dev-seaweedfs-03", cluster_name="dev_01", collection="s3tests-9l6epbl489iir29a082ua-10", group="seaweedfs_dev_01", id="121", instance="dev-seaweedfs-03.host:9324", job="seaweedfs_master_exporter", project="storage"} | 1
SeaweedFS_master_replica_placement_mismatch{alias="dev-seaweedfs-03", cluster_name="dev_01", collection="s3tests-9l6epbl489iir29a082ua-10", group="seaweedfs_dev_01", id="122", instance="dev-seaweedfs-03.host:9324", job="seaweedfs_master_exporter", project="storage"} | 1
SeaweedFS_master_replica_placement_mismatch{alias="dev-seaweedfs-03", cluster_name="dev_01", collection="s3tests-9l6epbl489iir29a082ua-12", group="seaweedfs_dev_01", id="126", instance="dev-seaweedfs-01.host:9324", job="seaweedfs_master_exporter", project="storage"} | 1
```
But volume.fix.replication does not show any problems and there are no such volumes
```
> volume.fix.replication -n

```

# How are we solving the problem?

set  zero for SeaweedFS_master_replica_placement_mismatch on unregister volume 

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
