### PR TITLE
update metric for ErrorCRC if it happens during volume readNeedleDataInto

### DIFF
--- a/weed/storage/volume_read.go
+++ b/weed/storage/volume_read.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
+	"github.com/seaweedfs/seaweedfs/weed/stats"
 	"github.com/seaweedfs/seaweedfs/weed/storage/backend"
 	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
 	"github.com/seaweedfs/seaweedfs/weed/storage/super_block"
@@ -180,6 +181,7 @@ func (v *Volume) readNeedleDataInto(n *needle.Needle, readOption *ReadOption, wr
 	}
 	if offset == 0 && size == int64(n.DataSize) && (n.Checksum != crc && uint32(n.Checksum) != crc.Value()) {
 		// the crc.Value() function is to be deprecated. this double checking is for backward compatible.
+		stats.VolumeServerHandlerCounter.WithLabelValues(stats.ErrorCRC).Inc()
 		return fmt.Errorf("ReadNeedleData checksum %v expected %v", crc, n.Checksum)
 	}
 	return nil


### PR DESCRIPTION
# What problem are we solving?

This allows to spot bitrot problems at volume servers with metric monitoring during routine cluster operation.  Without this patch CRC errors are not reported to a metric server during reading of a file from a fuse mounted filesystem. 

# How are we solving the problem?

We add `stats.VolumeServerHandlerCounter.WithLabelValues(stats.ErrorCRC).Inc()`
call when CRC error is detected. It is done in a similar manner as it is already implemented in   `ReadBytes` from `weed/storage/needle/needle_read.go` code.

# How is the PR tested?

Hand checked by creating a corrupted volume. Than reading a corrupted file from fuse filesystem. Observed the entries related to `ErrorCRC` shows up at `SeaweedFS_volumeServer_handler_total` metric.


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.

# Additional context

It is quite strange but it seems that `ReadBytes` from  `weed/storage/needle/needle_read.go`  code is not unused when a file is requested by fuse.