### PR TITLE
Resolve replica placement for EC volumes from master server defaults.

### DIFF
--- a/weed/shell/command_ec_balance.go
+++ b/weed/shell/command_ec_balance.go
@@ -17,6 +17,7 @@ func (c *commandEcBalance) Name() string {
 	return "ec.balance"
 }
 
+// TODO: Update help string and move to command_ec_common.go once shard replica placement logic is enabled.
 func (c *commandEcBalance) Help() string {
 	return `balance all ec shards among all racks and volume servers
 

--- a/weed/shell/command_ec_balance.go
+++ b/weed/shell/command_ec_balance.go
@@ -20,7 +20,7 @@ func (c *commandEcBalance) Name() string {
 func (c *commandEcBalance) Help() string {
 	return `balance all ec shards among all racks and volume servers
 
-	ec.balance [-c EACH_COLLECTION|<collection_name>] [-force] [-dataCenter <data_center>]
+	ec.balance [-c EACH_COLLECTION|<collection_name>] [-force] [-dataCenter <data_center>] [-shardReplicaPlacement <replica_placement>]
 
 	Algorithm:
 
@@ -100,6 +100,7 @@ func (c *commandEcBalance) Do(args []string, commandEnv *CommandEnv, writer io.W
 	balanceCommand := flag.NewFlagSet(c.Name(), flag.ContinueOnError)
 	collection := balanceCommand.String("collection", "EACH_COLLECTION", "collection name, or \"EACH_COLLECTION\" for each collection")
 	dc := balanceCommand.String("dataCenter", "", "only apply the balancing for this dataCenter")
+	shardReplicaPlacement := balanceCommand.String("shardReplicaPlacement", "", "replica placement for EC shards, or master default if empty (currently unused)")
 	applyBalancing := balanceCommand.Bool("force", false, "apply the balancing plan")
 	if err = balanceCommand.Parse(args); err != nil {
 		return nil
@@ -121,5 +122,10 @@ func (c *commandEcBalance) Do(args []string, commandEnv *CommandEnv, writer io.W
 	}
 	fmt.Printf("balanceEcVolumes collections %+v\n", len(collections))
 
-	return EcBalance(commandEnv, collections, *dc, *applyBalancing)
+	rp, err := parseReplicaPlacementArg(commandEnv, *shardReplicaPlacement)
+	if err != nil {
+		return err
+	}
+
+	return EcBalance(commandEnv, collections, *dc, rp, *applyBalancing)
 }

--- a/weed/shell/command_ec_common.go
+++ b/weed/shell/command_ec_common.go
@@ -847,11 +847,6 @@ func collectVolumeIdToEcNodes(allEcNodes []*EcNode, collection string) map[needl
 
 // TODO: EC volumes have no replica placement info :( We need a better solution to resolve topology, and balancing, for those.
 func volumeIdToReplicaPlacement(commandEnv *CommandEnv, vid needle.VolumeId, nodes []*EcNode) (*super_block.ReplicaPlacement, error) {
-	defaultReplicaPlacement, err := getDefaultReplicaPlacement(commandEnv)
-	if err != nil {
-		return nil, err
-	}
-
 	for _, ecNode := range nodes {
 		for _, diskInfo := range ecNode.info.DiskInfos {
 			for _, volumeInfo := range diskInfo.VolumeInfos {
@@ -861,6 +856,10 @@ func volumeIdToReplicaPlacement(commandEnv *CommandEnv, vid needle.VolumeId, nod
 			}
 			for _, ecShardInfo := range diskInfo.EcShardInfos {
 				if needle.VolumeId(ecShardInfo.Id) == vid {
+					defaultReplicaPlacement, err := getDefaultReplicaPlacement(commandEnv)
+					if err != nil {
+						return nil, err
+					}
 					return defaultReplicaPlacement, nil
 				}
 			}


### PR DESCRIPTION
# What problem are we solving?

Make EC balancing logic topology-aware: https://github.com/seaweedfs/seaweedfs/discussions/6179 .

# How are we solving the problem?

Implements a stopgap solution for EC re-balancing based on system topology, as Seaweed currently has no support for shard placement strategy options.

The plan is to rely on volume replication settings to filter destination racks/nodes for EC shards which need to move. Since EC shards have no replication information, we read EC replica settings from command line arguments, or master defaults if left unspecified.

Moving forward, we'll need a better solution in place - maybe as simple as a new `shard_placement` field.

# How is the PR tested?

New unit test for `parseReplicaPlacementArg()`, updated unit tests for `getDefaultReplicaPlacement()`.

# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
