### PR TITLE
fix case for keyAlgorithm in Helm chart

### DIFF
--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -870,7 +870,7 @@ s3:
 certificates:
   commonName: "SeaweedFS CA"
   ipAddresses: []
-  keyAlgorithm: rsa
+  keyAlgorithm: RSA
   keySize: 2048
   duration: 2160h  # 90d
   renewBefore: 360h  # 15d


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

# What problem are we solving?

when isntalling with `global.enableSecurity: true` cert manager can't issue certificate, because it expects algorithm name passed in upper case

# How are we solving the problem?

Update default value from `rsa` to `RSA`

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
