### PR TITLE
changing FindEntry error handling in cassandra store

### DIFF
--- a/weed/filer/cassandra/cassandra_store.go
+++ b/weed/filer/cassandra/cassandra_store.go
@@ -2,6 +2,7 @@ package cassandra
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/gocql/gocql"
 	"time"
@@ -129,13 +130,10 @@ func (store *CassandraStore) FindEntry(ctx context.Context, fullpath util.FullPa
 	if err := store.session.Query(
 		"SELECT meta FROM filemeta WHERE directory=? AND name=?",
 		dir, name).Scan(&data); err != nil {
-		if err != gocql.ErrNotFound {
+		if errors.Is(err, gocql.ErrNotFound) {
 			return nil, filer_pb.ErrNotFound
 		}
-	}
-
-	if len(data) == 0 {
-		return nil, filer_pb.ErrNotFound
+		return nil, err
 	}
 
 	entry = &filer.Entry{


### PR DESCRIPTION
# What problem are we solving?
At the moment, all errors from Casandra's "FindEntry" are being replaced with "filer_pb.ErrNotFound". The (fs *File server) DeleteEntry method returns err = 'nil' if "FindEntry" returned filer_pb.ErrNotFound. Because of this, we cannot accurately determine whether the object has been deleted if cassandra was experiencing problems.


# How are we solving the problem?
It is suggested to return all errors about cassandra, except Not Found, if they were received during the data collection process

# How is the PR tested?


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
