### PR TITLE
added access-control-expose-headers to put request

### DIFF
--- a/weed/s3api/s3api_server.go
+++ b/weed/s3api/s3api_server.go
@@ -112,7 +112,7 @@ func (s3a *S3ApiServer) registerRouter(router *mux.Router) {
 	// Readiness Probe
 	apiRouter.Methods(http.MethodGet).Path("/status").HandlerFunc(s3a.StatusHandler)
 
-	apiRouter.Methods(http.MethodOptions, http.MethodPut).HandlerFunc(
+	apiRouter.Methods(http.MethodOptions).HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			origin := r.Header.Get("Origin")
 			if origin != "" {

--- a/weed/s3api/s3api_server.go
+++ b/weed/s3api/s3api_server.go
@@ -112,7 +112,7 @@ func (s3a *S3ApiServer) registerRouter(router *mux.Router) {
 	// Readiness Probe
 	apiRouter.Methods(http.MethodGet).Path("/status").HandlerFunc(s3a.StatusHandler)
 
-	apiRouter.Methods(http.MethodOptions).HandlerFunc(
+	apiRouter.Methods(http.MethodOptions, http.MethodPut).HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			origin := r.Header.Get("Origin")
 			if origin != "" {

--- a/weed/s3api/s3err/error_handler.go
+++ b/weed/s3api/s3err/error_handler.go
@@ -79,6 +79,7 @@ func setCommonHeaders(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Accept-Ranges", "bytes")
 	if r.Header.Get("Origin") != "" {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Expose-Headers", "*")
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 	}
 }


### PR DESCRIPTION
# What problem are we solving?
added support of `Access-Control-Expose-Headers` in response to facilitate access to keys present in the Response Header.

# How are we solving the problem?
Added `Access-Control-Expose-Headers` to `setCommonHeaders` function in file `weed\s3api\s3err\error_handler.go`

# How is the PR tested?
Ran the updated seaweedfs code and tested it in browser.
![2024-08-10 03_30_05-ICfO Portal](https://github.com/user-attachments/assets/81e563f0-35df-48a6-8fe4-603f432e7b94)

![2024-08-10 03_28_50-ICfO Portal](https://github.com/user-attachments/assets/376f6355-46c0-4a64-a7bc-854401b49afa)
