### PR TITLE
[webdav] status code 500 if internal error from filer

### DIFF
--- a/weed/server/webdav_server.go
+++ b/weed/server/webdav_server.go
@@ -99,6 +99,7 @@ type FileInfo struct {
 	modifiedTime time.Time
 	etag         string
 	isDirectory  bool
+	err          error
 }
 
 func (fi *FileInfo) Name() string       { return fi.name }
@@ -109,6 +110,9 @@ func (fi *FileInfo) IsDir() bool        { return fi.isDirectory }
 func (fi *FileInfo) Sys() interface{}   { return nil }
 
 func (fi *FileInfo) ETag(ctx context.Context) (string, error) {
+	if fi.err != nil {
+		return "", fi.err
+	}
 	return fi.etag, nil
 }
 
@@ -269,7 +273,10 @@ func (fs *WebDavFileSystem) OpenFile(ctx context.Context, fullFilePath string, f
 
 	fi, err := fs.stat(ctx, fullFilePath)
 	if err != nil {
-		return nil, os.ErrNotExist
+		if err == os.ErrNotExist {
+			return nil, err
+		}
+		return &WebDavFile{fs: fs}, nil
 	}
 	if !strings.HasSuffix(fullFilePath, "/") && fi.IsDir() {
 		fullFilePath += "/"
@@ -365,11 +372,15 @@ func (fs *WebDavFileSystem) stat(ctx context.Context, fullFilePath string) (os.F
 
 	var fi FileInfo
 	entry, err := filer_pb.GetEntry(fs, fullpath)
+	if err != nil {
+		if err == filer_pb.ErrNotFound {
+			return nil, os.ErrNotExist
+		}
+		fi.err = err
+		return &fi, nil
+	}
 	if entry == nil {
 		return nil, os.ErrNotExist
-	}
-	if err != nil {
-		return nil, err
 	}
 	fi.size = int64(filer.FileSize(entry))
 	fi.name = string(fullpath)
@@ -514,7 +525,9 @@ func (f *WebDavFile) Write(buf []byte) (int, error) {
 func (f *WebDavFile) Close() error {
 
 	glog.V(2).Infof("WebDavFileSystem.Close %v", f.name)
-
+	if f.bufWriter == nil {
+		return nil
+	}
 	err := f.bufWriter.Close()
 
 	if f.entry != nil {


### PR DESCRIPTION
# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/5864
All errors in the handler are returned as 404

# How are we solving the problem?

Passed an error inside the file information structure and caught it in the etag search function

# How is the PR tested?

Localy
```
while true; do curl -o /dev/null -vs "http://127.0.0.1:7333/buckets/warp-benchmark-bucket/xyla1SAS/99.dIWkjopAvnLG(3VR.rnd" 2>&1;done
HTTP/1.1 200 OK
Accept-Ranges: bytes
Content-Length: 10485760
Content-Type: application/octet-stream
Etag: 07c5c42f36b1a44f4a04bf5989082a21
Last-Modified: Tue, 06 Aug 2024 09:17:59 GMT
Date: Tue, 06 Aug 2024 13:19:38 GMT

HTTP/1.1 500 Internal Server Error
Date: Tue, 06 Aug 2024 13:19:38 GMT
Content-Length: 21
Content-Type: text/plain; charset=utf-8
```

non-existent-file is 404
````
curl -o /dev/null -vs "http://127.0.0.1:7333/buckets/warp-benchmark-bucket/xyla1SAS/non-existent-file"      
*   Trying 127.0.0.1:7333...
* Connected to 127.0.0.1 (127.0.0.1) port 7333
> GET /buckets/warp-benchmark-bucket/xyla1SAS/non-existent-file HTTP/1.1
> Host: 127.0.0.1:7333
> User-Agent: curl/8.4.0
> Accept: */*
> 
< HTTP/1.1 404 Not Found
< Date: Tue, 06 Aug 2024 13:32:13 GMT
< Content-Length: 9
< Content-Type: text/plain; charset=utf-8
< 
{ [9 bytes data]
* Connection #0 to host 127.0.0.1 left intact

````
# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
