### PR TITLE
k8s/charts/seaweedfs/templates: s3 deployment: rm blocking matchLabel

### DIFF
--- a/k8s/charts/seaweedfs/templates/s3-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/s3-deployment.yaml
@@ -14,7 +14,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
-      helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: s3
   template:


### PR DESCRIPTION
`helm upgrade` has then following error

> Error: UPGRADE FAILED: release objectstorage failed, and has been rolled back due to atomic being set: cannot patch "seaweedfs-s3" with kind Deployment: Deployment.apps "seaweedfs-s3" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app.kubernetes.io/component":"s3", "app.kubernetes.io/instance":"objectstorage", "app.kubernetes.io/name":"seaweedfs", "helm.sh/chart":"seaweedfs-3.66.0"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable

# How are we solving the problem?
Remove helm.sh/chart from s3 selector.matchLabels

# Env

```shell
/usr/local/bin/helm3 version
version.BuildInfo{Version:"v3.8.2", GitCommit:"6e3701edea09e5d55a8ca2aae03a68917630e91b", GitTreeState:"clean", GoVersion:"go1.17.5"}
/cnab/app # /usr/local/bin/kubectl version
Client Version: v1.28.3
Kustomize Version: v5.0.4-0.20230601165947-6ce0bf390ce3
Server Version: v1.28.3
```

Related to https://github.com/seaweedfs/seaweedfs/issues/5263
