### PR TITLE
Update command_fs_merge_volumes.go

### DIFF
--- a/weed/shell/command_fs_merge_volumes.go
+++ b/weed/shell/command_fs_merge_volumes.go
@@ -112,13 +112,13 @@ func (c *commandFsMergeVolumes) Do(args []string, commandEnv *CommandEnv, writer
 				return
 			}
 			for _, chunk := range entry.Chunks {
-				if chunk.IsChunkManifest {
-					fmt.Printf("Change volume id for large file is not implemented yet: %s/%s\n", parentPath, entry.Name)
-					continue
-				}
 				chunkVolumeId := needle.VolumeId(chunk.Fid.VolumeId)
 				toVolumeId, found := plan[chunkVolumeId]
 				if !found {
+					continue
+				}
+				if chunk.IsChunkManifest {
+					fmt.Printf("Change volume id for large file is not implemented yet: %s/%s\n", parentPath, entry.Name)
 					continue
 				}
 				path := parentPath.Child(entry.Name)


### PR DESCRIPTION
Moved warning about large files after the check to see if the file exists on the source

# What problem are we solving?

When running `fs.mergeVolumes` there are warnings about large files that can't be moved for all large files in the cluster regardless of whether those particular files are on the source volume or not.

# How are we solving the problem?

Moving the warning report after the code sees if the file is on the source volume.

# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
