### PR TITLE
Fix a bug where Get/Head a s3 path returns unexpected results

### DIFF
--- a/weed/server/filer_server_handlers_read.go
+++ b/weed/server/filer_server_handlers_read.go
@@ -125,6 +125,12 @@ func (fs *FilerServer) GetOrHeadHandler(w http.ResponseWriter, r *http.Request) 
 			writeJsonQuiet(w, r, http.StatusOK, entry)
 			return
 		}
+		// The input `r.URL.Path` is like `abc`, while filer.FindEntry() returns an entry `abc/`,
+		// which doesn't match the input `abc`, then return `http.StatusNotFound` to follow the s3 standard.
+		if !isForDirectory {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
 		if entry.Attr.Mime == "" || (entry.Attr.Mime == s3_constants.FolderMimeType && r.Header.Get(s3_constants.AmzIdentityId) == "") {
 			// Don't return directory meta if config value is set to true
 			if fs.option.ExposeDirectoryData == false {


### PR DESCRIPTION
# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/6001#:~:text=If%20the%20contentType%20is%20%22httpd/unix%2Ddirectory%22%2C%20no%20matter%20if%20the%20request%20is%20%22HEAD%20bucket/folder%22%20or%20%22HEAD%20bucket/folder/%22%2C%20the%20response%20will%20be%20200%20OK.%20It%20confuses%20our%20program%20because%20we%20think%20the%20%22folder%22%20and%20%22folder/%22%20both%20exist.


# How are we solving the problem?



# How is the PR tested?



# Checks
- [] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
