### PR TITLE
use same time format in volume volume UI and filter UI

### DIFF
--- a/weed/server/volume_server_ui/volume.html
+++ b/weed/server/volume_server_ui/volume.html
@@ -185,7 +185,7 @@
                 <td>{{ .Collection }}</td>
                 <td>{{ bytesToHumanReadable .ShardSize }}</td>
                 <td>{{ .ShardIdList }}</td>
-                <td>{{ .CreatedAt.Format "02 Jan 06 15:04 -0700" }}</td>
+                <td>{{ .CreatedAt.Format "2006-01-02 15:04" }}</td>
             </tr>
             {{ end }}
             </tbody>


### PR DESCRIPTION
# What problem are we solving?

currently we use different time format in web ui:

![image](https://github.com/user-attachments/assets/f2139c93-68dd-465e-9d30-c10559cdee3c)
![image](https://github.com/user-attachments/assets/d6af9852-1311-4f26-8a50-cd9e27967a29)


# How are we solving the problem?

change time format in volume server UI to `"2006-01-02 15:04"` to match them


# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
