### PR TITLE
[s3] reducing the number of metrics for 403

### DIFF
--- a/weed/s3api/stats.go
+++ b/weed/s3api/stats.go
@@ -16,10 +16,7 @@ func track(f http.HandlerFunc, action string) http.HandlerFunc {
 		start := time.Now()
 		f(recorder, r)
 		if recorder.Status == http.StatusForbidden {
-			if m, _ := stats_collect.S3RequestCounter.GetMetricWithLabelValues(
-				action, strconv.Itoa(http.StatusOK), bucket); m == nil {
-				bucket = ""
-			}
+			bucket = ""
 		}
 		stats_collect.S3RequestHistogram.WithLabelValues(action, bucket).Observe(time.Since(start).Seconds())
 		stats_collect.S3RequestCounter.WithLabelValues(action, strconv.Itoa(recorder.Status), bucket).Inc()


### PR DESCRIPTION
# What problem are we solving?

Metrics are created for non-existent buckets
```
curl -s http://127.0.0.1:9324/metrics | grep LIST                                                            
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest",type="LIST",le="0.0001"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest",type="LIST",le="0.0002"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest",type="LIST",le="0.0004"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest",type="LIST",le="0.0008"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest",type="LIST",le="0.0016"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest",type="LIST",le="0.0032"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest",type="LIST",le="0.0064"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest",type="LIST",le="0.0128"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest",type="LIST",le="0.0256"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest",type="LIST",le="0.0512"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest",type="LIST",le="0.1024"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest",type="LIST",le="0.2048"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest",type="LIST",le="0.4096"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest",type="LIST",le="0.8192"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest",type="LIST",le="1.6384"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest",type="LIST",le="3.2768"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest",type="LIST",le="6.5536"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest",type="LIST",le="13.1072"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest",type="LIST",le="26.2144"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest",type="LIST",le="52.4288"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest",type="LIST",le="104.8576"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest",type="LIST",le="209.7152"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest",type="LIST",le="419.4304"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest",type="LIST",le="838.8608"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest",type="LIST",le="+Inf"} 1
SeaweedFS_s3_request_seconds_sum{bucket="withouttest",type="LIST"} 5.75e-05
SeaweedFS_s3_request_seconds_count{bucket="withouttest",type="LIST"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest1",type="LIST",le="0.0001"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest1",type="LIST",le="0.0002"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest1",type="LIST",le="0.0004"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest1",type="LIST",le="0.0008"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest1",type="LIST",le="0.0016"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest1",type="LIST",le="0.0032"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest1",type="LIST",le="0.0064"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest1",type="LIST",le="0.0128"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest1",type="LIST",le="0.0256"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest1",type="LIST",le="0.0512"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest1",type="LIST",le="0.1024"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest1",type="LIST",le="0.2048"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest1",type="LIST",le="0.4096"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest1",type="LIST",le="0.8192"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest1",type="LIST",le="1.6384"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest1",type="LIST",le="3.2768"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest1",type="LIST",le="6.5536"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest1",type="LIST",le="13.1072"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest1",type="LIST",le="26.2144"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest1",type="LIST",le="52.4288"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest1",type="LIST",le="104.8576"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest1",type="LIST",le="209.7152"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest1",type="LIST",le="419.4304"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest1",type="LIST",le="838.8608"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest1",type="LIST",le="+Inf"} 1
SeaweedFS_s3_request_seconds_sum{bucket="withouttest1",type="LIST"} 4.85e-05
SeaweedFS_s3_request_seconds_count{bucket="withouttest1",type="LIST"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest2",type="LIST",le="0.0001"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest2",type="LIST",le="0.0002"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest2",type="LIST",le="0.0004"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest2",type="LIST",le="0.0008"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest2",type="LIST",le="0.0016"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest2",type="LIST",le="0.0032"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest2",type="LIST",le="0.0064"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest2",type="LIST",le="0.0128"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest2",type="LIST",le="0.0256"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest2",type="LIST",le="0.0512"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest2",type="LIST",le="0.1024"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest2",type="LIST",le="0.2048"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest2",type="LIST",le="0.4096"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest2",type="LIST",le="0.8192"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest2",type="LIST",le="1.6384"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest2",type="LIST",le="3.2768"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest2",type="LIST",le="6.5536"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest2",type="LIST",le="13.1072"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest2",type="LIST",le="26.2144"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest2",type="LIST",le="52.4288"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest2",type="LIST",le="104.8576"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest2",type="LIST",le="209.7152"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest2",type="LIST",le="419.4304"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest2",type="LIST",le="838.8608"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest2",type="LIST",le="+Inf"} 1
SeaweedFS_s3_request_seconds_sum{bucket="withouttest2",type="LIST"} 5.2042e-05
SeaweedFS_s3_request_seconds_count{bucket="withouttest2",type="LIST"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest3",type="LIST",le="0.0001"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest3",type="LIST",le="0.0002"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest3",type="LIST",le="0.0004"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest3",type="LIST",le="0.0008"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest3",type="LIST",le="0.0016"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest3",type="LIST",le="0.0032"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest3",type="LIST",le="0.0064"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest3",type="LIST",le="0.0128"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest3",type="LIST",le="0.0256"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest3",type="LIST",le="0.0512"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest3",type="LIST",le="0.1024"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest3",type="LIST",le="0.2048"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest3",type="LIST",le="0.4096"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest3",type="LIST",le="0.8192"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest3",type="LIST",le="1.6384"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest3",type="LIST",le="3.2768"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest3",type="LIST",le="6.5536"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest3",type="LIST",le="13.1072"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest3",type="LIST",le="26.2144"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest3",type="LIST",le="52.4288"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest3",type="LIST",le="104.8576"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest3",type="LIST",le="209.7152"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest3",type="LIST",le="419.4304"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest3",type="LIST",le="838.8608"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest3",type="LIST",le="+Inf"} 1
SeaweedFS_s3_request_seconds_sum{bucket="withouttest3",type="LIST"} 4.475e-05
SeaweedFS_s3_request_seconds_count{bucket="withouttest3",type="LIST"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest4",type="LIST",le="0.0001"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest4",type="LIST",le="0.0002"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest4",type="LIST",le="0.0004"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest4",type="LIST",le="0.0008"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest4",type="LIST",le="0.0016"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest4",type="LIST",le="0.0032"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest4",type="LIST",le="0.0064"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest4",type="LIST",le="0.0128"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest4",type="LIST",le="0.0256"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest4",type="LIST",le="0.0512"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest4",type="LIST",le="0.1024"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest4",type="LIST",le="0.2048"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest4",type="LIST",le="0.4096"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest4",type="LIST",le="0.8192"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest4",type="LIST",le="1.6384"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest4",type="LIST",le="3.2768"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest4",type="LIST",le="6.5536"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest4",type="LIST",le="13.1072"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest4",type="LIST",le="26.2144"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest4",type="LIST",le="52.4288"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest4",type="LIST",le="104.8576"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest4",type="LIST",le="209.7152"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest4",type="LIST",le="419.4304"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest4",type="LIST",le="838.8608"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest4",type="LIST",le="+Inf"} 1
SeaweedFS_s3_request_seconds_sum{bucket="withouttest4",type="LIST"} 4.5458e-05
SeaweedFS_s3_request_seconds_count{bucket="withouttest4",type="LIST"} 1
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest5",type="LIST",le="0.0001"} 4
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest5",type="LIST",le="0.0002"} 4
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest5",type="LIST",le="0.0004"} 4
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest5",type="LIST",le="0.0008"} 4
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest5",type="LIST",le="0.0016"} 4
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest5",type="LIST",le="0.0032"} 4
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest5",type="LIST",le="0.0064"} 4
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest5",type="LIST",le="0.0128"} 4
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest5",type="LIST",le="0.0256"} 4
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest5",type="LIST",le="0.0512"} 4
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest5",type="LIST",le="0.1024"} 4
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest5",type="LIST",le="0.2048"} 4
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest5",type="LIST",le="0.4096"} 4
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest5",type="LIST",le="0.8192"} 4
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest5",type="LIST",le="1.6384"} 4
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest5",type="LIST",le="3.2768"} 4
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest5",type="LIST",le="6.5536"} 4
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest5",type="LIST",le="13.1072"} 4
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest5",type="LIST",le="26.2144"} 4
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest5",type="LIST",le="52.4288"} 4
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest5",type="LIST",le="104.8576"} 4
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest5",type="LIST",le="209.7152"} 4
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest5",type="LIST",le="419.4304"} 4
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest5",type="LIST",le="838.8608"} 4
SeaweedFS_s3_request_seconds_bucket{bucket="withouttest5",type="LIST",le="+Inf"} 4
SeaweedFS_s3_request_seconds_sum{bucket="withouttest5",type="LIST"} 0.000182916
SeaweedFS_s3_request_seconds_count{bucket="withouttest5",type="LIST"} 4
SeaweedFS_s3_request_total{bucket="withouttest",code="200",type="LIST"} 0
SeaweedFS_s3_request_total{bucket="withouttest",code="403",type="LIST"} 1
SeaweedFS_s3_request_total{bucket="withouttest1",code="200",type="LIST"} 0
SeaweedFS_s3_request_total{bucket="withouttest1",code="403",type="LIST"} 1
SeaweedFS_s3_request_total{bucket="withouttest2",code="200",type="LIST"} 0
SeaweedFS_s3_request_total{bucket="withouttest2",code="403",type="LIST"} 1
SeaweedFS_s3_request_total{bucket="withouttest3",code="200",type="LIST"} 0
SeaweedFS_s3_request_total{bucket="withouttest3",code="403",type="LIST"} 1
SeaweedFS_s3_request_total{bucket="withouttest4",code="200",type="LIST"} 0
SeaweedFS_s3_request_total{bucket="withouttest4",code="403",type="LIST"} 1
SeaweedFS_s3_request_total{bucket="withouttest5",code="200",type="LIST"} 0
SeaweedFS_s3_request_total{bucket="withouttest5",code="403",type="LIST"} 4
```

# How are we solving the problem?

There is no way to check for the presence of a bucket at stage 403, so it is more efficient not to collect them.


# How is the PR tested?

localy
```
make server
curl -s http://127.0.0.1:9324/metrics | grep LIST     
SeaweedFS_s3_request_seconds_bucket{bucket="",type="LIST",le="0.0001"} 5
SeaweedFS_s3_request_seconds_bucket{bucket="",type="LIST",le="0.0002"} 5
SeaweedFS_s3_request_seconds_bucket{bucket="",type="LIST",le="0.0004"} 5
SeaweedFS_s3_request_seconds_bucket{bucket="",type="LIST",le="0.0008"} 5
SeaweedFS_s3_request_seconds_bucket{bucket="",type="LIST",le="0.0016"} 5
SeaweedFS_s3_request_seconds_bucket{bucket="",type="LIST",le="0.0032"} 5
SeaweedFS_s3_request_seconds_bucket{bucket="",type="LIST",le="0.0064"} 5
SeaweedFS_s3_request_seconds_bucket{bucket="",type="LIST",le="0.0128"} 5
SeaweedFS_s3_request_seconds_bucket{bucket="",type="LIST",le="0.0256"} 5
SeaweedFS_s3_request_seconds_bucket{bucket="",type="LIST",le="0.0512"} 5
SeaweedFS_s3_request_seconds_bucket{bucket="",type="LIST",le="0.1024"} 5
SeaweedFS_s3_request_seconds_bucket{bucket="",type="LIST",le="0.2048"} 5
SeaweedFS_s3_request_seconds_bucket{bucket="",type="LIST",le="0.4096"} 5
SeaweedFS_s3_request_seconds_bucket{bucket="",type="LIST",le="0.8192"} 5
SeaweedFS_s3_request_seconds_bucket{bucket="",type="LIST",le="1.6384"} 5
SeaweedFS_s3_request_seconds_bucket{bucket="",type="LIST",le="3.2768"} 5
SeaweedFS_s3_request_seconds_bucket{bucket="",type="LIST",le="6.5536"} 5
SeaweedFS_s3_request_seconds_bucket{bucket="",type="LIST",le="13.1072"} 5
SeaweedFS_s3_request_seconds_bucket{bucket="",type="LIST",le="26.2144"} 5
SeaweedFS_s3_request_seconds_bucket{bucket="",type="LIST",le="52.4288"} 5
SeaweedFS_s3_request_seconds_bucket{bucket="",type="LIST",le="104.8576"} 5
SeaweedFS_s3_request_seconds_bucket{bucket="",type="LIST",le="209.7152"} 5
SeaweedFS_s3_request_seconds_bucket{bucket="",type="LIST",le="419.4304"} 5
SeaweedFS_s3_request_seconds_bucket{bucket="",type="LIST",le="838.8608"} 5
SeaweedFS_s3_request_seconds_bucket{bucket="",type="LIST",le="+Inf"} 5
SeaweedFS_s3_request_seconds_sum{bucket="",type="LIST"} 0.00023858299999999998
SeaweedFS_s3_request_seconds_count{bucket="",type="LIST"} 5
SeaweedFS_s3_request_total{bucket="",code="403",type="LIST"} 5
```

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
