### PR TITLE
Add Prometheus Metric to Expose Filer inFlightDataSize(#6017)

### DIFF
--- a/weed/server/filer_server.go
+++ b/weed/server/filer_server.go
@@ -159,6 +159,7 @@ func NewFilerServer(defaultMux, readonlyMux *http.ServeMux, option *FilerOption)
 	fs.checkWithMaster()
 
 	go stats.LoopPushingMetric("filer", string(fs.option.Host), fs.metricsAddress, fs.metricsIntervalSec)
+	go fs.loopUpdateMetric()
 	go fs.filer.KeepMasterClientConnected(context.Background())
 
 	if !util.LoadConfiguration("filer", false) {

--- a/weed/server/filer_server_metric.go
+++ b/weed/server/filer_server_metric.go
@@ -1,0 +1,20 @@
+package weed_server
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/stats"
+)
+
+func (fs *FilerServer) loopUpdateMetric() {
+
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		inFlightDataSize := atomic.LoadInt64(&fs.inFlightDataSize)
+		stats.FilerInFlightDataSizeGauge.Set(float64(inFlightDataSize))
+	}
+
+}

--- a/weed/stats/metrics.go
+++ b/weed/stats/metrics.go
@@ -135,6 +135,14 @@ var (
 			Help:      "The last send timestamp of the filer subscription.",
 		}, []string{"sourceFiler", "clientName", "path"})
 
+	FilerInFlightDataSizeGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Subsystem: "filer",
+			Name:      "in_flight_data_size",
+			Help:      "",
+		})
+
 	FilerStoreCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: Namespace,
@@ -299,6 +307,7 @@ func init() {
 	Gather.MustRegister(FilerStoreHistogram)
 	Gather.MustRegister(FilerSyncOffsetGauge)
 	Gather.MustRegister(FilerServerLastSendTsOfSubscribeGauge)
+	Gather.MustRegister(FilerInFlightDataSizeGauge)
 	Gather.MustRegister(collectors.NewGoCollector())
 	Gather.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 


### PR DESCRIPTION
# What problem are we solving?
Adding a metric to expose the concurrent data volume for uploads in the filer, reflecting the system's throughput.
#6017 


# How are we solving the problem?
Adding a Prometheus gauge metric, and starting a goroutine in the NewFilerServer method to periodically read inFlightDataSize and set the gauge.



# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
