### PR TITLE
Update filer_multipart.go

### DIFF
--- a/weed/s3api/filer_multipart.go
+++ b/weed/s3api/filer_multipart.go
@@ -209,6 +209,7 @@ func (s3a *S3ApiServer) completeMultipartUpload(input *s3.CompleteMultipartUploa
 					ModifiedTsNs: chunk.ModifiedTsNs,
 					CipherKey:    chunk.CipherKey,
 					ETag:         chunk.ETag,
+					IsCompressed: chunk.IsCompressed,
 				}
 				finalParts = append(finalParts, p)
 				offset += int64(chunk.Size)


### PR DESCRIPTION
fix the #6177 bug

# What problem are we solving?
this bug
https://github.com/seaweedfs/seaweedfs/issues/6177


# How are we solving the problem?



# How is the PR tested?
Upload files using cipher
Can read the correct value of IsCompressed when reading files


# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
