### PR TITLE
Add support for OpenBSD

### DIFF
--- a/weed/stats/disk_notsupported.go
+++ b/weed/stats/disk_notsupported.go
@@ -1,5 +1,5 @@
-//go:build openbsd || netbsd || plan9 || solaris
-// +build openbsd netbsd plan9 solaris
+//go:build netbsd || plan9 || solaris
+// +build netbsd plan9 solaris
 
 package stats
 

--- a/weed/stats/disk_openbsd.go
+++ b/weed/stats/disk_openbsd.go
@@ -1,0 +1,25 @@
+//go:build openbsd
+// +build openbsd
+
+package stats
+
+import (
+    "syscall"
+
+    "github.com/seaweedfs/seaweedfs/weed/pb/volume_server_pb"
+)
+
+func fillInDiskStatus(disk *volume_server_pb.DiskStatus) {
+    fs := syscall.Statfs_t{}
+    err := syscall.Statfs(disk.Dir, &fs)
+    if err != nil {
+        return
+    }
+    disk.All = fs.F_blocks * uint64(fs.F_bsize)
+    disk.Free = fs.F_bfree * uint64(fs.F_bsize)
+    disk.Used = disk.All - disk.Free
+    disk.PercentFree = float32((float64(disk.Free) / float64(disk.All)) * 100)
+    disk.PercentUsed = float32((float64(disk.Used) / float64(disk.All)) * 100)
+    return
+}
+


### PR DESCRIPTION
# What problem are we solving?

Allowing OpenBSD to run seaweedfs. Without this change, disk sizes aren't available. 

# How are we solving the problem?

`syscall.Statfs_t` is [slightly different.](https://github.com/golang/go/issues/47958) The code otherwise is identical.

# How is the PR tested?

I'm successfully running seaweedfs on OpenBSD/arm64. I haven't tested it on other architectures, but it should work the same.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
