### PR TITLE
Feature: compress before encryption

### DIFF
--- a/weed/operation/upload_content.go
+++ b/weed/operation/upload_content.go
@@ -221,7 +221,7 @@ func (uploader *Uploader) doUploadData(data []byte, option *UploadOption) (uploa
 	// this could be double copying
 	clearDataLen = len(data)
 	clearData := data
-	if shouldGzipNow && !option.Cipher {
+	if shouldGzipNow {
 		compressed, compressErr := util.GzipData(data)
 		// fmt.Printf("data is compressed from %d ==> %d\n", len(data), len(compressed))
 		if compressErr == nil {
@@ -241,7 +241,7 @@ func (uploader *Uploader) doUploadData(data []byte, option *UploadOption) (uploa
 
 		// encrypt
 		cipherKey := util.GenCipherKey()
-		encryptedData, encryptionErr := util.Encrypt(clearData, cipherKey)
+		encryptedData, encryptionErr := util.Encrypt(data, cipherKey)
 		if encryptionErr != nil {
 			err = fmt.Errorf("encrypt input: %v", encryptionErr)
 			return
@@ -267,6 +267,9 @@ func (uploader *Uploader) doUploadData(data []byte, option *UploadOption) (uploa
 		uploadResult.Mime = option.MimeType
 		uploadResult.CipherKey = cipherKey
 		uploadResult.Size = uint32(clearDataLen)
+		if contentIsGzipped {
+			uploadResult.Gzip = 1
+		}
 	} else {
 		// upload data
 		uploadResult, err = uploader.upload_content(func(w io.Writer) (err error) {


### PR DESCRIPTION
Addresses #5524

Prior to the patch, the encryption disabled compression.
Now we compress (if beneficial) ==> encrypt (if requested). As result, data takes less space on the volume servers.

Lucky bonus: the old volumes/meta is compatible with new method, since `isCompressed` flag was always `false` when encryption is on.

# How are we solving the problem?

Effectively by not disabling compression.

# How is the PR tested?

filler was run with `-encryptVolumeData`, test data was saved into the weed fuse mount, the data was read back and checksums were compared. No deviation was observed. Meanwhile the volume server storage was checked, and it shows that it takes less space than uncompressed file sizes.

A relevant part of `fs.meta on_a_file`

````
      "cipherKey": "HY/Kzc9W26EQIzBC8sX7LGQ7lpzBNiTkY+DvVj7KJtA=",
      "isCompressed": true,
````
