### PR TITLE
chore: hot fix panic fs.verify

### DIFF
--- a/weed/shell/command_fs_verify.go
+++ b/weed/shell/command_fs_verify.go
@@ -163,9 +163,10 @@ func (c *commandFsVerify) verifyProcessMetadata(path string, wg *sync.WaitGroup)
 					Directory: message.NewParentPath,
 					Name:      message.NewEntry.Name,
 				})
-				if strings.HasSuffix(errReq.Error(), "no entry is found in filer store") {
-					return nil
-				} else if errReq != nil {
+				if errReq != nil {
+					if strings.HasSuffix(errReq.Error(), "no entry is found in filer store") {
+						return nil
+					}
 					return errReq
 				}
 				if entryResp.Entry.Attributes.Mtime == message.NewEntry.Attributes.Mtime &&


### PR DESCRIPTION
# What problem are we solving?

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x192be07]

goroutine 1 [running]:
github.com/seaweedfs/seaweedfs/weed/shell.(*commandFsVerify).verifyProcessMetadata.func1.1({0x2c16618, 0xc000d40f40})
	/builds/infrastructure/utils/storage/seaweedfs/weed/shell/command_fs_verify.go:166 +0x107
github.com/seaweedfs/seaweedfs/weed/pb.WithGrpcFilerClient.func1(0xc0007dcc08)
	/builds/infrastructure/utils/storage/seaweedfs/weed/pb/grpc_client_server.go:262 +0x68
github.com/seaweedfs/seaweedfs/weed/pb.WithGrpcClient(0xd0?, 0xc0?, 0xc0007a12d8, {0xc000d36480, 0x12}, 0x90?, {0xc0007a12c8?, 0xc0007a13b0?, 0xc0007a12e8?})
	/builds/infrastructure/utils/storage/seaweedfs/weed/pb/grpc_client_server.go:129 +0x490
github.com/seaweedfs/seaweedfs/weed/pb.WithGrpcFilerClient(0x0, 0x0, {0xc0008925d0?, 0x35?}, {0x2bda2a0, 0xc000884eb8}, 0xc0007a1370)
	/builds/infrastructure/utils/storage/seaweedfs/weed/pb/grpc_client_server.go:260 +0xae
github.com/seaweedfs/seaweedfs/weed/shell.(*CommandEnv).WithFilerClient(...)
	/builds/infrastructure/utils/storage/seaweedfs/weed/shell/commands.go:114
github.com/seaweedfs/seaweedfs/weed/shell.(*commandFsVerify).verifyProcessMetadata.func1(0xc0005a9e90?)
	/builds/infrastructure/utils/storage/seaweedfs/weed/shell/command_fs_verify.go:161 +0x2bc
github.com/seaweedfs/seaweedfs/weed/pb.FollowMetadata.makeSubscribeMetadataFunc.func1({0x2c16618, 0xc0005a9c20})
	/builds/infrastructure/utils/storage/seaweedfs/weed/pb/filer_pb_tail.go:87 +0x293
github.com/seaweedfs/seaweedfs/weed/pb.WithGrpcFilerClient.func1(0xc0002a5c08)
	/builds/infrastructure/utils/storage/seaweedfs/weed/pb/grpc_client_server.go:262 +0x68
github.com/seaweedfs/seaweedfs/weed/pb.WithGrpcClient(0xd0?, 0xc0?, 0xc0007a17d0, {0xc0007bfb90, 0x12}, 0x0?, {0xc0007a17c0?, 0x4?, 0x4?})
	/builds/infrastructure/utils/storage/seaweedfs/weed/pb/grpc_client_server.go:155 +0x343
github.com/seaweedfs/seaweedfs/weed/pb.WithGrpcFilerClient(0x1, 0x0, {0xc0008925d0?, 0x4?}, {0x2bda2a0, 0xc000884eb8}, 0xc0007a1820)
	/builds/infrastructure/utils/storage/seaweedfs/weed/pb/grpc_client_server.go:260 +0xae
github.com/seaweedfs/seaweedfs/weed/pb.WithFilerClient(...)
	/builds/infrastructure/utils/storage/seaweedfs/weed/pb/grpc_client_server.go:254
github.com/seaweedfs/seaweedfs/weed/pb.FollowMetadata({0xc0008925d0?, 0xffffec6aa12d1642?}, {0x2bda2a0?, 0xc000884eb8?}, 0x30?, 0xc000308008?)
	/builds/infrastructure/utils/storage/seaweedfs/weed/pb/filer_pb_tail.go:42 +0x69
github.com/seaweedfs/seaweedfs/weed/shell.(*commandFsVerify).verifyProcessMetadata(0xc000628b00, {0xc000a04639, 0x1}, 0x11?)
	/builds/infrastructure/utils/storage/seaweedfs/weed/shell/command_fs_verify.go:200 +0x24e
github.com/seaweedfs/seaweedfs/weed/shell.(*commandFsVerify).Do(0xc000628b00, {0xc000a6e4e0, 0x6, 0x6}, 0xc0008682c0, {0x2bd8ba0, 0xc000148020})
	/builds/infrastructure/utils/storage/seaweedfs/weed/shell/command_fs_verify.go:96 +0x54a
github.com/seaweedfs/seaweedfs/weed/shell.processEachCmd(0xc000976000?, {0xc000976000, 0x3e}, 0xc0008682c0)
	/builds/infrastructure/utils/storage/seaweedfs/weed/shell/shell_liner.go:117 +0x34b
github.com/seaweedfs/seaweedfs/weed/shell.RunShell({0xc0005a8a20, {0x2bda2a0, 0xc000884eb8}, {0x0, 0x0}, 0x0, 0xc0005a8a30, {0x0, 0x0}, {0x2bc9048, ...}})
	/builds/infrastructure/utils/storage/seaweedfs/weed/shell/shell_liner.go:86 +0x5d0
github.com/seaweedfs/seaweedfs/weed/command.runShell(0x3f73db8?, {0xc000118030?, 0x0?, 0x0?})
	/builds/infrastructure/utils/storage/seaweedfs/weed/command/shell.go:64 +0x2d8
main.main()
	/builds/infrastructure/utils/storage/seaweedfs/weed/weed.go:95 +0x3d9
```

# How are we solving the problem?

check if err not nil

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
