### PR TITLE
Support specifying rack and dataCenter for filers in helm chart

### DIFF
--- a/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
@@ -190,6 +190,12 @@ spec:
               {{- if .Values.filer.filerGroup}}
               -filerGroup={{ .Values.filer.filerGroup}} \
               {{- end }}
+              {{- if .Values.filer.rack }}
+              -rack={{ .Values.filer.rack }} \
+              {{- end }}
+              {{- if .Values.filer.dataCenter }}
+              -dataCenter={{ .Values.filer.dataCenter }} \
+              {{- end }}
               {{- if .Values.filer.s3.enabled }}
               -s3 \
               -s3.port={{ .Values.filer.s3.port }} \

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -521,6 +521,10 @@ filer:
   metricsPort: 9327
   loggingOverrideLevel: null
   filerGroup: ""
+  # prefer to read and write to volumes in this data center (not set by default)
+  dataCenter: null
+  # prefer to write to volumes in this rack (not set by default)
+  rack: null
   #  replication type is XYZ:
   # X number of replica in other data centers
   # Y number of replica in other racks in the same data center


### PR DESCRIPTION
# What problem are we solving?

Trying to pass additional parameters to filers.

# How are we solving the problem?

By providing an option to specify `rack` and `dataCenter`.

# How is the PR tested?

Deployed to cluster and tested the config.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
