### PR TITLE
fix duplicate volumeClaimTemplates keys in Helm chart

### DIFF
--- a/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
@@ -352,6 +352,8 @@ spec:
       nodeSelector:
         {{ tpl .Values.filer.nodeSelector . | indent 8 | trim }}
       {{- end }}
+  {{- $pvc_exists := include "filer.pvc_exists" . -}}
+  {{- if not $pvc_exists }}
   {{- if and (.Values.filer.enablePVC) (eq .Values.filer.data.type "persistentVolumeClaim") }}
   # DEPRECATION: Deprecate in favor of filer.data section below
   volumeClaimTemplates:
@@ -367,8 +369,7 @@ spec:
       storageClassName: {{ .Values.filer.storageClass }}
       {{- end }}
   {{- end }}
-  {{- $pvc_exists := include "filer.pvc_exists" . -}}
-  {{- if $pvc_exists }}
+  {{- else }}
   volumeClaimTemplates:
     {{- if eq .Values.filer.data.type "persistentVolumeClaim" }}
     - metadata:


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

# What problem are we solving?

When isntalling seaweedfs chart using flux, a kustomize post-processsor used, it shows error of duplicated keys:

```
 seaweedfs-system       4m52s   False   Helm upgrade failed for release tenant-root/seaweedfs-system with chart cozy-seaweedfs@1.10.1: error while running post render on files: map[string]int erface {}(nil): yaml: unmarshal errors:...
```

# How are we solving the problem?

move standard `volumeClaimTemplates` block under `if not $pvc_exists` check, and add `else` condition

# How is the PR tested?


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
