### PR TITLE
Fix KeyMaterial nil bug

### DIFF
--- a/weed/command/s3.go
+++ b/weed/command/s3.go
@@ -180,8 +180,11 @@ func runS3(cmd *Command, args []string) bool {
 }
 
 // GetCertificateWithUpdate Auto refreshing TSL certificate
-func (S3opt *S3Options) GetCertificateWithUpdate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
-	certs, err := S3opt.certProvider.KeyMaterial(context.Background())
+func (s3opt *S3Options) GetCertificateWithUpdate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+	certs, err := s3opt.certProvider.KeyMaterial(context.Background())
+	if certs == nil {
+		return nil, err
+	}
 	return &certs.Certs[0], err
 }
 


### PR DESCRIPTION
# What problem are we solving?

1. s3opt.certProvider.KeyMaterial return maybe nil, certs.Certs[0] get nil bug
2. receiver names are different

# How are we solving the problem?

1. add judge nil
2. update receiver names to same

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
