### PR TITLE
fix invalid file read

### DIFF
--- a/weed/filer/filechunk_group.go
+++ b/weed/filer/filechunk_group.go
@@ -1,6 +1,7 @@
 package filer
 
 import (
+	"io"
 	"sync"
 
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
@@ -46,6 +47,9 @@ func (group *ChunkGroup) AddChunk(chunk *filer_pb.FileChunk) error {
 }
 
 func (group *ChunkGroup) ReadDataAt(fileSize int64, buff []byte, offset int64) (n int, tsNs int64, err error) {
+	if offset >= fileSize {
+		return 0, 0, io.EOF
+	}
 
 	group.sectionsLock.RLock()
 	defer group.sectionsLock.RUnlock()

--- a/weed/mount/filehandle_read.go
+++ b/weed/mount/filehandle_read.go
@@ -47,6 +47,9 @@ func (fh *FileHandle) readFromChunks(buff []byte, offset int64) (int64, int64, e
 	if fileSize == 0 {
 		glog.V(1).Infof("empty fh %v", fileFullPath)
 		return 0, 0, io.EOF
+	} else if offset >= fileSize {
+		glog.V(1).Infof("invalid read, fileSize %d, offset %d for %s", fileSize, offset, fileFullPath)
+		return 0, 0, io.EOF
 	}
 
 	if offset < int64(len(entry.Content)) {
@@ -66,7 +69,7 @@ func (fh *FileHandle) readFromChunks(buff []byte, offset int64) (int64, int64, e
 	return int64(totalRead), ts, err
 }
 
-func (fh *FileHandle) downloadRemoteEntry(entry *LockedEntry) (error) {
+func (fh *FileHandle) downloadRemoteEntry(entry *LockedEntry) error {
 
 	fileFullPath := fh.FullPath()
 	dir, _ := fileFullPath.DirAndName()


### PR DESCRIPTION
# What problem are we solving?
I encounter the following panic, function `Read` tries to read offset larger than file size.

```
ActiveLock 83 Read unlocked 2119352381 type=0 with waiters 0 active r0 w0.
ActiveLock 84 Read locked 2119352381 type=0 with waiters 0 active r0 w0.
I0907 12:06:52.668940 reader_at.go:179 zero2 [0,1048576) of file size 13 bytes
I0907 12:06:52.669356 page_writer.go:54 ReadDirtyDataAt 2119352381 [61931325, 62979901)
ActiveLock 84 Read unlocked 2119352381 type=0 with waiters 0 active r0 w0.
ActiveLock 85 Read locked 2119352381 type=0 with waiters 0 active r0 w0.
I0907 12:06:52.686595 reader_at.go:179 zero2 [0,1048576) of file size 13 bytes
I0907 12:06:52.686950 page_writer.go:54 ReadDirtyDataAt 2119352381 [62979901, 64028477)
ActiveLock 85 Read unlocked 2119352381 type=0 with waiters 0 active r0 w0.
ActiveLock 86 Read locked 2119352381 type=0 with waiters 0 active r0 w0.
I0907 12:06:52.704842 reader_at.go:179 zero2 [0,1048576) of file size 13 bytes
I0907 12:06:52.705250 page_writer.go:54 ReadDirtyDataAt 2119352381 [64028477, 65077053)
ActiveLock 86 Read unlocked 2119352381 type=0 with waiters 0 active r0 w0.
ActiveLock 87 Read locked 2119352381 type=0 with waiters 0 active r0 w0.
I0907 12:06:52.722847 reader_at.go:179 zero2 [0,1048576) of file size 13 bytes
I0907 12:06:52.723202 page_writer.go:54 ReadDirtyDataAt 2119352381 [65077053, 66125629)
ActiveLock 87 Read unlocked 2119352381 type=0 with waiters 0 active r0 w0.
ActiveLock 88 Read locked 2119352381 type=0 with waiters 0 active r0 w0.
I0907 12:06:52.739924 reader_at.go:179 zero2 [0,983235) of file size 13 bytes
I0907 12:06:52.740297 page_writer.go:54 ReadDirtyDataAt 2119352381 [66125629, 67174205)
ActiveLock 88 Read unlocked 2119352381 type=0 with waiters 0 active r0 w0.
panic: runtime error: slice bounds out of range [:-66125616]

goroutine 477 [running]:
github.com/seaweedfs/seaweedfs/weed/mount.(*WFS).Read(0x140007595d8?, 0x140001b5b88?, 0x140001b5d48, {0x14003a90000, 0x100000, 0x100000})
	/Users/lou/ws/jb/seaweedfs/weed/mount/weedfs_file_read.go:74 +0x4cc
github.com/hanwen/go-fuse/v2/fuse.doRead(0x14000398340, 0x140001b5b88)
	/Users/lou/go/pkg/mod/github.com/hanwen/go-fuse/v2@v2.5.1/fuse/opcode.go:398 +0x80
github.com/hanwen/go-fuse/v2/fuse.(*Server).handleRequest(0x14000398340, 0x140001b5b88)
	/Users/lou/go/pkg/mod/github.com/hanwen/go-fuse/v2@v2.5.1/fuse/server.go:527 +0x26c
created by github.com/hanwen/go-fuse/v2/fuse.(*Server).loop in goroutine 1
	/Users/lou/go/pkg/mod/github.com/hanwen/go-fuse/v2@v2.5.1/fuse/server.go:498 +0xdc
```


# How are we solving the problem?
check if offset > fizeSize, if yes, return 0 and EOF


# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
