### PR TITLE
weed/shell: Cluster check other disk types

### DIFF
--- a/weed/shell/command_cluster_check.go
+++ b/weed/shell/command_cluster_check.go
@@ -90,9 +90,7 @@ func (c *commandClusterCheck) Do(args []string, commandEnv *CommandEnv, writer i
 
 	// collect all masters
 	var masters []pb.ServerAddress
-	for _, master := range commandEnv.MasterClient.GetMasters() {
-		masters = append(masters, master)
-	}
+	masters = append(masters, commandEnv.MasterClient.GetMasters()...)
 
 	// check from master to volume servers
 	for _, master := range masters {

--- a/weed/shell/command_cluster_check.go
+++ b/weed/shell/command_cluster_check.go
@@ -73,6 +73,19 @@ func (c *commandClusterCheck) Do(args []string, commandEnv *CommandEnv, writer i
 	}
 	fmt.Fprintf(writer, "the cluster has %d filers: %+v\n", len(filers), filers)
 
+	if len(filers) > 0 {
+		genericDiskInfo, genericDiskInfoOk := topologyInfo.DiskInfos[""]
+		hddDiskInfo, hddDiskInfoOk := topologyInfo.DiskInfos["hdd"]
+
+		if !genericDiskInfoOk && !hddDiskInfoOk {
+			return fmt.Errorf("filer metadata logs need generic or hdd disk type to be defined")
+		}
+
+		if (genericDiskInfoOk && genericDiskInfo.MaxVolumeCount == 0) || (hddDiskInfoOk && hddDiskInfo.MaxVolumeCount == 0) {
+			return fmt.Errorf("filer metadata logs need generic or hdd volumes to be available")
+		}
+	}
+
 	// collect volume servers
 	var volumeServers []pb.ServerAddress
 	t, _, err := collectTopologyInfo(commandEnv, 0)

--- a/weed/shell/command_cluster_check.go
+++ b/weed/shell/command_cluster_check.go
@@ -46,13 +46,13 @@ func (c *commandClusterCheck) Do(args []string, commandEnv *CommandEnv, writer i
 	}
 	fmt.Fprintf(writer, "Topology volumeSizeLimit:%d MB%s\n", volumeSizeLimitMb, diskInfosToString(topologyInfo.DiskInfos))
 
-	emptyDiskTypeDiskInfo, emptyDiskTypeFound := topologyInfo.DiskInfos[""]
-	hddDiskTypeDiskInfo, hddDiskTypeFound := topologyInfo.DiskInfos["hdd"]
-	if !emptyDiskTypeFound && !hddDiskTypeFound {
-		return fmt.Errorf("Need to a hdd disk type!")
+	if len(topologyInfo.DiskInfos) == 0 {
+		return fmt.Errorf("no disk type defined")
 	}
-	if emptyDiskTypeFound && emptyDiskTypeDiskInfo.MaxVolumeCount == 0 || hddDiskTypeFound && hddDiskTypeDiskInfo.MaxVolumeCount == 0 {
-		return fmt.Errorf("Need to a hdd disk type!")
+	for diskType, diskInfo := range topologyInfo.DiskInfos {
+		if diskInfo.MaxVolumeCount == 0 {
+			return fmt.Errorf("no volume available for \"%s\" disk type", diskType)
+		}
 	}
 
 	// collect filers


### PR DESCRIPTION
# What problem are we solving?

The `cluster.check` command only took the empty (`""`) and `hdd` disk types into consideration, but a cluster with only `ssd` or `nvme` disk types would be equally valid.

# How are we solving the problem?

This commit simply checks that _any_ disk type is defined, and that some volumes are available for it.

# How is the PR tested?

Spawned a cluster and ran `cluster.check` on it.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
