### PR TITLE
Update volume_grpc_erasure_coding.go , fix no space left bug

### DIFF
--- a/weed/server/volume_grpc_erasure_coding.go
+++ b/weed/server/volume_grpc_erasure_coding.go
@@ -150,8 +150,10 @@ func (vs *VolumeServer) VolumeEcShardsCopy(ctx context.Context, req *volume_serv
 		})
 	} else {
 		location = vs.store.FindFreeLocation(func(location *storage.DiskLocation) bool {
-			_, found := location.FindEcVolume(needle.VolumeId(req.VolumeId))
-			return found
+			//(location.FindEcVolume) This method is error, will cause location is nil, redundant judgment
+			// _, found := location.FindEcVolume(needle.VolumeId(req.VolumeId))
+			// return found
+			return true
 		})
 	}
 	if location == nil {
@@ -191,12 +193,6 @@ func (vs *VolumeServer) VolumeEcShardsCopy(ctx context.Context, req *volume_serv
 				return err
 			}
 		}
-
-		if req.CopyEcxFile { //when location no volume before copy
-			glog.V(0).Infof("Re LoadNewVolumes: %v", req)
-			vs.store.LoadNewVolumes()
-		}
-
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
fix ‘no space left’ bug

# What problem are we solving?

If current location found current Volume ec, will cause location is nil ( ' no space left '), redundant judgment


# How are we solving the problem?

Return true or remove func

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
