### PR TITLE
Dont try lazy decode content in proxyToFiler if no accept-encoding provided

### DIFF
--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -149,6 +149,7 @@ func (s3a *S3ApiServer) proxyToFiler(w http.ResponseWriter, r *http.Request, des
 	}
 
 	proxyReq.Header.Set("X-Forwarded-For", r.RemoteAddr)
+	proxyReq.Header.Set("Accept-Encoding", "identity")
 	for k, v := range r.URL.Query() {
 		if _, ok := s3_constants.PassThroughHeaders[strings.ToLower(k)]; ok {
 			proxyReq.Header[k] = v


### PR DESCRIPTION
# What problem are we solving?

The net.http client has a feature for lazy decoding of content. For example:

The server responds with Content-Encoding: gzip.
The HTTP client decodes the gzip content and returns the body.
However, this behavior is now triggering another bug in the code at weed/s3api/s3api_object_handlers.go:214.

When the Accept-Encoding header is not provided, the server returns a 404 error. If I add a condition based on the request method, the response differs from what is expected. For instance, Minio and Ceph do not unpack the responses and return them as-is, including all the original headers (such as Content-Encoding).

# How are we solving the problem?

added Accept-Encoding: identity in proxyToFiler

# How is the PR tested?

PUT file with content-encoding: gzip
GET without header accept-encoding and receive 200 with content-encoding: gzip
GET with header accept-encoding and receive 200 with content-encoding: gzip


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
