### PR TITLE
filer.remote.gateway not filer.remote.sync for filer.remote.gateway help string.

### DIFF
--- a/weed/command/filer_remote_gateway.go
+++ b/weed/command/filer_remote_gateway.go
@@ -71,7 +71,7 @@ var cmdFilerRemoteGateway = &Command{
 	filer.remote.gateway listens on filer local buckets update events. 
 	If any bucket is created, deleted, or updated, it will mirror the changes to remote object store.
 
-		weed filer.remote.sync -createBucketAt=cloud1
+		weed filer.remote.gateway -createBucketAt=cloud1
 
 `,
 }


### PR DESCRIPTION
See also related PR #5934 

# What problem are we solving?

Incorrect (I think?) help strings for command documentation.


# How are we solving the problem?

Correcting the help string.

# How is the PR tested?

untested, doc string change, are there tests for that?

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging. -> I already updated the wiki when it caught me out.
