### PR TITLE
fix: record and delete bucket metrics after inactive

### DIFF
--- a/weed/s3api/stats.go
+++ b/weed/s3api/stats.go
@@ -1,12 +1,13 @@
 package s3api
 
 import (
-	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
-	stats_collect "github.com/seaweedfs/seaweedfs/weed/stats"
-	"github.com/seaweedfs/seaweedfs/weed/util"
 	"net/http"
 	"strconv"
 	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
+	stats_collect "github.com/seaweedfs/seaweedfs/weed/stats"
+	"github.com/seaweedfs/seaweedfs/weed/util"
 )
 
 func track(f http.HandlerFunc, action string) http.HandlerFunc {
@@ -25,10 +26,12 @@ func track(f http.HandlerFunc, action string) http.HandlerFunc {
 		}
 		stats_collect.S3RequestHistogram.WithLabelValues(action, bucket).Observe(time.Since(start).Seconds())
 		stats_collect.S3RequestCounter.WithLabelValues(action, strconv.Itoa(recorder.Status), bucket).Inc()
+		stats_collect.RecordBucketActiveTime(bucket)
 	}
 }
 
 func TimeToFirstByte(action string, start time.Time, r *http.Request) {
 	bucket, _ := s3_constants.GetBucketAndObject(r)
 	stats_collect.S3TimeToFirstByteHistogram.WithLabelValues(action, bucket).Observe(float64(time.Since(start).Milliseconds()))
+	stats_collect.RecordBucketActiveTime(bucket)
 }


### PR DESCRIPTION
# What problem are we solving?

Metrics related to collections and buckets should be deleted after they become inactive. If not, we will end up with more and more huge metrics as the system runs, especially in environments where buckets are created, uploaded to, and deleted over time.


# How are we solving the problem?

1 Delete collection metrics after the collection is deleted.
2 Record and delete bucket metrics after they become inactive for 10 minutes.

# How is the PR tested?

Tested in my development environment on the master branch.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
