### PR TITLE
fix s3api: delimeter properly takes prefixes into account

### DIFF
--- a/weed/s3api/s3api_objects_list_handlers.go
+++ b/weed/s3api/s3api_objects_list_handlers.go
@@ -167,12 +167,16 @@ func (s3a *S3ApiServer) listFilerEntries(bucket string, originalPrefix string, m
 					if delimiter != "" {
 						// keys that contain the same string between the prefix and the first occurrence of the delimiter are grouped together as a commonPrefix.
 						// extract the string between the prefix and the delimiter and add it to the commonPrefixes if it's unique.
-						fullPath := fmt.Sprintf("%s/%s", dir, entry.Name)[len(bucketPrefix):]
-						delimitedPath := strings.SplitN(fullPath, delimiter, 2)
-						if len(delimitedPath) == 2 {
+						undelimitedPath := fmt.Sprintf("%s/%s", dir, entry.Name)[len(bucketPrefix):]
 
-							// S3 clients expect the delimited prefix to contain the delimiter.
-							delimitedPrefix := delimitedPath[0] + delimiter
+						// take into account a prefix if supplied while delimiting.
+						undelimitedPath = strings.TrimPrefix(undelimitedPath, originalPrefix)
+
+						delimitedPath := strings.SplitN(undelimitedPath, delimiter, 2)
+
+						if len(delimitedPath) == 2 {
+							// S3 clients expect the delimited prefix to contain the delimiter and prefix.
+							delimitedPrefix := originalPrefix + delimitedPath[0] + delimiter
 
 							for i := range commonPrefixes {
 								if commonPrefixes[i].Prefix == delimitedPrefix {


### PR DESCRIPTION
# What problem are we solving?

Fixes s3 api regression introduced in #5350 reported here: https://github.com/seaweedfs/seaweedfs/pull/5350#issuecomment-2014709870

# How are we solving the problem?

Taking into account the prefix when splitting on the delimeter to decide whether or not something is a common prefix.
For the failing test the object was: `foo/bar`, with prefix `foo/` and delimeter `/`. the old code split on `/` even though `/` was in `foo/` so it included `foo/` as a commonPrefix when it shouldn't have been, only paths like: `foo/bar/baz` should get prefixed.

Tests are passing again, including the list for restic that @kmlebedev provided in the previous PR discussion.