### PR TITLE
Add volume-resize-hook

### DIFF
--- a/k8s/charts/seaweedfs/templates/volume-resize-hook.yaml
+++ b/k8s/charts/seaweedfs/templates/volume-resize-hook.yaml
@@ -1,0 +1,114 @@
+{{- if and .Values.volume.enabled .Values.volume.resizeHook.enabled }}
+{{- $seaweedfsName := include "seaweedfs.name" $ }}
+{{- $replicas := int .Values.volume.replicas -}}
+{{- $statefulsetName := printf "%s-volume" $seaweedfsName -}}
+{{- $statefulset := (lookup "apps/v1" "StatefulSet" .Release.Namespace $statefulsetName) -}}
+
+{{/* Check for changes in volumeClaimTemplates */}}
+{{- $templateChangesRequired := false -}}
+{{- if $statefulset -}}
+  {{- range $dir := .Values.volume.dataDirs -}}
+    {{- if eq .type "persistentVolumeClaim" -}}
+      {{- $desiredSize := .size -}}
+      {{- range $statefulset.spec.volumeClaimTemplates -}}
+        {{- if and (eq .metadata.name $dir.name) (ne .spec.resources.requests.storage $desiredSize) -}}
+          {{- $templateChangesRequired = true -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{/* Check for the need for patching existing PVCs */}}
+{{- $pvcChangesRequired := false -}}
+{{- range $dir := .Values.volume.dataDirs -}}
+  {{- if eq .type "persistentVolumeClaim" -}}
+    {{- $desiredSize := .size -}}
+    {{- range $i, $e := until $replicas }}
+      {{- $pvcName := printf "%s-%s-volume-%d" $dir.name $seaweedfsName $e -}}
+      {{- $currentPVC := (lookup "v1" "PersistentVolumeClaim" $.Release.Namespace $pvcName) -}}
+      {{- if and $currentPVC (ne ($currentPVC.spec.resources.requests.storage | toString) $desiredSize) -}}
+        {{- $pvcChangesRequired = true -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- if or $templateChangesRequired $pvcChangesRequired }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ $seaweedfsName }}-volume-resize-hook"
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
+spec:
+  template:
+    spec:
+      serviceAccountName: {{ $seaweedfsName }}-volume-resize-hook
+      restartPolicy: Never
+      backoffLimit: 1
+      containers:
+        - name: resize
+          image: {{ .Values.volume.resizeHook.image }}
+          command: ["sh", "-xec"]
+          args:
+            - |
+              {{- if $pvcChangesRequired -}}
+              {{- range $dir := .Values.volume.dataDirs -}}
+              {{- if eq .type "persistentVolumeClaim" -}}
+              {{- $desiredSize := .size -}}
+              {{- range $i, $e := until $replicas }}
+              kubectl patch pvc {{ printf "%s-%s-volume-%d" $dir.name $seaweedfsName $e }} -p '{"spec":{"resources":{"requests":{"storage":"{{ $desiredSize }}"}}}}'
+              {{- end }}
+              {{- end }}
+              {{- end }}
+              {{- end -}}
+
+              {{- if $templateChangesRequired }}
+              kubectl delete statefulset {{ $statefulsetName }} --cascade=orphan
+              {{- end }}
+{{- end }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $seaweedfsName }}-volume-resize-hook
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $seaweedfsName }}-volume-resize-hook
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation
+rules:
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["delete", "get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["patch", "get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $seaweedfsName }}-volume-resize-hook
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation
+subjects:
+  - kind: ServiceAccount
+    name: {{ $seaweedfsName }}-volume-resize-hook
+roleRef:
+  kind: Role
+  name: {{ $seaweedfsName }}-volume-resize-hook
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -305,6 +305,11 @@ volume:
    #   size: "800Gi"
    #   maxVolumes: 0
 
+  # This will automatically create a job for patching Kubernetes resources if the dataDirs type is 'persistentVolumeClaim' and the size has changed.
+  resizeHook:
+    enabled: true
+    image: bitnami/kubectl
+
   # idx can be defined by:
   #
   # idx:


### PR DESCRIPTION
# What problem are we solving?

Currently Helm chart does not support updating PVC size of volumes server

# How are we solving the problem?

Added hook which is triggered only if `.volume.dataDirs[*].type==persistentVolumeClaim` and `.volume.dataDirs[*].size` updated

the job is rendedred to:

```yaml
---
# Source: cozy-seaweedfs/charts/seaweedfs/templates/pre-resize-hook.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: "seaweedfs-volume-resize-hook"
  annotations:
    helm.sh/hook: pre-install,pre-upgrade
    helm.sh/hook-weight: "0"
    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
spec:
  template:
    spec:
      serviceAccountName: seaweedfs-volume-resize-hook
      restartPolicy: Never
      backoffLimit: 1
      containers:
        - name: resize
          image: bitnami/kubectl
          command: ["sh", "-xec"]
          args:
            - |
              kubectl patch pvc data1-seaweedfs-volume-0 -p '{"spec":{"resources":{"requests":{"storage":"20Gi"}}}}'
              kubectl patch pvc data1-seaweedfs-volume-1 -p '{"spec":{"resources":{"requests":{"storage":"20Gi"}}}}'
              kubectl delete statefulset seaweedfs-volume --cascade=orphan
```

Removing of STS is required because it not allowed to update `volumeClaimTemplate` however removal with `--cascade=orphan` option does not triggers pod restarts. And then Helm applies the newer version of STS.

# How is the PR tested?

Manually in Cozystack

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
