### PR TITLE
Allow defining labels and annotations per component

### DIFF
--- a/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
@@ -35,8 +35,14 @@ spec:
       {{ with .Values.podLabels }}
       {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.filer.podLabels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       annotations:
       {{ with .Values.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.filer.podAnnotations }}
       {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:

--- a/k8s/charts/seaweedfs/templates/master-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/master-statefulset.yaml
@@ -34,8 +34,14 @@ spec:
       {{ with .Values.podLabels }}
       {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.master.podLabels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       annotations:
       {{ with .Values.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.master.podAnnotations }}
       {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:

--- a/k8s/charts/seaweedfs/templates/s3-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/s3-deployment.yaml
@@ -27,8 +27,14 @@ spec:
       {{ with .Values.podLabels }}
       {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.s3.podLabels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       annotations:
       {{ with .Values.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.s3.podAnnotations }}
       {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:

--- a/k8s/charts/seaweedfs/templates/volume-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/volume-statefulset.yaml
@@ -28,8 +28,14 @@ spec:
       {{ with .Values.podLabels }}
       {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.volume.podLabels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       annotations:
       {{ with .Values.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.volume.podAnnotations }}
       {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -127,6 +127,12 @@ master:
   extraVolumes: ""
   extraVolumeMounts: ""
 
+  # Labels to be added to the master pods
+  podLabels: {}
+
+  # Annotations to be added to the master pods
+  podAnnotations: {}
+
   ## Set podManagementPolicy
   podManagementPolicy: Parallel
 
@@ -369,6 +375,12 @@ volume:
   extraVolumes: ""
   extraVolumeMounts: ""
 
+  # Labels to be added to the volume pods
+  podLabels: {}
+
+  # Annotations to be added to the volume pods
+  podAnnotations: {}
+
   ## Set podManagementPolicy
   podManagementPolicy: Parallel
 
@@ -550,6 +562,12 @@ filer:
 
   extraVolumes: ""
   extraVolumeMounts: ""
+
+  # Labels to be added to the filer pods
+  podLabels: {}
+
+  # Annotations to be added to the filer pods
+  podAnnotations: {}
 
   ## Set podManagementPolicy
   podManagementPolicy: Parallel
@@ -760,6 +778,12 @@ s3:
 
   extraVolumes: ""
   extraVolumeMounts: ""
+
+  # Labels to be added to the s3 pods
+  podLabels: {}
+
+  # Annotations to be added to the s3 pods
+  podAnnotations: {}
 
   # Resource requests, limits, etc. for the server cluster placement. This
   # should map directly to the value of the resources field for a PodSpec,


### PR DESCRIPTION
# What problem are we solving?

The current Helm chart template only allows defining global pod labels and annotations. This PR adds the ability to define labels and annotations at the component level.

# How are we solving the problem?

Added `podLabels` and `podAnnotations` Helm values for each component.

# How is the PR tested?

I couldn't find tests for Helm chart templating with values other than the default. Please let me know if I missed them and I'm happy add tests.

I tested it e2e and I can see labels and annotations show up:

**Filer**
```bash
# kubectl get pod seaweedfs-filer-0 -n seaweedfs -oyaml | grep test.filer.annotation.key
    test.filer.annotation.key1: test.filer.annotation.value1
    test.filer.annotation.key2: test.filer.annotation.value2

# kubectl get pod seaweedfs-filer-0 -n seaweedfs -oyaml | grep test.filer.label.key
    test.filer.label.key1: test.filer.label.value1
    test.filer.label.key2: test.filer.label.value2
```

**Master**
```bash
# kubectl get pod seaweedfs-master-0 -n seaweedfs -oyaml | grep test.master.annotation.key
    test.master.annotation.key1: test.master.annotation.value1
    test.master.annotation.key2: test.master.annotation.value2

# kubectl get pod seaweedfs-master-0 -n seaweedfs -oyaml | grep test.master.label.key
    test.master.label.key1: test.master.label.value1
    test.master.label.key2: test.master.label.value2
```

**Volume**
```bash
# kubectl get pod seaweedfs-volume-0 -n seaweedfs -oyaml | grep test.volume.annotation.key
    test.volume.annotation.key1: test.volume.annotation.value1
    test.volume.annotation.key2: test.volume.annotation.value2

# kubectl get pod seaweedfs-volume-0 -n seaweedfs -oyaml | grep test.volume.label.key
    test.volume.label.key1: test.volume.label.value1
    test.volume.label.key2: test.volume.label.value2
```

**S3**
```bash
# kubectl get pod seaweedfs-s3-5c549df446-q8d84 -n seaweedfs -oyaml | grep test.s3.annotation.key
    test.s3.annotation.key1: test.s3.annotation.value1
    test.s3.annotation.key2: test.s3.annotation.value2

# kubectl get pod seaweedfs-s3-5c549df446-q8d84 -n seaweedfs -oyaml | grep test.s3.label.key
    test.s3.label.key1: test.s3.label.value1
    test.s3.label.key2: test.s3.label.value2
```

# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
