### PR TITLE
[helm] Allow setting notification.toml config

### DIFF
--- a/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
@@ -234,10 +234,12 @@ spec:
             - name: data-filer
               mountPath: /data
             {{- end }}
+            {{- if .Values.filer.notificationConfig }}
             - name: notification-config
               readOnly: true
               mountPath: /etc/seaweedfs/notification.toml
               subPath: notification.toml
+            {{- end }}
             {{- if .Values.global.enableSecurity }}
             - name: security-config
               readOnly: true
@@ -353,9 +355,11 @@ spec:
             secretName: seaweedfs-s3-secret
             {{- end }}
         {{- end }}
+        {{- if .Values.filer.notificationConfig }}
         - name: notification-config
           configMap:
             name: {{ template "seaweedfs.name" . }}-notification-config
+        {{- end }}
         {{- if .Values.global.enableSecurity }}
         - name: security-config
           configMap:

--- a/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
@@ -234,6 +234,10 @@ spec:
             - name: data-filer
               mountPath: /data
             {{- end }}
+            - name: notification-config
+              readOnly: true
+              mountPath: /etc/seaweedfs/notification.toml
+              subPath: notification.toml
             {{- if .Values.global.enableSecurity }}
             - name: security-config
               readOnly: true
@@ -349,6 +353,9 @@ spec:
             secretName: seaweedfs-s3-secret
             {{- end }}
         {{- end }}
+        - name: notification-config
+          configMap:
+            name: {{ template "seaweedfs.name" . }}-notification-config
         {{- if .Values.global.enableSecurity }}
         - name: security-config
           configMap:

--- a/k8s/charts/seaweedfs/templates/notification-configmap.yaml
+++ b/k8s/charts/seaweedfs/templates/notification-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.filer.enabled }}
+{{- if and .Values.filer.enabled .Values.filer.notificationConfig }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/k8s/charts/seaweedfs/templates/notification-configmap.yaml
+++ b/k8s/charts/seaweedfs/templates/notification-configmap.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.filer.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "seaweedfs.name" . }}-notification-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Values.filer.annotations }}
+  annotations:
+    {{- toYaml .Values.filer.annotations | nindent 4 }}
+{{- end }}
+data:
+  notification.toml: |-
+    {{ .Values.filer.notificationConfig | nindent 4 }}
+{{- end }}

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -546,9 +546,18 @@ filer:
   # Disable http request, only gRpc operations are allowed
   disableHttp: false
 
-  notificationConfig: |-
-    # Enter any extra configuration for notification.toml here.
-    # It may be a multi-line string.
+  # Add a custom notification.toml to configure filer notifications
+  # Example:
+  # notificationConfig: |-
+  #   [notification.kafka]
+  #   enabled = false
+  #   hosts = [
+  #       "localhost:9092"
+  #   ]
+  #   topic = "seaweedfs_filer"
+  #   offsetFile = "./last.offset"
+  #   offsetSaveIntervalSeconds = 10
+  notificationConfig: ""
 
   # DEPRECATE: enablePVC, storage, storageClass
   # Consider replacing with filer.data section below instead.

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -546,6 +546,10 @@ filer:
   # Disable http request, only gRpc operations are allowed
   disableHttp: false
 
+  notificationConfig: |-
+    # Enter any extra configuration for notification.toml here.
+    # It may be a multi-line string.
+
   # DEPRECATE: enablePVC, storage, storageClass
   # Consider replacing with filer.data section below instead.
 


### PR DESCRIPTION
# What problem are we solving?

Following #6155, adding the possibility to configure event notifications by setting the content of the `notification.toml` configuration file from the helm chart.

# How are we solving the problem?

Expose `filer.notificationConfig` in values, which can be a multi-line string that will be mounted at `/etc/seaweed/notification.toml`.

I based most of the code on the work done for `master.toml`.

**Note**: I've also bumped the chart version (major).

# How is the PR tested?

Clone the repo and `cd k8s/charts/seaweedfs/` and run:

```
git checkout master
helm template . > output-master.yaml
git checkout dacalabrese-filer-notification-config
helm template . > output-filer-notification-config.yaml
diff --color output-master.yaml output-filer-notification-config.yaml
```

The output shows the addition of introduced resources:

```

31a32,48
> # Source: seaweedfs/templates/notification-configmap.yaml
> apiVersion: v1
> kind: ConfigMap
> metadata:
>   name: seaweedfs-notification-config
>   namespace: default
>   labels:
>     [app.kubernetes.io/name](http://app.kubernetes.io/name): seaweedfs
>     [helm.sh/chart](http://helm.sh/chart): seaweedfs-5.0.377
>     [app.kubernetes.io/managed-by](http://app.kubernetes.io/managed-by): Helm
>     [app.kubernetes.io/instance](http://app.kubernetes.io/instance): release-name
> data:
>   notification.toml: |-
>    
>     # Enter any extra configuration for notification.toml here.
>     # It may be a multi-line string.
> ---

318a336,339
>             - name: notification-config
>               readOnly: true
>               mountPath: /etc/seaweedfs/notification.toml
>               subPath: notification.toml
358a380,382
>         - name: notification-config
>           configMap:
>             name: seaweedfs-notification-config
```

**Note**: diff in chart versions have been omitted in the text above.

To be extra sure, I've also installed the charts in a `minikube` cluster:

```
minikube start
helm install seaweedfs .
kubectl logs seaweedfs-filer-0
```
Logs show that the filer correctly finds and reads the `/etc/seaweedfs/notification.toml` file.

# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
