### PR TITLE
Document default method used by compact

### DIFF
--- a/weed/command/compact.go
+++ b/weed/command/compact.go
@@ -28,7 +28,7 @@ var (
 	compactVolumePath        = cmdCompact.Flag.String("dir", ".", "data directory to store files")
 	compactVolumeCollection  = cmdCompact.Flag.String("collection", "", "volume collection name")
 	compactVolumeId          = cmdCompact.Flag.Int("volumeId", -1, "a volume id. The volume should already exist in the dir.")
-	compactMethod            = cmdCompact.Flag.Int("method", 0, "option to choose which compact method. use 0 or 1.")
+	compactMethod            = cmdCompact.Flag.Int("method", 0, "option to choose which compact method. use 0 (default) or 1.")
 	compactVolumePreallocate = cmdCompact.Flag.Int64("preallocateMB", 0, "preallocate volume disk space")
 )
 


### PR DESCRIPTION
# What problem are we solving?
User running weed compact isn't informed what command is going to do.
There are two methods of data modification and none is listed as default

# How are we solving the problem?
Adding short info in CLI help


# How is the PR tested?
If it compiles, it will be 👌

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
