### PR TITLE
Fixes unlocked read from logBuffer.LastTsNs that is racey.

### DIFF
--- a/weed/util/log_buffer/log_read.go
+++ b/weed/util/log_buffer/log_read.go
@@ -66,9 +66,17 @@ func (logBuffer *LogBuffer) LoopProcessLogData(readerName string, startPosition 
 				isDone = true
 				return
 			}
+			logBuffer.RLock()
 			lastTsNs := logBuffer.LastTsNs
-			for lastTsNs == logBuffer.LastTsNs {
+			logBuffer.RUnlock()
+			loopTsNs := lastTsNs // make a copy
+
+			for lastTsNs == loopTsNs {
 				if waitForDataFn() {
+					// Update loopTsNs and loop again
+					logBuffer.RLock()
+					loopTsNs = logBuffer.LastTsNs
+					logBuffer.RUnlock()
 					continue
 				} else {
 					isDone = true


### PR DESCRIPTION
# What problem are we solving?
in log_read.go, logBuffer.LastTsNs is being read _outside_ a lock. In log_buffer.go it is being written inside a lock.


# How are we solving the problem?
As logBuffer is an RWMutex, I am using the Read lock/unlock to lock the reads.


# How is the PR tested?
Existing test suite passes.


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
