### PR TITLE
[helm] fix s3 servicemonitor label matching

### DIFF
--- a/k8s/charts/seaweedfs/templates/s3-servicemonitor.yaml
+++ b/k8s/charts/seaweedfs/templates/s3-servicemonitor.yaml
@@ -26,8 +26,8 @@ spec:
       scrapeTimeout: 5s
   selector:
     matchLabels:
-      app: {{ template "seaweedfs.name" . }}
-      component: s3
+      app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+      app.kubernetes.io/component: s3
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
# What problem are we solving?
Fixes issue #6217


# How are we solving the problem?
Applying fully qualified labels to the ServiceMonitor which match [the service template](https://github.com/seaweedfs/seaweedfs/blob/113c9ce6a83e0554e73aa881a6eb94690a05a0a7/k8s/charts/seaweedfs/templates/s3-service.yaml#L9):



# How is the PR tested?
```
helm upgrade --install seaweedfs
```


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
