### PR TITLE
filer: reduce delete entry ErrNotFound logs

### DIFF
--- a/weed/server/filer_server_handlers_write.go
+++ b/weed/server/filer_server_handlers_write.go
@@ -213,14 +213,12 @@ func (fs *FilerServer) DeleteHandler(w http.ResponseWriter, r *http.Request) {
 
 	err := fs.filer.DeleteEntryMetaAndData(context.Background(), util.FullPath(objectPath), isRecursive, ignoreRecursiveError, !skipChunkDeletion, false, nil)
 	if err != nil {
-		glog.V(1).Infoln("deleting", objectPath, ":", err.Error())
-		httpStatus := http.StatusInternalServerError
 		if err == filer_pb.ErrNotFound {
-			httpStatus = http.StatusNoContent
-			writeJsonQuiet(w, r, httpStatus, nil)
+			writeJsonQuiet(w, r, http.StatusNoContent, nil)
 			return
 		}
-		writeJsonError(w, r, httpStatus, err)
+		glog.V(1).Infoln("deleting", objectPath, ":", err.Error())
+		writeJsonError(w, r, http.StatusInternalServerError, err)
 		return
 	}
 


### PR DESCRIPTION
# What problem are we solving?

Too many logs when deleting non existing object in filer: "filer: no entry is found in filer store"

# How are we solving the problem?

Make these "error" silent: only log error when not ErrNotFound

