### PR TITLE
[Helm chart] use `/healthz` as default route in readiness/liveness

### DIFF
--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -459,7 +459,7 @@ volume:
   livenessProbe:
     enabled: true
     httpGet:
-      path: /status
+      path: /healthz
       scheme: HTTP
     initialDelaySeconds: 20
     periodSeconds: 90
@@ -472,7 +472,7 @@ volume:
   readinessProbe:
     enabled: true
     httpGet:
-      path: /status
+      path: /healthz
       scheme: HTTP
     initialDelaySeconds: 15
     periodSeconds: 15


### PR DESCRIPTION
# What problem are we solving?

As we discuss in #1627, volume server will meet issue https://github.com/seaweedfs/seaweedfs/issues/3964 if /status is used as a liveness probe/readiness probe while the size of response body is larger than 10KB, caused by https://github.com/kubernetes/kubernetes/issues/122948, and probe.Warn (instead of probe.Succeess currently) after https://github.com/kubernetes/kubernetes/pull/122970.


# How are we solving the problem?

Use `/healthz` instead of `/status` as default route in readiness/liveness in helm chart values file.

# How is the PR tested?

Helm templated and installed.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
