### PR TITLE
Update store.go

### DIFF
--- a/weed/storage/store.go
+++ b/weed/storage/store.go
@@ -381,6 +381,7 @@ func (s *Store) CollectHeartbeat() *master_pb.Heartbeat {
 
 func (s *Store) deleteExpiredEcVolumes() (ecShards, deleted []*master_pb.VolumeEcShardInformationMessage) {
 	for _, location := range s.Locations {
+		location.ecVolumesLock.RLock()
 		for _, ev := range location.ecVolumes {
 			messages := ev.ToVolumeEcShardInformationMessage()
 			if ev.IsTimeToDestroy() {
@@ -395,6 +396,7 @@ func (s *Store) deleteExpiredEcVolumes() (ecShards, deleted []*master_pb.VolumeE
 				ecShards = append(ecShards, messages...)
 			}
 		}
+		location.ecVolumesLock.RUnlock()
 	}
 	return
 }


### PR DESCRIPTION
Add lock for location.ecVolumes when for each location.ecVolumes

# What problem are we solving?
fatal error: concurrent map iteration and map write


# How are we solving the problem?
Add lock


# How is the PR tested?
no test


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
