### PR TITLE
Add s3 postpolicy support header

### DIFF
--- a/weed/s3api/s3api_object_handlers_postpolicy.go
+++ b/weed/s3api/s3api_object_handlers_postpolicy.go
@@ -128,6 +128,7 @@ func (s3a *S3ApiServer) PostPolicyBucketHandler(w http.ResponseWriter, r *http.R
 	for k, _ := range formValues {
 		if k == "Cache-Control" || k == "Expires" || k == "Content-Disposition" {
 			r.Header.Set(k, formValues.Get(k))
+			continue
 		}
 
 		if strings.HasPrefix(k, s3_constants.AmzUserMetaPrefix) {

--- a/weed/s3api/s3api_object_handlers_postpolicy.go
+++ b/weed/s3api/s3api_object_handlers_postpolicy.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/policy"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
 )
 
@@ -122,6 +123,17 @@ func (s3a *S3ApiServer) PostPolicyBucketHandler(w http.ResponseWriter, r *http.R
 		contentType = fileContentType
 	}
 	r.Header.Set("Content-Type", contentType)
+
+	// Add s3 postpolicy support header
+	for k, _ := range formValues {
+		if k == "Cache-Control" || k == "Expires" || k == "Content-Disposition" {
+			r.Header.Set(k, formValues.Get(k))
+		}
+
+		if strings.HasPrefix(k, s3_constants.AmzUserMetaPrefix) {
+			r.Header.Set(k, formValues.Get(k))
+		}
+	}
 
 	etag, errCode := s3a.putToFiler(r, uploadUrl, fileBody, "", bucket)
 


### PR DESCRIPTION
# What problem are we solving?

 S3 POST form item to http header is missing. such as Cache-Control.

# How are we solving the problem?

Add some S3 POST form item to header, include "Cache-Control", "Expires", "Content-Disposition" and "X-Amz-Meta-*"

# How is the PR tested?

By hand on a test server.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.

