### PR TITLE
Set the capacity of clientChan to 10000

### DIFF
--- a/weed/server/master_grpc_server.go
+++ b/weed/server/master_grpc_server.go
@@ -361,8 +361,7 @@ func (ms *MasterServer) addClient(filerGroup, clientType string, clientAddress p
 	// the KeepConnected loop is no longer listening on this channel but we're
 	// trying to send to it in SendHeartbeat and so we can't lock the
 	// clientChansLock to remove the channel and we're stuck writing to it
-	// 100 is probably overkill
-	messageChan = make(chan *master_pb.KeepConnectedResponse, 100)
+	messageChan = make(chan *master_pb.KeepConnectedResponse, 10000)
 
 	ms.clientChansLock.Lock()
 	ms.clientChans[clientName] = messageChan


### PR DESCRIPTION
# What problem are we solving?
Setting the capacity of clientChan to 100 is too conservative; it will block jobs like KeepConnected/SendHeartbeat/ProcessGrowRequest when a large number of events occur.



# How are we solving the problem?
Set the capacity of clientChan to 10000


# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
