### PR TITLE
Do CRC check if the buffer contains the full needle data before it is sent

### DIFF
--- a/weed/storage/volume_read.go
+++ b/weed/storage/volume_read.go
@@ -164,6 +164,13 @@ func (v *Volume) readNeedleDataInto(n *needle.Needle, readOption *ReadOption, wr
 		toWrite := min(count, int(offset+size-x))
 		if toWrite > 0 {
 			crc = crc.Update(buf[0:toWrite])
+			if offset == 0 && size == int64(n.DataSize) && int64(count) == size && (n.Checksum != crc) {
+				// This check works only if the buffer is big enough to hold the whole needle data
+				// and we ask for all needle data.
+				// Otherwise we cannot check the validity of partially aquired data.
+				stats.VolumeServerHandlerCounter.WithLabelValues(stats.ErrorCRC).Inc()
+				return fmt.Errorf("ReadNeedleData checksum %v expected %v for Needle: %v,%v", crc, n.Checksum, v.Id, n)
+			}
 			if _, err = writer.Write(buf[0:toWrite]); err != nil {
 				return fmt.Errorf("ReadNeedleData write: %v", err)
 			}
@@ -182,7 +189,7 @@ func (v *Volume) readNeedleDataInto(n *needle.Needle, readOption *ReadOption, wr
 	if offset == 0 && size == int64(n.DataSize) && (n.Checksum != crc && uint32(n.Checksum) != crc.Value()) {
 		// the crc.Value() function is to be deprecated. this double checking is for backward compatible.
 		stats.VolumeServerHandlerCounter.WithLabelValues(stats.ErrorCRC).Inc()
-		return fmt.Errorf("ReadNeedleData checksum %v expected %v", crc, n.Checksum)
+		return fmt.Errorf("ReadNeedleData checksum %v expected %v for Needle: %v,%v", crc, n.Checksum, v.Id, n)
 	}
 	return nil
 


### PR DESCRIPTION
…  to a writer.

Partial fix for issues #5972 and #5959
Also improves, error message which reports which needle and at what volume is faulty.

# What problem are we solving?

Partial fix for issue #5972, i.e. non reporting CRC errors by volume server on request of a needle.
At least we get error message when the full needle is requested.

# How are we solving the problem?

If the complete needle is already in the buffer, we check CRC before `write`. If CRC is wrong,
the error is generated and *no write* is done.

A check of partially read needle (when offset >0 and/or required data size is smaller then needle) requires change of the logic (since only full needle has error). Also if buffer is smaller than the needle, we cannot perform the CRC check before data is sent.

# How is the PR tested?

Manually:

~~~~~~~~~~~
> curl -w '%{header_json}\n%{http_code}\n'  http://redacted:18081/3,049728c119 -o tt

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0 1024k    0   144    0     0  19045      0  0:00:55 --:--:--  0:00:55 20571
curl: (18) transfer closed with 1048432 bytes remaining to read
{"accept-ranges":["bytes"],
"content-disposition":["inline; filename=\"tr\""],
"content-length":["1048576"],
"content-type":["text/plain; charset=utf-8"],
"etag":["\"4d007b3f\""],
"last-modified":["Thu, 29 Aug 2024 02:32:47 GMT"],
"server":["SeaweedFS Volume 30GB 3.72"],
"x-content-type-options":["nosniff"],
"date":["Thu, 05 Sep 2024 23:18:20 GMT"]
}
500
~~~~~~~~~~~
The error 500 is generated as it should.

Note that content length is wrong (it should be small, size of the error message) which
is properly reported in the downloaded file. I will follow up with an appropriate patch.

Also, if the 2nd healthy replica is available, the healthy file is read  from a fuse mounted filesystem, since the SeaweedFS already has logic to repeat attempt from another volume server in case of an error. I.e. this patch addresses issue #5979 with limitations about the buffer size mentioned above.

