### PR TITLE
Replaced https.client.enabled with false in scaffold/security

### DIFF
--- a/weed/command/scaffold/security.toml
+++ b/weed/command/scaffold/security.toml
@@ -98,7 +98,7 @@ key = ""
 # https client for master|volume|filer|etc connection
 # It is necessary that the parameters  [https.volume]|[https.master]|[https.filer] are set
 [https.client]
-enabled = true
+enabled = false
 cert = ""
 key = ""
 ca = ""


### PR DESCRIPTION
# What problem are we solving?
The value of the `https.client.enabled` parameter in the `scaffold/security` file, which is used as an example for configuration setup, has been updated. Previously, this parameter was always set to true. After introducing TLS, some users encountered issues caused by the parameter being enabled by default, even though it was not used before. The value has now been changed to false to prevent such situations in the future.


# Checks
- [ - ] I have added unit tests if possible.
- [ - ] I will add related wiki document changes and link to this PR after merging.
