### PR TITLE
[Helm chart] Remove createClusterRole dependency from serviceAccount usage from filer statefulset

### DIFF
--- a/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
@@ -56,9 +56,7 @@ spec:
         {{ tpl .Values.filer.tolerations . | nindent 8 | trim }}
       {{- end }}
       {{- include "seaweedfs.imagePullSecrets" . | nindent 6 }}
-      {{- if .Values.global.createClusterRole }}
       serviceAccountName: {{ .Values.filer.serviceAccountName | default .Values.global.serviceAccountName | quote }} # for deleting statefulset pods after migration
-      {{- end }}
       terminationGracePeriodSeconds: 60
       {{- if .Values.filer.priorityClassName }}
       priorityClassName: {{ .Values.filer.priorityClassName | quote }}

--- a/k8s/charts/seaweedfs/templates/service-account.yaml
+++ b/k8s/charts/seaweedfs/templates/service-account.yaml
@@ -8,3 +8,4 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -19,6 +19,7 @@ global:
       filerRead: false
   # we will use this serviceAccountName for all ClusterRoles/ClusterRoleBindings
   serviceAccountName: "seaweedfs"
+  automountServiceAccountToken: true
   certificates:
     alphacrds: false
   monitoring:


### PR DESCRIPTION
# What problem are we solving?
Recently through PR https://github.com/seaweedfs/seaweedfs/pull/5721 cluster role creation and service account dependency is removed but there is still left over in filer startefulset where `serviceAccount` usage depends in `createClusterRole` condition which is unnecessary. 
Originally part of issue https://github.com/seaweedfs/seaweedfs/issues/5612
Also added option for automountServiceAccountToken for service account at global level

# How are we solving the problem?
Remove the condition of `createClusterRole` condition usage from filer statefulset. 


# How is the PR tested?
Helm templated and installed.


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
