### PR TITLE
[shell] add admin noLock for balance

### DIFF
--- a/weed/shell/command_volume_balance.go
+++ b/weed/shell/command_volume_balance.go
@@ -76,14 +76,19 @@ func (c *commandVolumeBalance) Do(args []string, commandEnv *CommandEnv, writer 
 	dc := balanceCommand.String("dataCenter", "", "only apply the balancing for this dataCenter")
 	racks := balanceCommand.String("racks", "", "only apply the balancing for this racks")
 	nodes := balanceCommand.String("nodes", "", "only apply the balancing for this nodes")
+	noLock := balanceCommand.Bool("noLock", false, "do not lock the admin shell at one's own risk")
 	applyBalancing := balanceCommand.Bool("force", false, "apply the balancing plan.")
 	if err = balanceCommand.Parse(args); err != nil {
 		return nil
 	}
 	infoAboutSimulationMode(writer, *applyBalancing, "-force")
 
-	if err = commandEnv.confirmIsLocked(args); err != nil {
-		return
+	if *noLock {
+		commandEnv.noLock = true
+	} else {
+		if err = commandEnv.confirmIsLocked(args); err != nil {
+			return
+		}
 	}
 
 	// collect topology information

--- a/weed/shell/commands.go
+++ b/weed/shell/commands.go
@@ -35,6 +35,7 @@ type CommandEnv struct {
 	MasterClient *wdclient.MasterClient
 	option       *ShellOptions
 	locker       *exclusive_locks.ExclusiveLocker
+	noLock       bool
 }
 
 func NewCommandEnv(options *ShellOptions) *CommandEnv {
@@ -42,6 +43,7 @@ func NewCommandEnv(options *ShellOptions) *CommandEnv {
 		env:          make(map[string]string),
 		MasterClient: wdclient.NewMasterClient(options.GrpcDialOption, *options.FilerGroup, pb.AdminShellClient, "", "", "", *pb.ServerAddresses(*options.Masters).ToServiceDiscovery()),
 		option:       options,
+		noLock:       false,
 	}
 	ce.locker = exclusive_locks.NewExclusiveLocker(ce.MasterClient, "shell")
 	return ce
@@ -78,6 +80,9 @@ func (ce *CommandEnv) confirmIsLocked(args []string) error {
 func (ce *CommandEnv) isLocked() bool {
 	if ce == nil {
 		return true
+	}
+	if ce.noLock {
+		return false
 	}
 	return ce.locker.IsLocked()
 }


### PR DESCRIPTION
# What problem are we solving?

Manual rebalancing takes a long time, during which other shell scripts are blocked. It seems quite safe to do rebalancing, since most of the time is spent copying volumes, if you do not interfere with the work.

This also allows you to manually launch rebalancing for specific nodes in parallel, which significantly speeds up the process.

# How are we solving the problem?

Added an option to not block through lock those who understand what they are doing

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
