### PR TITLE
increase helm chart version to include the emptyDir storage feature

### DIFF
--- a/k8s/charts/seaweedfs/Chart.yaml
+++ b/k8s/charts/seaweedfs/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: SeaweedFS
 name: seaweedfs
 appVersion: "3.67"
-version: 3.67.0
+version: 3.67.1


### PR DESCRIPTION
Increasing the helm chart version to get a release with the [emptyDir storage](https://github.com/seaweedfs/seaweedfs/pull/5610) feature and the [s3 resources fix](https://github.com/seaweedfs/seaweedfs/pull/5611) that were merged yesterday