### PR TITLE
[shell] don't require lock when there are no changes for volume.fix.replication

### DIFF
--- a/weed/shell/command_volume_fix_replication.go
+++ b/weed/shell/command_volume_fix_replication.go
@@ -74,7 +74,9 @@ func (c *commandVolumeFixReplication) Do(args []string, commandEnv *CommandEnv, 
 	}
 
 	commandEnv.noLock = *skipChange
-	if err = commandEnv.confirmIsLocked(args); !*skipChange && err != nil {
+	takeAction := !*skipChange
+
+	if err = commandEnv.confirmIsLocked(args); takeAction && err != nil {
 		return
 	}
 

--- a/weed/shell/command_volume_fix_replication.go
+++ b/weed/shell/command_volume_fix_replication.go
@@ -73,11 +73,10 @@ func (c *commandVolumeFixReplication) Do(args []string, commandEnv *CommandEnv, 
 		return nil
 	}
 
-	if err = commandEnv.confirmIsLocked(args); err != nil {
+	commandEnv.noLock = *skipChange
+	if err = commandEnv.confirmIsLocked(args); !*skipChange && err != nil {
 		return
 	}
-
-	takeAction := !*skipChange
 
 	underReplicatedVolumeIdsCount := 1
 	for underReplicatedVolumeIdsCount > 0 {


### PR DESCRIPTION
# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/pull/6209


# How are we solving the problem?

set noLock for skip change param

# How is the PR tested?

```
> volume.fix.replication -n
replicating volume 3317 100 from 192.168.1.1:8101 to dataNode 192.168.0.3:8117 ...
replicating volume 11417 100 from 192.168.1.3:8090 to dataNode 192.168.0.1:8101 ...
```


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
