### PR TITLE
feat(filer.backup): add ignore errors option

### DIFF
--- a/weed/command/filer_backup.go
+++ b/weed/command/filer_backup.go
@@ -178,7 +178,7 @@ func doFilerBackup(grpcDialOption grpc.DialOption, backupOption *FilerBackupOpti
 	}
 
 	eventErrorType := pb.RetryForeverOnError
-	if backupOption.disableErrorRetry != nil && *backupOption.disableErrorRetry {
+	if *backupOption.disableErrorRetry {
 		eventErrorType = pb.TrivialOnError
 	}
 

--- a/weed/command/filer_backup.go
+++ b/weed/command/filer_backup.go
@@ -1,12 +1,15 @@
 package command
 
 import (
+	"errors"
 	"fmt"
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb"
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/replication/source"
 	"github.com/seaweedfs/seaweedfs/weed/security"
 	"github.com/seaweedfs/seaweedfs/weed/util"
+	"github.com/seaweedfs/seaweedfs/weed/util/http"
 	"google.golang.org/grpc"
 	"regexp"
 	"strings"
@@ -14,16 +17,18 @@ import (
 )
 
 type FilerBackupOptions struct {
-	isActivePassive *bool
-	filer           *string
-	path            *string
-	excludePaths    *string
-	excludeFileName *string
-	debug           *bool
-	proxyByFiler    *bool
-	doDeleteFiles   *bool
-	timeAgo         *time.Duration
-	retentionDays   *int
+	isActivePassive   *bool
+	filer             *string
+	path              *string
+	excludePaths      *string
+	excludeFileName   *string
+	debug             *bool
+	proxyByFiler      *bool
+	doDeleteFiles     *bool
+	disableErrorRetry *bool
+	ignore404Error    *bool
+	timeAgo           *time.Duration
+	retentionDays     *int
 }
 
 var (
@@ -41,6 +46,8 @@ func init() {
 	filerBackupOptions.debug = cmdFilerBackup.Flag.Bool("debug", false, "debug mode to print out received files")
 	filerBackupOptions.timeAgo = cmdFilerBackup.Flag.Duration("timeAgo", 0, "start time before now. \"300ms\", \"1.5h\" or \"2h45m\". Valid time units are \"ns\", \"us\" (or \"µs\"), \"ms\", \"s\", \"m\", \"h\"")
 	filerBackupOptions.retentionDays = cmdFilerBackup.Flag.Int("retentionDays", 0, "incremental backup retention days")
+	filerBackupOptions.disableErrorRetry = cmdFilerBackup.Flag.Bool("disableErrorRetry", false, "disables errors retry, only logs will print")
+	filerBackupOptions.ignore404Error = cmdFilerBackup.Flag.Bool("ignore404Error", false, "ignore 404 errors from filer")
 }
 
 var cmdFilerBackup = &Command{
@@ -131,6 +138,19 @@ func doFilerBackup(grpcDialOption grpc.DialOption, backupOption *FilerBackupOpti
 	dataSink.SetSourceFiler(filerSource)
 
 	processEventFn := genProcessFunction(sourcePath, targetPath, excludePaths, reExcludeFileName, dataSink, *backupOption.doDeleteFiles, debug)
+	if backupOption.ignore404Error != nil && *backupOption.ignore404Error {
+		processEventFn = func(resp *filer_pb.SubscribeMetadataResponse) error {
+			err := processEventFn(resp)
+			if err == nil {
+				return nil
+			}
+			if errors.Is(err, http.ErrNotFound) {
+				glog.V(0).Infof("got 404 error, ignore it: %s", err.Error())
+				return nil
+			}
+			return err
+		}
+	}
 
 	processEventFnWithOffset := pb.AddOffsetFunc(processEventFn, 3*time.Second, func(counter int64, lastTsNs int64) error {
 		glog.V(0).Infof("backup %s progressed to %v %0.2f/sec", sourceFiler, time.Unix(0, lastTsNs), float64(counter)/float64(3))
@@ -154,6 +174,11 @@ func doFilerBackup(grpcDialOption grpc.DialOption, backupOption *FilerBackupOpti
 		prefix = prefix + "/"
 	}
 
+	eventErrorType := pb.RetryForeverOnError
+	if backupOption.disableErrorRetry != nil && *backupOption.disableErrorRetry {
+		eventErrorType = pb.TrivialOnError
+	}
+
 	metadataFollowOption := &pb.MetadataFollowOption{
 		ClientName:             "backup_" + dataSink.GetName(),
 		ClientId:               clientId,
@@ -164,7 +189,7 @@ func doFilerBackup(grpcDialOption grpc.DialOption, backupOption *FilerBackupOpti
 		DirectoriesToWatch:     nil,
 		StartTsNs:              startFrom.UnixNano(),
 		StopTsNs:               0,
-		EventErrorType:         pb.RetryForeverOnError,
+		EventErrorType:         eventErrorType,
 	}
 
 	return pb.FollowMetadata(sourceFiler, grpcDialOption, metadataFollowOption, processEventFnWithOffset)

--- a/weed/command/filer_backup.go
+++ b/weed/command/filer_backup.go
@@ -138,7 +138,7 @@ func doFilerBackup(grpcDialOption grpc.DialOption, backupOption *FilerBackupOpti
 	dataSink.SetSourceFiler(filerSource)
 
 	var processEventFn func(*filer_pb.SubscribeMetadataResponse) error
-	if backupOption.ignore404Error != nil && *backupOption.ignore404Error {
+	if *backupOption.ignore404Error {
 		processEventFnGenerated := genProcessFunction(sourcePath, targetPath, excludePaths, reExcludeFileName, dataSink, *backupOption.doDeleteFiles, debug)
 		processEventFn = func(resp *filer_pb.SubscribeMetadataResponse) error {
 			err := processEventFnGenerated(resp)

--- a/weed/command/filer_backup.go
+++ b/weed/command/filer_backup.go
@@ -47,7 +47,7 @@ func init() {
 	filerBackupOptions.timeAgo = cmdFilerBackup.Flag.Duration("timeAgo", 0, "start time before now. \"300ms\", \"1.5h\" or \"2h45m\". Valid time units are \"ns\", \"us\" (or \"µs\"), \"ms\", \"s\", \"m\", \"h\"")
 	filerBackupOptions.retentionDays = cmdFilerBackup.Flag.Int("retentionDays", 0, "incremental backup retention days")
 	filerBackupOptions.disableErrorRetry = cmdFilerBackup.Flag.Bool("disableErrorRetry", false, "disables errors retry, only logs will print")
-	filerBackupOptions.ignore404Error = cmdFilerBackup.Flag.Bool("ignore404Error", false, "ignore 404 errors from filer")
+	filerBackupOptions.ignore404Error = cmdFilerBackup.Flag.Bool("ignore404Error", true, "ignore 404 errors from filer")
 }
 
 var cmdFilerBackup = &Command{

--- a/weed/command/filer_sync.go
+++ b/weed/command/filer_sync.go
@@ -436,7 +436,7 @@ func genProcessFunction(sourcePath string, targetPath string, excludePaths []str
 			}
 			key := buildKey(dataSink, message, targetPath, sourceNewKey, sourcePath)
 			if err := dataSink.CreateEntry(key, message.NewEntry, message.Signatures); err != nil {
-				return fmt.Errorf("create entry1 : %v", err)
+				return fmt.Errorf("create entry1 : %w", err)
 			} else {
 				return nil
 			}
@@ -462,13 +462,13 @@ func genProcessFunction(sourcePath string, targetPath string, excludePaths []str
 
 					// not able to find old entry
 					if err = dataSink.DeleteEntry(string(oldKey), message.OldEntry.IsDirectory, false, message.Signatures); err != nil {
-						return fmt.Errorf("delete old entry %v: %v", oldKey, err)
+						return fmt.Errorf("delete old entry %v: %w", oldKey, err)
 					}
 				}
 				// create the new entry
 				newKey := buildKey(dataSink, message, targetPath, sourceNewKey, sourcePath)
 				if err := dataSink.CreateEntry(newKey, message.NewEntry, message.Signatures); err != nil {
-					return fmt.Errorf("create entry2 : %v", err)
+					return fmt.Errorf("create entry2 : %w", err)
 				} else {
 					return nil
 				}
@@ -486,7 +486,7 @@ func genProcessFunction(sourcePath string, targetPath string, excludePaths []str
 				// new key is in the watched directory
 				key := buildKey(dataSink, message, targetPath, sourceNewKey, sourcePath)
 				if err := dataSink.CreateEntry(key, message.NewEntry, message.Signatures); err != nil {
-					return fmt.Errorf("create entry3 : %v", err)
+					return fmt.Errorf("create entry3 : %w", err)
 				} else {
 					return nil
 				}

--- a/weed/util/http/http_global_client_util.go
+++ b/weed/util/http/http_global_client_util.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/seaweedfs/seaweedfs/weed/util/mem"
 	"github.com/seaweedfs/seaweedfs/weed/util"
+	"github.com/seaweedfs/seaweedfs/weed/util/mem"
 	"io"
 	"net/http"
 	"net/url"
@@ -15,6 +15,8 @@ import (
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 )
+
+var ErrNotFound = fmt.Errorf("not found")
 
 func Post(url string, values url.Values) ([]byte, error) {
 	r, err := GetGlobalHttpClient().PostForm(url, values)
@@ -311,7 +313,10 @@ func ReadUrlAsStreamAuthenticated(fileUrl, jwt string, cipherKey []byte, isConte
 	}
 	defer CloseResponse(r)
 	if r.StatusCode >= 400 {
-		retryable = r.StatusCode == http.StatusNotFound || r.StatusCode >= 499
+		if r.StatusCode == http.StatusNotFound {
+			return true, fmt.Errorf("%s: %s: %w", fileUrl, r.Status, err)
+		}
+		retryable = r.StatusCode >= 499
 		return retryable, fmt.Errorf("%s: %s", fileUrl, r.Status)
 	}
 

--- a/weed/util/http/http_global_client_util.go
+++ b/weed/util/http/http_global_client_util.go
@@ -314,7 +314,7 @@ func ReadUrlAsStreamAuthenticated(fileUrl, jwt string, cipherKey []byte, isConte
 	defer CloseResponse(r)
 	if r.StatusCode >= 400 {
 		if r.StatusCode == http.StatusNotFound {
-			return true, fmt.Errorf("%s: %s: %w", fileUrl, r.Status, err)
+			return true, fmt.Errorf("%s: %s: %w", fileUrl, r.Status, ErrNotFound)
 		}
 		retryable = r.StatusCode >= 499
 		return retryable, fmt.Errorf("%s: %s", fileUrl, r.Status)


### PR DESCRIPTION
# What problem are we solving?
After [this commit](https://github.com/seaweedfs/seaweedfs/commit/a829f36d17cedfe12a1c4a58e58ee464a958cd4e) we encountered errors in our replication pipeline. 
Replication process stuck in infinite loop with one file 

`
E1112 12:21:42.319391 filer_pb_tail.go:97 process directory:"/buckets/cdn-original" event_notification:{old_entry:{name:"639d0e2bc883f1425d517e5eb45c7e673382188a" chunks:{file_id:"6932,ffa4df5bd3deb37d00fd39fe" size:29080 modified_ts_ns:1731273999542172466 e_tag:"6xzLaouM+XTjCC1RdcK9Rw==" fid:{volume_id:6932 file_key:18421093961341776765 cookie:16595454}} attributes:{file_size:29080 mtime:1731273999 file_mode:432 crtime:1731273999 mime:"application/pdf" md5:"\xeb\x1c\xcbj\x8b\x8c\xf9t\xe3\x08-Qu½G"}} new_entry:{name:"639d0e2bc883f1425d517e5eb45c7e673382188a" chunks:{file_id:"11849,ffa4df5bd3deb380df25c239" size:29080 modified_ts_ns:1731273999548933998 e_tag:"6xzLaouM+XTjCC1RdcK9Rw==" fid:{volume_id:11849 file_key:18421093961341776768 cookie:3743793721}} attributes:{file_size:29080 mtime:1731273999 file_mode:432 crtime:1731273999 mime:"application/pdf" md5:"\xeb\x1c\xcbj\x8b\x8c\xf9t\xe3\x08-Qu½G"}} delete_chunks:true new_parent_path:"/buckets/cdn-original" signatures:-805745636} ts_ns:1731273999555630141: create entry2 : http://volume:8080/11849,ffa4df5bd3deb380df25c239?readDeleted=true: 404 Not Found
`

`
E1112 12:09:52.898070 filer_pb_tail.go:97 process directory:"/buckets/rog-content" event_notification:{new_entry:{name:"1241112047639433_AstralResult_data" chunks:{file_id:"6396,ffa4df5bd41c8cba8bc14e50" size:1054 modified_ts_ns:1731412718791810915 e_tag:"80lzESquUvUYLS8VwHZmRw==" fid:{volume_id:6396 file_key:18421093961345830074 cookie:2344701520} is_compressed:true} attributes:{file_size:1054 mtime:1731412718 file_mode:432 crtime:1731412718 md5:"\xf3Is\x11*\xaeR\xf5\x18-/\x15\xc0vfG"}} delete_chunks:true new_parent_path:"/buckets/rog-content" signatures:-805745636} ts_ns:1731412718799314954: create entry1 : http://filer:9090/?proxyChunkId=6396,ffa4df5bd41c8cba8bc14e50: 404 Not Found
`

This might happen because file deleted very soon.

# How are we solving the problem?
Add option to ignore 404 errors and option to ignore all errors (to not break replication process if error happens with some files)


# How is the PR tested?
Currently test it in our environment


# Checks
- [no] I have added unit tests if possible.
- [no] I will add related wiki document changes and link to this PR after merging.
