### PR TITLE
Check `ShouldGrowVolumes` before returning error in assign.

### DIFF
--- a/weed/server/master_grpc_server_assign.go
+++ b/weed/server/master_grpc_server_assign.go
@@ -84,7 +84,7 @@ func (ms *MasterServer) Assign(ctx context.Context, req *master_pb.AssignRequest
 
 	for time.Now().Sub(startTime) < maxTimeout {
 		fid, count, dnList, shouldGrow, err := ms.Topo.PickForWrite(req.Count, option, vl)
-		if shouldGrow && !vl.HasGrowRequest() {
+		if shouldGrow && !vl.HasGrowRequest() && vl.ShouldGrowVolumes(option) {
 			// if picked volume is almost full, trigger a volume-grow request
 			if ms.Topo.AvailableSpaceFor(option) <= 0 {
 				return nil, fmt.Errorf("no free volumes left for " + option.String())


### PR DESCRIPTION
# What problem are we solving?
The problem is described in #5818


# How are we solving the problem?
The master server will still discard the grow request if not necessary in `ProcessGrowRequest`, but the assign request will fail before that.
By checking that the request is not necessary, the assign request and hence the write operation can succeed when there is a lot of volumes that are not crowded, but there are no free volumes to allocate. This usually happens when the cluster is full then cleaned up.


# How is the PR tested?
I tested the PR on our cluster of 8 volume servers + 1 master/filer server. Now the error will not be triggered.



# Checks
- [ ] I have added unit tests if possible. [Not Applicable?]
- [ ] I will add related wiki document changes and link to this PR after merging. [Not Applicable]
