### PR TITLE
chore: add missing concurrency help in fs.meta.load command

### DIFF
--- a/weed/shell/command_fs_meta_load.go
+++ b/weed/shell/command_fs_meta_load.go
@@ -32,6 +32,7 @@ func (c *commandFsMetaLoad) Help() string {
 
 	fs.meta.load <filer_host>-<port>-<time>.meta
 	fs.meta.load -v=false <filer_host>-<port>-<time>.meta // skip printing out the verbose output
+ 	fs.meta.load -concurrency=1 <filer_host>-<port>-<time>.meta // number of parallel meta load to filer
 	fs.meta.load -dirPrefix=/buckets/important* <filer_host>.meta // load any dirs with prefix "important"
 
 `


### PR DESCRIPTION
# What problem are we solving?

I remember that this was added, but I was a little confused when I didn't see it in the help in the command.

I also clarified this in the wiki https://github.com/seaweedfs/seaweedfs/wiki/Filer-Stores/60410f97c5fe6b029cb2d5ff277a099e40896eb5

# Checks
- [ ] I have added unit tests if possible.
- [X] I will add related wiki document changes and link to this PR after merging. 
