### PR TITLE
[security] reload whiteList on http seerver

### DIFF
--- a/weed/command/scaffold/security.toml
+++ b/weed/command/scaffold/security.toml
@@ -121,3 +121,7 @@ cert = ""
 key = ""
 ca = ""
 # disable_tls_verify_client_cert = true|false (default: false)
+
+# white list. It's checking request ip address.
+[guard]
+white_list = ""

--- a/weed/command/volume.go
+++ b/weed/command/volume.go
@@ -280,6 +280,7 @@ func (v VolumeServerOptions) startVolumeServer(volumeFolders, maxVolumeCounts, v
 	clusterHttpServer := v.startClusterHttpService(volumeMux)
 
 	grace.OnReload(volumeServer.LoadNewVolumes)
+	grace.OnReload(volumeServer.Reload)
 
 	stopChan := make(chan bool)
 	grace.OnInterrupt(func() {

--- a/weed/server/filer_server.go
+++ b/weed/server/filer_server.go
@@ -152,8 +152,8 @@ func NewFilerServer(defaultMux, readonlyMux *http.ServeMux, option *FilerOption)
 		}
 	})
 	fs.filer.Cipher = option.Cipher
-	// we do not support IP whitelist right now
-	fs.filerGuard = security.NewGuard([]string{}, signingKey, expiresAfterSec, readSigningKey, readExpiresAfterSec)
+	whiteList := util.StringSplit(v.GetString("guard.whiteList"), ",")
+	fs.filerGuard = security.NewGuard(whiteList, signingKey, expiresAfterSec, readSigningKey, readExpiresAfterSec)
 	fs.volumeGuard = security.NewGuard([]string{}, volumeSigningKey, volumeExpiresAfterSec, volumeReadSigningKey, volumeReadExpiresAfterSec)
 
 	fs.checkWithMaster()
@@ -187,12 +187,12 @@ func NewFilerServer(defaultMux, readonlyMux *http.ServeMux, option *FilerOption)
 	handleStaticResources(defaultMux)
 	if !option.DisableHttp {
 		defaultMux.HandleFunc("/healthz", fs.filerHealthzHandler)
-		defaultMux.HandleFunc("/", fs.filerHandler)
+		defaultMux.HandleFunc("/", fs.filerGuard.WhiteList(fs.filerHandler))
 	}
 	if defaultMux != readonlyMux {
 		handleStaticResources(readonlyMux)
 		readonlyMux.HandleFunc("/healthz", fs.filerHealthzHandler)
-		readonlyMux.HandleFunc("/", fs.readonlyFilerHandler)
+		readonlyMux.HandleFunc("/", fs.filerGuard.WhiteList(fs.readonlyFilerHandler))
 	}
 
 	existingNodes := fs.filer.ListExistingPeerUpdates(context.Background())
@@ -209,6 +209,7 @@ func NewFilerServer(defaultMux, readonlyMux *http.ServeMux, option *FilerOption)
 
 	fs.filer.LoadRemoteStorageConfAndMapping()
 
+	grace.OnReload(fs.Reload)
 	grace.OnInterrupt(func() {
 		fs.filer.Shutdown()
 	})
@@ -239,5 +240,12 @@ func (fs *FilerServer) checkWithMaster() {
 			}
 		}
 	}
+}
 
+func (fs *FilerServer) Reload() {
+	glog.V(0).Infoln("Reload filer server...")
+
+	util.LoadConfiguration("security", false)
+	v := util.GetViper()
+	fs.filerGuard.UpdateWhiteList(util.StringSplit(v.GetString("guard.whiteList"), ","))
 }

--- a/weed/server/filer_server.go
+++ b/weed/server/filer_server.go
@@ -152,7 +152,7 @@ func NewFilerServer(defaultMux, readonlyMux *http.ServeMux, option *FilerOption)
 		}
 	})
 	fs.filer.Cipher = option.Cipher
-	whiteList := util.StringSplit(v.GetString("guard.whiteList"), ",")
+	whiteList := util.StringSplit(v.GetString("guard.white_list"), ",")
 	fs.filerGuard = security.NewGuard(whiteList, signingKey, expiresAfterSec, readSigningKey, readExpiresAfterSec)
 	fs.volumeGuard = security.NewGuard([]string{}, volumeSigningKey, volumeExpiresAfterSec, volumeReadSigningKey, volumeReadExpiresAfterSec)
 
@@ -247,5 +247,5 @@ func (fs *FilerServer) Reload() {
 
 	util.LoadConfiguration("security", false)
 	v := util.GetViper()
-	fs.filerGuard.UpdateWhiteList(util.StringSplit(v.GetString("guard.whiteList"), ","))
+	fs.filerGuard.UpdateWhiteList(util.StringSplit(v.GetString("guard.white_list"), ","))
 }

--- a/weed/server/master_server.go
+++ b/weed/server/master_server.go
@@ -104,7 +104,7 @@ func NewMasterServer(r *mux.Router, option *MasterOption, peers map[string]pb.Se
 	topology.VolumeGrowStrategy.Copy3Count = v.GetUint32("master.volume_growth.copy_3")
 	topology.VolumeGrowStrategy.CopyOtherCount = v.GetUint32("master.volume_growth.copy_other")
 	topology.VolumeGrowStrategy.Threshold = v.GetFloat64("master.volume_growth.threshold")
-	whiteList := util.StringSplit(v.GetString("master.options.whiteList"), ",")
+	whiteList := util.StringSplit(v.GetString("guard.white_list"), ",")
 
 	var preallocateSize int64
 	if option.VolumePreallocate {
@@ -418,6 +418,6 @@ func (ms *MasterServer) Reload() {
 	util.LoadConfiguration("security", false)
 	v := util.GetViper()
 	ms.guard.UpdateWhiteList(append(ms.option.WhiteList,
-		util.StringSplit(v.GetString("guard.whiteList"), ",")...),
+		util.StringSplit(v.GetString("guard.white_list"), ",")...),
 	)
 }

--- a/weed/server/volume_server.go
+++ b/weed/server/volume_server.go
@@ -106,7 +106,7 @@ func NewVolumeServer(adminMux, publicMux *http.ServeMux, ip string,
 		whiteList:                     whiteList,
 	}
 
-	whiteList = append(whiteList, util.StringSplit(v.GetString("whiteList"), ",")...)
+	whiteList = append(whiteList, util.StringSplit(v.GetString("guard.white_list"), ",")...)
 	vs.SeedMasterNodes = masterNodes
 
 	vs.checkWithMaster()
@@ -160,5 +160,5 @@ func (vs *VolumeServer) Reload() {
 
 	util.LoadConfiguration("security", false)
 	v := util.GetViper()
-	vs.guard.UpdateWhiteList(append(vs.whiteList, util.StringSplit(v.GetString("guard.whiteList"), ",")...))
+	vs.guard.UpdateWhiteList(append(vs.whiteList, util.StringSplit(v.GetString("guard.white_list"), ",")...))
 }

--- a/weed/server/volume_server.go
+++ b/weed/server/volume_server.go
@@ -32,6 +32,7 @@ type VolumeServer struct {
 	readBufferSizeMB              int
 
 	SeedMasterNodes []pb.ServerAddress
+	whiteList       []string
 	currentMaster   pb.ServerAddress
 	pulseSeconds    int
 	dataCenter      string
@@ -102,7 +103,10 @@ func NewVolumeServer(adminMux, publicMux *http.ServeMux, ip string,
 		hasSlowRead:                   hasSlowRead,
 		readBufferSizeMB:              readBufferSizeMB,
 		ldbTimout:                     ldbTimeout,
+		whiteList:                     whiteList,
 	}
+
+	whiteList = append(whiteList, util.StringSplit(v.GetString("whiteList"), ",")...)
 	vs.SeedMasterNodes = masterNodes
 
 	vs.checkWithMaster()
@@ -149,4 +153,12 @@ func (vs *VolumeServer) Shutdown() {
 	glog.V(0).Infoln("Shutting down volume server...")
 	vs.store.Close()
 	glog.V(0).Infoln("Shut down successfully!")
+}
+
+func (vs *VolumeServer) Reload() {
+	glog.V(0).Infoln("Reload volume server...")
+
+	util.LoadConfiguration("security", false)
+	v := util.GetViper()
+	vs.guard.UpdateWhiteList(append(vs.whiteList, util.StringSplit(v.GetString("guard.whiteList"), ",")...))
 }


### PR DESCRIPTION
# What problem are we solving?

When adding or removing a new server volume, each disk requires updating all whitelists and a lengthy restart of each server volume in turn.


# How are we solving the problem?

Added reading and reloading of whitelist from security config

# How is the PR tested?

No, in progress

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
