### PR TITLE
Support topologySpreadConstraints in helm chart

### DIFF
--- a/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
@@ -57,6 +57,10 @@ spec:
       affinity:
         {{ tpl .Values.filer.affinity . | nindent 8 | trim }}
       {{- end }}
+      {{- with .Values.filer.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.filer.tolerations }}
       tolerations:
         {{ tpl .Values.filer.tolerations . | nindent 8 | trim }}

--- a/k8s/charts/seaweedfs/templates/master-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/master-statefulset.yaml
@@ -50,6 +50,10 @@ spec:
       affinity:
         {{ tpl .Values.master.affinity . | nindent 8 | trim }}
       {{- end }}
+      {{- with .Values.master.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.master.tolerations }}
       tolerations:
         {{ tpl .Values.master.tolerations . | nindent 8 | trim }}

--- a/k8s/charts/seaweedfs/templates/volume-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/volume-statefulset.yaml
@@ -43,6 +43,10 @@ spec:
       affinity:
         {{ tpl .Values.volume.affinity . | nindent 8 | trim }}
       {{- end }}
+      {{- with .Values.volume.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       restartPolicy: {{ default .Values.global.restartPolicy .Values.volume.restartPolicy }}
       {{- if .Values.volume.tolerations }}
       tolerations:

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -166,6 +166,11 @@ master:
               app.kubernetes.io/component: master
           topologyKey: kubernetes.io/hostname
 
+  # Topology Spread Constraints Settings
+  # This should map directly to the value of the topologySpreadConstraints
+  # for a PodSpec. By Default no constraints are set.
+  topologySpreadConstraints: {}
+
   # Toleration Settings for master pods
   # This should be a multi-line string matching the Toleration array
   # in a PodSpec.
@@ -421,6 +426,11 @@ volume:
               app.kubernetes.io/component: volume
           topologyKey: kubernetes.io/hostname
 
+  # Topology Spread Constraints Settings
+  # This should map directly to the value of the topologySpreadConstraints
+  # for a PodSpec. By Default no constraints are set.
+  topologySpreadConstraints: {}
+
   # Resource requests, limits, etc. for the server cluster placement. This
   # should map directly to the value of the resources field for a PodSpec,
   # formatted as a multi-line string. By default no direct resource request
@@ -614,6 +624,11 @@ filer:
               app.kubernetes.io/instance: {{ .Release.Name }}
               app.kubernetes.io/component: filer
           topologyKey: kubernetes.io/hostname
+
+  # Topology Spread Constraints Settings
+  # This should map directly to the value of the topologySpreadConstraints
+  # for a PodSpec. By Default no constraints are set.
+  topologySpreadConstraints: {}
 
   # updatePartition is used to control a careful rolling update of SeaweedFS
   # masters.


### PR DESCRIPTION
# What problem are we solving?

Trying to spread the pods across AZs.

# How are we solving the problem?

By providing an option to specify `topologySpreadConstraints`.

# How is the PR tested?

Helm was deployed to an existing cluster and proper topology spreading was verified.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
