### PR TITLE
weed/storage: Fix volume info file permissions

### DIFF
--- a/weed/storage/volume_info/volume_info.go
+++ b/weed/storage/volume_info/volume_info.go
@@ -76,9 +76,8 @@ func SaveVolumeInfo(fileName string, volumeInfo *volume_server_pb.VolumeInfo) er
 		return fmt.Errorf("failed to marshal %s: %v", fileName, marshalErr)
 	}
 
-	writeErr := util.WriteFile(fileName, text, 0755)
-	if writeErr != nil {
-		return fmt.Errorf("failed to write %s: %v", fileName, writeErr)
+	if err := util.WriteFile(fileName, text, 0644); err != nil {
+		return fmt.Errorf("failed to write %s: %v", fileName, err)
 	}
 
 	return nil


### PR DESCRIPTION
# What problem are we solving?

The `*.vif` files are written with the executable bit set (`0755`), but there's no need for them to be executable.


# How are we solving the problem?

Set `*.vif` file permissions to `0644` instead.

# How is the PR tested?

Changing permissions on `*.vif` files to `0644` and restarting `weed volume`, making sure everything still works properly.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
