### PR TITLE
Allow using a PVC to store filer and master logs - changes in values.yaml

### DIFF
--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -100,6 +100,15 @@ master:
     storageClass: ""
     hostPathPrefix: /ssd
 
+  # You may use ANY storage-class, example with local-path-provisioner
+  # Annotations are optional.
+  # logs:
+  #   type: "persistentVolumeClaim"
+  #   size: "24Ti"
+  #   storageClass: "local-path-provisioner"
+  #   annotations:
+  #     "key": "value"
+
   # You can also use emptyDir storage:
   #  logs:
   #    type: "emptyDir"
@@ -534,6 +543,15 @@ filer:
     size: ""
     storageClass: ""
     hostPathPrefix: /storage
+
+  # You may use ANY storage-class, example with local-path-provisioner
+  # Annotations are optional.
+  # logs:
+  #   type: "persistentVolumeClaim"
+  #   size: "24Ti"
+  #   storageClass: "local-path-provisioner"
+  #   annotations:
+  #     "key": "value"
 
   # You can also use emptyDir storage:
   #  logs:


### PR DESCRIPTION
# What problem are we solving?
The values.yaml file was missing the configuration for the logs storage, which was already correctly set up in the templates/filer-statefulset.yaml and templates/master-statefulset.yaml files. 
[5653](https://github.com/seaweedfs/seaweedfs/pull/5653)

# How are we solving the problem?
Added the following configuration for master and filer to the values.yaml file to ensure consistency across all related components:

```
  # You may use ANY storage-class, example with local-path-provisioner
  # Annotations are optional.
  # logs:
  #   type: "persistentVolumeClaim"
  #   size: "24Ti"
  #   storageClass: "local-path-provisioner"
  #   annotations:
  #     "key": "value"
```

# How is the PR tested?
The changes were validated by deploying the updated Helm chart in a test environment, ensuring that the logs are correctly provisioned.

# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.