### PR TITLE
fix(volume.fix.replication): adjust volume count, not free volume count

### DIFF
--- a/weed/shell/command_volume_fix_replication.go
+++ b/weed/shell/command_volume_fix_replication.go
@@ -315,8 +315,8 @@ func (c *commandVolumeFixReplication) fixOneUnderReplicatedVolume(commandEnv *Co
 			fmt.Fprintf(writer, "replicating volume %d %s from %s to dataNode %s ...\n", replica.info.Id, replicaPlacement, replica.location.dataNode.Id, dst.dataNode.Id)
 
 			if !takeAction {
-				// adjust free volume count
-				dst.dataNode.DiskInfos[replica.info.DiskType].FreeVolumeCount--
+				// adjust volume count
+				dst.dataNode.DiskInfos[replica.info.DiskType].VolumeCount++
 				break
 			}
 
@@ -349,8 +349,8 @@ func (c *commandVolumeFixReplication) fixOneUnderReplicatedVolume(commandEnv *Co
 				return err
 			}
 
-			// adjust free volume count
-			dst.dataNode.DiskInfos[replica.info.DiskType].FreeVolumeCount--
+			// adjust volume count
+			dst.dataNode.DiskInfos[replica.info.DiskType].VolumeCount++
 			break
 		}
 	}


### PR DESCRIPTION
# What problem are we solving?

In the keepDataNodesSorted function, the calculation of the free volume count uses MaxVolumeCount - VolumeCount, thus it's necessary to adjust VolumeCount, rather than FreeVolumeCount.


# How are we solving the problem?



# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
