### PR TITLE
Fixes race with unlocked setter.

### DIFF
--- a/weed/cluster/lock_manager/lock_ring.go
+++ b/weed/cluster/lock_manager/lock_ring.go
@@ -72,7 +72,9 @@ func (r *LockRing) SetSnapshot(servers []pb.ServerAddress) {
 		return servers[i] < servers[j]
 	})
 
+	r.Lock()
 	r.lastUpdateTime = time.Now()
+	r.Unlock()
 
 	r.addOneSnapshot(servers)
 


### PR DESCRIPTION
# What problem are we solving?
LockRing.lastUpdateTime was being set outside of a lock in SetSnapshot, and blowing up in race conditions.


# How are we solving the problem?
This update properly uses the exiting locking.


# How is the PR tested?
Existing test suite passes. Contrived races now properly wait.


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
