### PR TITLE
change comment for expect header

### DIFF
--- a/weed/s3api/auth_signature_v4.go
+++ b/weed/s3api/auth_signature_v4.go
@@ -665,24 +665,6 @@ func extractSignedHeaders(signedHeaders []string, r *http.Request) (http.Header,
 			continue
 		}
 		switch header {
-		case "expect":
-			// Golang http server strips off 'Expect' header, if the
-			// client sent this as part of signed headers we need to
-			// handle otherwise we would see a signature mismatch.
-			// `aws-cli` sets this as part of signed headers.
-			//
-			// According to
-			// http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.20
-			// Expect header is always of form:
-			//
-			//   Expect       =  "Expect" ":" 1#expectation
-			//   expectation  =  "100-continue" | expectation-extension
-			//
-			// So it safe to assume that '100-continue' is what would
-			// be sent, for the time being keep this work around.
-			// Adding a *TODO* to remove this later when Golang server
-			// doesn't filter out the 'Expect' header.
-			extractedSignedHeaders.Set(header, "100-continue")
 		case "host":
 			// Go http server removes "host" from Request.Header
 			if forwardedHost := r.Header.Get("X-Forwarded-Host"); forwardedHost != "" {

--- a/weed/s3api/auth_signature_v4.go
+++ b/weed/s3api/auth_signature_v4.go
@@ -665,6 +665,23 @@ func extractSignedHeaders(signedHeaders []string, r *http.Request) (http.Header,
 			continue
 		}
 		switch header {
+		case "expect":
+			// Set the default value of the Expect header for compatibility.
+			//
+			// In NGINX v1.1, the Expect header is removed when handling 100-continue requests.
+			//
+			// `aws-cli` sets this as part of signed headers.
+			//
+			// According to
+			// http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.20
+			// Expect header is always of form:
+			//
+			//   Expect       =  "Expect" ":" 1#expectation
+			//   expectation  =  "100-continue" | expectation-extension
+			//
+			// So it safe to assume that '100-continue' is what would
+			// be sent, for the time being keep this work around.
+			extractedSignedHeaders.Set(header, "100-continue")
 		case "host":
 			// Go http server removes "host" from Request.Header
 			if forwardedHost := r.Header.Get("X-Forwarded-Host"); forwardedHost != "" {


### PR DESCRIPTION
# What problem are we solving?
golang server now do not strips off 'Expect' header, so we can remove this piece of code now.


# How are we solving the problem?



# How is the PR tested?

```
// curl -v -X POST "http://localhost:8080" -H "Expect: 100-continue" --data "Hello, World"
func Test100ContinueServer(t *testing.T) {
	http.HandleFunc("/", handler)
	http.ListenAndServe(":8080", nil)
}

func handler(w http.ResponseWriter, r *http.Request) {
	expectValue := r.Header.Get("Expect")
        // output: Expect Header: 100-continue
	fmt.Printf("Expect Header: %s\n", expectValue)

	body, err := io.ReadAll(r.Body)
	if err != nil {
		http.Error(w, "Failed to read request body", http.StatusInternalServerError)
		return
	}
	defer r.Body.Close()

	fmt.Printf("Request Body: %s\n", string(body))

	fmt.Fprintf(w, "Request received and processed")
}

```

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
