### PR TITLE
[s3] fix s3 test_multipart_resend_first_finishes_last 

### DIFF
--- a/weed/s3api/filer_multipart_test.go
+++ b/weed/s3api/filer_multipart_test.go
@@ -50,7 +50,7 @@ func TestListPartsResult(t *testing.T) {
 
 }
 
-func Test_parseByPartNumber(t *testing.T) {
+func Test_parsePartNumber(t *testing.T) {
 	tests := []struct {
 		name     string
 		fileName string
@@ -69,8 +69,8 @@ func Test_parseByPartNumber(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			partNumber, _ := parseByPartNumber(tt.fileName)
-			assert.Equalf(t, tt.partNum, partNumber, "parseByPartNumber(%v)", tt.fileName)
+			partNumber, _ := parsePartNumber(tt.fileName)
+			assert.Equalf(t, tt.partNum, partNumber, "parsePartNumber(%v)", tt.fileName)
 		})
 	}
 }

--- a/weed/s3api/filer_multipart_test.go
+++ b/weed/s3api/filer_multipart_test.go
@@ -50,88 +50,27 @@ func TestListPartsResult(t *testing.T) {
 
 }
 
-func Test_findByPartNumber(t *testing.T) {
-	type args struct {
-		fileName string
-		parts    []CompletedPart
-	}
-
-	parts := []CompletedPart{
-		{
-			ETag:       "xxx",
-			PartNumber: 1,
-		},
-		{
-			ETag:       "lll",
-			PartNumber: 1,
-		},
-		{
-			ETag:       "yyy",
-			PartNumber: 3,
-		},
-		{
-			ETag:       "zzz",
-			PartNumber: 5,
-		},
-	}
-
+func Test_parseByPartNumber(t *testing.T) {
 	tests := []struct {
-		name      string
-		args      args
-		wantEtag  string
-		wantFound bool
+		name     string
+		fileName string
+		partNum  int
 	}{
 		{
 			"first",
-			args{
-				"0001.part",
-				parts,
-			},
-			"lll",
-			true,
+			"0001_uuid.part",
+			1,
 		},
 		{
 			"second",
-			args{
-				"0002.part",
-				parts,
-			},
-			"",
-			false,
-		},
-		{
-			"third",
-			args{
-				"0003.part",
-				parts,
-			},
-			"yyy",
-			true,
-		},
-		{
-			"fourth",
-			args{
-				"0004.part",
-				parts,
-			},
-			"",
-			false,
-		},
-		{
-			"fifth",
-			args{
-				"0005.part",
-				parts,
-			},
-			"zzz",
-			true,
+			"0002.part",
+			2,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotEtag, gotFound := findByPartNumber(tt.args.fileName, tt.args.parts)
-			assert.Equalf(t, tt.wantEtag, gotEtag, "findByPartNumber(%v, %v)", tt.args.fileName, tt.args.parts)
-			assert.Equalf(t, tt.wantFound, gotFound, "findByPartNumber(%v, %v)", tt.args.fileName, tt.args.parts)
+			partNumber, _ := parseByPartNumber(tt.fileName)
+			assert.Equalf(t, tt.partNum, partNumber, "parseByPartNumber(%v)", tt.fileName)
 		})
 	}
 }

--- a/weed/stats/metrics.go
+++ b/weed/stats/metrics.go
@@ -241,7 +241,13 @@ var (
 			Name:      "request_total",
 			Help:      "Counter of s3 requests.",
 		}, []string{"type", "code", "bucket"})
-
+	S3HandlerCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: "s3",
+			Name:      "handler_total",
+			Help:      "Counter of s3 server handlers.",
+		}, []string{"type"})
 	S3RequestHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: Namespace,
@@ -292,6 +298,7 @@ func init() {
 	Gather.MustRegister(VolumeServerResourceGauge)
 
 	Gather.MustRegister(S3RequestCounter)
+	Gather.MustRegister(S3HandlerCounter)
 	Gather.MustRegister(S3RequestHistogram)
 	Gather.MustRegister(S3TimeToFirstByteHistogram)
 }

--- a/weed/stats/metrics_names.go
+++ b/weed/stats/metrics_names.go
@@ -43,4 +43,13 @@ const (
 	ErrorChunkAssign         = "chunkAssign.failed"
 	ErrorReadCache           = "read.cache.failed"
 	ErrorReadStream          = "read.stream.failed"
+
+	// s3 handler
+	ErrorCompletedNoSuchUpload      = "errorCompletedNoSuchUpload"
+	ErrorCompletedPartEmpty         = "ErrorCompletedPartEmpty"
+	ErrorCompletedPartNumber        = "ErrorCompletedPartNumber"
+	ErrorCompletedPartNotFound      = "errorCompletedPartNotFound"
+	ErrorCompletedEtagInvalid       = "errorCompletedEtagInvalid"
+	ErrorCompletedEtagMismatch      = "errorCompletedEtagMismatch"
+	ErrorCompletedPartEntryMismatch = "errorCompletedPartEntryMismatch"
 )


### PR DESCRIPTION
https://github.com/seaweedfs/seaweedfs/pull/5466

# What problem are we solving?

Fix s3 test after https://github.com/seaweedfs/seaweedfs/pull/5460

before
```
> fs.meta.cat /buckets/s3tests-dd5yzog4kxg6oyf0sgvkz-1/mymultipart
{
  "name": "mymultipart",
  "isDirectory": false,
  "chunks": [
    {
      "fileId": "17,274308ee6411",
      "offset": "0",
      "size": "8",
      "modifiedTsNs": "1712310513156040000",
      "eTag": "liHt+a4GC4KwqQsJleGvKA==",
      "sourceFileId": "",
      "fid": {
        "volumeId": 17,
        "fileKey": "10051",
        "cookie": 149840913
      },
      "sourceFid": null,
      "cipherKey": "",
      "isCompressed": false,
      "isChunkManifest": false
    },
    {
      "fileId": "18,274416d812ee",
      "offset": "8",
      "size": "8",
      "modifiedTsNs": "1712310513159642000",
      "eTag": "runjjLTUDsJ5RUJWdTm0yA==",
      "sourceFileId": "",
      "fid": {
        "volumeId": 18,
        "fileKey": "10052",
        "cookie": 383259374
      },
      "sourceFid": null,
      "cipherKey": "",
      "isCompressed": false,
      "isChunkManifest": false
    }
  ],
  "attributes": {
    "fileSize": "16",
    "mtime": "1712310513",
    "fileMode": 504,
    "uid": 501,
    "gid": 20,
    "crtime": "1712310513",
    "mime": "",
    "ttlSec": 0,
    "userName": "",
    "groupName": [],
    "symlinkTarget": "",
    "md5": "",
    "rdev": 0,
    "inode": "0"
  },
  "extended": {},
  "hardLinkId": "",
  "hardLinkCounter": 0,
  "content": "",
  "remoteEntry": null,
  "quota": "0"
}chunks 2 meta size: 177 gzip:205

```

# How are we solving the problem?

add sorting function by modification time

# How is the PR tested?

action tests

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
