### PR TITLE
fix helm: s3 allowEmptyFolder flag if (#6204)

### DIFF
--- a/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
@@ -209,7 +209,7 @@ spec:
               -s3.cert.file=/usr/local/share/ca-certificates/client/tls.crt \
               -s3.key.file=/usr/local/share/ca-certificates/client/tls.key \
               {{- end }}
-              {{- if .Values.filer.s3.allowEmptyFolder }}
+              {{- if eq (typeOf .Values.filer.s3.allowEmptyFolder) "bool" }}
               -s3.allowEmptyFolder={{ .Values.filer.s3.allowEmptyFolder }} \
               {{- end }}
               {{- if .Values.filer.s3.enableAuth }}

--- a/k8s/charts/seaweedfs/templates/s3-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/s3-deployment.yaml
@@ -134,7 +134,7 @@ spec:
               {{- if .Values.s3.domainName }}
               -domainName={{ .Values.s3.domainName }} \
               {{- end }}
-              {{- if .Values.s3.allowEmptyFolder }}
+              {{- if eq (typeOf .Values.s3.allowEmptyFolder) "bool" }}
               -allowEmptyFolder={{ .Values.s3.allowEmptyFolder }} \
               {{- end }}
               {{- if .Values.s3.enableAuth }}


### PR DESCRIPTION
# What problem are we solving?
the issue of conditional rendering based on a boolean value.
helm chart s3 allowEmptyFolder value not Effective
[#6204](https://github.com/seaweedfs/seaweedfs/issues/6204)


# How are we solving the problem?
Added type check for boolean values: The if condition has been updated to check whether the value of .Values.someBool is of type bool using the typeOf function. This ensures that the flag were rendered when the value is explicitly set as true or false, and prevents rendering when the value is not a boolean or is missing.


# How is the PR tested?
helm template test


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
