### PR TITLE
Fix secretName for seaweedfs-cosi-driver

### DIFF
--- a/k8s/charts/seaweedfs/templates/cosi-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/cosi-deployment.yaml
@@ -173,7 +173,7 @@ spec:
             {{- if .Values.cosi.existingConfigSecret }}
             secretName: {{ .Values.cosi.existingConfigSecret }}
             {{- else }}
-            secretName: seaweedfs-cosi-secret
+            secretName: seaweedfs-client-cert
             {{- end }}
         {{- end }}
         {{- if .Values.global.enableSecurity }}


### PR DESCRIPTION
Fix secret mounting for seaweedfs-cosi-driver, in case seaweedfs running with `enableSecurity=true`