### PR TITLE
helm: restart filer when the s3-configuration changes

### DIFF
--- a/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
@@ -32,18 +32,24 @@ spec:
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: filer
-      {{ with .Values.podLabels }}
+      {{- with .Values.podLabels }}
       {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.filer.podLabels }}
       {{- toYaml . | nindent 8 }}
       {{- end }}
       annotations:
-      {{ with .Values.podAnnotations }}
+      {{- with .Values.podAnnotations }}
       {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.filer.podAnnotations }}
       {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.filer.s3.existingConfigSecret }}
+        {{- $configSecret := (lookup "v1" "Secret" .Release.Namespace .Values.filer.s3.existingConfigSecret) | default dict }}
+        checksum/s3config: {{ $configSecret | toYaml | sha256sum }}
+      {{- else }}
+        checksum/s3config: {{ include (print .Template.BasePath "/s3-secret.yaml") . | sha256sum }}
       {{- end }}
     spec:
       restartPolicy: {{ default .Values.global.restartPolicy .Values.filer.restartPolicy }}


### PR DESCRIPTION
# What problem are we solving?

/closes #5767 

# How are we solving the problem?

* we generate a checksum of the s3-secret in an annotation. If the config is changed during an upgrade, the filer will automatically rolled over. 
* this is a common pattern in Helm: https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
* This only applies to changes made via helm. Manual changes outside this chart will not trigger a rollover until the next helm upgrade.


# How is the PR tested?

* installed in a fresh namespace
* tested with disabled s3 config
* tested with enabled s3/auth 
* tested with enabled s3/auth and a custom secret