### PR TITLE
Update volume_grpc_erasure_coding.go

### DIFF
--- a/weed/server/volume_grpc_erasure_coding.go
+++ b/weed/server/volume_grpc_erasure_coding.go
@@ -192,6 +192,11 @@ func (vs *VolumeServer) VolumeEcShardsCopy(ctx context.Context, req *volume_serv
 			}
 		}
 
+		if req.CopyEcxFile { //when location no volume before copy
+			glog.V(0).Infof("Re LoadNewVolumes: %v", req)
+			vs.store.LoadNewVolumes()
+		}
+
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
fix 'no space left' bug

# What problem are we solving?
seaweedfs-master[111701]: missing shard 105.5
seaweedfs-master[111701]: 10.0.x.x:10009 failed to copy 105.6 from 10.0.x.1:10003: rpc error: code = Unknown desc = no space left
seaweedfs-master[111701]: 10.0.x.x:10009 failed to copy 105.7 from 10.0.x.1:10024: rpc error: code = Unknown desc = no space left
seaweedfs-master[111701]: 10.0.x.x:10009 failed to copy 105.8 from 10.0.x.2:10022: rpc error: code = Unknown desc = no space left
seaweedfs-master[111701]: 10.0.x.x:10009 failed to copy 105.9 from 10.0.x.3:10018: rpc error: code = Unknown desc = no space left
seaweedfs-master[111701]: missing shard 105.10
seaweedfs-master[111701]: 10.0.x.x:10009 failed to copy 105.11 from 10.0.x.3:10009: rpc error: code = Unknown desc = no space left
seaweedfs-master[111701]: 10.0.x.x:10009 failed to copy 105.12 from 10.0.x.3:10001: rpc error: code = Unknown desc = no space left
seaweedfs-master[111701]: 10.0.x.x:10009 failed to copy 105.13 from 10.0.x.4:10019: rpc error: code = Unknown desc = no space left
seaweedfs-master[111701]: I0925 14:12:31.906140 master_server.go:319 error: 1 shards are not enough to recover volume 105

# How are we solving the problem?
LoadNewVolumes after copy


# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
