### PR TITLE
Fix extractToFile gz file nil bug

### DIFF
--- a/weed/command/update.go
+++ b/weed/command/update.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/util"
-	"golang.org/x/net/context/ctxhttp"
 	util_http "github.com/seaweedfs/seaweedfs/weed/util/http"
+	"golang.org/x/net/context/ctxhttp"
 )
 
 //copied from https://github.com/restic/restic/tree/master/internal/selfupdate
@@ -309,7 +309,12 @@ func extractToFile(buf []byte, filename, target string) error {
 		trd := tar.NewReader(gr)
 		hdr, terr := trd.Next()
 		if terr != nil {
-			glog.Errorf("uncompress file(%s) failed:%s", hdr.Name, terr)
+			if hdr != nil {
+				glog.Errorf("uncompress file(%s) failed:%s", hdr.Name, terr)
+			} else {
+				glog.Errorf("uncompress file is nil, failed:%s", terr)
+			}
+
 			return terr
 		}
 		rd = trd


### PR DESCRIPTION
# What problem are we solving?

tar包解压文件时，获取Header指针时会出现nil情况，此时打印数据获取Header.Name会报错

# How are we solving the problem?

增加Header指针的判空分支

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
