### PR TITLE
fix: avoid data loss after truncate on init volume

### DIFF
--- a/weed/storage/volume_checking.go
+++ b/weed/storage/volume_checking.go
@@ -14,7 +14,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/util"
 )
 
-const dataLossLimitPerc = 1
+const dataLossLimitPercent = 1
 
 func CheckAndFixVolumeDataIntegrity(v *Volume, indexFile *os.File) (lastAppendAtNs uint64, err error) {
 	var indexSize int64
@@ -120,7 +120,7 @@ func verifyNeedleIntegrity(datFile backend.BackendStorageFile, v needle.Version,
 			return n.AppendAtNs, nil
 		}
 		if fileSize > fileTailOffset {
-			if (100 - (fileTailOffset * 100 / fileSize)) > dataLossLimitPerc {
+			if (100 - (fileTailOffset * 100 / fileSize)) > dataLossLimitPercent {
 				return n.AppendAtNs, ErrorDataSizeMismatch
 			}
 			glog.Warningf("Truncate %s from %d bytes to %d bytes!", datFile.Name(), fileSize, fileTailOffset)

--- a/weed/storage/volume_write.go
+++ b/weed/storage/volume_write.go
@@ -14,6 +14,7 @@ import (
 var ErrorNotFound = errors.New("not found")
 var ErrorDeleted = errors.New("already deleted")
 var ErrorSizeMismatch = errors.New("size mismatch")
+var ErrorDataSizeMismatch = errors.New("data size mismatch")
 
 func (v *Volume) checkReadWriteError(err error) {
 	if err == nil {


### PR DESCRIPTION
# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/4991

This is not exactly a solution to the problem, about the restriction on deleting data from dat files due to a broken idx
I want to avoid:
```
volume_checking.go:123 Truncate /data/bucket_254.dat from 421324863000 bytes to 234354667858 bytes!
```
If you don’t do Truncate, the volume will go into read-only mode and you can rebuild the index manually using a `weed fix`

It's not the best solution, but it's better than nothing.
The correct thing to do would be to rebuild the index. But this is an expensive operation.

# How are we solving the problem?

avoid truncate dat file on init volume

# How is the PR tested?

localy after fix
```
make server
warp put --insecure --host 192.168.3.43:8000 --noclear  --obj.size 1KiB --concurrent 300 --noprefix --duration 20s --access-key some_access_key1 --secret-key some_secret_key1
# stop server
truncate -s 219632 /var/folders/g9/bmz0lmtj5d1714v0g7pkdqvc0000gn/T/warp-benchmark-bucket_7.idx
```

```
make server
W0130 01:12:05.589731 volume_checking.go:123 Truncate /var/folders/g9/bmz0lmtj5d1714v0g7pkdqvc0000gn/T/warp-benchmark-bucket_7.dat from 21829240 bytes to 14980336 bytes!
I0130 01:12:05.594169 volume_loading.go:128 volumeDataIntegrityChecking failed data size mismatch
I0

volume id:7  size:21829240  collection:"warp-benchmark-bucket"  file_count:13727  read_only:true  version:3  modified_at_second:1706554626 
```

before fix:
```
I0130 13:23:16.356967 volume_loading.go:121 open to write file /var/folders/g9/bmz0lmtj5d1714v0g7pkdqvc0000gn/T/warp-benchmark-bucket_7.idx
W0130 13:23:16.357495 volume_checking.go:121 Truncate /var/folders/g9/bmz0lmtj5d1714v0g7pkdqvc0000gn/T/warp-benchmark-bucket_7.dat from 21829240 bytes to 14980336 bytes!
I0130 13:23:16.374413 needle_map_memory.go:54 max file key: 97964 for file: /var/folders/g9/bmz0lmtj5d1714v0g7pkdqvc0000gn/T/warp-benchmark-bucket_7.idx
I0130 13:23:16.374423 disk_location.go:182 data file /var/folders/g9/bmz0lmtj5d1714v0g7pkdqvc0000gn/T//warp-benchmark-bucket_7.dat, replication=000 v=3 size=14980336 ttl=
I0130 13:23:16.378492 volume_layout.go:406 Volume 7 becomes writable

```
# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
