### PR TITLE
fix(s3api): make post api upload object default return 204

### DIFF
--- a/weed/s3api/s3api_object_handlers_postpolicy.go
+++ b/weed/s3api/s3api_object_handlers_postpolicy.go
@@ -60,7 +60,6 @@ func (s3a *S3ApiServer) PostPolicyBucketHandler(w http.ResponseWriter, r *http.R
 
 	successRedirect := formValues.Get("success_action_redirect")
 	successStatus := formValues.Get("success_action_status")
-	fmt.Printf("successRedirect:%s, successStatus:%s\n", successRedirect, successStatus)
 	var redirectURL *url.URL
 	if successRedirect != "" {
 		redirectURL, err = url.Parse(successRedirect)
@@ -168,10 +167,8 @@ func (s3a *S3ApiServer) PostPolicyBucketHandler(w http.ResponseWriter, r *http.R
 	case "200":
 		s3err.WriteEmptyResponse(w, r, http.StatusOK)
 	case "204":
-		fmt.Println("204")
 		s3err.WriteEmptyResponse(w, r, http.StatusNoContent)
 	default:
-		fmt.Println("default")
 		s3err.WriteEmptyResponse(w, r, http.StatusNoContent)
 	}
 

--- a/weed/s3api/s3api_object_handlers_postpolicy.go
+++ b/weed/s3api/s3api_object_handlers_postpolicy.go
@@ -60,6 +60,7 @@ func (s3a *S3ApiServer) PostPolicyBucketHandler(w http.ResponseWriter, r *http.R
 
 	successRedirect := formValues.Get("success_action_redirect")
 	successStatus := formValues.Get("success_action_status")
+	fmt.Printf("successRedirect:%s, successStatus:%s\n", successRedirect, successStatus)
 	var redirectURL *url.URL
 	if successRedirect != "" {
 		redirectURL, err = url.Parse(successRedirect)
@@ -166,8 +167,12 @@ func (s3a *S3ApiServer) PostPolicyBucketHandler(w http.ResponseWriter, r *http.R
 		s3err.PostLog(r, http.StatusCreated, s3err.ErrNone)
 	case "200":
 		s3err.WriteEmptyResponse(w, r, http.StatusOK)
+	case "204":
+		fmt.Println("204")
+		s3err.WriteEmptyResponse(w, r, http.StatusNoContent)
 	default:
-		writeSuccessResponseEmpty(w, r)
+		fmt.Println("default")
+		s3err.WriteEmptyResponse(w, r, http.StatusNoContent)
 	}
 
 }


### PR DESCRIPTION
# What problem are we solving?
- according to: https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html
  - default status is 204


# How are we solving the problem?
- change `case ... default: ` to set status `NoContent` as `204`


# How is the PR tested?
- generate presign post url to upload
- upload it, check status return 204


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
