### PR TITLE
fix: panic: assignment to entry in nil map on S3Sink.CreateEntry

### DIFF
--- a/weed/replication/sink/s3sink/s3_sink.go
+++ b/weed/replication/sink/s3sink/s3_sink.go
@@ -175,18 +175,23 @@ func (s3sink *S3Sink) CreateEntry(key string, entry *filer_pb.Entry, signatures 
 			uploader.PartSize = 0
 		}
 	}
-	if _, ok := entry.Extended[s3_constants.AmzUserMetaMtime]; !ok {
+
+	doSaveMtime := true
+	if entry.Extended == nil {
+		entry.Extended = make(map[string][]byte)
+	} else if _, ok := entry.Extended[s3_constants.AmzUserMetaMtime]; ok {
+		doSaveMtime = false
+	}
+	if doSaveMtime {
 		entry.Extended[s3_constants.AmzUserMetaMtime] = []byte(strconv.FormatInt(entry.Attributes.Mtime, 10))
 	}
 	// process tagging
 	tags := ""
-	if true {
-		for k, v := range entry.Extended {
-			if len(tags) > 0 {
-				tags = tags + "&"
-			}
-			tags = tags + k + "=" + string(v)
+	for k, v := range entry.Extended {
+		if len(tags) > 0 {
+			tags = tags + "&"
 		}
+		tags = tags + k + "=" + string(v)
 	}
 
 	// Upload the file to S3.


### PR DESCRIPTION
# What problem are we solving?

```
 I0321 08:32:17.891003 s3_sink.go:78 sink.s3.region: us-east-2
 I0321 08:32:17.891059 s3_sink.go:79 sink.s3.bucket: backups
 I0321 08:32:17.891068 s3_sink.go:80 sink.s3.directory: /
 I0321 08:32:17.891077 s3_sink.go:81 sink.s3.endpoint: http://lol:8333
 I0321 08:32:17.891086 s3_sink.go:82 sink.s3.acl:
 I0321 08:32:17.891110 s3_sink.go:83 sink.s3.is_incremental: false
 I0321 08:32:17.891121 s3_sink.go:84 sink.s3.s3_disable_content_md5_validation: true
 I0321 08:32:17.891130 s3_sink.go:85 sink.s3.s3_force_path_style: true
 I0321 08:32:17.891139 s3_sink.go:86 sink.s3.keep_part_size: true
 I0321 08:32:17.891149 s3_sink.go:92 sink.s3.uploader_max_upload_parts: 1000
 I0321 08:32:17.891160 s3_sink.go:94 sink.s3.uploader_part_size_mb: 0
 I0321 08:32:17.891170 s3_sink.go:95 sink.s3.uploader_concurrency: 8
 I0321 08:32:17.891269 filer_replication.go:129 Configure sink to s3
 I0321 08:32:18.596704 filer_backup.go:116 resuming from 2024-01-24 09:34:14.580661804 +0000 UTC
 panic: assignment to entry in nil map

 github.com/seaweedfs/seaweedfs/weed/replication/sink/s3sink.(*S3Sink).CreateEntry(0xc0006cc000, {0xc00011b620?, 0xc000574380?}, 0xc000>
         /github/workspace/weed/replication/sink/s3sink/s3_sink.go:179 +0x1f1
 github.com/seaweedfs/seaweedfs/weed/command.doFilerBackup.genProcessFunction.func3(0xc0009bc500)
         /github/workspace/weed/command/filer_sync.go:433 +0x50b
 github.com/seaweedfs/seaweedfs/weed/command.doFilerBackup.AddOffsetFunc.func4(0xc0009bc500)
         /github/workspace/weed/pb/filer_pb_tail.go:112 +0x47
 github.com/seaweedfs/seaweedfs/weed/pb.FollowMetadata.makeSubscribeMetadataFunc.func1({0x2c28598, 0xc000973ae0})
         /github/workspace/weed/pb/filer_pb_tail.go:86 +0x298
 github.com/seaweedfs/seaweedfs/weed/pb.WithGrpcFilerClient.func1(0xc0009a8408)
         /github/workspace/weed/pb/grpc_client_server.go:262 +0x68
 github.com/seaweedfs/seaweedfs/weed/pb.WithGrpcClient(0xd0?, 0x7ffc?, 0xc00099fa40, {0xc0008a23e0, 0xf}, 0x9?, {0xc00099fa30?, 0x2?, 0>
         /github/workspace/weed/pb/grpc_client_server.go:155 +0x343
 github.com/seaweedfs/seaweedfs/weed/pb.WithGrpcFilerClient(0x1, 0x0, {0x7ffc62fd2ed0?, 0x45bb0a?}, {0x2bea500, 0xc00007b910}, 0xc00099>
         /github/workspace/weed/pb/grpc_client_server.go:260 +0xae
 github.com/seaweedfs/seaweedfs/weed/pb.WithFilerClient(...)
         /github/workspace/weed/pb/grpc_client_server.go:254
 github.com/seaweedfs/seaweedfs/weed/pb.FollowMetadata({0x7ffc62fd2ed0?, 0x24209cd?}, {0x2bea500?, 0xc00007b910?}, 0xc00099fdc0?, 0x7ff>
         /github/workspace/weed/pb/filer_pb_tail.go:41 +0x69
 github.com/seaweedfs/seaweedfs/weed/command.doFilerBackup({0x2bea500, 0xc00007b910}, 0x3f82320, 0x81bfa159, 0x1)
         /github/workspace/weed/command/filer_backup.go:164 +0xa58
 github.com/seaweedfs/seaweedfs/weed/command.runFilerBackup(0x3f65798?, {0xc00013e050?, 0x7?, 0x7?})
         /github/workspace/weed/command/filer_backup.go:71 +0x99
 main.main()
         /github/workspace/weed/weed.go:80 +0x2c2
```


# How are we solving the problem?

create map `entry.Extended = make(map[string][]byte)` before:
```
entry.Extended[s3_constants.AmzUserMetaMtime] = []byte(strconv.FormatInt(entry.Attributes.Mtime, 10))
```

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
