### PR TITLE
Fix volume.tier.upload nil pointer panic

### DIFF
--- a/weed/shell/command_volume_tier_upload.go
+++ b/weed/shell/command_volume_tier_upload.go
@@ -139,6 +139,12 @@ func uploadDatToRemoteTier(grpcDialOption grpc.DialOption, writer io.Writer, vol
 			KeepLocalDatFile:       keepLocalDatFile,
 		})
 
+		if stream == nil && copyErr == nil {
+			// when the volume is already uploaded, VolumeTierMoveDatToRemote will return nil stream and nil error
+			// so we should directly return in this case
+			fmt.Fprintf(writer, "volume %v already uploaded", volumeId)
+			return nil
+		}
 		var lastProcessed int64
 		for {
 			resp, recvErr := stream.Recv()


### PR DESCRIPTION
# What problem are we solving?

when the volume is already uploaded, VolumeTierMoveDatToRemote will return nil stream and nil error, causing `stream.Recv()` making SIGSEGV panic.

# How are we solving the problem?

We added an additional check to avoid the panic.

# How is the PR tested?

This is a bug-fix PR. No additional logic was introduced.

# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
