### PR TITLE
fix rename event

### DIFF
--- a/weed/server/filer_grpc_server_rename.go
+++ b/weed/server/filer_grpc_server_rename.go
@@ -173,8 +173,8 @@ func (fs *FilerServer) moveSelfEntry(ctx context.Context, stream filer_pb.Seawee
 		Remote:          entry.Remote,
 		Quota:           entry.Quota,
 	}
-	if createErr := fs.filer.CreateEntry(ctx, newEntry, false, false, signatures, false, fs.filer.MaxFilenameLength); createErr != nil {
-		return createErr
+	if renameErr := fs.filer.RenameEntry(ctx, entry, newEntry, false, false, signatures, false, fs.filer.MaxFilenameLength); renameErr != nil {
+		return renameErr
 	}
 	if stream != nil {
 		if err := stream.Send(&filer_pb.StreamRenameEntryResponse{


### PR DESCRIPTION
# What problem are we solving?
fix https://github.com/seaweedfs/seaweedfs/issues/6187


# How are we solving the problem?
fuse calls StreamRenameEntry to rename a file, StreamRenameEntry calls filer.CreateEntry to create a new entry, so only a create evnent will be generated which has not old path info and old entry(with old name) info. I add a new method RenameEntry and fix the logic

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
