### PR TITLE
Detect underflow when calculating unused space

### DIFF
--- a/weed/storage/disk_location.go
+++ b/weed/storage/disk_location.go
@@ -60,6 +60,7 @@ func GenerateDirUuid(dir string) (dirUuidString string, err error) {
 }
 
 func NewDiskLocation(dir string, maxVolumeCount int32, minFreeSpace util.MinFreeSpace, idxDir string, diskType types.DiskType) *DiskLocation {
+	glog.V(4).Infof("Added new Disk %s: maxVolumes=%d", dir, maxVolumeCount)
 	dir = util.ResolvePath(dir)
 	if idxDir == "" {
 		idxDir = dir
@@ -417,7 +418,6 @@ func (l *DiskLocation) LocateVolume(vid needle.VolumeId) (os.DirEntry, bool) {
 }
 
 func (l *DiskLocation) UnUsedSpace(volumeSizeLimit uint64) (unUsedSpace uint64) {
-
 	l.volumesLock.RLock()
 	defer l.volumesLock.RUnlock()
 
@@ -426,7 +426,11 @@ func (l *DiskLocation) UnUsedSpace(volumeSizeLimit uint64) (unUsedSpace uint64) 
 			continue
 		}
 		datSize, idxSize, _ := vol.FileStat()
-		unUsedSpace += volumeSizeLimit - (datSize + idxSize)
+		unUsedSpaceVolume := int64(volumeSizeLimit) - int64(datSize+idxSize)
+		glog.V(4).Infof("Volume stats for %d: volumeSizeLimit=%d, datSize=%d idxSize=%d unused=%d", vol.Id, volumeSizeLimit, datSize, idxSize, unUsedSpaceVolume)
+		if unUsedSpaceVolume >= 0 {
+			unUsedSpace += uint64(unUsedSpaceVolume)
+		}
 	}
 
 	return

--- a/weed/storage/disk_location_test.go
+++ b/weed/storage/disk_location_test.go
@@ -1,0 +1,78 @@
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/storage/backend"
+	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+)
+
+type (
+	mockBackendStorageFile struct {
+		backend.DiskFile
+
+		datSize int64
+	}
+)
+
+func (df *mockBackendStorageFile) GetStat() (datSize int64, modTime time.Time, err error) {
+	return df.datSize, time.Now(), nil
+}
+
+type (
+	mockNeedleMapper struct {
+		NeedleMap
+
+		idxSize uint64
+	}
+)
+
+func (nm *mockNeedleMapper) IndexFileSize() (idxSize uint64) {
+	return nm.idxSize
+}
+
+func TestUnUsedSpace(t *testing.T) {
+	minFreeSpace := util.MinFreeSpace{Type: util.AsPercent, Percent: 1, Raw: "1"}
+
+	diskLocation := DiskLocation{
+		Directory:              "/test/",
+		DirectoryUuid:          "1234",
+		IdxDirectory:           "/test/",
+		DiskType:               "hdd",
+		MaxVolumeCount:         0,
+		OriginalMaxVolumeCount: 0,
+		MinFreeSpace:           minFreeSpace,
+	}
+	diskLocation.volumes = make(map[needle.VolumeId]*Volume)
+
+	volumes := [3]*Volume{
+		{dir: diskLocation.Directory, dirIdx: diskLocation.IdxDirectory, Collection: "", Id: 0, DataBackend: &mockBackendStorageFile{datSize: 990}, nm: &mockNeedleMapper{idxSize: 10}},
+		{dir: diskLocation.Directory, dirIdx: diskLocation.IdxDirectory, Collection: "", Id: 1, DataBackend: &mockBackendStorageFile{datSize: 990}, nm: &mockNeedleMapper{idxSize: 10}},
+		{dir: diskLocation.Directory, dirIdx: diskLocation.IdxDirectory, Collection: "", Id: 2, DataBackend: &mockBackendStorageFile{datSize: 990}, nm: &mockNeedleMapper{idxSize: 10}},
+	}
+
+	for i, vol := range volumes {
+		diskLocation.SetVolume(needle.VolumeId(i), vol)
+	}
+
+	// Testing when there's still space
+	unUsedSpace := diskLocation.UnUsedSpace(1200)
+	if unUsedSpace != 600 {
+		t.Errorf("unUsedSpace incorrect: %d != %d", unUsedSpace, 1500)
+	}
+
+	// Testing when there's exactly 0 space
+	unUsedSpace = diskLocation.UnUsedSpace(1000)
+	if unUsedSpace != 0 {
+		t.Errorf("unUsedSpace incorrect: %d != %d", unUsedSpace, 0)
+	}
+
+	// Testing when there's negative free space
+	unUsedSpace = diskLocation.UnUsedSpace(900)
+	if unUsedSpace != 0 {
+		t.Errorf("unUsedSpace incorrect: %d != %d", unUsedSpace, 0)
+	}
+
+}


### PR DESCRIPTION
# What problem are we solving?

Somehow my volumes are bigger than the volumeSizeLimit. I'm not sure how this happened, but when it does the calculation for how much unused space there is on a disk, there is an underflow on the unsigned integer, which causes it to report a large amount of unused space.
This results in no new volumes being allocated.

```
Jul 08 22:09:58 zaphod weed[2298821]: I0708 22:09:58.446979 store.go:600 disk /disks/disk1 max 64 unclaimedSpace:574462MB, unused:17592186039891MB volumeSizeLimit:30000MB
```

# How are we solving the problem?

Perform the calculation of the per-volume unused space as a signed integer. Then we can check if we are <0 before adding it to the disk total unused space.

It does mean we have 2 casts, maybe there's a nicer way?


# How is the PR tested?

Manually and unit tests.

We can now see each volume reports it negative number in the verbose logging, but the unused space for the whole disk is zero:

```
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475542 disk_location.go:430 Volume stats for 257: volumeSizeLimit=31457280000, datSize=31548859120 idxSize=240736 unused=-91819856
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475551 disk_location.go:430 Volume stats for 285: volumeSizeLimit=31457280000, datSize=31583125200 idxSize=241040 unused=-126086240
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475556 disk_location.go:430 Volume stats for 241: volumeSizeLimit=31457280000, datSize=31529361248 idxSize=240560 unused=-72321808
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475562 disk_location.go:430 Volume stats for 229: volumeSizeLimit=31457280000, datSize=31492546992 idxSize=249520 unused=-35516512
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475567 disk_location.go:430 Volume stats for 271: volumeSizeLimit=31457280000, datSize=31631755432 idxSize=241392 unused=-174716824
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475572 disk_location.go:430 Volume stats for 279: volumeSizeLimit=31457280000, datSize=31528156352 idxSize=248192 unused=-71124544
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475577 disk_location.go:430 Volume stats for 289: volumeSizeLimit=31457280000, datSize=31622971176 idxSize=241312 unused=-165932488
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475582 disk_location.go:430 Volume stats for 286: volumeSizeLimit=31457280000, datSize=31493018320 idxSize=240320 unused=-35978640
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475587 disk_location.go:430 Volume stats for 230: volumeSizeLimit=31457280000, datSize=31501364016 idxSize=250416 unused=-44334432
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475592 disk_location.go:430 Volume stats for 237: volumeSizeLimit=31457280000, datSize=31588659688 idxSize=241024 unused=-131620712
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475597 disk_location.go:430 Volume stats for 251: volumeSizeLimit=31457280000, datSize=31495344536 idxSize=250960 unused=-38315496
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475602 disk_location.go:430 Volume stats for 255: volumeSizeLimit=31457280000, datSize=31514991880 idxSize=250944 unused=-57962824
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475607 disk_location.go:430 Volume stats for 259: volumeSizeLimit=31457280000, datSize=31578306792 idxSize=240912 unused=-121267704
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475612 disk_location.go:430 Volume stats for 265: volumeSizeLimit=31457280000, datSize=31497688944 idxSize=240272 unused=-40649216
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475628 disk_location.go:430 Volume stats for 267: volumeSizeLimit=31457280000, datSize=31488357464 idxSize=240240 unused=-31317704
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475635 disk_location.go:430 Volume stats for 272: volumeSizeLimit=31457280000, datSize=31586449848 idxSize=241008 unused=-129410856
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475640 disk_location.go:430 Volume stats for 233: volumeSizeLimit=31457280000, datSize=31470968512 idxSize=240144 unused=-13928656
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475644 disk_location.go:430 Volume stats for 284: volumeSizeLimit=31457280000, datSize=31547089272 idxSize=240704 unused=-90049976
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475649 disk_location.go:430 Volume stats for 275: volumeSizeLimit=31457280000, datSize=31523659832 idxSize=247680 unused=-66627512
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475654 disk_location.go:430 Volume stats for 245: volumeSizeLimit=31457280000, datSize=31534514856 idxSize=251488 unused=-77486344
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475659 disk_location.go:430 Volume stats for 240: volumeSizeLimit=31457280000, datSize=31487568288 idxSize=240256 unused=-30528544
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475663 disk_location.go:430 Volume stats for 260: volumeSizeLimit=31457280000, datSize=31613102280 idxSize=241216 unused=-156063496
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475667 disk_location.go:430 Volume stats for 252: volumeSizeLimit=31457280000, datSize=31516802624 idxSize=251344 unused=-59773968
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475672 disk_location.go:430 Volume stats for 269: volumeSizeLimit=31457280000, datSize=31521851616 idxSize=240480 unused=-64812096
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475677 disk_location.go:430 Volume stats for 278: volumeSizeLimit=31457280000, datSize=31491998176 idxSize=247616 unused=-34965792
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475681 disk_location.go:430 Volume stats for 236: volumeSizeLimit=31457280000, datSize=31596430144 idxSize=241136 unused=-139391280
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475686 disk_location.go:430 Volume stats for 250: volumeSizeLimit=31457280000, datSize=31541684824 idxSize=251472 unused=-84656296
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475692 disk_location.go:430 Volume stats for 266: volumeSizeLimit=31457280000, datSize=31473885920 idxSize=240176 unused=-16846096
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475697 disk_location.go:430 Volume stats for 235: volumeSizeLimit=31457280000, datSize=31620189832 idxSize=241264 unused=-163151096
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475702 disk_location.go:430 Volume stats for 253: volumeSizeLimit=31457280000, datSize=31504142056 idxSize=252064 unused=-47114120
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475709 disk_location.go:430 Volume stats for 294: volumeSizeLimit=31457280000, datSize=32729436016 idxSize=249824 unused=-1272405840
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475714 disk_location.go:430 Volume stats for 244: volumeSizeLimit=31457280000, datSize=31466156264 idxSize=250720 unused=-9126984
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475719 disk_location.go:430 Volume stats for 231: volumeSizeLimit=31457280000, datSize=31467493568 idxSize=249424 unused=-10462992
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475723 disk_location.go:430 Volume stats for 246: volumeSizeLimit=31457280000, datSize=31515417976 idxSize=251488 unused=-58389464
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475728 disk_location.go:430 Volume stats for 238: volumeSizeLimit=31457280000, datSize=31542881208 idxSize=240672 unused=-85841880
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475733 disk_location.go:430 Volume stats for 247: volumeSizeLimit=31457280000, datSize=31546198704 idxSize=251808 unused=-89170512
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475738 disk_location.go:430 Volume stats for 274: volumeSizeLimit=31457280000, datSize=31521742960 idxSize=247872 unused=-64710832
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475743 disk_location.go:430 Volume stats for 287: volumeSizeLimit=31457280000, datSize=31544030936 idxSize=240720 unused=-86991656
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475748 disk_location.go:430 Volume stats for 225: volumeSizeLimit=31457280000, datSize=31660779672 idxSize=287104 unused=-203786776
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475752 disk_location.go:430 Volume stats for 248: volumeSizeLimit=31457280000, datSize=31518809600 idxSize=251456 unused=-61781056
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475757 disk_location.go:430 Volume stats for 261: volumeSizeLimit=31457280000, datSize=31513637824 idxSize=240448 unused=-56598272
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475762 disk_location.go:430 Volume stats for 264: volumeSizeLimit=31457280000, datSize=31525159992 idxSize=240576 unused=-68120568
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475769 disk_location.go:430 Volume stats for 268: volumeSizeLimit=31457280000, datSize=31568052800 idxSize=240896 unused=-111013696
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475774 disk_location.go:430 Volume stats for 288: volumeSizeLimit=31457280000, datSize=31485442176 idxSize=240272 unused=-28402448
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475779 disk_location.go:430 Volume stats for 308: volumeSizeLimit=31457280000, datSize=31484133512 idxSize=252208 unused=-27105720
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475784 disk_location.go:430 Volume stats for 232: volumeSizeLimit=31457280000, datSize=31553707296 idxSize=240736 unused=-96668032
Jul 08 22:14:56 zaphod weed[2300287]: I0708 22:14:56.475788 store.go:607 disk /disks/disk1 max 63 unclaimedSpace:569938MB, unused:0MB volumeSizeLimit:30000MB
```



# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
