### PR TITLE
Remove "Content-Length" header if http.Error is issued

### DIFF
--- a/weed/server/common.go
+++ b/weed/server/common.go
@@ -303,11 +303,13 @@ func ProcessRangeRequest(r *http.Request, w http.ResponseWriter, totalSize int64
 		writeFn, err := prepareWriteFn(0, totalSize)
 		if err != nil {
 			glog.Errorf("ProcessRangeRequest: %v", err)
+			w.Header().Del("Content-Length")
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return fmt.Errorf("ProcessRangeRequest: %v", err)
 		}
 		if err = writeFn(bufferedWriter); err != nil {
 			glog.Errorf("ProcessRangeRequest: %v", err)
+			w.Header().Del("Content-Length")
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return fmt.Errorf("ProcessRangeRequest: %v", err)
 		}
@@ -351,6 +353,7 @@ func ProcessRangeRequest(r *http.Request, w http.ResponseWriter, totalSize int64
 		writeFn, err := prepareWriteFn(ra.start, ra.length)
 		if err != nil {
 			glog.Errorf("ProcessRangeRequest range[0]: %+v err: %v", w.Header(), err)
+			w.Header().Del("Content-Length")
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return fmt.Errorf("ProcessRangeRequest: %v", err)
 		}
@@ -358,6 +361,7 @@ func ProcessRangeRequest(r *http.Request, w http.ResponseWriter, totalSize int64
 		err = writeFn(bufferedWriter)
 		if err != nil {
 			glog.Errorf("ProcessRangeRequest range[0]: %+v err: %v", w.Header(), err)
+			w.Header().Del("Content-Length")
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return fmt.Errorf("ProcessRangeRequest range[0]: %v", err)
 		}


### PR DESCRIPTION
The code which attempts to send the data, sets Content-Length to expected values. But if there were an error and we issue http.Error the Content-Length header should be reset to the error message length.

This should be unnesesary, since it is already done net/http package, see
https://cs.opensource.google/go/go/+/refs/tags/go1.23.0:src/net/http/server.go;drc=773767def0e0f29584a69bd760430167b7479d7d;l=2245

But maybe SeaweedFS uses an earlier version.

# What problem are we solving?

This is followup to commit bc01f09
which generates proper http headers in case of the http.Error call


# How are we solving the problem?

We Del "Content-Length" which automatically recreated with the proper length.

# How is the PR tested?
Manually

~~~~~~~~~~~~~~
curl -w '%{header_json}\n%{http_code}\n'  http://redacted.net:18081/3,049728c119 -o tt

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   144  100   144    0     0  21126      0 --:--:-- --:--:-- --:--:-- 24000
{"accept-ranges":["bytes"],
"content-disposition":["inline; filename=\"tr\""],
"content-type":["text/plain; charset=utf-8"],
"etag":["\"4d007b3f\""],
"last-modified":["Thu, 29 Aug 2024 02:32:47 GMT"],
"server":["SeaweedFS Volume 30GB 3.72"],
"x-content-type-options":["nosniff"],
"date":["Fri, 06 Sep 2024 00:08:17 GMT"],
"content-length":["144"]
}
500

~~~~~~~~~~~~~~

Note that "content-length" is correctly set for the payload 
in file "tt" with the error message
"ReadNeedleData checksum 2211509256 expected 1291877183 for Needle: 3,049728c119 Size:1048590, DataSize:1048576, Name:tr, Mime: Compressed:false"


