### PR TITLE
filer.remote.gateway not filer.remote.sync for remote.mount.buckets help string.

### DIFF
--- a/weed/shell/command_remote_mount_buckets.go
+++ b/weed/shell/command_remote_mount_buckets.go
@@ -33,7 +33,7 @@ func (c *commandRemoteMountBuckets) Help() string {
 	remote.mount.buckets -remote=cloud1
 
 	# after mount, start a separate process to write updates to remote storage
-	weed filer.remote.sync -filer=<filerHost>:<filerPort> -createBucketAt=cloud1
+	weed filer.remote.gateway -filer=<filerHost>:<filerPort> -createBucketAt=cloud1
 
 `
 }


### PR DESCRIPTION
# What problem are we solving?

Incorrect (I think?) help strings for command documentation.


# How are we solving the problem?

Correcting the help string.

# How is the PR tested?

untested, doc string change, are there tests for that?

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging. -> I already updated the wiki when it caught me out.
