### PR TITLE
feat: add resource annotations

### DIFF
--- a/k8s/charts/seaweedfs/templates/filer-cert.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-cert.yaml
@@ -10,6 +10,10 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: filer
+  {{- if .Values.filer.annotations }}
+  annotations:
+    {{- toYaml .Values.filer.annotations | nindent 4 }}
+  {{- end }}
 spec:
   secretName: {{ template "seaweedfs.name" . }}-filer-cert
   issuerRef:

--- a/k8s/charts/seaweedfs/templates/filer-service-client.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-service-client.yaml
@@ -13,6 +13,10 @@ metadata:
 {{- if .Values.filer.metricsPort }}
     monitoring: "true"
 {{- end }}
+{{- if .Values.filer.annotations }}
+  annotations:
+    {{- toYaml .Values.filer.annotations | nindent 4 }}
+{{- end }}
 spec:
   clusterIP: None
   ports:

--- a/k8s/charts/seaweedfs/templates/filer-service.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-service.yaml
@@ -12,6 +12,10 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: filer
+{{- if .Values.filer.annotations }}
+  annotations:
+    {{- toYaml .Values.filer.annotations | nindent 4 }}
+{{- end }}
 spec:
   clusterIP: None
   publishNotReadyAddresses: true

--- a/k8s/charts/seaweedfs/templates/filer-servicemonitor.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-servicemonitor.yaml
@@ -15,6 +15,10 @@ metadata:
     {{- with .Values.global.monitoring.additionalLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+{{- if .Values.filer.annotations }}
+  annotations:
+    {{- toYaml .Values.filer.annotations | nindent 4 }}
+{{- end }}
 spec:
   endpoints:
     - interval: 30s

--- a/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
@@ -10,6 +10,10 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: filer
+{{- if .Values.filer.annotations }}
+  annotations:
+    {{- toYaml .Values.filer.annotations | nindent 4 }}
+{{- end }}
 spec:
   serviceName: {{ template "seaweedfs.name" . }}-filer
   podManagementPolicy: {{ .Values.filer.podManagementPolicy }}

--- a/k8s/charts/seaweedfs/templates/master-cert.yaml
+++ b/k8s/charts/seaweedfs/templates/master-cert.yaml
@@ -10,6 +10,10 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: master
+{{- if .Values.master.annotations }}
+  annotations:
+    {{- toYaml .Values.master.annotations | nindent 4 }}
+{{- end }}
 spec:
   secretName: {{ template "seaweedfs.name" . }}-master-cert
   issuerRef:

--- a/k8s/charts/seaweedfs/templates/master-configmap.yaml
+++ b/k8s/charts/seaweedfs/templates/master-configmap.yaml
@@ -9,6 +9,10 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Values.master.annotations }}
+  annotations:
+    {{- toYaml .Values.master.annotations | nindent 4 }}
+{{- end }}
 data:
   master.toml: |-
     {{ .Values.master.config | nindent 4 }}

--- a/k8s/charts/seaweedfs/templates/master-service.yaml
+++ b/k8s/charts/seaweedfs/templates/master-service.yaml
@@ -11,6 +11,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+{{- if .Values.master.annotations }}
+    {{- toYaml .Values.master.annotations | nindent 4 }}
+{{- end }}
 spec:
   clusterIP: None
   publishNotReadyAddresses: true

--- a/k8s/charts/seaweedfs/templates/master-servicemonitor.yaml
+++ b/k8s/charts/seaweedfs/templates/master-servicemonitor.yaml
@@ -15,6 +15,10 @@ metadata:
     {{- with .Values.global.monitoring.additionalLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+{{- if .Values.master.annotations }}
+  annotations:
+    {{- toYaml .Values.master.annotations | nindent 4 }}
+{{- end }}
 spec:
   endpoints:
     - interval: 30s

--- a/k8s/charts/seaweedfs/templates/master-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/master-statefulset.yaml
@@ -9,6 +9,10 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Values.master.annotations }}
+  annotations:
+    {{- toYaml .Values.master.annotations | nindent 4 }}
+{{- end }}
 spec:
   serviceName: {{ template "seaweedfs.name" . }}-master
   podManagementPolicy: {{ .Values.master.podManagementPolicy }}

--- a/k8s/charts/seaweedfs/templates/s3-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/s3-deployment.yaml
@@ -9,6 +9,10 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Values.s3.annotations }}
+  annotations:
+    {{- toYaml .Values.s3.annotations | nindent 4 }}
+{{- end }}
 spec:
   replicas: {{ .Values.s3.replicas }}
   selector:

--- a/k8s/charts/seaweedfs/templates/s3-service.yaml
+++ b/k8s/charts/seaweedfs/templates/s3-service.yaml
@@ -9,6 +9,10 @@ metadata:
     app.kubernetes.io/component: s3
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.s3.annotations }}
+  annotations:
+    {{- toYaml .Values.s3.annotations | nindent 4 }}
+{{- end }}
 spec:
   internalTrafficPolicy: {{ .Values.s3.internalTrafficPolicy | default "Cluster" }}
   ports:

--- a/k8s/charts/seaweedfs/templates/s3-servicemonitor.yaml
+++ b/k8s/charts/seaweedfs/templates/s3-servicemonitor.yaml
@@ -15,6 +15,10 @@ metadata:
     {{- with .Values.global.monitoring.additionalLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+{{- if .Values.s3.annotations }}
+  annotations:
+    {{- toYaml .Values.s3.annotations | nindent 4 }}
+{{- end }}
 spec:
   endpoints:
     - interval: 30s

--- a/k8s/charts/seaweedfs/templates/volume-cert.yaml
+++ b/k8s/charts/seaweedfs/templates/volume-cert.yaml
@@ -10,6 +10,10 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: volume
+{{- if .Values.volume.annotations }}
+  annotations:
+    {{- toYaml .Values.volume.annotations | nindent 4 }}
+{{- end }}
 spec:
   secretName: {{ template "seaweedfs.name" . }}-volume-cert
   issuerRef:

--- a/k8s/charts/seaweedfs/templates/volume-service.yaml
+++ b/k8s/charts/seaweedfs/templates/volume-service.yaml
@@ -9,6 +9,10 @@ metadata:
     app.kubernetes.io/component: volume
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.volume.annotations }}
+  annotations:
+    {{- toYaml .Values.volume.annotations | nindent 4 }}
+{{- end }}
 spec:
   clusterIP: None
   internalTrafficPolicy: {{ .Values.volume.internalTrafficPolicy | default "Cluster" }}

--- a/k8s/charts/seaweedfs/templates/volume-servicemonitor.yaml
+++ b/k8s/charts/seaweedfs/templates/volume-servicemonitor.yaml
@@ -15,6 +15,10 @@ metadata:
     {{- with .Values.global.monitoring.additionalLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+{{- if .Values.volume.annotations }}
+  annotations:
+    {{- toYaml .Values.volume.annotations | nindent 4 }}
+{{- end }}
 spec:
   endpoints:
     - interval: 30s

--- a/k8s/charts/seaweedfs/templates/volume-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/volume-statefulset.yaml
@@ -9,6 +9,10 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Values.volume.annotations }}
+  annotations:
+    {{- toYaml .Values.volume.annotations | nindent 4 }}
+{{- end }}
 spec:
   serviceName: {{ template "seaweedfs.name" . }}-volume
   replicas: {{ .Values.volume.replicas }}

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -140,6 +140,9 @@ master:
   # Annotations to be added to the master pods
   podAnnotations: {}
 
+  # Annotations to be added to the master resources
+  annotations: {}
+
   ## Set podManagementPolicy
   podManagementPolicy: Parallel
 
@@ -410,6 +413,9 @@ volume:
   # Annotations to be added to the volume pods
   podAnnotations: {}
 
+  # Annotations to be added to the volume resources
+  annotations: {}
+
   ## Set podManagementPolicy
   podManagementPolicy: Parallel
 
@@ -608,6 +614,9 @@ filer:
 
   # Annotations to be added to the filer pods
   podAnnotations: {}
+
+  # Annotations to be added to the filer resource
+  annotations: {}
 
   ## Set podManagementPolicy
   podManagementPolicy: Parallel
@@ -827,6 +836,9 @@ s3:
 
   # Annotations to be added to the s3 pods
   podAnnotations: {}
+
+  # Annotations to be added to the s3 resources
+  annotations: {}
 
   # Resource requests, limits, etc. for the server cluster placement. This
   # should map directly to the value of the resources field for a PodSpec,


### PR DESCRIPTION
Added resource-level annotations to be able to set helm chart hooks globally

# What problem are we solving?
I want to add SeaweedFS as a subchart of other Helm Charts, and I want to use Helm Hooks to install it before the parent Helm Chart.


# How are we solving the problem?
Adding annotations at the resource level for the resources


# How is the PR tested?
`helm template seaweedfs k8s/charts/seaweedfs -f values-override.yml`


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
