### PR TITLE
[master] Revert back automatic volume grow in case of compensate for crowded volumes

### DIFF
--- a/weed/server/master_grpc_server_volume.go
+++ b/weed/server/master_grpc_server_volume.go
@@ -71,6 +71,9 @@ func (ms *MasterServer) ProcessGrowRequest() {
 				case mustGrow > 0:
 					vgr.WritableVolumeCount = uint32(mustGrow)
 					_, err = ms.VolumeGrow(ctx, vgr)
+				case lastGrowCount > 0 && writable < int(lastGrowCount*2) && float64(crowded+volumeGrowStepCount) > float64(writable)*topology.VolumeGrowStrategy.Threshold:
+					vgr.WritableVolumeCount = volumeGrowStepCount
+					_, err = ms.VolumeGrow(ctx, vgr)
 				default:
 					for _, dc := range dcs {
 						if vl.ShouldGrowVolumesByDataNode("DataCenter", dc) {


### PR DESCRIPTION
# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/6121

# How are we solving the problem?

Returned the advanced growth of volumes to compensate for the volumes leaving due to crowded
Also added a limit on the growth of volumes available for writable, if suddenly something goes wrong with the calculation of crowded volumes

# How is the PR tested?

On dev cluster

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
