### PR TITLE
helm chart: add s3 and s3-tls ports where missing

### DIFF
--- a/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
@@ -249,6 +249,14 @@ spec:
               name: metrics
             - containerPort: {{ .Values.filer.grpcPort }}
               #name: swfs-filer-grpc
+            {{- if .Values.filer.s3.enabled }}
+            - containerPort: {{ .Values.filer.s3.port }}
+              name: swfs-s3
+            {{- if .Values.filer.s3.httpsPort }}
+            - containerPort: {{ .Values.filer.s3.httpsPort }}
+              name: swfs-s3-tls
+            {{- end }}
+            {{- end }}
           {{- if .Values.filer.readinessProbe.enabled }}
           readinessProbe:
             httpGet:

--- a/k8s/charts/seaweedfs/templates/s3-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/s3-deployment.yaml
@@ -176,9 +176,13 @@ spec:
           ports:
             - containerPort: {{ .Values.s3.port }}
               name: swfs-s3
+            {{- if .Values.s3.httpsPort }}
+            - containerPort: {{ .Values.s3.httpsPort }}
+              name: swfs-s3-tls
+            {{- end }}
             {{- if .Values.s3.metricsPort }}
             - containerPort: {{ .Values.s3.metricsPort }}
-              name: "metrics"
+              name: metrics
             {{- end }}
           {{- if .Values.s3.readinessProbe.enabled }}
           readinessProbe:


### PR DESCRIPTION
# What problem are we solving?

The Filer StatefulSet was missing `ports` declarations for the s3 and s3-tls ports when filer.s3.enabled is true. The s3 Deployment was missing a `ports` declaration for s3-tls.

These modifications do not bring any functional changes: `ports` declaration are mostly informational.

# How are we solving the problem?

Adding the appropriate `ports` declarations in the Helm templates.

# How is the PR tested?

Manual generation and inspection of the Helm charts:
- When disabling `filer.s3.enabled`/`s3.enabled`, no swfs-s3 ports are present in the resulting chart.
- When enabling `filer.s3.enabled`/`s3.enabled`, swfs-s3 ports are present in the filer STS/s3 Deployment and their associated Services
- When enabling `filer.s3.enabled`/`s3.enabled` and setting a non-zero value for `httpsPort`, swfs-s3-tls ports are present in the filer STS/s3 Deployment and their associated Services


# Checks
- ~[ ] I have added unit tests if possible.~ (I believe there is no testing framework for the Helm chart?)
- ~[ ] I will add related wiki document changes and link to this PR after merging.~ (unapplicable)
