### PR TITLE
Fix/parse upload filename

### DIFF
--- a/weed/operation/needle_parse_test.go
+++ b/weed/operation/needle_parse_test.go
@@ -44,7 +44,7 @@ func TestCreateNeedleFromRequest(t *testing.T) {
 	{
 		mockClient.needleHandling = func(n *needle.Needle, originalSize int, err error) {
 			assert.Equal(t, nil, err, "upload: %v", err)
-			assert.Equal(t, "", string(n.Mime), "mime detection failed: %v", string(n.Mime))
+			assert.Equal(t, "text/plain; charset=utf-8", string(n.Mime), "mime detection failed: %v", string(n.Mime))
 			assert.Equal(t, true, n.IsCompressed(), "this should be compressed")
 			assert.Equal(t, true, util.IsGzippedContent(n.Data), "this should be gzip")
 			fmt.Printf("needle: %v, originalSize: %d\n", n, originalSize)

--- a/weed/server/master_ui/master.html
+++ b/weed/server/master_ui/master.html
@@ -33,14 +33,14 @@
                 {{ with .RaftServer }}
                 <tr>
                     <th>Leader</th>
-                    <td><a href="http://{{ .Leader }}">{{ .Leader }}</a></td>
+                    <td><a href="{{ url .Leader }}">{{ .Leader }}</a></td>
                 </tr>
                 <tr>
                     <th>Other Masters</th>
                     <td class="col-sm-5">
                         <ul class="list-unstyled">
                             {{ range $k, $p := .Peers }}
-                            <li><a href="http://{{ $p.Name }}/ui/index.html">{{ $p.Name }}</a></li>
+                            <li><a href="{{ url $p.Name }}/ui/index.html">{{ $p.Name }}</a></li>
                             {{ end }}
                         </ul>
                     </td>
@@ -88,9 +88,9 @@
             <tr>
                 <td><code>{{ $dc.Id }}</code></td>
                 <td>{{ $rack.Id }}</td>
-                <td><a href="http://{{ $dn.Url }}/ui/index.html">{{ $dn.Url }}</a>
+                <td><a href="{{ url $dn.Url }}/ui/index.html">{{ $dn.Url }}</a>
                     {{ if ne $dn.PublicUrl $dn.Url }}
-                    / <a href="http://{{ $dn.PublicUrl }}/ui/index.html">{{ $dn.PublicUrl }}</a>
+                    / <a href="{{ url $dn.PublicUrl }}/ui/index.html">{{ $dn.PublicUrl }}</a>
                     {{ end }}
                 </td>
                 <td>{{ $dn.Volumes }}</td>

--- a/weed/server/master_ui/templates.go
+++ b/weed/server/master_ui/templates.go
@@ -3,6 +3,7 @@ package master_ui
 import (
 	_ "embed"
 	"html/template"
+	"strings"
 )
 
 //go:embed master.html
@@ -11,5 +12,17 @@ var masterHtml string
 //go:embed masterNewRaft.html
 var masterNewRaftHtml string
 
-var StatusTpl = template.Must(template.New("status").Parse(masterHtml))
+var templateFunctions = template.FuncMap{
+	"url": func(input string) string {
+
+		if !strings.HasPrefix(input, "http://") && !strings.HasPrefix(input, "https://") {
+			return "http://" + input
+		}
+
+		return input
+	},
+}
+
+var StatusTpl = template.Must(template.New("status").Funcs(templateFunctions).Parse(masterHtml))
+
 var StatusNewRaftTpl = template.Must(template.New("status").Parse(masterNewRaftHtml))

--- a/weed/storage/needle/needle_parse_upload.go
+++ b/weed/storage/needle/needle_parse_upload.go
@@ -43,19 +43,8 @@ func ParseUpload(r *http.Request, sizeLimit int64, bytesBuffer *bytes.Buffer) (p
 		}
 	}
 
-	if r.Method == http.MethodPost {
-		contentType := r.Header.Get("Content-Type")
+	e = parseUpload(r, sizeLimit, pu)
 
-		// If content-type is explicitly set, upload the file without parsing form-data
-		if contentType != "" && !strings.Contains(contentType, "form-data") {
-			e = parseRawPost(r, sizeLimit, pu)
-		} else {
-			e = parseMultipart(r, sizeLimit, pu)
-		}
-
-	} else {
-		e = parsePut(r, sizeLimit, pu)
-	}
 	if e != nil {
 		return
 	}
@@ -108,87 +97,123 @@ func ParseUpload(r *http.Request, sizeLimit int64, bytesBuffer *bytes.Buffer) (p
 	return
 }
 
-func parsePut(r *http.Request, sizeLimit int64, pu *ParsedUpload) error {
-	pu.IsGzipped = r.Header.Get("Content-Encoding") == "gzip"
-	// pu.IsZstd = r.Header.Get("Content-Encoding") == "zstd"
-	pu.MimeType = r.Header.Get("Content-Type")
-	pu.FileName = ""
-	dataSize, err := pu.bytesBuffer.ReadFrom(io.LimitReader(r.Body, sizeLimit+1))
-	if err == io.EOF || dataSize == sizeLimit+1 {
-		io.Copy(io.Discard, r.Body)
-	}
-	pu.Data = pu.bytesBuffer.Bytes()
-	r.Body.Close()
-	return nil
-}
+func parseUpload(r *http.Request, sizeLimit int64, pu *ParsedUpload) (e error) {
 
-func parseMultipart(r *http.Request, sizeLimit int64, pu *ParsedUpload) (e error) {
 	defer func() {
 		if e != nil && r.Body != nil {
 			io.Copy(io.Discard, r.Body)
 			r.Body.Close()
 		}
 	}()
-	form, fe := r.MultipartReader()
-	if fe != nil {
-		glog.V(0).Infoln("MultipartReader [ERROR]", fe)
-		e = fe
-		return
-	}
 
-	// first multi-part item
-	part, fe := form.NextPart()
-	if fe != nil {
-		glog.V(0).Infoln("Reading Multi part [ERROR]", fe)
-		e = fe
-		return
-	}
-
-	pu.FileName = part.FileName()
-	if pu.FileName != "" {
-		pu.FileName = path.Base(pu.FileName)
-	}
-
+	contentType := r.Header.Get("Content-Type")
 	var dataSize int64
-	dataSize, e = pu.bytesBuffer.ReadFrom(io.LimitReader(part, sizeLimit+1))
-	if e != nil {
-		glog.V(0).Infoln("Reading Content [ERROR]", e)
-		return
-	}
-	if dataSize == sizeLimit+1 {
-		e = fmt.Errorf("file over the limited %d bytes", sizeLimit)
-		return
-	}
-	pu.Data = pu.bytesBuffer.Bytes()
 
-	// if the filename is empty string, do a search on the other multi-part items
-	for pu.FileName == "" {
-		part2, fe := form.NextPart()
+	if r.Method == http.MethodPost && (contentType == "" || strings.Contains(contentType, "form-data")) {
+		form, fe := r.MultipartReader()
+
 		if fe != nil {
-			break // no more or on error, just safely break
+			glog.V(0).Infoln("MultipartReader [ERROR]", fe)
+			e = fe
+			return
 		}
 
-		fName := part2.FileName()
-
-		// found the first <file type> multi-part has filename
-		if fName != "" {
-			pu.bytesBuffer.Reset()
-			dataSize2, fe2 := pu.bytesBuffer.ReadFrom(io.LimitReader(part2, sizeLimit+1))
-			if fe2 != nil {
-				glog.V(0).Infoln("Reading Content [ERROR]", fe2)
-				e = fe2
-				return
-			}
-			if dataSize2 == sizeLimit+1 {
-				e = fmt.Errorf("file over the limited %d bytes", sizeLimit)
-				return
-			}
-
-			// update
-			pu.Data = pu.bytesBuffer.Bytes()
-			pu.FileName = path.Base(fName)
-			break
+		// first multi-part item
+		part, fe := form.NextPart()
+		if fe != nil {
+			glog.V(0).Infoln("Reading Multi part [ERROR]", fe)
+			e = fe
+			return
 		}
+
+		pu.FileName = part.FileName()
+		if pu.FileName != "" {
+			pu.FileName = path.Base(pu.FileName)
+		}
+
+		dataSize, e = pu.bytesBuffer.ReadFrom(io.LimitReader(part, sizeLimit+1))
+		if e != nil {
+			glog.V(0).Infoln("Reading Content [ERROR]", e)
+			return
+		}
+		if dataSize == sizeLimit+1 {
+			e = fmt.Errorf("file over the limited %d bytes", sizeLimit)
+			return
+		}
+		pu.Data = pu.bytesBuffer.Bytes()
+
+		contentType = part.Header.Get("Content-Type")
+
+		// if the filename is empty string, do a search on the other multi-part items
+		for pu.FileName == "" {
+			part2, fe := form.NextPart()
+			if fe != nil {
+				break // no more or on error, just safely break
+			}
+
+			fName := part2.FileName()
+
+			// found the first <file type> multi-part has filename
+			if fName != "" {
+				pu.bytesBuffer.Reset()
+				dataSize2, fe2 := pu.bytesBuffer.ReadFrom(io.LimitReader(part2, sizeLimit+1))
+				if fe2 != nil {
+					glog.V(0).Infoln("Reading Content [ERROR]", fe2)
+					e = fe2
+					return
+				}
+				if dataSize2 == sizeLimit+1 {
+					e = fmt.Errorf("file over the limited %d bytes", sizeLimit)
+					return
+				}
+
+				// update
+				pu.Data = pu.bytesBuffer.Bytes()
+				pu.FileName = path.Base(fName)
+				contentType = part.Header.Get("Content-Type")
+				part = part2
+				break
+			}
+		}
+
+		pu.IsGzipped = part.Header.Get("Content-Encoding") == "gzip"
+		// pu.IsZstd = part.Header.Get("Content-Encoding") == "zstd"
+
+	} else {
+		disposition := r.Header.Get("Content-Disposition")
+
+		if pu.FileName != "" && strings.Contains(disposition, "filename=") {
+			_, mediaTypeParams, err := mime.ParseMediaType(disposition)
+
+			if err == nil {
+				pu.FileName = mediaTypeParams["filename"]
+			}
+
+		} else {
+			pu.FileName = ""
+		}
+
+		if pu.FileName != "" {
+			pu.FileName = path.Base(pu.FileName)
+		} else {
+			pu.FileName = path.Base(r.URL.Path)
+		}
+
+		dataSize, e = pu.bytesBuffer.ReadFrom(io.LimitReader(r.Body, sizeLimit+1))
+
+		if e != nil {
+			glog.V(0).Infoln("Reading Content [ERROR]", e)
+			return
+		}
+		if dataSize == sizeLimit+1 {
+			e = fmt.Errorf("file over the limited %d bytes", sizeLimit)
+			return
+		}
+
+		pu.Data = pu.bytesBuffer.Bytes()
+		pu.MimeType = contentType
+		pu.IsGzipped = r.Header.Get("Content-Encoding") == "gzip"
+		// pu.IsZstd = r.Header.Get("Content-Encoding") == "zstd"
 	}
 
 	pu.IsChunkedFile, _ = strconv.ParseBool(r.FormValue("cm"))
@@ -197,81 +222,19 @@ func parseMultipart(r *http.Request, sizeLimit int64, pu *ParsedUpload) (e error
 
 		dotIndex := strings.LastIndex(pu.FileName, ".")
 		ext, mtype := "", ""
+
 		if dotIndex > 0 {
 			ext = strings.ToLower(pu.FileName[dotIndex:])
 			mtype = mime.TypeByExtension(ext)
 		}
-		contentType := part.Header.Get("Content-Type")
-		if contentType != "" && contentType != "application/octet-stream" && mtype != contentType {
-			pu.MimeType = contentType // only return mime type if not deducible
-			mtype = contentType
-		}
-
-	}
-	pu.IsGzipped = part.Header.Get("Content-Encoding") == "gzip"
-	// pu.IsZstd = part.Header.Get("Content-Encoding") == "zstd"
-
-	return
-}
-
-func parseRawPost(r *http.Request, sizeLimit int64, pu *ParsedUpload) (e error) {
-
-	defer func() {
-		if e != nil && r.Body != nil {
-			io.Copy(io.Discard, r.Body)
-			r.Body.Close()
-		}
-	}()
-
-	pu.FileName = r.Header.Get("Content-Disposition")
-
-	if pu.FileName != "" && strings.Contains(pu.FileName, "filename=") {
-		parts := strings.Split(pu.FileName, "filename=")
-		parts = strings.Split(parts[1], "\"")
-
-		pu.FileName = parts[1]
-	} else {
-		pu.FileName = ""
-	}
-
-	if pu.FileName != "" {
-		pu.FileName = path.Base(pu.FileName)
-	} else {
-		pu.FileName = path.Base(r.URL.Path)
-	}
-
-	var dataSize int64
-	dataSize, e = pu.bytesBuffer.ReadFrom(io.LimitReader(r.Body, sizeLimit+1))
-
-	if e != nil {
-		glog.V(0).Infoln("Reading Content [ERROR]", e)
-		return
-	}
-	if dataSize == sizeLimit+1 {
-		e = fmt.Errorf("file over the limited %d bytes", sizeLimit)
-		return
-	}
-	pu.Data = pu.bytesBuffer.Bytes()
-	pu.IsChunkedFile, _ = strconv.ParseBool(r.FormValue("cm"))
-
-	if !pu.IsChunkedFile {
-
-		dotIndex := strings.LastIndex(pu.FileName, ".")
-		ext, mtype := "", ""
-		if dotIndex > 0 {
-			ext = strings.ToLower(pu.FileName[dotIndex:])
-			mtype = mime.TypeByExtension(ext)
-		}
-		contentType := r.Header.Get("Content-Type")
 
 		if contentType != "" && contentType != "application/octet-stream" && mtype != contentType {
 			pu.MimeType = contentType // only return mime type if not deducible
-			mtype = contentType
+		} else if mtype != "" && pu.MimeType == "" {
+			pu.MimeType = mtype
 		}
 
 	}
-	pu.IsGzipped = r.Header.Get("Content-Encoding") == "gzip"
-	// pu.IsZstd = r.Header.Get("Content-Encoding") == "zstd"
 
 	return
 }

--- a/weed/storage/needle/needle_parse_upload.go
+++ b/weed/storage/needle/needle_parse_upload.go
@@ -243,7 +243,7 @@ func parseUpload(r *http.Request, sizeLimit int64, pu *ParsedUpload) (e error) {
 
 		if contentType != "" && contentType != "application/octet-stream" && mtype != contentType {
 			pu.MimeType = contentType // only return mime type if not deducible
-		} else if mtype != "" && pu.MimeType == "" {
+		} else if mtype != "" && pu.MimeType == "" && mtype != "application/octet-stream" {
 			pu.MimeType = mtype
 		}
 

--- a/weed/storage/needle/needle_parse_upload.go
+++ b/weed/storage/needle/needle_parse_upload.go
@@ -182,11 +182,24 @@ func parseUpload(r *http.Request, sizeLimit int64, pu *ParsedUpload) (e error) {
 	} else {
 		disposition := r.Header.Get("Content-Disposition")
 
-		if pu.FileName != "" && strings.Contains(disposition, "filename=") {
+		if strings.Contains(disposition, "name=") {
+
+			if !strings.HasPrefix(disposition, "inline") && !strings.HasPrefix(disposition, "attachment") {
+				disposition = "attachment; " + disposition
+			}
+
 			_, mediaTypeParams, err := mime.ParseMediaType(disposition)
 
 			if err == nil {
-				pu.FileName = mediaTypeParams["filename"]
+				dpFilename, hasFilename := mediaTypeParams["filename"]
+				dpName, hasName := mediaTypeParams["name"]
+
+				if hasFilename {
+					pu.FileName = dpFilename
+				} else if hasName {
+					pu.FileName = dpName
+				}
+
 			}
 
 		} else {


### PR DESCRIPTION
# What problem are we solving?
Refactoring `needle_parse_upload` and better handle filenames (`content-disposition` header).
Also a small fix to admin UI when `publicUrl` already contains `https://`.

# How are we solving the problem?
Use `mime` lib to parse the header and handle variants of the given header value.
Also combine the different upload methods (`PUT`/ `POST`) and
content type `form-data` or `{mime-type}` e.g `image/png`.

# How is the PR tested?
I tested that the variants worked and viewed in browser and used these commands:

```cli
curl 'http://localhost:9333/dir/assign?count=3'
{"fid":"6,62109ceee3","url":"192.168.2.23:8080","publicUrl":"192.168.2.23:8080","count":3}

curl -X PUT -H 'Content-Disposition: filename="1.png"' -H 'Content-Type: image/png' --data-binary @1.png 'http://192.168.2.23:8080/6,62109ceee3_0'
{"name":"1.png","size":306542,"eTag":"5e530dd3","mime":"image/png"}                                                                                                                                                   

curl -X POST -H 'Content-Disposition: filename="2.png"' -H 'Content-Type: image/png' --data-binary @2.png 'http://192.168.2.23:8080/6,62109ceee3_1'
{"name":"2.png","size":293856,"eTag":"b28728ee","mime":"image/png"}

curl -X POST -F file=@3.png 'http://192.168.2.23:8080/6,62109ceee3_2' 
{"name":"3.png","size":525586,"eTag":"bb9b7005","mime":"image/png"}

```


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
