### PR TITLE
fix: sync without dir /buckets/some/.uploads/hash_hash

### DIFF
--- a/weed/command/filer_sync.go
+++ b/weed/command/filer_sync.go
@@ -394,7 +394,7 @@ func genProcessFunction(sourcePath string, targetPath string, excludePaths []str
 			glog.V(0).Infof("received %v", resp)
 		}
 
-		if isMultipartUploadDir(resp.Directory) {
+		if isMultipartUploadDir(resp.Directory + "/") {
 			return nil
 		}
 


### PR DESCRIPTION
# What problem are we solving?

Empty temporary folders are synchronized:
```
> fs.ls -l /buckets/some/.uploads
drwxrwxrwx   0 seaweed seaweed      0 /buckets/some/.uploads/fffb6e5dab032b115cbf196272e47a6cdbfa9ac9_6fad541aee2d46f0b1a9c5d63b31d380
total 6208

> fs.du /buckets/some/.uploads
block:   0	logical size:         0	/buckets/some/.uploads
```

# How are we solving the problem?

Add a postfix slash to the check function

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
