### PR TITLE
fix #5681 convert all resources parameters to maps instead of strings

### DIFF
--- a/k8s/charts/seaweedfs/Chart.yaml
+++ b/k8s/charts/seaweedfs/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: SeaweedFS
 name: seaweedfs
 appVersion: "3.68"
-version: 3.68.0
+version: 4.0.0

--- a/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
@@ -269,9 +269,9 @@ spec:
             failureThreshold: {{ .Values.filer.livenessProbe.failureThreshold }}
             timeoutSeconds: {{ .Values.filer.livenessProbe.timeoutSeconds }}
           {{- end }}
-          {{- if .Values.filer.resources }}
+          {{- with .Values.filer.resources }}
           resources:
-            {{ tpl .Values.filer.resources . | nindent 12 | trim }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- if .Values.filer.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.filer.containerSecurityContext "enabled" | toYaml | nindent 12 }}

--- a/k8s/charts/seaweedfs/templates/master-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/master-statefulset.yaml
@@ -227,9 +227,9 @@ spec:
             failureThreshold: {{ .Values.master.livenessProbe.failureThreshold }}
             timeoutSeconds: {{ .Values.master.livenessProbe.timeoutSeconds }}
           {{- end }}
-          {{- if .Values.master.resources }}
+          {{- with .Values.master.resources }}
           resources:
-            {{ tpl .Values.master.resources . | nindent 12 | trim }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- if .Values.master.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.master.containerSecurityContext "enabled" | toYaml | nindent 12 }}

--- a/k8s/charts/seaweedfs/templates/s3-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/s3-deployment.yaml
@@ -204,9 +204,9 @@ spec:
             failureThreshold: {{ .Values.s3.livenessProbe.failureThreshold }}
             timeoutSeconds: {{ .Values.s3.livenessProbe.timeoutSeconds }}
           {{- end }}
-          {{- if .Values.s3.resources }}
+          {{- with .Values.s3.resources }}
           resources:
-            {{ tpl .Values.s3.resources . | nindent 12 | trim }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- if .Values.s3.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.s3.containerSecurityContext "enabled" | toYaml | nindent 12 }}

--- a/k8s/charts/seaweedfs/templates/volume-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/volume-statefulset.yaml
@@ -242,9 +242,9 @@ spec:
             failureThreshold: {{ .Values.volume.livenessProbe.failureThreshold }}
             timeoutSeconds: {{ .Values.volume.livenessProbe.timeoutSeconds }}
           {{- end }}
-          {{- if .Values.volume.resources }}
+          {{- with .Values.volume.resources }}
           resources:
-            {{ tpl .Values.volume.resources . | nindent 12 | trim }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- if .Values.volume.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.volume.containerSecurityContext "enabled" | toYaml | nindent 12 }}

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -140,7 +140,7 @@ master:
   # should map directly to the value of the resources field for a PodSpec,
   # formatted as a multi-line string. By default no direct resource request
   # is made.
-  resources: null
+  resources: {}
 
   # updatePartition is used to control a careful rolling update of SeaweedFS
   # masters.
@@ -401,7 +401,7 @@ volume:
   # should map directly to the value of the resources field for a PodSpec,
   # formatted as a multi-line string. By default no direct resource request
   # is made.
-  resources: null
+  resources: {}
 
   # Toleration Settings for server pods
   # This should be a multi-line string matching the Toleration array
@@ -593,7 +593,7 @@ filer:
   # should map directly to the value of the resources field for a PodSpec,
   # formatted as a multi-line string. By default no direct resource request
   # is made.
-  resources: null
+  resources: {}
 
   # Toleration Settings for server pods
   # This should be a multi-line string matching the Toleration array
@@ -789,7 +789,7 @@ s3:
   # should map directly to the value of the resources field for a PodSpec,
   # formatted as a multi-line string. By default no direct resource request
   # is made.
-  resources: null
+  resources: {}
 
   # Toleration Settings for server pods
   # This should be a multi-line string matching the Toleration array


### PR DESCRIPTION
# What problem are we solving?
Convert all strings to be maps `{}` instead of strings `""` or `null` for `resources` parameters for all StatefulSets and Deployments, in order to be consistent with helm chart standards.

- Fixes #5681 

# How are we solving the problem?
- Change all `resources: null` to `resources: {}` in values.yaml
- Change all instances of templating that string to templating a map. So from this:
  ```golang
          {{- if .Values.filer.resources }}
          resources:
            {{ tpl .Values.filer.resources . | nindent 12 | trim }}
          {{- end }}
  ```
  To this (note we're using `with` which is an implicit `if`. This also removes the trim as it's not needed for maps:

  ```golang
          {{- with .Values.filer.resources }}
          resources:
            {{ . | nindent 12 }}
          {{- end }}
  ```

I've also bumped the chart version, but if this is merged, it will be a major version, as the previous types are changing. The commit will also need to be tagged.

# How is the PR tested?

1. Clone the repo and `cd k8s/charts/` and run:
```yaml
helm template .
```
You should see no resources templated for any of the statefulsets or the deployment.

2. Change the following parameters to have test `limits` and `requests` in `values.yaml`:
```diff
--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -140,7 +140,13 @@ master:
   # should map directly to the value of the resources field for a PodSpec,
   # formatted as a multi-line string. By default no direct resource request
   # is made.
-  resources: {}
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi

   # updatePartition is used to control a careful rolling update of SeaweedFS
   # masters.
@@ -401,7 +407,13 @@ volume:
   # should map directly to the value of the resources field for a PodSpec,
   # formatted as a multi-line string. By default no direct resource request
   # is made.
-  resources: {}
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi

   # Toleration Settings for server pods
   # This should be a multi-line string matching the Toleration array
@@ -593,7 +605,13 @@ filer:
   # should map directly to the value of the resources field for a PodSpec,
   # formatted as a multi-line string. By default no direct resource request
   # is made.
-  resources: {}
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi

   # Toleration Settings for server pods
   # This should be a multi-line string matching the Toleration array
@@ -789,7 +807,13 @@ s3:
   # should map directly to the value of the resources field for a PodSpec,
   # formatted as a multi-line string. By default no direct resource request
   # is made.
-  resources: {}
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
```
Run helm template again, and you should see resources sections for each StatefulSet and Deployment.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
