### PR TITLE
Replaces volume.unmount in the help of the volumeServer.leave

### DIFF
--- a/weed/shell/command_volume_server_leave.go
+++ b/weed/shell/command_volume_server_leave.go
@@ -25,7 +25,7 @@ func (c *commandVolumeServerLeave) Name() string {
 func (c *commandVolumeServerLeave) Help() string {
 	return `stop a volume server from sending heartbeats to the master
 
-	volume.unmount -node <volume server host:port> -force
+	volumeServer.leave -node <volume server host:port> -force
 
 	This command enables gracefully shutting down the volume server.
 	The volume server will stop sending heartbeats to the master.


### PR DESCRIPTION

# What problem are we solving?

Fixes an error made when copying a `volume.unmount` command file.

# How are we solving the problem?



# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
