### PR TITLE
fix: correct command flag for master.raftBootstrap option in server.go

### DIFF
--- a/weed/command/server.go
+++ b/weed/command/server.go
@@ -97,7 +97,7 @@ func init() {
 	masterOptions.metricsIntervalSec = cmdServer.Flag.Int("master.metrics.intervalSeconds", 15, "Prometheus push interval in seconds")
 	masterOptions.raftResumeState = cmdServer.Flag.Bool("master.resumeState", false, "resume previous state on start master server")
 	masterOptions.raftHashicorp = cmdServer.Flag.Bool("master.raftHashicorp", false, "use hashicorp raft")
-	masterOptions.raftBootstrap = cmdMaster.Flag.Bool("master.raftBootstrap", false, "Whether to bootstrap the Raft cluster")
+	masterOptions.raftBootstrap = cmdServer.Flag.Bool("master.raftBootstrap", false, "Whether to bootstrap the Raft cluster")
 	masterOptions.heartbeatInterval = cmdServer.Flag.Duration("master.heartbeatInterval", 300*time.Millisecond, "heartbeat interval of master servers, and will be randomly multiplied by [1, 1.25)")
 	masterOptions.electionTimeout = cmdServer.Flag.Duration("master.electionTimeout", 10*time.Second, "election timeout of master servers")
 


### PR DESCRIPTION
Addressed an inconsistency where the master.raftBootstrap option was assigned to cmdMaster instead of cmdServer.

# What problem are we solving?
The master.raftBootstrap option was incorrectly assigned to cmdMaster instead of cmdServer. This inconsistency could cause confusion and potential misconfigurations when users attempt to bootstrap the Raft cluster using the wrong command context.

# How are we solving the problem?
I have corrected the assignment by changing cmdMaster.Flag.Bool to cmdServer.Flag.Bool for the master.raftBootstrap option. This ensures that the option is correctly tied to the cmdServer commands, aligning with the other master options.

# How is the PR tested?
Manual testing was performed to ensure that the master.raftBootstrap option works correctly in the cmdServer context.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
