### PR TITLE
bug fix in the data received from cache processing

### DIFF
--- a/weed/util/chunk_cache/chunk_cache.go
+++ b/weed/util/chunk_cache/chunk_cache.go
@@ -57,7 +57,7 @@ func (c *TieredChunkCache) ReadChunkAt(data []byte, fileId string, offset uint64
 		if err != nil {
 			glog.Errorf("failed to read from memcache: %s", err)
 		}
-		if n >= int(minSize) {
+		if n == int(len(data)) {
 			return n, nil
 		}
 	}
@@ -65,24 +65,24 @@ func (c *TieredChunkCache) ReadChunkAt(data []byte, fileId string, offset uint64
 	fid, err := needle.ParseFileIdFromString(fileId)
 	if err != nil {
 		glog.Errorf("failed to parse file id %s", fileId)
-		return n, nil
+		return 0, nil
 	}
 
 	if minSize <= c.onDiskCacheSizeLimit0 {
 		n, err = c.diskCaches[0].readChunkAt(data, fid.Key, offset)
-		if n >= int(minSize) {
+		if n == int(len(data)) {
 			return
 		}
 	}
 	if minSize <= c.onDiskCacheSizeLimit1 {
 		n, err = c.diskCaches[1].readChunkAt(data, fid.Key, offset)
-		if n >= int(minSize) {
+		if n == int(len(data)) {
 			return
 		}
 	}
 	{
 		n, err = c.diskCaches[2].readChunkAt(data, fid.Key, offset)
-		if n >= int(minSize) {
+		if n == int(len(data)) {
 			return
 		}
 	}


### PR DESCRIPTION
The patch addresses issue #3745.

The cache should return the exact amount of data requested by the buffer. By construction of the cache it is always all requested data range or we have error happening.

The old use of minsize miscalculate the requested data size, if non zero offset is requested.

# What problem are we solving?

Redownloading of cached needles, if the cache request comes with non zero offset.


# How is the PR tested?

Manually.
