### PR TITLE
fix ec volume lookup data sync

### DIFF
--- a/weed/server/master_grpc_server.go
+++ b/weed/server/master_grpc_server.go
@@ -80,7 +80,7 @@ func (ms *MasterServer) SendHeartbeat(stream master_pb.Seaweed_SendHeartbeatServ
 				message.DeletedVids = append(message.DeletedVids, uint32(v.Id))
 			}
 			for _, s := range dn.GetEcShards() {
-				message.DeletedVids = append(message.DeletedVids, uint32(s.VolumeId))
+				message.DeletedEcVids = append(message.DeletedEcVids, uint32(s.VolumeId))
 			}
 
 			// if the volume server disconnects and reconnects quickly
@@ -89,7 +89,7 @@ func (ms *MasterServer) SendHeartbeat(stream master_pb.Seaweed_SendHeartbeatServ
 			glog.V(0).Infof("unregister disconnected volume server %s:%d", dn.Ip, dn.Port)
 			ms.UnRegisterUuids(dn.Ip, dn.Port)
 
-			if len(message.DeletedVids) > 0 {
+			if len(message.DeletedVids) > 0 || len(message.DeletedEcVids) > 0 {
 				ms.broadcastToClients(&master_pb.KeepConnectedResponse{VolumeLocation: message})
 			}
 		}


### PR DESCRIPTION
当一个volume server停止服务时，调用lookup接口查询某个volume的位置时，会出现调用不同的master节点，返回不同的ip列表的情况；
进一步排查发现只有ec后的volume会有这个情况：
1. leader节点返回的ip列表没有停止服务的机器
2. 非leader节点会继续返回已经停止服务的机器

解决办法：
1.通过代码debug发现在master接收volume心跳时，defer代码中会删除停止心跳的volume server的volumes和ec shards，但是处理ec shards时，没有将ec shards正确的添加到对应的slice
2.在判断是否需要通知其他节点时，因为正常停机时，volume server会发出停机心跳，所以volume的信息其实在其他地方已经处理了，这时的 `len(message.DeletedVids) > 0` 是不能匹配的，需要增加判断条件，针对ec shards的变化通知其他节点