### PR TITLE
fix: adjust condition in prefixFilterEntries prevent infinite loop

### DIFF
--- a/weed/filer/filerstore_wrapper.go
+++ b/weed/filer/filerstore_wrapper.go
@@ -303,7 +303,7 @@ func (fsw *FilerStoreWrapper) prefixFilterEntries(ctx context.Context, dirPath u
 				}
 			}
 		}
-		if count < limit && lastFileName <= prefix {
+		if count < limit && lastFileName < prefix {
 			notPrefixed = notPrefixed[:0]
 			lastFileName, err = actualStore.ListDirectoryEntries(ctx, dirPath, lastFileName, false, limit, func(entry *Entry) bool {
 				notPrefixed = append(notPrefixed, entry)


### PR DESCRIPTION
# What problem are we solving?

In certain scenarios (see #5426) , the prefixFilterEntries function could enter an  loop (not actually infinite, it has 10000limit) when processing file entries list with specific prefixes.


# How are we solving the problem?
Adjusted the logic in the prefixFilterEntries function to improve the condition that determines when to continue processing records. The updated condition allows processing to continue only if the last processed filename is lexicographically smaller than the search prefix, preventing an infinite loop.


# How is the PR tested?
local tests with ceph s3 tests from #5427 


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
