### PR TITLE
Fix KeyMaterial nil bug

### DIFF
--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -240,6 +240,9 @@ func runFiler(cmd *Command, args []string) bool {
 // GetCertificateWithUpdate Auto refreshing TSL certificate
 func (fo *FilerOptions) GetCertificateWithUpdate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
 	certs, err := fo.certProvider.KeyMaterial(context.Background())
+	if certs == nil {
+		return nil, err
+	}
 	return &certs.Certs[0], err
 }
 


### PR DESCRIPTION
# What problem are we solving?

1. s3opt.certProvider.KeyMaterial return maybe nil, certs.Certs[0] get nil bug

# How are we solving the problem?

1. add judge nil

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
