### PR TITLE
helm: Fix annotations parameters to be standard maps

### DIFF
--- a/k8s/charts/seaweedfs/Chart.yaml
+++ b/k8s/charts/seaweedfs/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: SeaweedFS
 name: seaweedfs
 appVersion: "3.65"
-version: 3.65.0
+version: 3.65.1

--- a/k8s/charts/seaweedfs/templates/filer-ingress.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-ingress.yaml
@@ -11,9 +11,9 @@ kind: Ingress
 metadata:
   name: ingress-{{ template "seaweedfs.name" . }}-filer
   namespace: {{ .Release.Namespace }}
-  {{- if .Values.filer.ingress.annotations }}
+  {{- with .Values.filer.ingress.annotations }}
   annotations:
-    {{ tpl .Values.filer.ingress.annotations . | nindent 4 | trim }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
     app.kubernetes.io/name: {{ template "seaweedfs.name" . }}

--- a/k8s/charts/seaweedfs/templates/master-ingress.yaml
+++ b/k8s/charts/seaweedfs/templates/master-ingress.yaml
@@ -11,9 +11,9 @@ kind: Ingress
 metadata:
   name: ingress-{{ template "seaweedfs.name" . }}-master
   namespace: {{ .Release.Namespace }}
-  {{- if .Values.master.ingress.annotations }}
+  {{- with .Values.master.ingress.annotations }}
   annotations:
-    {{ tpl .Values.master.ingress.annotations . | nindent 4 | trim }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
     app.kubernetes.io/name: {{ template "seaweedfs.name" . }}

--- a/k8s/charts/seaweedfs/templates/s3-ingress.yaml
+++ b/k8s/charts/seaweedfs/templates/s3-ingress.yaml
@@ -10,9 +10,9 @@ kind: Ingress
 metadata:
   name: ingress-{{ template "seaweedfs.name" . }}-s3
   namespace: {{ .Release.Namespace }}
-  {{- if .Values.s3.ingress.annotations }}
+  {{- with .Values.s3.ingress.annotations }}
   annotations:
-    {{- tpl .Values.s3.ingress.annotations . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
     app.kubernetes.io/name: {{ template "seaweedfs.name" . }}

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -171,7 +171,7 @@ master:
     className: "nginx"
     # host: false for "*" hostname
     host: "master.seaweedfs.local"
-    annotations: |
+    annotations:
       nginx.ingress.kubernetes.io/auth-type: "basic"
       nginx.ingress.kubernetes.io/auth-secret: "default/ingress-basic-auth-secret"
       nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required - SW-Master'
@@ -540,7 +540,7 @@ filer:
     className: "nginx"
     # host: false for "*" hostname
     host: "seaweedfs.cluster.local"
-    annotations: |
+    annotations:
       nginx.ingress.kubernetes.io/backend-protocol: GRPC
       nginx.ingress.kubernetes.io/auth-type: "basic"
       nginx.ingress.kubernetes.io/auth-secret: "default/ingress-basic-auth-secret"
@@ -746,7 +746,7 @@ s3:
     # host: false for "*" hostname
     host: "seaweedfs.cluster.local"
     # additional ingress annotations for the s3 endpoint
-    annotations: ""
+    annotations: {}
     tls: []
 
 certificates:


### PR DESCRIPTION
# What problem are we solving?

- fixes #5542 

Please read the above issue to learn more about this PR.

# How are we solving the problem?

I've converted all annotations back to map types. The reason is that this is the default behavior of helm charts to have annotations be maps. I've also bumped the helm chart version to release the chart.

**Background**: The two PRs that originally changed these were because they said it allowed them to override annotations (https://github.com/seaweedfs/seaweedfs/pull/4799) but that can still be done by setting any of the annotation fields to `{}` if you'd like to not have any annotations, or by just using the standard map to supply your own in your local values.yaml.

The second PR (https://github.com/seaweedfs/seaweedfs/pull/5463) was to make all the annotations behave the same way, which is non-standard.

# How is the PR tested?
Clone the repo, and then run:
```
# change to the correct directory
cd k8s/charts/seaweedfs

# test that templating renders fine, which will render every template
helm template .

# lint the chart
helm lint
```

Then, try changing the values.yaml to have a standard annotation for `s3.ingress.annotations` (don't forget to set `s3.ingress.enabled` to `true`):
```yaml
s3:
  ingress:
    enabled: true
    annotations:
      nginx.ingress.kubernetes.io/proxy-body-size: 1G
```

Now run the `helm template .` again, and you will get all the manifests rendered, but the most important one is this:

<details>
  <summary><code>seaweedfs/templates/s3-ingress.yaml</code></summary>
  
```yaml
---
# Source: seaweedfs/templates/s3-ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: ingress-seaweedfs-s3
  namespace: argocd
  annotations:
    nginx.ingress.kubernetes.io/proxy-body-size: 1G
  labels:
    app.kubernetes.io/name: seaweedfs
    helm.sh/chart: seaweedfs-3.65.1
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/component: s3
spec:
  ingressClassName: "nginx"
  tls:

      []
  rules:
  - http:
      paths:
      - path: /
        pathType: ImplementationSpecific
        backend:
          service:
            name: seaweedfs-s3
            port:
              number: 8333
              #name:
    host: seaweedfs.cluster.local
```

</details>

# Checks
- [x] I have added unit tests if possible. - not applicable for helm at this time
- [x] I will add related wiki document changes and link to this PR after merging.
