### PR TITLE
reduce ambiguity about use memory_sequencer

### DIFF
--- a/weed/sequence/memory_sequencer.go
+++ b/weed/sequence/memory_sequencer.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 )
 
-// just for testing
+// default Sequencer
 type MemorySequencer struct {
 	counter      uint64
 	sequenceLock sync.Mutex

--- a/weed/server/master_server.go
+++ b/weed/server/master_server.go
@@ -59,7 +59,7 @@ type MasterServer struct {
 
 	preallocateSize int64
 
-	Topo *topology.Topology
+	Topo                    *topology.Topology
 	vg                      *topology.VolumeGrowth
 	volumeGrowthRequestChan chan *topology.VolumeGrowRequest
 
@@ -347,6 +347,8 @@ func (ms *MasterServer) createSequencer(option *MasterOption) sequence.Sequencer
 			glog.Error(err)
 			seq = nil
 		}
+	case "raft":
+		fallthrough
 	default:
 		seq = sequence.NewMemorySequencer()
 	}


### PR DESCRIPTION
# What problem are we solving?

1. a log "just for test" may be a history comment.   default config it will be used.
2. make 'raft' type clearer to create its sequencer

# How are we solving the problem?



# How is the PR tested?
Its simple and no need new tests


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
