### PR TITLE
[s3] revert skip deletion error, since the error file was not found is already skipped on the side of the grpc function

### DIFF
--- a/weed/s3api/s3api_bucket_handlers.go
+++ b/weed/s3api/s3api_bucket_handlers.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -346,7 +347,9 @@ func (s3a *S3ApiServer) GetBucketLifecycleConfigurationHandler(w http.ResponseWr
 			Expiration: Expiration{Days: days, set: true},
 		})
 	}
-
+	sort.Slice(response.Rules, func(i, j int) bool {
+		return response.Rules[i].ID < response.Rules[j].ID
+	})
 	writeSuccessResponseXML(w, r, response)
 }
 

--- a/weed/s3api/s3api_bucket_handlers.go
+++ b/weed/s3api/s3api_bucket_handlers.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"math"
 	"net/http"
-	"sort"
 	"strings"
 	"time"
 
@@ -347,9 +346,7 @@ func (s3a *S3ApiServer) GetBucketLifecycleConfigurationHandler(w http.ResponseWr
 			Expiration: Expiration{Days: days, set: true},
 		})
 	}
-	sort.Slice(response.Rules, func(i, j int) bool {
-		return response.Rules[i].ID < response.Rules[j].ID
-	})
+
 	writeSuccessResponseXML(w, r, response)
 }
 

--- a/weed/s3api/s3api_object_handlers_delete.go
+++ b/weed/s3api/s3api_object_handlers_delete.go
@@ -32,10 +32,9 @@ func (s3a *S3ApiServer) DeleteObjectHandler(w http.ResponseWriter, r *http.Reque
 
 	s3a.WithFilerClient(false, func(client filer_pb.SeaweedFilerClient) error {
 
-		err := doDeleteEntry(client, dir, name, true, false)
-		if err != nil {
-			// skip deletion error, usually the file is not found
-			return nil
+		if err := doDeleteEntry(client, dir, name, true, false); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return err
 		}
 
 		if s3a.option.AllowEmptyFolder {

--- a/weed/s3api/s3api_object_handlers_delete.go
+++ b/weed/s3api/s3api_object_handlers_delete.go
@@ -30,10 +30,9 @@ func (s3a *S3ApiServer) DeleteObjectHandler(w http.ResponseWriter, r *http.Reque
 	target := util.FullPath(fmt.Sprintf("%s/%s%s", s3a.option.BucketsPath, bucket, object))
 	dir, name := target.DirAndName()
 
-	s3a.WithFilerClient(false, func(client filer_pb.SeaweedFilerClient) error {
+	err := s3a.WithFilerClient(false, func(client filer_pb.SeaweedFilerClient) error {
 
 		if err := doDeleteEntry(client, dir, name, true, false); err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
 			return err
 		}
 
@@ -52,6 +51,10 @@ func (s3a *S3ApiServer) DeleteObjectHandler(w http.ResponseWriter, r *http.Reque
 
 		return nil
 	})
+	if err != nil {
+		s3err.WriteErrorResponse(w, r, s3err.ErrInternalError)
+		return
+	}
 
 	w.WriteHeader(http.StatusNoContent)
 }


### PR DESCRIPTION
# What problem are we solving?

return an error when deleting a file

# How are we solving the problem?

There should not be a `filer_pb.ErrNotFound` error at this location
since it is already passed on the server side

https://github.com/seaweedfs/seaweedfs/blob/master/weed/server/filer_grpc_server.go#L296

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
