### PR TITLE
Helm: Fix warning when rendering with secretExtraEnvVars set

### DIFF
--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -605,7 +605,7 @@ filer:
     timeoutSeconds: 10
 
   # secret env variables
-  secretExtraEnvironmentVars: []
+  secretExtraEnvironmentVars: {}
       # WEED_POSTGRES_USERNAME:
       #   secretKeyRef:
       #     name: postgres-credentials


### PR DESCRIPTION
# What problem are we solving?
When filer.secretExtraEnvironmentVars is configured, helm prints a warning during rendering (the result will still be correct):

```
coalesce.go:289: warning: destination for q-mes.seaweedfs.filer.secretExtraEnvironmentVars is a table. Ignoring non-table value ([])
coalesce.go:289: warning: destination for q-mes.seaweedfs.filer.secretExtraEnvironmentVars is a table. Ignoring non-table value ([])
coalesce.go:289: warning: destination for q-mes.seaweedfs.filer.secretExtraEnvironmentVars is a table. Ignoring non-table value ([])
```

# How are we solving the problem?
I changed the default to be a dict. That seems to be the intended type, looking at the commented out example below.

# How is the PR tested?
Rendered the template using "helm template ."

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
