### PR TITLE
Helm: Allow adding additional labels to the service monitors

### DIFF
--- a/k8s/charts/seaweedfs/templates/filer-servicemonitor.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-servicemonitor.yaml
@@ -12,6 +12,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: filer
+    {{- with .Values.global.monitoring.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   endpoints:
     - interval: 30s

--- a/k8s/charts/seaweedfs/templates/master-servicemonitor.yaml
+++ b/k8s/charts/seaweedfs/templates/master-servicemonitor.yaml
@@ -12,6 +12,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: master
+    {{- with .Values.global.monitoring.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   endpoints:
     - interval: 30s

--- a/k8s/charts/seaweedfs/templates/s3-servicemonitor.yaml
+++ b/k8s/charts/seaweedfs/templates/s3-servicemonitor.yaml
@@ -12,6 +12,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: s3
+    {{- with .Values.global.monitoring.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   endpoints:
     - interval: 30s

--- a/k8s/charts/seaweedfs/templates/volume-servicemonitor.yaml
+++ b/k8s/charts/seaweedfs/templates/volume-servicemonitor.yaml
@@ -12,6 +12,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: volume
+    {{- with .Values.global.monitoring.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   endpoints:
     - interval: 30s

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -25,6 +25,7 @@ global:
     enabled: false
     gatewayHost: null
     gatewayPort: null
+    additionalLabels: {}
   # if enabled will use global.replicationPlacment and override master & filer defaultReplicaPlacement config
   enableReplication: false
   #  replication type is XYZ:


### PR DESCRIPTION
# What problem are we solving?
We deploy seaweedfs using the helm chart. Our Monitoring requires additional labels as it uses ServiceMonitorSelectors, which currently cannot be set.

# How are we solving the problem?
Allow adding additional labels to the ServiceMonitor

# How is the PR tested?
* template rendered using "helm template"
* deployed in our internal cluster 

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
