### PR TITLE
Begin implementing EC balancing parallelization support.

### DIFF
--- a/weed/shell/command_ec_balance.go
+++ b/weed/shell/command_ec_balance.go
@@ -36,6 +36,7 @@ func (c *commandEcBalance) Do(args []string, commandEnv *CommandEnv, writer io.W
 	collection := balanceCommand.String("collection", "EACH_COLLECTION", "collection name, or \"EACH_COLLECTION\" for each collection")
 	dc := balanceCommand.String("dataCenter", "", "only apply the balancing for this dataCenter")
 	shardReplicaPlacement := balanceCommand.String("shardReplicaPlacement", "", "replica placement for EC shards, or master default if empty")
+	parallelize := balanceCommand.Bool("parallelize", true, "parallelize operations whenever possible")
 	applyBalancing := balanceCommand.Bool("force", false, "apply the balancing plan")
 	if err = balanceCommand.Parse(args); err != nil {
 		return nil
@@ -62,5 +63,5 @@ func (c *commandEcBalance) Do(args []string, commandEnv *CommandEnv, writer io.W
 		return err
 	}
 
-	return EcBalance(commandEnv, collections, *dc, rp, *applyBalancing)
+	return EcBalance(commandEnv, collections, *dc, rp, *parallelize, *applyBalancing)
 }

--- a/weed/shell/command_ec_balance.go
+++ b/weed/shell/command_ec_balance.go
@@ -17,7 +17,6 @@ func (c *commandEcBalance) Name() string {
 	return "ec.balance"
 }
 
-// TODO: Update help string and move to command_ec_common.go once shard replica placement logic is enabled.
 func (c *commandEcBalance) Help() string {
 	return `balance all ec shards among all racks and volume servers
 

--- a/weed/shell/command_ec_common.go
+++ b/weed/shell/command_ec_common.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand/v2"
-  "sort"
+	"sort"
 	"sync"
 	"time"
 
@@ -560,7 +560,7 @@ type ecBalancer struct {
 	parallelize      bool
 
 	wg *sync.WaitGroup
-	// TOOD: Maybe accumulate all errors instead of just the last one.
+	// TODO: Maybe accumulate all errors instead of just the last one.
 	wgError error
 }
 

--- a/weed/shell/command_ec_common.go
+++ b/weed/shell/command_ec_common.go
@@ -523,14 +523,14 @@ type ecBalancer struct {
 	wgError error
 }
 
-type wgFunction func() error
+type ecBalancerTask func() error
 
 func (ecb *ecBalancer) WgInit() {
 	ecb.wg = sync.WaitGroup{}
 	ecb.wgError = nil
 }
 
-func (ecb *ecBalancer) WgAdd(f wgFunction) {
+func (ecb *ecBalancer) WgAdd(f ecBalancerTask) {
 	if !ecb.parallelize {
 		if err := f(); err != nil {
 			ecb.wgError = err

--- a/weed/shell/command_ec_common.go
+++ b/weed/shell/command_ec_common.go
@@ -550,7 +550,7 @@ func (ecb *ecBalancer) wgAdd(f ecBalancerTask) {
 }
 
 func (ecb *ecBalancer) wgWait() error {
-	if ecb.wg == nil {
+	if ecb.wg != nil {
 		ecb.wg.Wait()
 	}
 	err := ecb.wgError

--- a/weed/shell/command_ec_encode.go
+++ b/weed/shell/command_ec_encode.go
@@ -68,8 +68,7 @@ func (c *commandEcEncode) Do(args []string, commandEnv *CommandEnv, writer io.Wr
 	collection := encodeCommand.String("collection", "", "the collection name")
 	fullPercentage := encodeCommand.Float64("fullPercent", 95, "the volume reaches the percentage of max volume size")
 	quietPeriod := encodeCommand.Duration("quietFor", time.Hour, "select volumes without no writes for this period")
-	// TODO: Add concurrency support to EcBalance and reenable this switch?
-	//parallelCopy := encodeCommand.Bool("parallelCopy", true, "copy shards in parallel")
+	parallelize := encodeCommand.Bool("parallelize", true, "parallelize operations whenever possible")
 	forceChanges := encodeCommand.Bool("force", false, "force the encoding even if the cluster has less than recommended 4 nodes")
 	shardReplicaPlacement := encodeCommand.String("shardReplicaPlacement", "", "replica placement for EC shards, or master default if empty")
 	applyBalancing := encodeCommand.Bool("rebalance", false, "re-balance EC shards after creation")
@@ -132,7 +131,7 @@ func (c *commandEcEncode) Do(args []string, commandEnv *CommandEnv, writer io.Wr
 		}
 	}
 	// ...then re-balance ec shards.
-	if err := EcBalance(commandEnv, collections, "", rp, *applyBalancing); err != nil {
+	if err := EcBalance(commandEnv, collections, "", rp, *parallelize, *applyBalancing); err != nil {
 		return fmt.Errorf("re-balance ec shards for collection(s) %v: %v", collections, err)
 	}
 


### PR DESCRIPTION
# What problem are we solving?

Make EC balancing logic topology-aware: https://github.com/seaweedfs/seaweedfs/discussions/6179 .

# How are we solving the problem?

Begin the implementation of parallel EC re-balancing operations within `shell.EcBalance()`.

This impacts both `ec.encode` and `ec.balance`.

# How is the PR tested?

No algorithmic changes, other than running EC sub-tasks in parallel. Following changes will likely require at least unit testing.

# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
