### PR TITLE
Move cluster role to a separate template.

### DIFF
--- a/k8s/charts/seaweedfs/templates/cluster-role.yaml
+++ b/k8s/charts/seaweedfs/templates/cluster-role.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.global.createClusterRole }}
+#hack for delete pod master after migration
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Values.global.serviceAccountName }}-rw-cr
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:serviceaccount:{{ .Values.global.serviceAccountName }}:default
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.global.serviceAccountName }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.global.serviceAccountName }}-rw-cr
+{{- end }}

--- a/k8s/charts/seaweedfs/templates/service-account.yaml
+++ b/k8s/charts/seaweedfs/templates/service-account.yaml
@@ -1,20 +1,3 @@
-{{- if .Values.global.createClusterRole }}
-#hack for delete pod master after migration
----
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: {{ .Values.global.serviceAccountName }}-rw-cr
-  labels:
-    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-rules:
-  - apiGroups: [""]
-    resources: ["pods"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -25,22 +8,3 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: system:serviceaccount:{{ .Values.global.serviceAccountName }}:default
-  labels:
-    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-subjects:
-- kind: ServiceAccount
-  name: {{ .Values.global.serviceAccountName }}
-  namespace: {{ .Release.Namespace }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ .Values.global.serviceAccountName }}-rw-cr
-{{- end }}


### PR DESCRIPTION
# What problem are we solving?

/closes #5612 
The template has a flag for disabling the cluster role. This has the side-effect that disables the service account,  which breaks the deployment.

# How are we solving the problem?

I moved the cluster role to its own template to make sure the service account is not accidentally toggled out.

# How is the PR tested?

Installed this without cluster role into a separate namespace.

# Checks
- [ ] I will add related wiki document changes and link to this PR after merging.

I would love to see a wiki page explaining what the cluster role is for - the comments in the chart suggest that it is used for migration, but I don't really understand what is being migrated. Is that still required?