### PR TITLE
fix filer address parsing

### DIFF
--- a/weed/command/shell.go
+++ b/weed/command/shell.go
@@ -19,7 +19,7 @@ func init() {
 	cmdShell.Run = runShell // break init cycle
 	shellOptions.Masters = cmdShell.Flag.String("master", "", "comma-separated master servers, e.g. localhost:9333")
 	shellOptions.FilerGroup = cmdShell.Flag.String("filerGroup", "", "filerGroup for the filers")
-	shellInitialFiler = cmdShell.Flag.String("filer", "", "filer host and port, e.g. localhost:8888")
+	shellInitialFiler = cmdShell.Flag.String("filer", "", "filer host and port for initial connection, e.g. localhost:8888")
 	shellCluster = cmdShell.Flag.String("cluster", "", "cluster defined in shell.toml")
 }
 
@@ -30,32 +30,36 @@ var cmdShell = &Command{
 
 	Generate shell.toml via "weed scaffold -config=shell"
 
-  `,
+`,
 }
 
 func runShell(command *Command, args []string) bool {
 
 	util.LoadConfiguration("security", false)
 	shellOptions.GrpcDialOption = security.LoadClientTLS(util.GetViper(), "grpc.client")
+	shellOptions.Directory = "/"
+
+	util.LoadConfiguration("shell", false)
+	viper := util.GetViper()
+	cluster := viper.GetString("cluster.default")
+	if *shellCluster != "" {
+		cluster = *shellCluster
+	}
 
 	if *shellOptions.Masters == "" {
-		util.LoadConfiguration("shell", false)
-		v := util.GetViper()
-		cluster := v.GetString("cluster.default")
-		if *shellCluster != "" {
-			cluster = *shellCluster
-		}
 		if cluster == "" {
 			*shellOptions.Masters = "localhost:9333"
 		} else {
-			*shellOptions.Masters = v.GetString("cluster." + cluster + ".master")
-			*shellInitialFiler = v.GetString("cluster." + cluster + ".filer")
-			fmt.Printf("master: %s filer: %s\n", *shellOptions.Masters, *shellInitialFiler)
+			*shellOptions.Masters = viper.GetString("cluster." + cluster + ".master")
 		}
 	}
 
-	shellOptions.FilerAddress = pb.ServerAddress(*shellInitialFiler)
-	shellOptions.Directory = "/"
+	filerAddress := *shellInitialFiler
+	if filerAddress == "" && cluster != "" {
+		filerAddress = viper.GetString("cluster." + cluster + ".filer")
+	}
+	shellOptions.FilerAddress = pb.ServerAddress(filerAddress)
+	fmt.Printf("master: %s filer: %s\n", *shellOptions.Masters, shellOptions.FilerAddress)
 
 	shell.RunShell(shellOptions)
 


### PR DESCRIPTION
# What problem are we solving?

`-filer` option is ignored when `-master` is not set but master addresses present in config.

If in this case filer address exists in `shell.toml` too it for some reason icorrectly parsed and causes errors like

```
# test command: fs.ls

# for multiple comma-separated addresses
# filer = "127.0.0.1:1111.1112,127.0.0.2:1111.1112"
dial tcp: lookup 127.0.0.1:1111.1112,127.0.0.2: no such host

# for single address with grpc port
# filer = "127.0.0.1:1111.1112"
error: rpc error: code = Unimplemented desc = unknown service filer_pb.SeaweedFiler

# for single address without grpc port
# filer = "127.0.0.1:1111"
transport: Error while dialing: dial tcp 127.0.0.1:11111: connect: connection refused
```

:warning: Note: I use non default grpc ports

Only working combinations I found:
1. both -master and -filer provided through command line / env
2. master address in config without filer address (so later one is auto-discovered)


# How are we solving the problem?
1. Always checking for filer address
2. `*shellInitialFiler` dereferenced before usage


# How is the PR tested?
With hope for gh actions


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
