### PR TITLE
Display details upon failures to re-balance EC shards racks.

### DIFF
--- a/weed/shell/command_ec_common_test.go
+++ b/weed/shell/command_ec_common_test.go
@@ -122,7 +122,12 @@ func TestPickRackToBalanceShardsInto(t *testing.T) {
 		rackToShardCount := countShardsByRack(vid, locations)
 		averageShardsPerEcRack := ceilDivide(erasure_coding.TotalShardsCount, len(racks))
 
-		got := pickRackToBalanceShardsInto(racks, rackToShardCount, nil, averageShardsPerEcRack)
+		got, gotErr := pickRackToBalanceShardsInto(racks, rackToShardCount, nil, averageShardsPerEcRack)
+		if gotErr != nil {
+			t.Errorf("volume %q: %s", tc.vid, gotErr.Error())
+			continue
+		}
+
 		if string(got) == "" && len(tc.wantOneOf) == 0 {
 			continue
 		}


### PR DESCRIPTION
Unifies the logic for `pickRackToBalanceShardsInto()` with ca499de1.

# What problem are we solving?

Make EC balancing logic topology-aware: https://github.com/seaweedfs/seaweedfs/discussions/6179 .

# How are we solving the problem?

Minor change to unify error reporting for EC re-balancing across shards & racks.

# How is the PR tested?

No changes on existing unit tests for the function, other than a check for a non-error status.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
