### PR TITLE
fix: ensure complete gRPC stream consumption in doListFilerEntries to prevent context canceled errors.

### DIFF
--- a/weed/s3api/s3api_objects_list_handlers.go
+++ b/weed/s3api/s3api_objects_list_handlers.go
@@ -374,7 +374,7 @@ func (s3a *S3ApiServer) doListFilerEntries(client filer_pb.SeaweedFilerClient, d
 		}
 		if cursor.maxKeys <= 0 {
 			cursor.isTruncated = true
-			return
+			continue
 		}
 		entry := resp.Entry
 		nextMarker = entry.Name


### PR DESCRIPTION
# What problem are we solving?

When using the etcd filer backend with SeaweedFS's S3 API, an issue has been identified related to gRPC stream handling in scenarios where the number of objects being listed is capped by the MaxKeys parameter. To reproduce this behavior, we can follow these steps with test data:

Three objects are created within a bucket using the ceph s3 tests create_objects method:
```create_objects(client, bucket_name, ['foo', 'bar', 'baz'])```

List Objects with MaxKeys: 
```client.list_objects(Bucket=bucket_name, MaxKeys=2)```

Error Log: Upon execution, the following warning is logged, indicating a premature stream closure caused by a context canceled error:
```{"level":"warn","ts":"2024-03-31T14:45:36.154175+0300","logger":"etcd-client","caller":"v3@v3.5.12/retry_interceptor.go:62","msg":"retrying of unary invoker failed","target":"etcd-endpoints://0x14001b75dc0/127.0.0.1:2379","attempt":0,"error":"rpc error: code = Canceled desc = context canceled"}```

This problem arises in scenarios where the gRPC stream from the etcd filer to the S3 API server is not fully consumed before being closed, leading to the context canceled error. The issue is observed when the SeaweedFS S3 API is configured to use an etcd filer backend.

# How are we solving the problem?

To address this issue, the function's logic has been updated to continue consuming the gRPC stream (stream.Recv()) even after reaching the maxKeys limit, ensuring that all server responses are acknowledged and the stream is properly closed. The loop will be exited when recvErr is equal to EOF

# How is the PR tested?
localy with ceph s3tests


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
