### PR TITLE
[volume] requests that were canceled by the client are not an internal server problem(500 => 499)

### DIFF
--- a/weed/server/filer_server_handlers_write_autochunk.go
+++ b/weed/server/filer_server_handlers_write_autochunk.go
@@ -50,7 +50,7 @@ func (fs *FilerServer) autoChunk(ctx context.Context, w http.ResponseWriter, r *
 	}
 	if err != nil {
 		if strings.HasPrefix(err.Error(), "read input:") || err.Error() == io.ErrUnexpectedEOF.Error() {
-			writeJsonError(w, r, 499, err)
+			writeJsonError(w, r, util.HttpStatusCancelled, err)
 		} else if strings.HasSuffix(err.Error(), "is a file") || strings.HasSuffix(err.Error(), "already exists") {
 			writeJsonError(w, r, http.StatusConflict, err)
 		} else {

--- a/weed/server/volume_server_handlers.go
+++ b/weed/server/volume_server_handlers.go
@@ -53,7 +53,7 @@ func (vs *VolumeServer) privateStoreHandler(w http.ResponseWriter, r *http.Reque
 			select {
 			case <-r.Context().Done():
 				glog.V(4).Infof("request cancelled from %s: %v", r.RemoteAddr, r.Context().Err())
-				w.WriteHeader(http.StatusInternalServerError)
+				w.WriteHeader(util.HttpStatusCancelled)
 				vs.inFlightDownloadDataLimitCond.L.Unlock()
 				return
 			default:

--- a/weed/util/constants.go
+++ b/weed/util/constants.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 )
 
+const HttpStatusCancelled = 499
+
 var (
 	VERSION_NUMBER = fmt.Sprintf("%.02f", 3.62)
 	VERSION        = sizeLimit + " " + VERSION_NUMBER


### PR DESCRIPTION
# What problem are we solving?

To avoid misunderstandings, this is not an internal error, as in fact there is no error that would be printed in the error log.

# How are we solving the problem?

replaced the error code when canceling a request by a client from 500 to 499

# How is the PR tested?

localy

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
