### PR TITLE
Move ListDirectoryEntries logic to ListDirectoryPrefixedEntries in etcd meta storage backend

### DIFF
--- a/weed/filer/etcd/etcd_store.go
+++ b/weed/filer/etcd/etcd_store.go
@@ -178,11 +178,7 @@ func (store *EtcdStore) DeleteFolderChildren(ctx context.Context, fullpath weed_
 }
 
 func (store *EtcdStore) ListDirectoryPrefixedEntries(ctx context.Context, dirPath weed_util.FullPath, startFileName string, includeStartFile bool, limit int64, prefix string, eachEntryFunc filer.ListEachEntryFunc) (lastFileName string, err error) {
-	return lastFileName, filer.ErrUnsupportedListDirectoryPrefixed
-}
-
-func (store *EtcdStore) ListDirectoryEntries(ctx context.Context, dirPath weed_util.FullPath, startFileName string, includeStartFile bool, limit int64, eachEntryFunc filer.ListEachEntryFunc) (lastFileName string, err error) {
-	directoryPrefix := genDirectoryKeyPrefix(dirPath, "")
+	directoryPrefix := genDirectoryKeyPrefix(dirPath, prefix)
 	lastFileStart := directoryPrefix
 	if startFileName != "" {
 		lastFileStart = genDirectoryKeyPrefix(dirPath, startFileName)
@@ -222,6 +218,10 @@ func (store *EtcdStore) ListDirectoryEntries(ctx context.Context, dirPath weed_u
 	}
 
 	return lastFileName, err
+}
+
+func (store *EtcdStore) ListDirectoryEntries(ctx context.Context, dirPath weed_util.FullPath, startFileName string, includeStartFile bool, limit int64, eachEntryFunc filer.ListEachEntryFunc) (lastFileName string, err error) {
+	return store.ListDirectoryPrefixedEntries(ctx, dirPath, startFileName, includeStartFile, limit, "", eachEntryFunc)
 }
 
 func genKey(dirPath, fileName string) (key []byte) {


### PR DESCRIPTION
# What problem are we solving?

After modifying the ListDirectoryEntries function (in previous pr) and adding clientv3.WithRange(clientv3.GetPrefixRangeEnd(store.etcdKeyPrefix+string(directoryPrefix))), the implementation of ListDirectoryPrefixedEntries has become feasible, making the use of fsw.prefixFilterEntries redundant.

# How are we solving the problem?

The logic of ListDirectoryEntries has been transferred to ListDirectoryPrefixedEntries, with the addition of prefix in the call to genDirectoryKeyPrefix. This makes the call to fsw.prefixFilterEntries unnecessary and reduces the complexity of the directory listing

# How is the PR tested?
Tested localy with s3cmd
Testing case:
1. upload test01 file to s3://bucket/
2. upload test02 file to s3://bucket/test/
3. upload test03 file to s3://bucket/test/
4. list s3://bucket/ output: 
5. list s3://bucket/test
6. list s3://bucket/test/
7.  list s3://bucket/test/test03

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
