### PR TITLE
Helm chart readme - clarify details about multiple filers and datastore

### DIFF
--- a/k8s/charts/seaweedfs/README.md
+++ b/k8s/charts/seaweedfs/README.md
@@ -30,11 +30,11 @@ so your deployment will be spread/HA.
 ## Prerequisites
 ### Database
 
-leveldb is the default database this only supports one filer replica.
+leveldb is the default database, this supports multiple filer replicas that will [sync automatically](https://github.com/seaweedfs/seaweedfs/wiki/Filer-Store-Replication), with some [limitations](https://github.com/seaweedfs/seaweedfs/wiki/Filer-Store-Replication#limitation).
 
-To have multiple filers a external datastore is recommened.
+When the [limitations](https://github.com/seaweedfs/seaweedfs/wiki/Filer-Store-Replication#limitation) apply, or for a large number of filer replicas, an external datastore is recommened.
 
-Such as MySQL-compatible database, as specified in the `values.yaml` at `filer.extraEnvironmentVars`. 
+Such as MySQL-compatible database, as specified in the `values.yaml` at `filer.extraEnvironmentVars`.
 This database should be pre-configured and initialized by running:
 ```sql
 CREATE TABLE IF NOT EXISTS `filemeta` (


### PR DESCRIPTION
# What problem are we solving?
Fixing an inconsistency between the helm chart readme and the wiki


# How are we solving the problem?
Updating the helm chart readme to match the details on the wiki, with links to the relevant wiki article


# How is the PR tested?
Only a readme change, but I also tested running multiple filer replicas with leveldb on a K8s cluster and everything worked correctly, so the info in the wiki seems accurate.


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
