### PR TITLE
Moved noapplexattr under runtime.GOARCH == "amd64" to resolve the fin…

### DIFF
--- a/weed/command/mount_std.go
+++ b/weed/command/mount_std.go
@@ -201,7 +201,9 @@ func RunMount(option *MountOptions, umask os.FileMode) bool {
 			ioSizeMB *= 2
 		}
 		fuseMountOptions.Options = append(fuseMountOptions.Options, "daemon_timeout=600")
-		fuseMountOptions.Options = append(fuseMountOptions.Options, "noapplexattr")
+		if runtime.GOARCH == "amd64" {
+			fuseMountOptions.Options = append(fuseMountOptions.Options, "noapplexattr")
+		}
 		// fuseMountOptions.Options = append(fuseMountOptions.Options, "novncache") // need to test effectiveness
 		fuseMountOptions.Options = append(fuseMountOptions.Options, "slow_statfs")
 		fuseMountOptions.Options = append(fuseMountOptions.Options, "volname="+serverFriendlyName)


### PR DESCRIPTION
…der copy bug on arm64 macOS devices.

# What problem are we solving?
This pull request fixes #2445


# How are we solving the problem?
Moved noapplexattr under an if statement the switches on runtime.GOARCH == "amd64"


# How is the PR tested?
Compiled and tested on macOS Sonoma 14.11 (arm64)


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
