### PR TITLE
Fixes races with tests.

### DIFF
--- a/weed/cluster/lock_manager/lock_ring_test.go
+++ b/weed/cluster/lock_manager/lock_ring_test.go
@@ -19,25 +19,41 @@ func TestAddServer(t *testing.T) {
 	r.RemoveServer("localhost:8082")
 	r.RemoveServer("localhost:8080")
 
+	r.RLock()
 	assert.Equal(t, 8, len(r.snapshots))
+	r.RUnlock()
 
 	time.Sleep(110 * time.Millisecond)
 
+	r.RLock()
 	assert.Equal(t, 2, len(r.snapshots))
-
+	r.RUnlock()
 }
 
 func TestLockRing(t *testing.T) {
 	r := NewLockRing(100 * time.Millisecond)
 	r.SetSnapshot([]pb.ServerAddress{"localhost:8080", "localhost:8081"})
+	r.RLock()
 	assert.Equal(t, 1, len(r.snapshots))
+	r.RUnlock()
+
 	r.SetSnapshot([]pb.ServerAddress{"localhost:8080", "localhost:8081", "localhost:8082"})
+	r.RLock()
 	assert.Equal(t, 2, len(r.snapshots))
+	r.RUnlock()
 	time.Sleep(110 * time.Millisecond)
+
 	r.SetSnapshot([]pb.ServerAddress{"localhost:8080", "localhost:8081", "localhost:8082", "localhost:8083"})
+	r.RLock()
 	assert.Equal(t, 3, len(r.snapshots))
+	r.RUnlock()
 	time.Sleep(110 * time.Millisecond)
+	r.RLock()
 	assert.Equal(t, 2, len(r.snapshots))
+	r.RUnlock()
+
 	r.SetSnapshot([]pb.ServerAddress{"localhost:8080", "localhost:8081", "localhost:8082", "localhost:8083", "localhost:8084"})
+	r.RLock()
 	assert.Equal(t, 3, len(r.snapshots))
+	r.RUnlock()
 }


### PR DESCRIPTION
# What problem are we solving?

Tests of the lock manager lazily read from concurrently-written variables without using read locks.  This can result in false failures of the tests when the testing system is under heavy load.

# How are we solving the problem?

Using the provided read locks in the tests.

# How is the PR tested?

Existing test suite passes, and previously failing occurrences under contrived conditions are no longer failing. 

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
