### PR TITLE
fix evacuate volume to different disk types

### DIFF
--- a/weed/shell/command_volume_server_evacuate.go
+++ b/weed/shell/command_volume_server_evacuate.go
@@ -3,14 +3,15 @@ package shell
 import (
 	"flag"
 	"fmt"
+	"io"
+	"os"
+
 	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
 	"github.com/seaweedfs/seaweedfs/weed/storage/erasure_coding"
 	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
 	"github.com/seaweedfs/seaweedfs/weed/storage/super_block"
 	"github.com/seaweedfs/seaweedfs/weed/storage/types"
 	"golang.org/x/exp/slices"
-	"io"
-	"os"
 )
 
 func init() {
@@ -219,7 +220,7 @@ func moveAwayOneNormalVolume(commandEnv *CommandEnv, volumeReplicas map[uint32][
 	})
 	for i := 0; i < len(otherNodes); i++ {
 		emptyNode := otherNodes[i]
-		if freeVolumeCountfn(emptyNode.info) < 0 {
+		if freeVolumeCountfn(emptyNode.info) <= 0 {
 			continue
 		}
 		hasMoved, err = maybeMoveOneVolume(commandEnv, volumeReplicas, thisNode, vol, emptyNode, applyChange)


### PR DESCRIPTION
# What problem are we solving?
fix evacuate volume to different disk types


# How are we solving the problem?
set different  types disk free count to -1
 


# How is the PR tested?
volumeServer.evacuate


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
