### PR TITLE
master:fix empty target in Build()

### DIFF
--- a/weed/server/raft_server.go
+++ b/weed/server/raft_server.go
@@ -130,7 +130,7 @@ func NewRaftServer(option *RaftServerOption) (*RaftServer, error) {
 	}
 
 	stateMachine := StateMachine{topo: option.Topo}
-	s.raftServer, err = raft.NewServer(string(s.serverAddr), s.dataDir, transporter, stateMachine, option.Topo, "")
+	s.raftServer, err = raft.NewServer(string(s.serverAddr), s.dataDir, transporter, stateMachine, option.Topo, s.serverAddr.ToGrpcAddress())
 	if err != nil {
 		glog.V(0).Infoln(err)
 		return nil, err


### PR DESCRIPTION
# What problem are we solving?
master  failed  send rpc to peers for empty grpc address.
![image](https://github.com/user-attachments/assets/7bcce2ac-ab24-4733-93e1-1bd8e51dad9c)

SeaweedFS master start with null string for connectionString itself, only set peers' connectionString.
it works for most cases,because leader do not need to flush rpc to itself.
When it  takes a snapshot, master will recoder all connectionStrings to file include itself.
![image](https://github.com/user-attachments/assets/956399b5-de0b-44e1-b093-49082e27ae51)
  
1. if the follower restart it will reload leaders snapshot, then the leader's connectionString will be empty from view of the follower.
2. This follower becomes a leader for some reason, it will fail to the flush rpc to the original leader.

# How are we solving the problem?
Init connectionString with server's grpc value.


# How is the PR tested?
check snapshot file.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
