### PR TITLE
Fix Filer Sync Issue: 5455

### DIFF
--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -63,6 +63,7 @@ type FilerOptions struct {
 	diskType                *string
 	allowedOrigins          *string
 	exposeDirectoryData     *bool
+	joinExistingFiler       *bool
 }
 
 func init() {
@@ -95,6 +96,7 @@ func init() {
 	f.diskType = cmdFiler.Flag.String("disk", "", "[hdd|ssd|<tag>] hard drive or solid state drive or any tag")
 	f.allowedOrigins = cmdFiler.Flag.String("allowedOrigins", "*", "comma separated list of allowed origins")
 	f.exposeDirectoryData = cmdFiler.Flag.Bool("exposeDirectoryData", true, "whether to return directory metadata and content in Filer UI")
+	f.joinExistingFiler = cmdFiler.Flag.Bool("joinExistingFiler", false, "enable if new filer wants to join existing cluster")
 
 	// start s3 on filer
 	filerStartS3 = cmdFiler.Flag.Bool("s3", false, "whether to start S3 gateway")
@@ -262,6 +264,7 @@ func (fo *FilerOptions) startFiler() {
 		DownloadMaxBytesPs:    int64(*fo.downloadMaxMBps) * 1024 * 1024,
 		DiskType:              *fo.diskType,
 		AllowedOrigins:        strings.Split(*fo.allowedOrigins, ","),
+		JoinExistingFiler:     *fo.joinExistingFiler,
 	})
 	if nfs_err != nil {
 		glog.Fatalf("Filer startup error: %v", nfs_err)

--- a/weed/server/filer_server.go
+++ b/weed/server/filer_server.go
@@ -74,6 +74,7 @@ type FilerOption struct {
 	DiskType              string
 	AllowedOrigins        []string
 	ExposeDirectoryData   bool
+	JoinExistingFiler     bool
 }
 
 type FilerServer struct {
@@ -197,6 +198,9 @@ func NewFilerServer(defaultMux, readonlyMux *http.ServeMux, option *FilerOption)
 
 	existingNodes := fs.filer.ListExistingPeerUpdates()
 	startFromTime := time.Now().Add(-filer.LogFlushInterval)
+	if option.JoinExistingFiler {
+		startFromTime = time.Time{}
+	}
 	if isFresh {
 		glog.V(0).Infof("%s bootstrap from peers %+v", option.Host, existingNodes)
 		if err := fs.filer.MaybeBootstrapFromPeers(option.Host, existingNodes, startFromTime); err != nil {


### PR DESCRIPTION
# What problem are we solving?
[5455](https://github.com/seaweedfs/seaweedfs/issues/5455)


# How are we solving the problem?
There is an issue in filer sync when new nodes are getting added to the cluster(config: 1 master, 3 filer, 3 volume) using leveldb2 filer. When we scale volume and filer on 4th node, it doesn't sync all the data from the start but picks any data within 1 minute range. 


# How is the PR tested?
Yes, the default behavior for seaweedfs remains same. If anyone wants to enable it, a flag is added in filer  "joinExistingFiler"


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
