### PR TITLE
[master] grow volumes if no writable volumes in current dataCenter

### DIFF
--- a/weed/operation/assign_file_id.go
+++ b/weed/operation/assign_file_id.go
@@ -6,6 +6,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
 	"github.com/seaweedfs/seaweedfs/weed/security"
+	"github.com/seaweedfs/seaweedfs/weed/stats"
 	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
 	"google.golang.org/grpc"
 	"sync"
@@ -193,6 +194,7 @@ func Assign(masterFn GetMasterFn, grpcDialOption grpc.DialOption, primaryRequest
 		})
 
 		if lastError != nil {
+			stats.FilerHandlerCounter.WithLabelValues(stats.ErrorChunkAssign).Inc()
 			continue
 		}
 

--- a/weed/operation/assign_file_id.go
+++ b/weed/operation/assign_file_id.go
@@ -262,6 +262,7 @@ func (so *StorageOption) ToAssignRequests(count int) (ar *VolumeAssignRequest, a
 		WritableVolumeCount: so.VolumeGrowthCount,
 	}
 	if so.DataCenter != "" || so.Rack != "" || so.DataNode != "" {
+		ar.WritableVolumeCount = uint32(count)
 		altRequest = &VolumeAssignRequest{
 			Count:               uint64(count),
 			Replication:         so.Replication,

--- a/weed/stats/metrics_names.go
+++ b/weed/stats/metrics_names.go
@@ -40,6 +40,7 @@ const (
 	ErrorReadInternal        = "read.internal.error"
 	ErrorWriteEntry          = "write.entry.failed"
 	RepeatErrorUploadContent = "upload.content.repeat.failed"
+	ErrorChunkAssign         = "chunkAssign.failed"
 	ErrorReadCache           = "read.cache.failed"
 	ErrorReadStream          = "read.stream.failed"
 )

--- a/weed/topology/volume_growth_test.go
+++ b/weed/topology/volume_growth_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/seaweedfs/seaweedfs/weed/storage/types"
+	"github.com/seaweedfs/seaweedfs/weed/util"
 	"testing"
 
 	"github.com/seaweedfs/seaweedfs/weed/sequence"
@@ -419,6 +420,8 @@ func TestPickForWrite(t *testing.T) {
 		Rack:       "",
 		DataNode:   "",
 	}
+	v := util.GetViper()
+	v.Set("master.volume_growth.threshold", 0.9)
 	for _, rpStr := range []string{"001", "010", "100"} {
 		rp, _ := super_block.NewReplicaPlacementFromString(rpStr)
 		vl := topo.GetVolumeLayout("test", rp, needle.EMPTY_TTL, types.HardDriveType)
@@ -447,8 +450,8 @@ func TestPickForWrite(t *testing.T) {
 					} else if len(fileId) == 0 {
 						fmt.Println(dc, r, dn, "pick for write file id is empty")
 						t.Fail()
-					} else if !shouldGrow {
-						fmt.Println(dc, r, dn, "pick for write file id not should grow")
+					} else if shouldGrow {
+						fmt.Println(dc, r, dn, "pick for write error : not should grow")
 						t.Fail()
 					}
 				}

--- a/weed/topology/volume_growth_test.go
+++ b/weed/topology/volume_growth_test.go
@@ -423,7 +423,7 @@ func TestPickForWrite(t *testing.T) {
 		rp, _ := super_block.NewReplicaPlacementFromString(rpStr)
 		vl := topo.GetVolumeLayout("test", rp, needle.EMPTY_TTL, types.HardDriveType)
 		volumeGrowOption.ReplicaPlacement = rp
-		for _, dc := range []string{"", "dc1", "dc2", "dc3"} {
+		for _, dc := range []string{"", "dc1", "dc2", "dc3", "dc0"} {
 			volumeGrowOption.DataCenter = dc
 			for _, r := range []string{""} {
 				volumeGrowOption.Rack = r
@@ -432,8 +432,13 @@ func TestPickForWrite(t *testing.T) {
 						continue
 					}
 					volumeGrowOption.DataNode = dn
-					fileId, count, _, _, err := topo.PickForWrite(1, volumeGrowOption, vl)
-					if err != nil {
+					fileId, count, _, shouldGrow, err := topo.PickForWrite(1, volumeGrowOption, vl)
+					if dc == "dc0" {
+						if err == nil || count != 0 || !shouldGrow {
+							fmt.Println(dc, r, dn, "pick for write should be with error")
+							t.Fail()
+						}
+					} else if err != nil {
 						fmt.Println(dc, r, dn, "pick for write error :", err)
 						t.Fail()
 					} else if count == 0 {
@@ -441,6 +446,9 @@ func TestPickForWrite(t *testing.T) {
 						t.Fail()
 					} else if len(fileId) == 0 {
 						fmt.Println(dc, r, dn, "pick for write file id is empty")
+						t.Fail()
+					} else if !shouldGrow {
+						fmt.Println(dc, r, dn, "pick for write file id not should grow")
 						t.Fail()
 					}
 				}

--- a/weed/topology/volume_layout.go
+++ b/weed/topology/volume_layout.go
@@ -336,7 +336,7 @@ func (vl *VolumeLayout) PickForWrite(count uint64, option *VolumeGrowOption) (vi
 			return
 		}
 	}
-	return vid, count, locationList, shouldGrow, fmt.Errorf("No writable volumes in DataCenter:%v Rack:%v DataNode:%v", option.DataCenter, option.Rack, option.DataNode)
+	return vid, count, locationList, true, fmt.Errorf("No writable volumes in DataCenter:%v Rack:%v DataNode:%v", option.DataCenter, option.Rack, option.DataNode)
 }
 
 func (vl *VolumeLayout) HasGrowRequest() bool {


### PR DESCRIPTION
# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/3886

# How are we solving the problem?

iDo grow if writable volumes not found in current dataCenter

# How is the PR tested?

1. make cluster
2. checking the empty list of volumes in dc3
```
> volume.list -dataCenter=dc3
Topology volumeSizeLimit:100 MB hdd(volume:6/1326 active:6 free:1320 remote:0)
  DataCenter dc3 hdd(volume:0/442 active:0 free:442 remote:0)
    Rack v3 hdd(volume:0/442 active:0 free:442 remote:0)
      DataNode volume3:8083 hdd(volume:0/442 active:0 free:442 remote:0)
        Disk hdd(volume:0/442 active:0 free:442 remote:0)
        Disk hdd total size:0 file_count:0 
      DataNode volume3:8083 total size:0 file_count:0 
    Rack v3 total size:0 file_count:0 
  DataCenter dc3 total size:0 file_count:0 
total size:0 file_count:0 
```
**Before**
3. put file **10.11s**
```
docker exec -it seaweedfs-filer-1 time curl -v -X PUT -d 'testdata' http://127.0.0.1:8888/test_file3
*   Trying 127.0.0.1:8888...
* Connected to 127.0.0.1 (127.0.0.1) port 8888
> PUT /test_file3 HTTP/1.1
> Host: 127.0.0.1:8888
> User-Agent: curl/8.5.0
> Accept: */*
> Content-Length: 8
> Content-Type: application/x-www-form-urlencoded
> 
< HTTP/1.1 201 Created
< Content-Md5: 72VMQKtPF0f8aZkV1PcJAg==
< Content-Type: application/json
< Server: SeaweedFS Filer 30GB 3.64
< Date: Thu, 28 Mar 2024 18:22:07 GMT
< Content-Length: 30
< 
* Connection #0 to host 127.0.0.1 left intact
{"name":"test_file3","size":8}real      0m 10.11s
user    0m 0.00s
sys     0m 0.00s
```
4.  checking volume is no created in dc3
```
> volume.list -dataCenter=dc3
Topology volumeSizeLimit:100 MB hdd(volume:6/1326 active:6 free:1320 remote:0)
  DataCenter dc3 hdd(volume:0/442 active:0 free:442 remote:0)
    Rack v3 hdd(volume:0/442 active:0 free:442 remote:0)
      DataNode volume3:8083 hdd(volume:0/442 active:0 free:442 remote:0)
        Disk hdd(volume:0/442 active:0 free:442 remote:0)
        Disk hdd total size:0 file_count:0 
      DataNode volume3:8083 total size:0 file_count:0 
    Rack v3 total size:0 file_count:0 
  DataCenter dc3 total size:0 file_count:0 
total size:0 file_count:0 
```

**After**
3.  put file **0.22s**
```
docker exec -it seaweedfs-filer-1 time curl -v -X PUT -d 'testdata' http://127.0.0.1:8888/test_file4
*   Trying 127.0.0.1:8888...
* Connected to 127.0.0.1 (127.0.0.1) port 8888
> PUT /test_file4 HTTP/1.1
> Host: 127.0.0.1:8888
> User-Agent: curl/8.5.0
> Accept: */*
> Content-Length: 8
> Content-Type: application/x-www-form-urlencoded
> 
< HTTP/1.1 201 Created
< Content-Md5: 72VMQKtPF0f8aZkV1PcJAg==
< Content-Type: application/json
< Server: SeaweedFS Filer 30GB 3.64
< Date: Thu, 28 Mar 2024 18:29:02 GMT
< Content-Length: 30
< 
* Connection #0 to host 127.0.0.1 left intact
{"name":"test_file4","size":8}real      0m 0.22s
user    0m 0.00s
sys     0m 0.00s
```
4. checking volume is created in dc3
```
> volume.list -dataCenter=dc3
Topology volumeSizeLimit:100 MB hdd(volume:10/1323 active:10 free:1313 remote:0)
  DataCenter dc3 hdd(volume:2/441 active:2 free:439 remote:0)
    Rack v3 hdd(volume:2/441 active:2 free:439 remote:0)
      DataNode volume3:8083 hdd(volume:2/441 active:2 free:439 remote:0)
        Disk hdd(volume:2/441 active:2 free:439 remote:0)
          volume id:5  size:104  file_count:1  replica_placement:100  version:3  modified_at_second:1711650542 
          volume id:6  size:8  replica_placement:100  version:3  modified_at_second:1711650542 
        Disk hdd total size:112 file_count:1 
      DataNode volume3:8083 total size:112 file_count:1 
    Rack v3 total size:112 file_count:1 
  DataCenter dc3 total size:112 file_count:1 
total size:112 file_count:1 
```

**if there is no such data center**
```
seaweedfs-master0-1  | I0328 18:34:48.792850 master_grpc_server_volume.go:56 finished automatic volume grow, cost  83.167µs
seaweedfs-master0-1  | I0328 18:34:48.994282 master_grpc_server_volume.go:53 starting automatic volume grow
seaweedfs-master0-1  | I0328 18:34:48.994451 volume_growth.go:99 create 2 volume, created 0: No matching data node found! 
seaweedfs-master0-1  | dc3:Not matching preferred data center:dc0
seaweedfs-master0-1  | dc2:Not matching preferred data center:dc0
seaweedfs-master0-1  | dc1:Not matching preferred data center:dc0
seaweedfs-master0-1  | I0328 18:34:48.994492 master_grpc_server_volume.go:56 finished automatic volume grow, cost  116.458µs
```
put file **10.12s**
```
docker exec -it seaweedfs-filer-1 time curl -v -X PUT -d 'testdata' http://127.0.0.1:8888/test_file5
*   Trying 127.0.0.1:8888...
* Connected to 127.0.0.1 (127.0.0.1) port 8888
> PUT /test_file5 HTTP/1.1
> Host: 127.0.0.1:8888
> User-Agent: curl/8.5.0
> Accept: */*
> Content-Length: 8
> Content-Type: application/x-www-form-urlencoded
> 
< HTTP/1.1 201 Created
< Content-Md5: 72VMQKtPF0f8aZkV1PcJAg==
< Content-Type: application/json
< Server: SeaweedFS Filer 30GB 3.64
< Date: Thu, 28 Mar 2024 18:34:49 GMT
< Content-Length: 30
< 
* Connection #0 to host 127.0.0.1 left intact
{"name":"test_file5","size":8}real      0m 10.12s
user    0m 0.00s
sys     0m 0.00s

```
# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
