### PR TITLE
Move file deletion logging to v2 verbisity

### DIFF
--- a/weed/filer/filer_delete_entry.go
+++ b/weed/filer/filer_delete_entry.go
@@ -38,7 +38,7 @@ func (f *Filer) DeleteEntryMetaAndData(ctx context.Context, p util.FullPath, isR
 			return nil
 		})
 		if err != nil {
-			glog.V(0).Infof("delete directory %s: %v", p, err)
+			glog.V(2).Infof("delete directory %s: %v", p, err)
 			return fmt.Errorf("delete directory %s: %v", p, err)
 		}
 	}
@@ -76,7 +76,7 @@ func (f *Filer) doBatchDeleteFolderMetaAndData(ctx context.Context, entry *Entry
 			}
 			if lastFileName == "" && !isRecursive && len(entries) > 0 {
 				// only for first iteration in the loop
-				glog.V(0).Infof("deleting a folder %s has children: %+v ...", entry.FullPath, entries[0].Name())
+				glog.V(2).Infof("deleting a folder %s has children: %+v ...", entry.FullPath, entries[0].Name())
 				return fmt.Errorf("%s: %s", MsgFailDelNonEmptyFolder, entry.FullPath)
 			}
 


### PR DESCRIPTION
# What problem are we solving?
In current implementation, the logging of file and directory deletions is set at a verbosity level that might be too verbose for regular operational logs, which could lead to cluttered log outputs that are difficult to manage and analyze in production environments.
# How are we solving the problem?
This PR addresses the issue by adjusting the verbosity level for logging deletion errors. Specifically, logs that were previously recorded at verbosity level 0 are now moved to 2 verbosity level.

# How is the PR tested?
no tests required


# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
