### PR TITLE
Improve EC shards rebalancing logic across nodes

### DIFF
--- a/weed/shell/command_ec_common.go
+++ b/weed/shell/command_ec_common.go
@@ -712,9 +712,13 @@ func doBalanceEcRack(commandEnv *CommandEnv, ecRack *EcRack, applyBalancing bool
 }
 
 func pickEcNodeToBalanceShardsInto(vid needle.VolumeId, existingLocation *EcNode, possibleDestinations []*EcNode, replicaPlacement *super_block.ReplicaPlacement, averageShardsPerEcNode int) (*EcNode, error) {
-	if existingLocation == nil || len(possibleDestinations) == 0 {
-		return nil, fmt.Errorf("invalid source/destination nodes")
+	if existingLocation == nil {
+		return nil, fmt.Errorf("INTERNAL: missing source nodes")
 	}
+	if len(possibleDestinations) == 0 {
+		return nil, fmt.Errorf("INTERNAL: missing destination nodes")
+	}
+
 	nodeShards := map[*EcNode]int{}
 	for _, node := range possibleDestinations {
 		nodeShards[node] = findEcVolumeShards(node, vid).ShardIdCount()

--- a/weed/shell/command_ec_common_test.go
+++ b/weed/shell/command_ec_common_test.go
@@ -146,8 +146,8 @@ func TestPickEcNodeToBalanceShardsInto(t *testing.T) {
 		wantOneOf []string
 		wantErr   string
 	}{
-		{topologyEc, "", "", nil, "invalid source/destination nodes"},
-		{topologyEc, "idontexist", "12737", nil, "invalid source/destination nodes"},
+		{topologyEc, "", "", nil, "INTERNAL: missing source nodes"},
+		{topologyEc, "idontexist", "12737", nil, "INTERNAL: missing source nodes"},
 		// Non-EC nodes. We don't care about these, but the function should return all available target nodes as a safeguard.
 		{
 			topologyEc, "172.19.0.10:8702", "6225", []string{

--- a/weed/shell/command_ec_common_test.go
+++ b/weed/shell/command_ec_common_test.go
@@ -148,13 +148,12 @@ func TestPickEcNodeToBalanceShardsInto(t *testing.T) {
 	}{
 		{topologyEc, "", "", nil, "invalid source/destination nodes"},
 		{topologyEc, "idontexist", "12737", nil, "invalid source/destination nodes"},
-
 		// Non-EC nodes. We don't care about these, but the function should return all available target nodes as a safeguard.
 		{
 			topologyEc, "172.19.0.10:8702", "6225", []string{
 				"172.19.0.13:8701", "172.19.0.14:8711", "172.19.0.16:8704", "172.19.0.17:8703",
 				"172.19.0.19:8700", "172.19.0.20:8706", "172.19.0.21:8710", "172.19.0.3:8708",
-				"172.19.0.4:8707 ", "172.19.0.5:8705", "172.19.0.6:8713", "172.19.0.8:8709",
+				"172.19.0.4:8707", "172.19.0.5:8705", "172.19.0.6:8713", "172.19.0.8:8709",
 				"172.19.0.9:8712"},
 			"",
 		},

--- a/weed/shell/command_ec_common_test.go
+++ b/weed/shell/command_ec_common_test.go
@@ -2,6 +2,7 @@ package shell
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
@@ -15,6 +16,22 @@ var (
 	topology2  = parseOutput(topoData2)
 	topologyEc = parseOutput(topoDataEc)
 )
+
+func errorCheck(got error, want string) error {
+	if got == nil && want == "" {
+		return nil
+	}
+	if got != nil && want == "" {
+		return fmt.Errorf("expected no error, got %q", got.Error())
+	}
+	if got == nil && want != "" {
+		return fmt.Errorf("got no error, expected %q", want)
+	}
+	if !strings.Contains(got.Error(), want) {
+		return fmt.Errorf("expected error %q, got %q", want, got.Error())
+	}
+	return nil
+}
 
 func TestEcDistribution(t *testing.T) {
 
@@ -59,19 +76,9 @@ func TestVolumeIdToReplicaPlacement(t *testing.T) {
 		ecNodes, _ := collectEcVolumeServersByDc(tc.topology, "")
 		got, gotErr := volumeIdToReplicaPlacement(vid, ecNodes)
 
-		if tc.wantErr == "" && gotErr != nil {
-			t.Errorf("expected no error for volume %q, got %q", tc.vid, gotErr.Error())
+		if err := errorCheck(gotErr, tc.wantErr); err != nil {
+			t.Errorf("volume %q: %s", tc.vid, err.Error())
 			continue
-		}
-		if tc.wantErr != "" {
-			if gotErr == nil {
-				t.Errorf("got no error for volume %q, expected %q", tc.vid, tc.wantErr)
-				continue
-			}
-			if gotErr.Error() != tc.wantErr {
-				t.Errorf("expected error %q for volume %q, got %q", tc.wantErr, tc.vid, gotErr.Error())
-				continue
-			}
 		}
 
 		if got == nil {
@@ -128,6 +135,88 @@ func TestPickRackToBalanceShardsInto(t *testing.T) {
 		}
 		if !(found) {
 			t.Errorf("expected one of %v for volume %q, got %q", tc.wantOneOf, tc.vid, got)
+		}
+	}
+}
+func TestPickEcNodeToBalanceShardsInto(t *testing.T) {
+	testCases := []struct {
+		topology  *master_pb.TopologyInfo
+		nodeId    string
+		vid       string
+		wantOneOf []string
+		wantErr   string
+	}{
+		{topologyEc, "", "", nil, "invalid source/destination nodes"},
+		{topologyEc, "idontexist", "12737", nil, "invalid source/destination nodes"},
+
+		// Non-EC nodes. We don't care about these, but the function should return all available target nodes as a safeguard.
+		{
+			topologyEc, "172.19.0.10:8702", "6225", []string{
+				"172.19.0.13:8701", "172.19.0.14:8711", "172.19.0.16:8704", "172.19.0.17:8703",
+				"172.19.0.19:8700", "172.19.0.20:8706", "172.19.0.21:8710", "172.19.0.3:8708",
+				"172.19.0.4:8707 ", "172.19.0.5:8705", "172.19.0.6:8713", "172.19.0.8:8709",
+				"172.19.0.9:8712"},
+			"",
+		},
+		{
+			topologyEc, "172.19.0.8:8709", "6226", []string{
+				"172.19.0.10:8702", "172.19.0.13:8701", "172.19.0.14:8711", "172.19.0.16:8704",
+				"172.19.0.17:8703", "172.19.0.19:8700", "172.19.0.20:8706", "172.19.0.21:8710",
+				"172.19.0.3:8708", "172.19.0.4:8707", "172.19.0.5:8705", "172.19.0.6:8713",
+				"172.19.0.9:8712"},
+			"",
+		},
+		// EC volumes.
+		{topologyEc, "172.19.0.10:8702", "14322", []string{
+			"172.19.0.14:8711", "172.19.0.5:8705", "172.19.0.6:8713"},
+			""},
+		{topologyEc, "172.19.0.13:8701", "10457", []string{
+			"172.19.0.10:8702", "172.19.0.6:8713"},
+			""},
+		{topologyEc, "172.19.0.17:8703", "12737", []string{
+			"172.19.0.13:8701"},
+			""},
+		{topologyEc, "172.19.0.20:8706", "14322", []string{
+			"172.19.0.14:8711", "172.19.0.5:8705", "172.19.0.6:8713"},
+			""},
+	}
+
+	for _, tc := range testCases {
+		vid, _ := needle.NewVolumeId(tc.vid)
+		allEcNodes, _ := collectEcVolumeServersByDc(tc.topology, "")
+
+		// Resolve target node by name
+		var ecNode *EcNode
+		for _, n := range allEcNodes {
+			if n.info.Id == tc.nodeId {
+				ecNode = n
+				break
+			}
+		}
+
+		averageShardsPerEcNode := 5
+		got, gotErr := pickEcNodeToBalanceShardsInto(vid, ecNode, allEcNodes, nil, averageShardsPerEcNode)
+		if err := errorCheck(gotErr, tc.wantErr); err != nil {
+			t.Errorf("node %q, volume %q: %s", tc.nodeId, tc.vid, err.Error())
+			continue
+		}
+
+		if got == nil {
+			if len(tc.wantOneOf) == 0 {
+				continue
+			}
+			t.Errorf("node %q, volume %q: got no node, want %q", tc.nodeId, tc.vid, tc.wantOneOf)
+			continue
+		}
+		found := false
+		for _, want := range tc.wantOneOf {
+			if got := got.info.Id; got == want {
+				found = true
+				break
+			}
+		}
+		if !(found) {
+			t.Errorf("expected one of %v for volume %q, got %q", tc.wantOneOf, tc.vid, got.info.Id)
 		}
 	}
 }


### PR DESCRIPTION
# What problem are we solving?

Make EC balancing logic topology-aware: https://github.com/seaweedfs/seaweedfs/discussions/6179 .

# How are we solving the problem?

- Favor target nodes with less preexisting shards, to ensure a fair distribution.
- Randomize selection when multiple possible target nodes are available.
- Add logic to account for replication settings when selecting target nodes (currently disabled).

# How is the PR tested?

Added new unit tests for `pickEcNodeToBalanceShardsInto()`.

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
