### PR TITLE
Fix/s3 config secret

### DIFF
--- a/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
@@ -286,7 +286,7 @@ spec:
         - name: db-schema-config-volume
           configMap:
             name: seaweedfs-db-init-config
-        {{- if .Values.filer.s3.enableAuth }}
+        {{- if and .Values.filer.s3.enabled .Values.filer.s3.enableAuth }}
         - name: config-users
           secret:
             defaultMode: 420

--- a/k8s/charts/seaweedfs/templates/s3-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/s3-deployment.yaml
@@ -191,7 +191,7 @@ spec:
         - name: config-users
           secret:
             defaultMode: 420
-            {{- if .Values.filer.s3.existingConfigSecret }}
+            {{- if .Values.s3.existingConfigSecret }}
             secretName: {{ .Values.s3.existingConfigSecret }}
             {{- else }}
             secretName: seaweedfs-s3-secret

--- a/k8s/charts/seaweedfs/templates/s3-secret.yaml
+++ b/k8s/charts/seaweedfs/templates/s3-secret.yaml
@@ -1,4 +1,4 @@
-{{- if not (or .Values.filer.s3.skipAuthSecretCreation .Values.s3.skipAuthSecretCreation .Values.filer.s3.existingConfigSecret .Values.s3.existingConfigSecret ) }}
+{{- if or (and .Values.filer.s3.enabled .Values.filer.s3.enableAuth (not .Values.filer.s3.existingConfigSecret)) (and .Values.s3.enabled .Values.s3.enableAuth (not .Values.s3.existingConfigSecret)) }}
 {{- $access_key_admin := randAlphaNum 16 -}}
 {{- $secret_key_admin := randAlphaNum 32 -}}
 {{- $access_key_read := randAlphaNum 16 -}}

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -610,7 +610,7 @@ filer:
       #     key: password
 
   s3:
-    enabled: true
+    enabled: false
     port: 8333
     # add additional https port
     httpsPort: 0
@@ -619,11 +619,10 @@ filer:
     # Suffix of the host name, {bucket}.{domainName}
     domainName: ""
     # enable user & permission to s3 (need to inject to all services)
-    enableAuth: true
-    skipAuthSecretCreation: false
+    enableAuth: false
     # set to the name of an existing kubernetes Secret with the s3 json config file
     # should have a secret key called seaweedfs_s3_config with an inline json configure
-    existingConfigSecret: ""
+    existingConfigSecret: null
     auditLogConfig: {}
     # You may specify buckets to be created during the install process.
     # Buckets may be exposed publicly by setting `anonymousRead` to `true`
@@ -650,10 +649,9 @@ s3:
   allowEmptyFolder: true
   # enable user & permission to s3 (need to inject to all services)
   enableAuth: false
-  skipAuthSecretCreation: false
   # set to the name of an existing kubernetes Secret with the s3 json config file
   # should have a secret key called seaweedfs_s3_config with an inline json config
-  existingConfigSecret: false
+  existingConfigSecret: null
   auditLogConfig: {}
 
   # Suffix of the host name, {bucket}.{domainName}


### PR DESCRIPTION
# What problem are we solving?

This PR fixes couple of issues with s3 and its config as a secret :

1. the filer statefulset would try to mount the secret even if s3 is not enabled
2. the s3 deployment tests `existingConfigSecret` wrongly from `.Values.filer.s3`
3. the secret could be created enven if s3 is not enabled or enableAuth is not on


# How are we solving the problem?

1. use the secret only when `Values.filer.s3.enabled` is on in `filer-statefulset.yaml`
2. fix wrong condition to test if an existingConfigSecret is used in s3-deployment (.Values.filer.s3.existingConfigSecret vs .Values.s3.existingConfigSecret)
3. rewrite the condtion to create the secret to make sure we check for both s3 and filer.s3 if s3 is enabled and .enableAuth is on + removed the use of `skipAuthSecretCreation` which is redondant with `existingConfigSecret`


# How is the PR tested?

Manually


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
