### PR TITLE
Account for replication placement settings when balancing EC shards across racks.

### DIFF
--- a/weed/shell/command_ec_test.go
+++ b/weed/shell/command_ec_test.go
@@ -28,7 +28,7 @@ func TestCommandEcBalanceSmall(t *testing.T) {
 	}
 
 	racks := collectRacks(allEcNodes)
-	balanceEcVolumes(nil, "c1", allEcNodes, racks, false)
+	balanceEcVolumes(nil, "c1", allEcNodes, racks, nil, false)
 }
 
 func TestCommandEcBalanceNothingToMove(t *testing.T) {
@@ -43,7 +43,7 @@ func TestCommandEcBalanceNothingToMove(t *testing.T) {
 	}
 
 	racks := collectRacks(allEcNodes)
-	balanceEcVolumes(nil, "c1", allEcNodes, racks, false)
+	balanceEcVolumes(nil, "c1", allEcNodes, racks, nil, false)
 }
 
 func TestCommandEcBalanceAddNewServers(t *testing.T) {
@@ -60,7 +60,7 @@ func TestCommandEcBalanceAddNewServers(t *testing.T) {
 	}
 
 	racks := collectRacks(allEcNodes)
-	balanceEcVolumes(nil, "c1", allEcNodes, racks, false)
+	balanceEcVolumes(nil, "c1", allEcNodes, racks, nil, false)
 }
 
 func TestCommandEcBalanceAddNewRacks(t *testing.T) {
@@ -77,7 +77,7 @@ func TestCommandEcBalanceAddNewRacks(t *testing.T) {
 	}
 
 	racks := collectRacks(allEcNodes)
-	balanceEcVolumes(nil, "c1", allEcNodes, racks, false)
+	balanceEcVolumes(nil, "c1", allEcNodes, racks, nil, false)
 }
 
 func TestCommandEcBalanceVolumeEvenButRackUneven(t *testing.T) {
@@ -119,7 +119,7 @@ func TestCommandEcBalanceVolumeEvenButRackUneven(t *testing.T) {
 	}
 
 	racks := collectRacks(allEcNodes)
-	balanceEcVolumes(nil, "c1", allEcNodes, racks, false)
+	balanceEcVolumes(nil, "c1", allEcNodes, racks, nil, false)
 	balanceEcRacks(nil, racks, false)
 }
 


### PR DESCRIPTION
# What problem are we solving?

Make EC balancing logic topology-aware: https://github.com/seaweedfs/seaweedfs/discussions/6179 .

# How are we solving the problem?

Now that `ec.balance` has replication placement settings for EC shards, obey them when re-balancing shards across racks.

# How is the PR tested?

Updated unit tests for `pickRackToBalanceShardsInto()'.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
