### PR TITLE
Feature limit caching to prescribed number of bytes per file

### DIFF
--- a/weed/filer/reader_at.go
+++ b/weed/filer/reader_at.go
@@ -199,7 +199,7 @@ func (c *ChunkReadAt) readChunkSliceAt(buffer []byte, chunkView *ChunkView, next
 		return fetchChunkRange(buffer, c.readerCache.lookupFileIdFn, chunkView.FileId, chunkView.CipherKey, chunkView.IsGzipped, int64(offset))
 	}
 
-	n, err = c.readerCache.ReadChunkAt(buffer, chunkView.FileId, chunkView.CipherKey, chunkView.IsGzipped, int64(offset), int(chunkView.ChunkSize), chunkView.ViewOffset == 0)
+	n, err = c.readerCache.ReadChunkAt(buffer, chunkView.FileId, chunkView.CipherKey, chunkView.IsGzipped, int64(offset), int(chunkView.ChunkSize), (uint64(chunkView.ViewOffset)+chunkView.ChunkSize) <= c.readerCache.chunkCache.GetMaxFilePartSizeInCache())
 	if c.lastChunkFid != chunkView.FileId {
 		if chunkView.OffsetInChunk == 0 { // start of a new chunk
 			if c.lastChunkFid != "" {

--- a/weed/filer/reader_at_test.go
+++ b/weed/filer/reader_at_test.go
@@ -31,6 +31,14 @@ func (m *mockChunkCache) ReadChunkAt(data []byte, fileId string, offset uint64) 
 func (m *mockChunkCache) SetChunk(fileId string, data []byte) {
 }
 
+func (m *mockChunkCache) GetMaxFilePartSizeInCache() (uint64) {
+	return 0
+}
+
+func (m *mockChunkCache) IsInCache(fileId string, lockNeeded bool) (answer bool) {
+	return false
+}
+
 func TestReaderAt(t *testing.T) {
 
 	visibles := NewIntervalList[*VisibleInterval]()

--- a/weed/filer/reader_cache.go
+++ b/weed/filer/reader_cache.go
@@ -61,6 +61,10 @@ func (rc *ReaderCache) MaybeCache(chunkViews *Interval[*ChunkView]) {
 		if _, found := rc.downloaders[chunkView.FileId]; found {
 			continue
 		}
+		if rc.chunkCache.IsInCache(chunkView.FileId, true) {
+			glog.V(4).Infof("%s is in cache", chunkView.FileId)
+			continue
+		}
 
 		if len(rc.downloaders) >= rc.limit {
 			// abort when slots are filled

--- a/weed/filer/reader_cache.go
+++ b/weed/filer/reader_cache.go
@@ -6,6 +6,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/util/chunk_cache"
 	util_http "github.com/seaweedfs/seaweedfs/weed/util/http"
 	"github.com/seaweedfs/seaweedfs/weed/util/mem"
@@ -73,7 +74,7 @@ func (rc *ReaderCache) MaybeCache(chunkViews *Interval[*ChunkView]) {
 
 		// glog.V(4).Infof("prefetch %s offset %d", chunkView.FileId, chunkView.ViewOffset)
 		// cache this chunk if not yet
-		cacher := newSingleChunkCacher(rc, chunkView.FileId, chunkView.CipherKey, chunkView.IsGzipped, int(chunkView.ChunkSize), chunkView.ViewOffset == 0)
+		cacher := newSingleChunkCacher(rc, chunkView.FileId, chunkView.CipherKey, chunkView.IsGzipped, int(chunkView.ChunkSize), (uint64(chunkView.ViewOffset)+chunkView.ChunkSize) <= rc.chunkCache.GetMaxFilePartSizeInCache())
 		go cacher.startCaching()
 		<-cacher.cacheStartedCh
 		rc.downloaders[chunkView.FileId] = cacher


### PR DESCRIPTION
# What problem are we solving?

The patch addresses #3745.

In particular it protects against putting the same needle into the cache multiple time. This is done by implementing a new method which checks if fileId is already in the cache.

It also does not create `downloader` if fileId is already in the cache. This would not
be normally triggered prior to the patch since only the 1st needle of a file were subject to caching.

New feature: several needles of the large file are cached as long as they collectively less than `maxFilePartSizeInCache` (new parameter in the Chunk Cache).

Rationale for the above: prior to the parch only the first needle of a file was subject to caching (2MB by default). This is quite small size for a modern data analysis. With this patch,  the cached portion of a file limited to total permitted cache size divided by 4. Which allows a user to be in control of the caching strategy.

# How is the PR tested?

Manual tests seem to work. Major speed up is seen for reading files large then 2MB on consequent requests.

