### PR TITLE
Ignore remote volume when selecting volumes in operation (ec.encode/volume.tier.upload)

### DIFF
--- a/weed/shell/command_ec_encode.go
+++ b/weed/shell/command_ec_encode.go
@@ -304,6 +304,10 @@ func collectVolumeIdsForEcEncode(commandEnv *CommandEnv, selectedCollection stri
 	eachDataNode(topologyInfo, func(dc string, rack RackId, dn *master_pb.DataNodeInfo) {
 		for _, diskInfo := range dn.DiskInfos {
 			for _, v := range diskInfo.VolumeInfos {
+				// ignore remote volumes
+				if v.RemoteStorageName != "" && v.RemoteStorageKey != "" {
+					continue
+				}
 				if v.Collection == selectedCollection && v.ModifiedAtSecond+quietSeconds < nowUnixSeconds {
 					if float64(v.Size) > fullPercentage/100*float64(volumeSizeLimitMb)*1024*1024 {
 						vidMap[v.Id] = true


### PR DESCRIPTION
# What problem are we solving?

ec.encode and volume.tier.upload uses `collectVolumeIdsForEcEncode`, which does not ignores remote volumes, causing both commands to do extra work and outputting garbage messages.

# How are we solving the problem?

We added an additional check to ignore the remote volume.

# How is the PR tested?

This PR is too minor to create a unit-test. However I've tested this code on my own production cluster.

# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
