### PR TITLE
[s3] Fixed s3 replication by sending content-md as base64

### DIFF
--- a/weed/replication/sink/s3sink/s3_sink.go
+++ b/weed/replication/sink/s3sink/s3_sink.go
@@ -11,6 +11,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 	"strconv"
 	"strings"
+	"encoding/base64"
 
 	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/glog"
@@ -202,7 +203,7 @@ func (s3sink *S3Sink) CreateEntry(key string, entry *filer_pb.Entry, signatures 
 		Tagging: aws.String(tags),
 	}
 	if len(entry.Attributes.Md5) > 0 {
-		uploadInput.ContentMD5 = aws.String(fmt.Sprintf("%x", entry.Attributes.Md5))
+		uploadInput.ContentMD5 = aws.String(base64.StdEncoding.EncodeToString([]byte(entry.Attributes.Md5)))
 	}
 	_, err = uploader.Upload(&uploadInput)
 


### PR DESCRIPTION
# What problem are we solving?

Async S3 replication wasn't working, because the Content-MD5 value was not encoded as base64.

https://github.com/seaweedfs/seaweedfs/issues/5572

# How are we solving the problem?

The content-md5 value is encoded as base64.

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
