### PR TITLE
fix allocate reduplicated volumeId to different volume

### DIFF
--- a/weed/server/master_grpc_server_volume.go
+++ b/weed/server/master_grpc_server_volume.go
@@ -3,12 +3,13 @@ package weed_server
 import (
 	"context"
 	"fmt"
-	"github.com/seaweedfs/seaweedfs/weed/topology"
 	"math/rand"
 	"reflect"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/topology"
 
 	"github.com/seaweedfs/raft"
 

--- a/weed/server/master_server.go
+++ b/weed/server/master_server.go
@@ -186,22 +186,7 @@ func (ms *MasterServer) SetRaftServer(raftServer *RaftServer) {
 		raftServerName = fmt.Sprintf("[%s]", ms.Topo.RaftServer.Name())
 	} else if raftServer.RaftHashicorp != nil {
 		ms.Topo.HashicorpRaft = raftServer.RaftHashicorp
-		leaderCh := raftServer.RaftHashicorp.LeaderCh()
-		prevLeader, _ := ms.Topo.HashicorpRaft.LeaderWithID()
 		raftServerName = ms.Topo.HashicorpRaft.String()
-		go func() {
-			for {
-				select {
-				case isLeader := <-leaderCh:
-					ms.Topo.RaftServerAccessLock.RLock()
-					leader, _ := ms.Topo.HashicorpRaft.LeaderWithID()
-					ms.Topo.RaftServerAccessLock.RUnlock()
-					glog.V(0).Infof("is leader %+v change event: %+v => %+v", isLeader, prevLeader, leader)
-					stats.MasterLeaderChangeCounter.WithLabelValues(fmt.Sprintf("%+v", leader)).Inc()
-					prevLeader = leader
-				}
-			}
-		}()
 	}
 	ms.Topo.RaftServerAccessLock.Unlock()
 

--- a/weed/server/raft_hashicorp.go
+++ b/weed/server/raft_hashicorp.go
@@ -70,17 +70,11 @@ func (s *RaftServer) monitorLeaderLoop(updatePeers bool) {
 					updatePeers = false
 				}
 
-				glog.V(0).Infof("raft do barrier")
-				barrier := s.RaftHashicorp.Barrier(2 * time.Minute)
-				if err := barrier.Error(); err != nil {
-					glog.Fatalf("failed to wait for barrier, error %s", err)
-				}
-				glog.V(0).Infof("raft do barrier done")
-				s.topo.HashicorpRaftBarrierDone = true
+				s.topo.DoBarrier()
 
 				stats.MasterLeaderChangeCounter.WithLabelValues(fmt.Sprintf("%+v", leader)).Inc()
 			} else {
-				s.topo.HashicorpRaftBarrierDone = false
+				s.topo.BarrierReset()
 			}
 			glog.V(0).Infof("is leader %+v change event: %+v => %+v", isLeader, prevLeader, leader)
 			prevLeader = leader

--- a/weed/server/raft_server.go
+++ b/weed/server/raft_server.go
@@ -2,12 +2,13 @@ package weed_server
 
 import (
 	"encoding/json"
-	transport "github.com/Jille/raft-grpc-transport"
 	"io"
 	"math/rand"
 	"os"
 	"path"
 	"time"
+
+	transport "github.com/Jille/raft-grpc-transport"
 
 	"google.golang.org/grpc"
 

--- a/weed/topology/topology.go
+++ b/weed/topology/topology.go
@@ -47,11 +47,12 @@ type Topology struct {
 
 	Configuration *Configuration
 
-	RaftServer           raft.Server
-	RaftServerAccessLock sync.RWMutex
-	HashicorpRaft        *hashicorpRaft.Raft
-	UuidAccessLock       sync.RWMutex
-	UuidMap              map[string][]string
+	RaftServer               raft.Server
+	RaftServerAccessLock     sync.RWMutex
+	HashicorpRaft            *hashicorpRaft.Raft
+	HashicorpRaftBarrierDone bool
+	UuidAccessLock           sync.RWMutex
+	UuidMap                  map[string][]string
 }
 
 func NewTopology(id string, seq sequence.Sequencer, volumeSizeLimit uint64, pulse int, replicationAsMin bool) *Topology {
@@ -113,7 +114,7 @@ func (t *Topology) IsLeader() bool {
 			}
 		}
 	} else if t.HashicorpRaft != nil {
-		if t.HashicorpRaft.State() == hashicorpRaft.Leader {
+		if t.HashicorpRaft.State() == hashicorpRaft.Leader && t.HashicorpRaftBarrierDone {
 			return true
 		}
 	}

--- a/weed/topology/topology.go
+++ b/weed/topology/topology.go
@@ -47,12 +47,14 @@ type Topology struct {
 
 	Configuration *Configuration
 
-	RaftServer               raft.Server
-	RaftServerAccessLock     sync.RWMutex
-	HashicorpRaft            *hashicorpRaft.Raft
-	HashicorpRaftBarrierDone bool
-	UuidAccessLock           sync.RWMutex
-	UuidMap                  map[string][]string
+	RaftServer           raft.Server
+	RaftServerAccessLock sync.RWMutex
+	HashicorpRaft        *hashicorpRaft.Raft
+	barrierLock          sync.Mutex
+	barrierDone          bool
+
+	UuidAccessLock sync.RWMutex
+	UuidMap        map[string][]string
 }
 
 func NewTopology(id string, seq sequence.Sequencer, volumeSizeLimit uint64, pulse int, replicationAsMin bool) *Topology {
@@ -114,11 +116,47 @@ func (t *Topology) IsLeader() bool {
 			}
 		}
 	} else if t.HashicorpRaft != nil {
-		if t.HashicorpRaft.State() == hashicorpRaft.Leader && t.HashicorpRaftBarrierDone {
+		if t.HashicorpRaft.State() == hashicorpRaft.Leader {
 			return true
 		}
 	}
 	return false
+}
+
+func (t *Topology) IsLeaderAndCanRead() bool {
+	if t.RaftServer != nil {
+		return t.IsLeader()
+	} else if t.HashicorpRaft != nil {
+		return t.IsLeader() && t.DoBarrier()
+	} else {
+		return false
+	}
+}
+
+func (t *Topology) DoBarrier() bool {
+	t.barrierLock.Lock()
+	defer t.barrierLock.Unlock()
+	if t.barrierDone {
+		return true
+	}
+
+	glog.V(0).Infof("raft do barrier")
+	barrier := t.HashicorpRaft.Barrier(2 * time.Minute)
+	if err := barrier.Error(); err != nil {
+		glog.Errorf("failed to wait for barrier, error %s", err)
+		return false
+
+	}
+
+	t.barrierDone = true
+	glog.V(0).Infof("raft do barrier success")
+	return true
+}
+
+func (t *Topology) BarrierReset() {
+	t.barrierLock.Lock()
+	defer t.barrierLock.Unlock()
+	t.barrierDone = false
 }
 
 func (t *Topology) Leader() (l pb.ServerAddress, err error) {
@@ -181,6 +219,10 @@ func (t *Topology) Lookup(collection string, vid needle.VolumeId) (dataNodes []*
 }
 
 func (t *Topology) NextVolumeId() (needle.VolumeId, error) {
+	if !t.IsLeaderAndCanRead() {
+		return 0, fmt.Errorf("as leader can not read yet")
+
+	}
 	vid := t.GetMaxVolumeId()
 	next := vid.Next()
 


### PR DESCRIPTION
# What problem are we solving?
when using HashicorpRaft， it may allocate a reduplicated volume ID to new volume just after restarting masters， the volume ID had been allocated to others。

when master restarts, it does these jobs:
1. restore snap
2. select leader , after this step, if leader master gets a growing request, the nextMaxVolumeId may be the old one in the raft log 
3. sync raft log
4. apply log


# How are we solving the problem?
when the master became the leader， using raft.Barrier() to wait for all applying logs to be done, then began to serve leader service.

# How is the PR tested?
grow volume after restarting the masters.


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
