### PR TITLE
Unify the re-balancing logic for `ec.encode` with `ec.balance`.

### DIFF
--- a/weed/shell/command_ec_balance.go
+++ b/weed/shell/command_ec_balance.go
@@ -24,73 +24,7 @@ func (c *commandEcBalance) Help() string {
 	ec.balance [-c EACH_COLLECTION|<collection_name>] [-force] [-dataCenter <data_center>] [-shardReplicaPlacement <replica_placement>]
 
 	Algorithm:
-
-	func EcBalance() {
-		for each collection:
-			balanceEcVolumes(collectionName)
-		for each rack:
-			balanceEcRack(rack)
-	}
-
-	func balanceEcVolumes(collectionName){
-		for each volume:
-			doDeduplicateEcShards(volumeId)
-
-		tracks rack~shardCount mapping
-		for each volume:
-			doBalanceEcShardsAcrossRacks(volumeId)
-
-		for each volume:
-			doBalanceEcShardsWithinRacks(volumeId)
-	}
-
-	// spread ec shards into more racks
-	func doBalanceEcShardsAcrossRacks(volumeId){
-		tracks rack~volumeIdShardCount mapping
-		averageShardsPerEcRack = totalShardNumber / numRacks  // totalShardNumber is 14 for now, later could varies for each dc
-		ecShardsToMove = select overflown ec shards from racks with ec shard counts > averageShardsPerEcRack
-		for each ecShardsToMove {
-			destRack = pickOneRack(rack~shardCount, rack~volumeIdShardCount, ecShardReplicaPlacement)
-			destVolumeServers = volume servers on the destRack
-			pickOneEcNodeAndMoveOneShard(destVolumeServers)
-		}
-	}
-
-	func doBalanceEcShardsWithinRacks(volumeId){
-		racks = collect all racks that the volume id is on
-		for rack, shards := range racks
-			doBalanceEcShardsWithinOneRack(volumeId, shards, rack)
-	}
-
-	// move ec shards 
-	func doBalanceEcShardsWithinOneRack(volumeId, shards, rackId){
-		tracks volumeServer~volumeIdShardCount mapping
-		averageShardCount = len(shards) / numVolumeServers
-		volumeServersOverAverage = volume servers with volumeId's ec shard counts > averageShardsPerEcRack
-		ecShardsToMove = select overflown ec shards from volumeServersOverAverage
-		for each ecShardsToMove {
-			destVolumeServer = pickOneVolumeServer(volumeServer~shardCount, volumeServer~volumeIdShardCount, ecShardReplicaPlacement)
-			pickOneEcNodeAndMoveOneShard(destVolumeServers)
-		}
-	}
-
-	// move ec shards while keeping shard distribution for the same volume unchanged or more even
-	func balanceEcRack(rack){
-		averageShardCount = total shards / numVolumeServers
-		for hasMovedOneEcShard {
-			sort all volume servers ordered by the number of local ec shards
-			pick the volume server A with the lowest number of ec shards x
-			pick the volume server B with the highest number of ec shards y
-			if y > averageShardCount and x +1 <= averageShardCount {
-				if B has a ec shard with volume id v that A does not have {
-					move one ec shard v from B to A
-					hasMovedOneEcShard = true
-				}
-			}
-		}
-	}
-
-`
+	` + ecBalanceAlgorithmDescription
 }
 
 func (c *commandEcBalance) HasTag(CommandTag) bool {

--- a/weed/shell/command_ec_common_test.go
+++ b/weed/shell/command_ec_common_test.go
@@ -32,6 +32,7 @@ func errorCheck(got error, want string) error {
 	}
 	return nil
 }
+
 func TestParseReplicaPlacementArg(t *testing.T) {
 	getDefaultReplicaPlacementOrig := getDefaultReplicaPlacement
 	getDefaultReplicaPlacement = func(commandEnv *CommandEnv) (*super_block.ReplicaPlacement, error) {

--- a/weed/shell/command_ec_decode.go
+++ b/weed/shell/command_ec_decode.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/storage/types"
@@ -239,25 +238,6 @@ func lookupVolumeIds(commandEnv *CommandEnv, volumeIds []string) (volumeIdLocati
 		return nil, err
 	}
 	return resp.VolumeIdLocations, nil
-}
-
-func collectTopologyInfo(commandEnv *CommandEnv, delayBeforeCollecting time.Duration) (topoInfo *master_pb.TopologyInfo, volumeSizeLimitMb uint64, err error) {
-
-	if delayBeforeCollecting > 0 {
-		time.Sleep(delayBeforeCollecting)
-	}
-
-	var resp *master_pb.VolumeListResponse
-	err = commandEnv.MasterClient.WithClient(false, func(client master_pb.SeaweedClient) error {
-		resp, err = client.VolumeList(context.Background(), &master_pb.VolumeListRequest{})
-		return err
-	})
-	if err != nil {
-		return
-	}
-
-	return resp.TopologyInfo, resp.VolumeSizeLimitMb, nil
-
 }
 
 func collectEcShardIds(topoInfo *master_pb.TopologyInfo, selectedCollection string) (vids []needle.VolumeId) {

--- a/weed/shell/command_ec_rebuild.go
+++ b/weed/shell/command_ec_rebuild.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"io"
 
 	"github.com/seaweedfs/seaweedfs/weed/operation"
+	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/volume_server_pb"
 	"github.com/seaweedfs/seaweedfs/weed/storage/erasure_coding"
 	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
@@ -74,7 +74,7 @@ func (c *commandEcRebuild) Do(args []string, commandEnv *CommandEnv, writer io.W
 	}
 
 	// collect all ec nodes
-	allEcNodes, _, err := collectEcNodes(commandEnv, "")
+	allEcNodes, _, err := collectEcNodes(commandEnv)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# What problem are we solving?

Make EC balancing logic topology-aware: https://github.com/seaweedfs/seaweedfs/discussions/6179 .

# How are we solving the problem?

`ec.encode` performs (basic) re-balancing after volumes are EC encoded. This change unifies this re-balancing logic with the one for `ec.balance`.

Among others, it enables recent changes related to topology aware re-balancing at EC encoding time.

# How is the PR tested?

No algorithmic changes; this MR swaps the EC re-balancing logic for `shell.EcBalance()`, which already has unit test coverage.

# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
