### PR TITLE
Fix dataDirs.maxVolumes default value when not included in a values.yaml

### DIFF
--- a/k8s/charts/seaweedfs/templates/volume-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/volume-statefulset.yaml
@@ -146,7 +146,9 @@ spec:
                 {{- if .Values.volume.idx }}
                 -dir.idx=/idx \
                 {{- end }}
-                -max {{range $index, $dir :=  .Values.volume.dataDirs }}{{if ne $index 0}},{{end}}{{$dir.maxVolumes}}{{end}} \
+                -max {{range $index, $dir :=  .Values.volume.dataDirs }}{{if ne $index 0}},{{end}}
+                {{- if eq ($dir.maxVolumes | toString) "0" }}0{{ else if not $dir.maxVolumes }}7{{ else }}{{$dir.maxVolumes}}{{ end }}
+                {{- end }} \
                 {{- if .Values.volume.rack }}
                 -rack={{ .Values.volume.rack }} \
                 {{- end }}


### PR DESCRIPTION
# What problem are we solving?
This PR addresses open issue #6106. Currently, when deploying SeaweedFS via a Helm chart, if custom dataDirs are specified in the values.yaml file and the maxVolumes parameter is not included, the deployment fails with the following error:

"volume.go:169 The max specified in -max not a valid number -ip.bind=0.0.0.0"

<img width="535" alt="Screenshot 2024-10-13 at 12 16 15 PM" src="https://github.com/user-attachments/assets/7daaa7c9-84e9-489e-be99-364b6844bee9">

# How are we solving the problem?

The following comment is present in the default values.yaml file included in the chart:

"maxVolumes: 0  # If set to zero on non-windows OS, the limit will be auto configured. (default "7")

I interpreted this comment as three cases:

1. If maxVolumes is not present, set the default to 7,
2. If maxVolumes is present and is equal to 0, set the value to 0, or
3. If maxVolumes is present and is not equal to 0, set the value to the number specified

I found that I could not use a basic "empty" check in the YAML template, because in the case where maxVolumes was 0 the parameter was evaluated as empty and would not preserve that value. So I had to add an additional if/else statement to address case 2. It may be the case that I missed something and my edits could be shortened to a single if/else.

# How is the PR tested?

After making my edits, I used Helm's built in template command with debugging enabled to ensure correct behavior.

I specified three different data directories to address each of the cases listed above. Given following values.yaml file, we'd expect to see three values corresponding to the three dataDirs specified: 4,0,7

<img width="353" alt="Screenshot 2024-10-13 at 1 55 06 PM" src="https://github.com/user-attachments/assets/03a5ea7f-9130-4ca9-b41b-ecc4a979e789">

Now, the container command (specifically the -max parameter) is filled in correctly:

<img width="512" alt="Screenshot 2024-10-13 at 1 55 17 PM" src="https://github.com/user-attachments/assets/eb08b821-c0c2-4c8b-b9c1-bc03ec65aea1">

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.