### PR TITLE
fix: always close volume file (#4530)

### DIFF
--- a/weed/storage/backend/disk_file.go
+++ b/weed/storage/backend/disk_file.go
@@ -81,13 +81,20 @@ func (df *DiskFile) Close() error {
 	if df.File == nil {
 		return nil
 	}
-	if err := df.Sync(); err != nil {
-		return err
+	err := df.Sync()
+	var err1 error
+	if df.File != nil {
+		// always try to close
+		err1 = df.File.Close()
 	}
-	if err := df.File.Close(); err != nil {
-		return err
-	}
+	// assume closed
 	df.File = nil
+	if err != nil {
+		return err
+	}
+	if err1 != nil {
+		return err1
+	}
 	return nil
 }
 


### PR DESCRIPTION
If sync fails then close is never called. We should always be calling close on the file.

# What problem are we solving?
The issue described in #4530 and #5066. When vacuuming the file is not closed properly so the file could not be deleted.


# How are we solving the problem?
Always make sure to close the file, even if error occurs during sync.


# How is the PR tested?
By running the seaweed, storing data, clearing it and then letting the vacuum process run.


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
