### PR TITLE
Limit EC re-balancing for `ec.encode` to relevant collections when a volume ID argument is provided.

### DIFF
--- a/weed/shell/command_ec_common.go
+++ b/weed/shell/command_ec_common.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand/v2"
+	"sort"
 	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
@@ -180,6 +181,46 @@ func collectEcNodesForDC(commandEnv *CommandEnv, selectedDataCenter string) (ecN
 
 func collectEcNodes(commandEnv *CommandEnv) (ecNodes []*EcNode, totalFreeEcSlots int, err error) {
 	return collectEcNodesForDC(commandEnv, "")
+}
+
+func collectCollectionsForVolumeIds(t *master_pb.TopologyInfo, vids []needle.VolumeId) []string {
+	if len(vids) == 0 {
+		return nil
+	}
+
+	found := map[string]bool{}
+	for _, dc := range t.DataCenterInfos {
+		for _, r := range dc.RackInfos {
+			for _, dn := range r.DataNodeInfos {
+				for _, diskInfo := range dn.DiskInfos {
+					for _, vi := range diskInfo.VolumeInfos {
+						for _, vid := range vids {
+							if needle.VolumeId(vi.Id) == vid && vi.Collection != "" {
+								found[vi.Collection] = true
+							}
+						}
+					}
+					for _, ecs := range diskInfo.EcShardInfos {
+						for _, vid := range vids {
+							if needle.VolumeId(ecs.Id) == vid && ecs.Collection != "" {
+								found[ecs.Collection] = true
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	if len(found) == 0 {
+		return nil
+	}
+
+	collections := []string{}
+	for k, _ := range found {
+		collections = append(collections, k)
+	}
+	sort.Strings(collections)
+	return collections
 }
 
 func moveMountedShardToEcNode(commandEnv *CommandEnv, existingLocation *EcNode, collection string, vid needle.VolumeId, shardId erasure_coding.ShardId, destinationEcNode *EcNode, applyBalancing bool) (err error) {

--- a/weed/shell/command_ec_encode.go
+++ b/weed/shell/command_ec_encode.go
@@ -118,11 +118,7 @@ func (c *commandEcEncode) Do(args []string, commandEnv *CommandEnv, writer io.Wr
 	if *collection != "" {
 		collections = []string{*collection}
 	} else {
-		// TODO: should we limit this to collections associated with the provided volume ID?
-		collections, err = ListCollectionNames(commandEnv, false, true)
-		if err != nil {
-			return err
-		}
+		collections = collectCollectionsForVolumeIds(topologyInfo, volumeIds)
 	}
 
 	// encode all requested volumes...


### PR DESCRIPTION
# What problem are we solving?

Make EC balancing logic topology-aware: https://github.com/seaweedfs/seaweedfs/discussions/6179 .

# How are we solving the problem?

TODO cleanup for https://github.com/seaweedfs/seaweedfs/discussions/6179 .

When a `volumeId` parameter is passed to `ec.encode`, limit the subsequent EC rebalance to collection(s) for that volume ID,
instead of the whole topology.

# How is the PR tested?

Added unit tests for the new function `shell.collectCollectionsForVolumeIds()`

# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
