### PR TITLE
feat: Add support for "custom" dataDirs type for volume server in kubernetes helm chart

### DIFF
--- a/k8s/charts/seaweedfs/templates/volume-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/volume-statefulset.yaml
@@ -176,8 +176,10 @@ spec:
                 -mserver={{ if .Values.global.masterServer }}{{.Values.global.masterServer}}{{ else }}{{ range $index := until (.Values.master.replicas | int) }}${SEAWEEDFS_FULLNAME}-master-{{ $index }}.${SEAWEEDFS_FULLNAME}-master.{{ $.Release.Namespace }}:{{ $.Values.master.port }}{{ if lt $index (sub ($.Values.master.replicas | int) 1) }},{{ end }}{{ end }}{{ end }}
           volumeMounts:
             {{- range $dir := .Values.volume.dataDirs }}
+            {{- if not ( eq $dir.type "custom" ) }}
             - name: {{ $dir.name }}
               mountPath: "/{{ $dir.name }}/"
+            {{- end }}
             {{- end }}
             {{- if .Values.volume.logs }}
             - name: logs

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -301,9 +301,9 @@ volume:
   #   - name: data
   #     type: "emptyDir"
   #     maxVolumes: 0  # If set to zero on non-windows OS, the limit will be auto configured. (default "7")
-  # 
+  #
   # If these don't meet your needs, you can use "custom" here along with extraVolumes and extraVolumeMounts
-  # Particularly useful when using more than 1 for the volume server replicas. 
+  # Particularly useful when using more than 1 for the volume server replicas.
   #   - name: data
   #     type: "custom"
   #     maxVolumes: 0  # If set to zero on non-windows OS, the limit will be auto configured. (default "7")
@@ -394,7 +394,7 @@ volume:
   #     subPathExpr: $(POD_NAME)
   # extraVolumes: |
   #   - name: drive
-  #     hostPath: 
+  #     hostPath:
   #       path: /var/mnt/
   extraVolumes: ""
   extraVolumeMounts: ""

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -301,6 +301,12 @@ volume:
   #   - name: data
   #     type: "emptyDir"
   #     maxVolumes: 0  # If set to zero on non-windows OS, the limit will be auto configured. (default "7")
+  # 
+  # If these don't meet your needs, you can use "custom" here along with extraVolumes and extraVolumeMounts
+  # Particularly useful when using more than 1 for the volume server replicas. 
+  #   - name: data
+  #     type: "custom"
+  #     maxVolumes: 0  # If set to zero on non-windows OS, the limit will be auto configured. (default "7")
 
   dataDirs:
   - name: data1
@@ -381,6 +387,15 @@ volume:
   sidecars: []
   initContainers: ""
 
+  # Example for use when using more than 1 volume server replica
+  # extraVolumeMounts: |
+  #   - name: drive
+  #     mountPath: /drive
+  #     subPathExpr: $(POD_NAME)
+  # extraVolumes: |
+  #   - name: drive
+  #     hostPath: 
+  #       path: /var/mnt/
   extraVolumes: ""
   extraVolumeMounts: ""
 


### PR DESCRIPTION
# What problem are we solving?
The helm chart doesn't seem to support running multiple volume servers with host paths for mounts. 

I have 5 drives mounted in one machine. With a replication of 000 I could mount all the drives into the volume server and it would work. But to support replication between drives I found that really needed multiple volume servers. When I tried to increase the number of replicas I found the mounts weren't generic enough and I could get 1 pod running but not any more. 

Ultimately I could use `extraVolumeMounts` and `subPathExpr: $(POD_NAME)` to generically mount in the pod, but  the dataDirs logic always created a volumeMount that conflicted with anything I put in extraVolumeMounts. 


# How are we solving the problem?
Added a "custom" type for the dataDirs parameter to allow use of extraVolumes and extraVolumeMounts 

After looking over the code I realized there was just one place I needed to change to support use of extraVolumeMounts as a dataDirs option. It was to skip adding the dataDirs volume to the volumeMount if the type is custom. 


# How is the PR tested?
Needed for my cluster, so that's where I've tested it. You can find my implementation here: https://github.com/OwnYourIO/SpencersLab/blob/9be00356009ee30951da16e7fde31ffc9c30224c/services/infra/prod/values.yaml#L388-L398

Probably worth noting I wrote this code in the wee hours and haven't really deployed any data yet. That'll come this week. 


# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.

# Other comments
- I put some documentation in the code itself. Would love some pointers on where else documentation might go. 
- This adds support for using extraVolumeMounts for dataDirs but another approach would be to add support for subPathExpr directly. 