### PR TITLE
fix volume.move io.EOF

### DIFF
--- a/weed/storage/volume_backup.go
+++ b/weed/storage/volume_backup.go
@@ -3,9 +3,10 @@ package storage
 import (
 	"context"
 	"fmt"
-	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"io"
 	"os"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb"
 
 	"google.golang.org/grpc"
 
@@ -200,7 +201,7 @@ func (v *Volume) BinarySearchByAppendAtNs(sinceNs uint64) (offset Offset, isLast
 				err = leftErr
 				return
 			}
-			rightIndex, rightOffset, rightNs, rightErr := v.readRightNs(m)
+			rightIndex, rightOffset, rightNs, rightErr := v.readRightNs(m, entryCount)
 			if rightErr != nil {
 				err = rightErr
 				return
@@ -249,10 +250,13 @@ func (v *Volume) BinarySearchByAppendAtNs(sinceNs uint64) (offset Offset, isLast
 
 }
 
-func (v *Volume) readRightNs(m int64) (index int64, offset Offset, ts uint64, err error) {
+func (v *Volume) readRightNs(m, max int64) (index int64, offset Offset, ts uint64, err error) {
 	index = m
 	for offset.IsZero() {
 		index++
+		if index >= max {
+			return
+		}
 		offset, err = v.readOffsetFromIndex(index)
 		if err != nil {
 			err = fmt.Errorf("read left entry at %d: %v", index, err)
@@ -269,6 +273,9 @@ func (v *Volume) readLeftNs(m int64) (index int64, offset Offset, ts uint64, err
 	index = m
 	for offset.IsZero() {
 		index--
+		if index < 0 {
+			return
+		}
 		offset, err = v.readOffsetFromIndex(index)
 		if err != nil {
 			err = fmt.Errorf("read right entry at %d: %v", index, err)


### PR DESCRIPTION
# What problem are we solving?
volume.move tail EOF
`move hdd volume 143180 xx => xxfailed, err:tail volume 143180 from xx to xx: rpc error: code = Unknown desc = streamFollow: fail to locate by appendAtNs 1724628315000000000: read entry 3088: EOF`


# How are we solving the problem?
check max entryCount when readRightNs


# How is the PR tested?
move the err volume success


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
