### PR TITLE
[shell] add noLock param for volume.move

### DIFF
--- a/weed/shell/commands.go
+++ b/weed/shell/commands.go
@@ -82,7 +82,7 @@ func (ce *CommandEnv) isLocked() bool {
 		return true
 	}
 	if ce.noLock {
-		return false
+		return true
 	}
 	return ce.locker.IsLocked()
 }


### PR DESCRIPTION
# What problem are we solving?

Manual rebalancing takes a long time, during which other shell scripts are blocked. It seems quite safe to do moving, since most of the time is spent copying volumes, if you do not interfere with the work.

This also allows you to manually launch moving to new DC for specific nodes in parallel, which significantly speeds up the process.

https://github.com/seaweedfs/seaweedfs/pull/6209

and fix `lock is lost`

# How are we solving the problem?

Added an option to not block through lock those who understand what they are doing

# How is the PR tested?

on dev
```
192.168.0.1:8137 => 192.168.1.1:8092 volume 3907 processed 253.40 GiB
192.168.0.1:8137 => 192.168.1.1:8092 volume 3907 processed 253.53 GiB
192.168.0.1:8137 => 192.168.1.1:8092 volume 3907 processed 253.65 GiB
192.168.0.1:8137 => 192.168.1.1:8092 volume 3907 processed 253.78 GiB
```

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
