### PR TITLE
fix: Ensure that the clientAddress is unique

### DIFF
--- a/weed/server/master_grpc_server.go
+++ b/weed/server/master_grpc_server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/google/uuid"
 	"github.com/seaweedfs/seaweedfs/weed/cluster"
 	"net"
 	"sort"
@@ -260,7 +261,12 @@ func (ms *MasterServer) KeepConnected(stream master_pb.Seaweed_KeepConnectedServ
 		return ms.informNewLeader(stream)
 	}
 
-	peerAddress := pb.ServerAddress(req.ClientAddress)
+	clientAddress := req.ClientAddress
+	// Ensure that the clientAddress is unique.
+	if clientAddress == "" {
+		clientAddress = uuid.New().String()
+	}
+	peerAddress := pb.ServerAddress(clientAddress)
 
 	// buffer by 1 so we don't end up getting stuck writing to stopChan forever
 	stopChan := make(chan bool, 1)


### PR DESCRIPTION
# What problem are we solving?
In the KeepConnected function, the parameter req.ClientAddress that is passed in might be ""（weed shell...）, leading to:

1. Multiple clients using the same key in clientChans.
2. The following code segment may result in goroutine leakage.
```
go func() {
	// consume message chan to avoid deadlock, go routine exit when message chan is closed
	for range messageChan {
	     // no op
	}
}()
```


# How are we solving the problem?
fix: Ensure that the clientAddress is unique


# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
