### PR TITLE
[s3] add s3 pass test_multipart_upload_size_too_small

### DIFF
--- a/.github/workflows/s3tests.yml
+++ b/.github/workflows/s3tests.yml
@@ -168,6 +168,7 @@ jobs:
           s3tests_boto3/functional/test_s3.py::test_multipart_copy_multiple_sizes \
           s3tests_boto3/functional/test_s3.py::test_multipart_upload_contents \
           s3tests_boto3/functional/test_s3.py::test_multipart_upload_overwrite_existing_object \
+          s3tests_boto3/functional/test_s3.py::test_multipart_upload_size_too_small \
           s3tests_boto3/functional/test_s3.py::test_abort_multipart_upload \
           s3tests_boto3/functional/test_s3.py::test_list_multipart_upload \
           s3tests_boto3/functional/test_s3.py::test_atomic_read_1mb \

--- a/.github/workflows/s3tests.yml
+++ b/.github/workflows/s3tests.yml
@@ -181,7 +181,6 @@ jobs:
           s3tests_boto3/functional/test_s3.py::test_atomic_dual_write_4mb \
           s3tests_boto3/functional/test_s3.py::test_atomic_dual_write_8mb \
           s3tests_boto3/functional/test_s3.py::test_atomic_multipart_upload_write \
-          s3tests_boto3/functional/test_s3.py::test_multipart_resend_first_finishes_last \
           s3tests_boto3/functional/test_s3.py::test_ranged_request_response_code \
           s3tests_boto3/functional/test_s3.py::test_ranged_big_request_response_code \
           s3tests_boto3/functional/test_s3.py::test_ranged_request_skip_leading_bytes_response_code \

--- a/weed/s3api/filer_multipart.go
+++ b/weed/s3api/filer_multipart.go
@@ -24,7 +24,10 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 )
 
-const multipartExt = ".part"
+const (
+	multipartExt     = ".part"
+	multiPartMinSize = 5 * 1024 * 1024
+)
 
 type InitiateMultipartUploadResult struct {
 	XMLName xml.Name `xml:"http://s3.amazonaws.com/doc/2006-03-01/ InitiateMultipartUploadResult"`
@@ -82,10 +85,11 @@ func (s3a *S3ApiServer) completeMultipartUpload(input *s3.CompleteMultipartUploa
 		}
 		completedPartMap[part.PartNumber] = append(completedPartMap[part.PartNumber], part.ETag)
 	}
-	uploadDirectory := s3a.genUploadsFolder(*input.Bucket) + "/" + *input.UploadId
+	sort.Ints(completedPartNumbers)
 
+	uploadDirectory := s3a.genUploadsFolder(*input.Bucket) + "/" + *input.UploadId
 	entries, _, err := s3a.list(uploadDirectory, "", "", false, maxPartsList)
-	if err != nil || len(entries) == 0 {
+	if err != nil {
 		glog.Errorf("completeMultipartUpload %s %s error: %v, entries:%d", *input.Bucket, *input.UploadId, err, len(entries))
 		stats.S3HandlerCounter.WithLabelValues(stats.ErrorCompletedNoSuchUpload).Inc()
 		return nil, s3err.ErrNoSuchUpload
@@ -100,6 +104,7 @@ func (s3a *S3ApiServer) completeMultipartUpload(input *s3.CompleteMultipartUploa
 
 	deleteEntries := []*filer_pb.Entry{}
 	partEntries := make(map[int][]*filer_pb.Entry, len(entries))
+	entityTooSmall := false
 	for _, entry := range entries {
 		foundEntry := false
 		glog.V(4).Infof("completeMultipartUpload part entries %s", entry.Name)
@@ -138,16 +143,23 @@ func (s3a *S3ApiServer) completeMultipartUpload(input *s3.CompleteMultipartUploa
 			partEntries[partNumber] = append(partEntries[partNumber], entry)
 			foundEntry = true
 		}
-		if !foundEntry {
+		if foundEntry {
+			if (len(completedPartNumbers) == 1 || partNumber != completedPartNumbers[len(completedPartNumbers)-1]) &&
+				entry.Attributes.FileSize < multiPartMinSize {
+				glog.Warningf("completeMultipartUpload %s part file size less 5mb", entry.Name)
+				entityTooSmall = true
+			}
+		} else {
 			deleteEntries = append(deleteEntries, entry)
 		}
 	}
-
+	if entityTooSmall {
+		stats.S3HandlerCounter.WithLabelValues(stats.ErrorCompleteEntityTooSmall).Inc()
+		return nil, s3err.ErrEntityTooSmall
+	}
 	mime := pentry.Attributes.Mime
-
 	var finalParts []*filer_pb.FileChunk
 	var offset int64
-	sort.Ints(completedPartNumbers)
 	for _, partNumber := range completedPartNumbers {
 		partEntriesByNumber, ok := partEntries[partNumber]
 		if !ok {

--- a/weed/s3api/filer_multipart.go
+++ b/weed/s3api/filer_multipart.go
@@ -89,7 +89,7 @@ func (s3a *S3ApiServer) completeMultipartUpload(input *s3.CompleteMultipartUploa
 
 	uploadDirectory := s3a.genUploadsFolder(*input.Bucket) + "/" + *input.UploadId
 	entries, _, err := s3a.list(uploadDirectory, "", "", false, maxPartsList)
-	if err != nil {
+	if err != nil || len(entries) == 0 {
 		glog.Errorf("completeMultipartUpload %s %s error: %v, entries:%d", *input.Bucket, *input.UploadId, err, len(entries))
 		stats.S3HandlerCounter.WithLabelValues(stats.ErrorCompletedNoSuchUpload).Inc()
 		return nil, s3err.ErrNoSuchUpload

--- a/weed/s3api/filer_multipart.go
+++ b/weed/s3api/filer_multipart.go
@@ -77,6 +77,10 @@ type CompleteMultipartUploadResult struct {
 func (s3a *S3ApiServer) completeMultipartUpload(input *s3.CompleteMultipartUploadInput, parts *CompleteMultipartUpload) (output *CompleteMultipartUploadResult, code s3err.ErrorCode) {
 
 	glog.V(2).Infof("completeMultipartUpload input %v", input)
+	if len(parts.Parts) == 0 {
+		stats.S3HandlerCounter.WithLabelValues(stats.ErrorCompletedNoSuchUpload).Inc()
+		return nil, s3err.ErrNoSuchUpload
+	}
 	completedPartNumbers := []int{}
 	completedPartMap := make(map[int][]string)
 	for _, part := range parts.Parts {

--- a/weed/s3api/filer_multipart.go
+++ b/weed/s3api/filer_multipart.go
@@ -148,7 +148,7 @@ func (s3a *S3ApiServer) completeMultipartUpload(input *s3.CompleteMultipartUploa
 			foundEntry = true
 		}
 		if foundEntry {
-			if (len(completedPartNumbers) == 1 || partNumber != completedPartNumbers[len(completedPartNumbers)-1]) &&
+			if len(completedPartNumbers) > 1 && partNumber != completedPartNumbers[len(completedPartNumbers)-1] &&
 				entry.Attributes.FileSize < multiPartMinSize {
 				glog.Warningf("completeMultipartUpload %s part file size less 5mb", entry.Name)
 				entityTooSmall = true

--- a/weed/stats/metrics_names.go
+++ b/weed/stats/metrics_names.go
@@ -46,8 +46,9 @@ const (
 
 	// s3 handler
 	ErrorCompletedNoSuchUpload      = "errorCompletedNoSuchUpload"
-	ErrorCompletedPartEmpty         = "ErrorCompletedPartEmpty"
-	ErrorCompletedPartNumber        = "ErrorCompletedPartNumber"
+	ErrorCompleteEntityTooSmall     = "errorCompleteEntityTooSmall"
+	ErrorCompletedPartEmpty         = "errorCompletedPartEmpty"
+	ErrorCompletedPartNumber        = "errorCompletedPartNumber"
 	ErrorCompletedPartNotFound      = "errorCompletedPartNotFound"
 	ErrorCompletedEtagInvalid       = "errorCompletedEtagInvalid"
 	ErrorCompletedEtagMismatch      = "errorCompletedEtagMismatch"


### PR DESCRIPTION
# What problem are we solving?

```
_________________________________ test_multipart_upload_size_too_small __________________________________

    def test_multipart_upload_size_too_small():
        bucket_name = get_new_bucket()
        key="mymultipart"
        client = get_client()
    
        size = 100*1024
        (upload_id, data, parts) = _multipart_upload(bucket_name=bucket_name, key=key, size=size, part_size=10*1024)
>       e = assert_raises(ClientError, client.complete_multipart_upload, Bucket=bucket_name, Key=key, UploadId=upload_id, MultipartUpload={'Parts': parts})

s3tests_boto3/functional/test_s3.py:6242: 

>           raise AssertionError("%s not raised" % excName)
E           AssertionError: ClientError not raised

```

# How are we solving the problem?

return error if part size less 5mb

# How is the PR tested?

s3 tests in actions

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
