### PR TITLE
bugfix: unregister ec shards when volume server disconnected

### DIFF
--- a/weed/topology/topology_event_handling.go
+++ b/weed/topology/topology_event_handling.go
@@ -90,6 +90,11 @@ func (t *Topology) UnRegisterDataNode(dn *DataNode) {
 		vl.SetVolumeUnavailable(dn, v.Id)
 	}
 
+	// unregister ec shards when volume server disconnected
+	for _, s := range dn.GetEcShards() {
+		t.UnRegisterEcShards(s, dn)
+	}
+
 	negativeUsages := dn.GetDiskUsages().negative()
 	dn.UpAdjustDiskUsageDelta(negativeUsages)
 	dn.DeltaUpdateVolumes([]storage.VolumeInfo{}, dn.GetVolumes())


### PR DESCRIPTION
# What problem are we solving?
![image](https://github.com/seaweedfs/seaweedfs/assets/44025291/32ee332d-a05b-4d9f-9341-c0319016092c)
When the volume server disconnect from the master server, the master server does not clean up the EC shards information belonging to that volume server. As a result, the filer server will attempt to access the offline volume server.

- If the machine of the volume server is not shut down, the filer server will immediately receive a "connection refused" error when attempting to access the offline volume server, and it will retry accessing other volume servers.
- If the machine of the volume server is shut down, the filer server's attempt to connect will result in a TCP SYN packet timeout. The Linux operating system will make multiple attempts to resend the SYN packet, which is a time-consuming process and will impact the response time for file downloads.

# How are we solving the problem?
unregister ec shards when volume server disconnected


# How is the PR tested?
test in my cluster
1. Power off the volume server that has stored the EC shard.
2. Curl http://<MASTER_LEADER_IP_Address>:9333/dir/lookup?volumeId=<volume_id>
3. Check if the JSON returned in step 2 contains the address of the shut down volume server.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
