### PR TITLE
filer read chunk retry if status code 499

### DIFF
--- a/weed/util/http_util.go
+++ b/weed/util/http_util.go
@@ -328,7 +328,7 @@ func ReadUrlAsStreamAuthenticated(fileUrl, jwt string, cipherKey []byte, isConte
 	}
 	defer CloseResponse(r)
 	if r.StatusCode >= 400 {
-		retryable = r.StatusCode == http.StatusNotFound || r.StatusCode >= 500
+		retryable = r.StatusCode == http.StatusNotFound || r.StatusCode >= 499
 		return retryable, fmt.Errorf("%s: %s", fileUrl, r.Status)
 	}
 


### PR DESCRIPTION
# What problem are we solving?

```
filer_server_handlers_read.go:291 failed to stream content /buckets/registry/docker/registry/v2/repositories/company/service/tags/_manifests/tags/latest/current/link: read chunk: http://192.168.1.21:8080/439,fc138c121ee17c6660855d43?readDeleted=true: 499 status code 499
```

# How are we solving the problem?

499 code add to retry

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
