### PR TITLE
fix: skip file size checking for volume with TTL

### DIFF
--- a/weed/storage/volume_checking.go
+++ b/weed/storage/volume_checking.go
@@ -109,6 +109,9 @@ func verifyNeedleIntegrity(datFile backend.BackendStorageFile, v needle.Version,
 			return 0, fmt.Errorf("verifyNeedleIntegrity check %s entry offset %d size %d: %v", datFile.Name(), offset, size, err)
 		}
 		n.AppendAtNs = util.BytesToUint64(bytes)
+		if n.HasTtl() {
+			return n.AppendAtNs, nil
+		}
 		fileTailOffset := offset + needle.GetActualSize(size, v)
 		fileSize, _, err := datFile.GetStat()
 		if err != nil {


### PR DESCRIPTION
# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/5508


# How are we solving the problem?

 skip file size checking for volume with TTL, since the compact deletes files with expired ttl

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
