### PR TITLE
Replace bolt dependency with bbolt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -369,3 +369,8 @@ require (
 )
 
 // replace github.com/seaweedfs/raft => /Users/chrislu/go/src/github.com/seaweedfs/raft
+
+replace (
+	github.com/boltdb/bolt => go.etcd.io/bbolt v1.3.10
+	go.etcd.io/bbolt => github.com/etcd-io/bbolt v1.3.10
+)

--- a/go.sum
+++ b/go.sum
@@ -699,8 +699,6 @@ github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932 h1:mXoPYz/Ul5HYE
 github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932/go.mod h1:NOuUCSz6Q9T7+igc/hlvDOUdtWKryOrtFyIVABv/p7k=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
-github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
-github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/bradenaw/juniper v0.15.2 h1:0JdjBGEF2jP1pOxmlNIrPhAoQN7Ng5IMAY5D0PHMW4U=
@@ -838,6 +836,8 @@ github.com/envoyproxy/protoc-gen-validate v0.9.1/go.mod h1:OKNgG7TCp5pF4d6XftA0+
 github.com/envoyproxy/protoc-gen-validate v0.10.0/go.mod h1:DRjgyB0I43LtJapqN6NiRwroiAU2PaFuvk/vjgh61ss=
 github.com/envoyproxy/protoc-gen-validate v1.1.0 h1:tntQDh69XqOCOZsDz0lVJQez/2L6Uu2PdjCQwWCJ3bM=
 github.com/envoyproxy/protoc-gen-validate v1.1.0/go.mod h1:sXRDRVmzEbkM7CVcM06s9shE/m23dg3wzjl0UWqJ2q4=
+github.com/etcd-io/bbolt v1.3.10 h1:ZRFKBa1zV7LzBwjKV2marp+1bWzM6PdMs1sEf5SLVl4=
+github.com/etcd-io/bbolt v1.3.10/go.mod h1:bK3UQLPJZly7IlNmV7uVHJDxfe5aK9Ll93e/74Y9oEQ=
 github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a h1:yDWHCSQ40h88yih2JAcL6Ls/kVkSE8GFACTGVnMPruw=
 github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a/go.mod h1:7Ga40egUymuWXxAe151lTNnCv97MddSOVsjpPPkityA=
 github.com/facebookgo/ensure v0.0.0-20200202191622-63f1cf65ac4c h1:8ISkoahWXwZR41ois5lSJBSVw4D0OV19Ht/JSTzvSv0=


### PR DESCRIPTION
# What problem are we solving?

There are some dependencies that still depends on the unmaintained bolt after https://github.com/seaweedfs/seaweedfs/pull/3554. Replace it so that we can have one less dependency, and build on newer architecture like RISC-V.

# How are we solving the problem?

Two lines of `replace` are required because Go refuses to replace `github.com/boltdb/bolt` with `go.etcd.io/bbolt` when the latter is also present in the dependency tree. Replace it again with `github.com/etcd-io/bbolt` solves the issue.

# How is the PR tested?

We are able to build SeaweedFS and pass tests on Arch Linux RISC-V: https://github.com/felixonmars/archriscv-packages/pull/4376

# Checks

The PR does not introduce visible changes to usage.

- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
