### PR TITLE
fix permission check in put request

### DIFF
--- a/weed/server/filer_server_handlers_write_autochunk.go
+++ b/weed/server/filer_server_handlers_write_autochunk.go
@@ -126,7 +126,7 @@ func (fs *FilerServer) doPutAutoChunk(ctx context.Context, w http.ResponseWriter
 		contentType = ""
 	}
 
-	if err := fs.checkPermissions(ctx, r, ""); err != nil {
+	if err := fs.checkPermissions(ctx, r, fileName); err != nil {
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
# What problem are we solving?
to resolve comment: https://github.com/seaweedfs/seaweedfs/pull/5983/files#r1803961113


# How are we solving the problem?
pass correct file name instead of empty string


# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
