### PR TITLE
fix: publish helm chart at new release

### DIFF
--- a/.github/workflows/helm_chart_release.yml
+++ b/.github/workflows/helm_chart_release.yml
@@ -1,10 +1,8 @@
 name: "helm: publish charts"
 on:
   push:
-    branches:
-      - master
-    paths:
-      - "k8s/charts/**"
+    tags:
+      - '*'
 
 permissions:
   contents: write


### PR DESCRIPTION
# What problem are we solving?

Close #5264

# How are we solving the problem?

Publish at new release (tags) instead of each push to master, to avoid silent breaking changes


@jessebot for your information
