### PR TITLE
volume.tier.upload: Fix deleting replicated volumes

### DIFF
--- a/weed/shell/command_volume_tier_upload.go
+++ b/weed/shell/command_volume_tier_upload.go
@@ -113,11 +113,14 @@ func doVolumeTierUpload(commandEnv *CommandEnv, writer io.Writer, collection str
 		return fmt.Errorf("copy dat file for volume %d on %s to %s: %v", vid, existingLocations[0].Url, dest, err)
 	}
 
+	if keepLocalDatFile {
+		return nil
+	}
 	// now the first replica has the .idx and .vif files.
 	// ask replicas on other volume server to delete its own local copy
 	for i, location := range existingLocations {
 		if i == 0 {
-			break
+			continue
 		}
 		fmt.Printf("delete volume %d from %s\n", vid, location.Url)
 		err = deleteVolume(commandEnv.option.GrpcDialOption, vid, location.ServerAddress(), false)


### PR DESCRIPTION
# What problem are we solving?

Old issue https://github.com/seaweedfs/seaweedfs/issues/3804 was said to be fixed but didn't seem to work

# How are we solving the problem?

Fix loop so it doesn't exit on the first iteration.

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
