### PR TITLE
Fix sorted needle file's write mode for (*SortedFileNeedleMap).Delete()

### DIFF
--- a/weed/storage/needle_map_sorted_file.go
+++ b/weed/storage/needle_map_sorted_file.go
@@ -27,7 +27,7 @@ func NewSortedFileNeedleMap(indexBaseFileName string, indexFile *os.File) (m *So
 	}
 	glog.V(1).Infof("Opening %s...", fileName)
 
-	if m.dbFile, err = os.Open(indexBaseFileName + ".sdx"); err != nil {
+	if m.dbFile, err = os.OpenFile(indexBaseFileName+".sdx", os.O_RDWR, 0); err != nil {
 		return
 	}
 	dbStat, _ := m.dbFile.Stat()


### PR DESCRIPTION
# What problem are we solving?

volume.fsck triggers (*SortedFileNeedleMap).Delete(), which is directly writing to .sdx file in `erasure_coding.MarkNeedleDeleted`, causing the command to fail.

# How are we solving the problem?

We had to change O_RDONLY to O_RDWR to avoid error.

# How is the PR tested?

This is a bug-fix PR. No additional logic was introduced.

# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
