### PR TITLE
[fs.verify] skip failed files if entry not found on filerStore

### DIFF
--- a/weed/pb/filer_pb_tail.go
+++ b/weed/pb/filer_pb_tail.go
@@ -17,6 +17,7 @@ const (
 	TrivialOnError EventErrorType = iota
 	FatalOnError
 	RetryForeverOnError
+	DontLogError
 )
 
 // MetadataFollowOption is used to control the behavior of the metadata following
@@ -96,6 +97,8 @@ func makeSubscribeMetadataFunc(option *MetadataFollowOption, processEventFn Proc
 						glog.Errorf("process %v: %v", resp, err)
 						return true
 					})
+				case DontLogError:
+					// pass
 				default:
 					glog.Errorf("process %v: %v", resp, err)
 				}


### PR DESCRIPTION
# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/pull/5678
If data from the log has been updated or deleted, then do not consider this an error

# How are we solving the problem?

If chunks are not found, then check for the presence of an entry in the filerstore

# How is the PR tested?

localy

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
