### PR TITLE
[filer] fix return 204 for DELETE on entry not found

### DIFF
--- a/weed/server/filer_server_handlers_write.go
+++ b/weed/server/filer_server_handlers_write.go
@@ -213,11 +213,7 @@ func (fs *FilerServer) DeleteHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	err := fs.filer.DeleteEntryMetaAndData(context.Background(), util.FullPath(objectPath), isRecursive, ignoreRecursiveError, !skipChunkDeletion, false, nil, 0)
-	if err != nil {
-		if err == filer_pb.ErrNotFound {
-			writeJsonQuiet(w, r, http.StatusNoContent, nil)
-			return
-		}
+	if err != nil && err != filer_pb.ErrNotFound {
 		glog.V(1).Infoln("deleting", objectPath, ":", err.Error())
 		writeJsonError(w, r, http.StatusInternalServerError, err)
 		return


### PR DESCRIPTION
# What problem are we solving?

```
 curl -v -X DELETE http://localhost:8888/buckets/test/lol.pdf
* Host localhost:8888 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8888...
* connect to ::1 port 8888 from ::1 port 61713 failed: Connection refused
*   Trying 127.0.0.1:8888...
* Connected to localhost (127.0.0.1) port 8888
> DELETE /buckets/test/lol.pdf HTTP/1.1
> Host: localhost:8888
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 200 OK
< Server: SeaweedFS 30GB 3.73
< Date: Mon, 16 Sep 2024 07:48:53 GMT
< Content-Length: 0

```

# How are we solving the problem?


```
curl -v -X DELETE http://localhost:8888/buckets/test/lol.pdf
* Host localhost:8888 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8888...
* connect to ::1 port 8888 from ::1 port 62455 failed: Connection refused
*   Trying 127.0.0.1:8888...
* Connected to localhost (127.0.0.1) port 8888
> DELETE /buckets/test/lol.pdf HTTP/1.1
> Host: localhost:8888
> User-Agent: curl/8.7.1
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 204 No Content
< Server: SeaweedFS 30GB 3.73
< Date: Mon, 16 Sep 2024 07:54:06 GMT

```

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
