### PR TITLE
stop renaming worm files

### DIFF
--- a/weed/mount/weedfs_rename.go
+++ b/weed/mount/weedfs_rename.go
@@ -3,15 +3,16 @@ package mount
 import (
 	"context"
 	"fmt"
+	"io"
+	"strings"
+	"syscall"
+
 	"github.com/hanwen/go-fuse/v2/fs"
 	"github.com/hanwen/go-fuse/v2/fuse"
 	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/util"
-	"io"
-	"strings"
-	"syscall"
 )
 
 /** Rename a file
@@ -159,6 +160,13 @@ func (wfs *WFS) Rename(cancel <-chan struct{}, in *fuse.RenameIn, oldName string
 		return
 	}
 	newPath := newDir.Child(newName)
+
+	if wfs.FilerConf != nil {
+		rule := wfs.FilerConf.MatchStorageRule(string(oldDir))
+		if rule.Worm {
+			return fuse.EPERM
+		}
+	}
 
 	glog.V(4).Infof("dir Rename %s => %s", oldPath, newPath)
 

--- a/weed/mount/weedfs_rename.go
+++ b/weed/mount/weedfs_rename.go
@@ -162,7 +162,7 @@ func (wfs *WFS) Rename(cancel <-chan struct{}, in *fuse.RenameIn, oldName string
 	newPath := newDir.Child(newName)
 
 	if wfs.FilerConf != nil {
-		rule := wfs.FilerConf.MatchStorageRule(string(oldDir))
+		rule := wfs.FilerConf.MatchStorageRule(string(oldPath))
 		if rule.Worm {
 			return fuse.EPERM
 		}

--- a/weed/server/filer_server_handlers_write.go
+++ b/weed/server/filer_server_handlers_write.go
@@ -160,6 +160,14 @@ func (fs *FilerServer) move(ctx context.Context, w http.ResponseWriter, r *http.
 		return
 	}
 
+	rule := fs.filer.FilerConf.MatchStorageRule(src)
+	if rule.Worm {
+		// you cannot move a worm file or directory
+		err = errors.New("operation not permitted")
+		writeJsonError(w, r, http.StatusForbidden, err)
+		return
+	}
+
 	oldDir, oldName := srcPath.DirAndName()
 	newDir, newName := dstPath.DirAndName()
 	newName = util.Nvl(newName, oldName)

--- a/weed/server/filer_server_handlers_write.go
+++ b/weed/server/filer_server_handlers_write.go
@@ -163,7 +163,7 @@ func (fs *FilerServer) move(ctx context.Context, w http.ResponseWriter, r *http.
 	rule := fs.filer.FilerConf.MatchStorageRule(src)
 	if rule.Worm {
 		// you cannot move a worm file or directory
-		err = fmt.Errorf("cannot move entry from '%s' to '%s': operation not permitted", src, dst)
+		err = fmt.Errorf("cannot move write-once entry from '%s' to '%s': operation not permitted", src, dst)
 		writeJsonError(w, r, http.StatusForbidden, err)
 		return
 	}

--- a/weed/server/filer_server_handlers_write.go
+++ b/weed/server/filer_server_handlers_write.go
@@ -163,7 +163,7 @@ func (fs *FilerServer) move(ctx context.Context, w http.ResponseWriter, r *http.
 	rule := fs.filer.FilerConf.MatchStorageRule(src)
 	if rule.Worm {
 		// you cannot move a worm file or directory
-		err = errors.New("operation not permitted")
+		err = fmt.Errorf("cannot move entry from '%s' to '%s': operation not permitted", src, dst)
 		writeJsonError(w, r, http.StatusForbidden, err)
 		return
 	}


### PR DESCRIPTION
# What problem are we solving?
renaming should not be allowed for worm files/dirs, since a file may be moved from a worm path to a non-worm path


# How are we solving the problem?
check if it is a worm file/dir before renaming


# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
