### PR TITLE
[shell] volume.grow 

### DIFF
--- a/weed/shell/command_volume_grow.go
+++ b/weed/shell/command_volume_grow.go
@@ -1,0 +1,64 @@
+package shell
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
+	"io"
+)
+
+func init() {
+	Commands = append(Commands, &commandGrow{})
+}
+
+type commandGrow struct {
+}
+
+func (c *commandGrow) Name() string {
+	return "volume.grow"
+}
+
+func (c *commandGrow) Help() string {
+	return `grow volumes
+
+	volume.grow [-collection=<collection name>] [-dataCenter=<data center name>]
+
+`
+}
+
+func (c *commandGrow) Do(args []string, commandEnv *CommandEnv, writer io.Writer) (err error) {
+
+	volumeVacuumCommand := flag.NewFlagSet(c.Name(), flag.ContinueOnError)
+	growCount := volumeVacuumCommand.Uint("count", 2, "")
+	collection := volumeVacuumCommand.String("collection", "", "grow this collection")
+	dataCenter := volumeVacuumCommand.String("dataCenter", "", "grow volumes only from the specified data center")
+
+	if err = volumeVacuumCommand.Parse(args); err != nil {
+		return nil
+	}
+
+	assignRequest := &master_pb.AssignRequest{
+		Count:               0,
+		Collection:          *collection,
+		WritableVolumeCount: uint32(*growCount),
+	}
+	if *dataCenter != "" {
+		assignRequest.DataCenter = *dataCenter
+	}
+
+	err = commandEnv.MasterClient.WithClient(false, func(client master_pb.SeaweedClient) error {
+		_, err := client.Assign(context.Background(), assignRequest)
+
+		if err != nil {
+			return fmt.Errorf("Assign: %v", err)
+		}
+		return nil
+	})
+
+	if err != nil {
+		return
+	}
+
+	return nil
+}


### PR DESCRIPTION
# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/pull/5821

ometimes you want to increase the number of active volumes in a comment, but it is not trivial to execute an assign http request

# How are we solving the problem?



# How is the PR tested?

localy
```
> volume.grow 
> collection.list
collection:""   volumeCount:2   size:16 fileCount:0     deletedBytes:0  deletion:0
Total 1 collections.

```

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
