### PR TITLE
fix java.lang.IllegalArgumentException: Comparison method violates its general contract!

### DIFF
--- a/other/java/client/src/main/java/seaweedfs/client/ReadChunks.java
+++ b/other/java/client/src/main/java/seaweedfs/client/ReadChunks.java
@@ -14,20 +14,23 @@ public class ReadChunks {
             points.add(new Point(chunk.getOffset(), chunk, true));
             points.add(new Point(chunk.getOffset() + chunk.getSize(), chunk, false));
         }
+
         Collections.sort(points, new Comparator<Point>() {
             @Override
             public int compare(Point a, Point b) {
-                int x = (int) (a.x - b.x);
-                if (a.x != b.x) {
-                    return (int) (a.x - b.x);
+                int xComparison = Long.compare(a.x, b.x);
+                if (xComparison != 0) {
+                    return xComparison;
                 }
-                if (a.ts != b.ts) {
-                    return (int) (a.ts - b.ts);
+
+                // If x values are equal, compare ts
+                int tsComparison = Long.compare(a.ts, b.ts);
+                if (tsComparison != 0) {
+                    return tsComparison;
                 }
-                if (!a.isStart) {
-                    return -1;
-                }
-                return 1;
+
+                // If both x and ts are equal, prioritize start points
+                return Boolean.compare(b.isStart, a.isStart); // b.isStart first to prioritize starts
             }
         });
 


### PR DESCRIPTION
# What problem are we solving?

```
java.lang.IllegalArgumentException: Comparison method violates its general contract!
        at java.base/java.util.TimSort.mergeHi(TimSort.java:903)
        at java.base/java.util.TimSort.mergeAt(TimSort.java:520)
        at java.base/java.util.TimSort.mergeForceCollapse(TimSort.java:461)
        at java.base/java.util.TimSort.sort(TimSort.java:254)
        at java.base/java.util.Arrays.sort(Arrays.java:1308)
        at java.base/java.util.ArrayList.sort(ArrayList.java:1804)
        at java.base/java.util.Collections.sort(Collections.java:178)
        at seaweedfs.client.ReadChunks.readResolvedChunks(ReadChunks.java:17)
        at seaweedfs.client.SeaweedRead.nonOverlappingVisibleIntervals(SeaweedRead.java:229)
        at seaweedfs.client.SeaweedInputStream.<init>(SeaweedInputStream.java:68)
        at seaweed.hdfs.SeaweedHadoopInputStream.<init>(SeaweedHadoopInputStream.java:26)
        at seaweed.hdfs.SeaweedFileSystemStore.openFileForRead(SeaweedFileSystemStore.java:236)
        at seaweed.hdfs.SeaweedFileSystem.open(SeaweedFileSystem.java:85)
        at org.apache.hadoop.fs.FileSystem.open(FileSystem.java:976)
```

# How are we solving the problem?

Reconstructed the comparator.

# How is the PR tested?

PASS

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
