### PR TITLE
Add seaweedfs-cosi-driver

### DIFF
--- a/k8s/charts/seaweedfs/templates/cosi-cluster-role.yaml
+++ b/k8s/charts/seaweedfs/templates/cosi-cluster-role.yaml
@@ -1,0 +1,66 @@
+{{- if .Values.cosi.enabled }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "seaweedfs.name" . }}-objectstorage-provisioner
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+rules:
+- apiGroups: ["objectstorage.k8s.io"]
+  resources:
+    - "buckets"
+    - "bucketaccesses"
+    - "bucketclaims"
+    - "bucketaccessclasses"
+    - "buckets/status"
+    - "bucketaccesses/status"
+    - "bucketclaims/status"
+    - "bucketaccessclasses/status"
+  verbs:
+    - "get"
+    - "list"
+    - "watch"
+    - "update"
+    - "create"
+    - "delete"
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs:
+    - "get"
+    - "watch"
+    - "list"
+    - "delete"
+    - "update"
+    - "create"
+- apiGroups: [""]
+  resources:
+    - "secrets"
+    - "events"
+  verbs:
+    - "get"
+    - "delete"
+    - "update"
+    - "create"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "seaweedfs.name" . }}-objectstorage-provisioner
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "seaweedfs.name" . }}-objectstorage-provisioner
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "seaweedfs.name" . }}-objectstorage-provisioner
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/k8s/charts/seaweedfs/templates/cosi-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/cosi-deployment.yaml
@@ -1,0 +1,199 @@
+{{- if .Values.cosi.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "seaweedfs.name" . }}-objectstorage-provisioner
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.cosi.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+      helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: objectstorage-provisioner
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: objectstorage-provisioner
+      {{ with .Values.podLabels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.cosi.podLabels }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      annotations:
+      {{ with .Values.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.cosi.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      restartPolicy: {{ default .Values.global.restartPolicy .Values.cosi.restartPolicy }}
+      {{- if .Values.cosi.tolerations }}
+      tolerations:
+        {{ tpl .Values.cosi.tolerations . | nindent 8 | trim }}
+      {{- end }}
+      {{- include "seaweedfs.imagePullSecrets" . | nindent 6 }}
+      terminationGracePeriodSeconds: 10
+      {{- if .Values.cosi.priorityClassName }}
+      priorityClassName: {{ .Values.cosi.priorityClassName | quote }}
+      {{- end }}
+      enableServiceLinks: false
+      serviceAccountName: {{ template "seaweedfs.name" . }}-objectstorage-provisioner
+      {{- if .Values.cosi.initContainers }}
+      initContainers:
+        {{ tpl .Values.cosi.initContainers . | nindent 8 | trim }}
+      {{- end }}
+      {{- if .Values.cosi.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.cosi.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: seaweedfs-cosi-driver
+          image: "{{ .Values.cosi.image }}"
+          imagePullPolicy: {{ default "IfNotPresent" .Values.global.imagePullPolicy }}
+          env:
+            - name: DRIVERNAME
+              value: "{{ .Values.cosi.driverName }}"
+            - name: ENDPOINT
+              {{- if .Values.cosi.endpoint }}
+              value: "{{ .Values.cosi.endpoint }}"
+              {{- else if .Values.s3.ingress.enabled }}
+              value: "{{ printf "https://%s" .Values.s3.ingress.host }}"
+              {{- else if .Values.s3.enabled }}
+              value: "{{ printf "https://%s-s3.%s.svc" (include "seaweedfs.name" .) .Release.Namespace }}"
+              {{- else }}
+              value: "{{ printf "https://%s-filer.%s.svc" (include "seaweedfs.name" .) .Release.Namespace }}"
+              {{- end }}
+            {{- with .Values.cosi.region }}
+            - name: REGION
+              value: "{{ . }}"
+            {{- end }}
+            - name: SEAWEEDFS_FILER
+              value: "{{ template "seaweedfs.name" . }}-filer:{{ .Values.filer.grpcPort }}"
+            {{- if .Values.global.enableSecurity }}
+            - name: WEED_GRPC_CLIENT_KEY
+              value: /usr/local/share/ca-certificates/client/tls.key
+            - name: WEED_GRPC_CLIENT_CERT
+              value: /usr/local/share/ca-certificates/client/tls.crt
+            - name: WEED_GRPC_CA
+              value: /usr/local/share/ca-certificates/client/ca.crt
+            {{- end }}
+            {{- if .Values.cosi.extraEnvironmentVars }}
+            {{- range $key, $value := .Values.cosi.extraEnvironmentVars }}
+            - name: {{ $key }}
+            {{- if kindIs "string" $value }}
+              value: {{ $value | quote }}
+            {{- else }}
+              valueFrom:
+                {{ toYaml $value | nindent 16 | trim }}
+            {{- end -}}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.global.extraEnvironmentVars }}
+            {{- range $key, $value := .Values.global.extraEnvironmentVars }}
+            - name: {{ $key }}
+            {{- if kindIs "string" $value }}
+              value: {{ $value | quote }}
+            {{- else }}
+              valueFrom:
+                {{ toYaml $value | nindent 16 | trim }}
+            {{- end -}}
+            {{- end }}
+            {{- end }}
+          volumeMounts:
+            - mountPath: /var/lib/cosi
+              name: socket
+            {{- if .Values.cosi.enableAuth }}
+            - mountPath: /etc/sw
+              name: config-users
+              readOnly: true
+            {{- end }}
+            {{- if .Values.global.enableSecurity }}
+            - name: security-config
+              readOnly: true
+              mountPath: /etc/seaweedfs/security.toml
+              subPath: security.toml
+            - name: ca-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/ca/
+            - name: master-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/master/
+            - name: volume-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/volume/
+            - name: filer-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/filer/
+            - name: client-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/client/
+            {{- end }}
+            {{ tpl .Values.cosi.extraVolumeMounts . | nindent 12 | trim }}
+        - name: seaweedfs-cosi-sidecar
+          image: "{{ .Values.cosi.sidecar.image }}"
+          imagePullPolicy: {{ default "IfNotPresent" .Values.global.imagePullPolicy }}
+          args:
+            - {{ printf "--v=%s" (default "5" .Values.cosi.sidecar.logLevel) }}
+          volumeMounts:
+            - mountPath: /var/lib/cosi
+              name: socket
+          {{- with .Values.cosi.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.cosi.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.cosi.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+      {{- if .Values.cosi.sidecars }}
+      {{- include "common.tplvalues.render" (dict "value" .Values.cosi.sidecars "context" $) | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: socket
+          emptyDir: {}
+        {{- if .Values.cosi.enableAuth }}
+        - name: config-users
+          secret:
+            defaultMode: 420
+            {{- if .Values.cosi.existingConfigSecret }}
+            secretName: {{ .Values.cosi.existingConfigSecret }}
+            {{- else }}
+            secretName: seaweedfs-cosi-secret
+            {{- end }}
+        {{- end }}
+        {{- if .Values.global.enableSecurity }}
+        - name: security-config
+          configMap:
+            name: {{ template "seaweedfs.name" . }}-security-config
+        - name: ca-cert
+          secret:
+            secretName: {{ template "seaweedfs.name" . }}-ca-cert
+        - name: master-cert
+          secret:
+            secretName: {{ template "seaweedfs.name" . }}-master-cert
+        - name: volume-cert
+          secret:
+            secretName: {{ template "seaweedfs.name" . }}-volume-cert
+        - name: filer-cert
+          secret:
+            secretName: {{ template "seaweedfs.name" . }}-filer-cert
+        - name: client-cert
+          secret:
+            secretName: {{ template "seaweedfs.name" . }}-client-cert
+        {{- end }}
+        {{ tpl .Values.cosi.extraVolumes . | indent 8 | trim }}
+      {{- if .Values.cosi.nodeSelector }}
+      nodeSelector:
+        {{ tpl .Values.cosi.nodeSelector . | indent 8 | trim }}
+      {{- end }}
+{{- end }}

--- a/k8s/charts/seaweedfs/templates/cosi-service-account.yaml
+++ b/k8s/charts/seaweedfs/templates/cosi-service-account.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.cosi.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "seaweedfs.name" . }}-objectstorage-provisioner
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+automountServiceAccountToken: {{ .Values.global.automountServiceAccountToken }}
+{{- end }}

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -867,6 +867,31 @@ s3:
     annotations: {}
     tls: []
 
+# Deploy Kubernetes COSI Driver for SeaweedFS
+# Requires COSI CRDs and controller to be installed in the cluster
+# For more information, visit: https://container-object-storage-interface.github.io/docs/deployment-guide
+cosi:
+  enabled: false
+  image: "ghcr.io/seaweedfs/seaweedfs-cosi-driver:v0.1.0"
+  driverName: "seaweedfs.objectstorage.k8s.io"
+  endpoint: ""
+  region: ""
+
+  sidecar:
+    image: gcr.io/k8s-staging-sig-storage/objectstorage-sidecar/objectstorage-sidecar:v20230130-v0.1.0-24-gc0cf995
+
+  # enable user & permission to s3 (need to inject to all services)
+  enableAuth: false
+  # set to the name of an existing kubernetes Secret with the s3 json config file
+  # should have a secret key called seaweedfs_s3_config with an inline json configure
+  existingConfigSecret: null
+
+  podSecurityContext: {}
+  containerSecurityContext: {}
+
+  extraVolumes: ""
+  extraVolumeMounts: ""
+
 certificates:
   commonName: "SeaweedFS CA"
   ipAddresses: []


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

# What problem are we solving?

This PR introduces automatic configuration for COSI Driver, which enables automatic provisioning of S3 Buckets in Kubernetes

# How are we solving the problem?

fixes: https://github.com/seaweedfs/seaweedfs/issues/5838

# How is the PR tested?

I tested this PR manually as part of adoption SeaweedFS in Cozystack https://github.com/aenix-io/cozystack/pull/131 
We deploy SeaweedFS with enabled security settings

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
