### PR TITLE
Allow using a PVC to store filer and master logs

### DIFF
--- a/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
@@ -129,7 +129,7 @@ spec:
             - "-ec"
             - |
               exec /usr/bin/weed \
-              {{- if or (eq .Values.filer.logs.type "hostPath") (eq .Values.filer.logs.type "emptyDir") }}
+              {{- if or (eq .Values.filer.logs.type "hostPath") (eq .Values.filer.logs.type "persistentVolumeClaim") (eq .Values.filer.logs.type "emptyDir") }}
               -logdir=/logs \
               {{- else }}
               -logtostderr=true \
@@ -197,7 +197,7 @@ spec:
               {{- end }}
               -master={{ if .Values.global.masterServer }}{{.Values.global.masterServer}}{{ else }}{{ range $index := until (.Values.master.replicas | int) }}${SEAWEEDFS_FULLNAME}-master-{{ $index }}.${SEAWEEDFS_FULLNAME}-master.{{ $.Release.Namespace }}:{{ $.Values.master.port }}{{ if lt $index (sub ($.Values.master.replicas | int) 1) }},{{ end }}{{ end }}{{ end }}
           volumeMounts:
-            {{- if or (eq .Values.filer.logs.type "hostPath") (eq .Values.filer.logs.type "emptyDir") }}
+            {{- if (or (eq .Values.filer.logs.type "hostPath") (eq .Values.filer.logs.type "persistentVolumeClaim") (eq .Values.filer.logs.type "emptyDir")) }}
             - name: seaweedfs-filer-log-volume
               mountPath: "/logs/"
             {{- end }}

--- a/k8s/charts/seaweedfs/templates/master-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/master-statefulset.yaml
@@ -110,7 +110,7 @@ spec:
             - "-ec"
             - |
               exec /usr/bin/weed \
-              {{- if or (eq .Values.master.logs.type "hostPath") (eq .Values.master.logs.type "emptyDir") }}
+              {{- if or (eq .Values.master.logs.type "hostPath") (eq .Values.master.logs.type "persistentVolumeClaim") (eq .Values.master.logs.type "emptyDir") }}
               -logdir=/logs \
               {{- else }}
               -logtostderr=true \
@@ -158,7 +158,7 @@ spec:
           volumeMounts:
             - name : data-{{ .Release.Namespace }}
               mountPath: /data
-            {{- if or (eq .Values.master.logs.type "hostPath") (eq .Values.master.logs.type "emptyDir") }}
+            {{- if or (eq .Values.master.logs.type "hostPath") (eq .Values.master.logs.type "persistentVolumeClaim") (eq .Values.master.logs.type "emptyDir") }}
             - name: seaweedfs-master-log-volume
               mountPath: "/logs/"
             {{- end }}


### PR DESCRIPTION
# What problem are we solving?

The current Helm chart template doesn't mount the filer and master logs PVC when the type is set to `persistentVolumeClaim`.

References:
- [filer -logdir flag](https://github.com/seaweedfs/seaweedfs/blob/fce8fc1e16978e398f4d55177328ea50ac8210b9/k8s/charts/seaweedfs/templates/filer-statefulset.yaml#L132-L134)
- [filer volume mounts](https://github.com/seaweedfs/seaweedfs/blob/fce8fc1e16978e398f4d55177328ea50ac8210b9/k8s/charts/seaweedfs/templates/filer-statefulset.yaml#L200-L202)
- [master -logdir flag](https://github.com/seaweedfs/seaweedfs/blob/fce8fc1e16978e398f4d55177328ea50ac8210b9/k8s/charts/seaweedfs/templates/master-statefulset.yaml#L113-L115)
- [master volume mounts](https://github.com/seaweedfs/seaweedfs/blob/fce8fc1e16978e398f4d55177328ea50ac8210b9/k8s/charts/seaweedfs/templates/master-statefulset.yaml#L161-L164)

# How are we solving the problem?

Added `(eq .Values.filer.logs.type "persistentVolumeClaim")` and `(eq .Values.master.logs.type "persistentVolumeClaim")` to the OR statements so that the volume mounts and the `-logdir` flag get configured when the storage type is `persistentVolumeClaim`

# How is the PR tested?

I couldn't find tests for Helm chart templating with values other than the default. Please let me know if I missed them and I'm happy add tests.

I tested it e2e and I can see the logs show up in the PVCs now:

**Filer**
```bash
# kubectl exec -it seaweedfs-filer-0 -n seaweedfs -- ls -lah /logs
total 16K    
drwxrwxrwx    2 root     root        4.0K Jun  7 00:23 .
drwxr-xr-x    1 root     root        4.0K Jun  7 00:23 ..
lrwxrwxrwx    1 root     root          54 Jun  7 00:23 weed.INFO -> weed.seaweedfs-filer-0.root.log.INFO.20240607-002305.1
lrwxrwxrwx    1 root     root          57 Jun  7 00:23 weed.WARNING -> weed.seaweedfs-filer-0.root.log.WARNING.20240607-002305.1
-rw-r--r--    1 root     root        3.5K Jun  7 00:23 weed.seaweedfs-filer-0.root.log.INFO.20240607-002305.1
-rw-r--r--    1 root     root         271 Jun  7 00:23 weed.seaweedfs-filer-0.root.log.WARNING.20240607-002305.1
```

**Master**
```bash
# kubectl exec -it seaweedfs-master-0 -n seaweedfs -- ls -lah /logs
total 24K    
drwxrwxrwx    2 root     root        4.0K Jun  7 00:22 .
drwxr-xr-x    1 root     root        4.0K Jun  7 00:22 ..
lrwxrwxrwx    1 root     root          55 Jun  7 00:22 weed.INFO -> weed.seaweedfs-master-0.root.log.INFO.20240607-002200.1
-rw-r--r--    1 root     root       15.1K Jun  7 00:37 weed.seaweedfs-master-0.root.log.INFO.20240607-002200.1
```

# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
