### PR TITLE
Fix for DeleteMultipleObjectsHandler wrongly deleting parent folders

### DIFF
--- a/weed/s3api/s3api_object_handlers_delete.go
+++ b/weed/s3api/s3api_object_handlers_delete.go
@@ -3,11 +3,12 @@ package s3api
 import (
 	"encoding/xml"
 	"fmt"
-	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
-	"golang.org/x/exp/slices"
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
+	"golang.org/x/exp/slices"
 
 	"github.com/seaweedfs/seaweedfs/weed/filer"
 
@@ -155,6 +156,10 @@ func (s3a *S3ApiServer) DeleteMultipleObjectsHandler(w http.ResponseWriter, r *h
 				auditLog.Key = entryName
 				s3err.PostAccessLog(*auditLog)
 			}
+		}
+
+		if s3a.option.AllowEmptyFolder {
+			return nil
 		}
 
 		// purge empty folders, only checking folders with deletions


### PR DESCRIPTION
# What problem are we solving?
Fix: #6379

# How are we solving the problem?
We check for the AllowEmptyFolders option prior to cascade deleting parent folders in S3 DeleteMultipleObjectsHandler.

# How is the PR tested?
We ran SeaweedFS in a Kubernetes Cluster with a joint Filer and S3 server in one container, with leveldb2 as the filer storage, and AllowEmptyFolders set to true.

When using the Distribution Registry as the S3 client, it calls the DeleteMultipleObjectsHandler as part of the artifact upload process (uploads to a temp location, then performs a copy and delete). Without this fix, the deletion cascade deleted parent folder until the entire contents of the bucket were gone.

With this fix, the existing content of the bucket remained, and the newly uploaded content was added.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.