### PR TITLE
Add bucket's traffic metrics

### DIFF
--- a/k8s/charts/seaweedfs/dashboards/seaweedfs-grafana-dashboard.json
+++ b/k8s/charts/seaweedfs/dashboards/seaweedfs-grafana-dashboard.json
@@ -1512,6 +1512,96 @@
       },
       "fieldConfig": {
         "defaults": {
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 36
+      },
+      "id": 84,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.3.1",
+      "targets": [
+        {
+          "expr": "sum(rate(SeaweedFS_s3_bucket_traffic_received_bytes_total{namespace=\"$NAMESPACE\"}[$__interval])) by (bucket)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{bucket}}",
+          "refId": "A"
+        }
+      ],
+      "title": "S3 Bucket Traffic Received",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 36
+      },
+      "id": 85,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.3.1",
+      "targets": [
+        {
+          "expr": "sum(rate(SeaweedFS_s3_bucket_traffic_sent_bytes_total{namespace=\"$NAMESPACE\"}[$__interval])) by (bucket)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{bucket}}",
+          "refId": "A"
+        }
+      ],
+      "title": "S3 Bucket Traffic Sent",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
           "color": {
             "mode": "palette-classic"
           },
@@ -1571,7 +1661,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 36
+        "y": 41
       },
       "id": 72,
       "links": [],
@@ -1689,7 +1779,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 50
       },
       "id": 73,
       "links": [],
@@ -1845,7 +1935,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 50
+        "y": 57
       },
       "id": 55,
       "links": [],
@@ -2002,7 +2092,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 57
+        "y": 64
       },
       "hideTimeOverride": false,
       "id": 59,
@@ -2074,7 +2164,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 64
+        "y": 71
       },
       "id": 62,
       "panels": [],
@@ -2146,7 +2236,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 65
+        "y": 72
       },
       "id": 47,
       "links": [],
@@ -2289,7 +2379,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 65
+        "y": 72
       },
       "id": 40,
       "links": [],
@@ -2386,7 +2476,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 72
+        "y": 79
       },
       "id": 48,
       "links": [],
@@ -2496,7 +2586,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 79
+        "y": 86
       },
       "id": 50,
       "links": [],
@@ -2598,7 +2688,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 86
+        "y": 93
       },
       "id": 51,
       "links": [],
@@ -2711,7 +2801,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 94
+        "y": 101
       },
       "id": 12,
       "links": [],
@@ -2806,7 +2896,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 94
+        "y": 101
       },
       "id": 14,
       "links": [],
@@ -2848,7 +2938,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 101
+        "y": 108
       },
       "id": 64,
       "panels": [],
@@ -2921,7 +3011,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 102
+        "y": 109
       },
       "id": 52,
       "links": [],
@@ -3049,7 +3139,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 102
+        "y": 109
       },
       "id": 54,
       "links": [],
@@ -3146,7 +3236,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 109
+        "y": 116
       },
       "id": 53,
       "links": [],

--- a/other/metrics/grafana_seaweedfs.json
+++ b/other/metrics/grafana_seaweedfs.json
@@ -810,6 +810,192 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "${DS_PROMETHEUS}",
+      "fill": 1,
+      "fillGradient": 0,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "hiddenSeries": false,
+      "id": 84,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.1.2",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(SeaweedFS_s3_bucket_traffic_received_bytes_total[$__interval])) by (bucket)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{bucket}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "S3 Bucket Traffic Received",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbytes",
+          "logBase": 1,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fill": 1,
+      "fillGradient": 0,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "hiddenSeries": false,
+      "id": 85,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.1.2",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(SeaweedFS_s3_bucket_traffic_sent_bytes_total[$__interval])) by (bucket)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{bucket}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "S3 Bucket Traffic Sent",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbytes",
+          "logBase": 1,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
       "editable": true,
       "error": false,
       "fill": 0,
@@ -819,7 +1005,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 9
+        "y": 16
       },
       "hiddenSeries": false,
       "id": 55,
@@ -928,7 +1114,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 23
       },
       "hiddenSeries": false,
       "hideTimeOverride": false,
@@ -1068,7 +1254,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 23
+        "y": 30
       },
       "id": 71,
       "panels": [],
@@ -1091,7 +1277,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 24
+        "y": 31
       },
       "hiddenSeries": false,
       "id": 47,
@@ -1195,7 +1381,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 24
+        "y": 31
       },
       "hiddenSeries": false,
       "id": 40,
@@ -1294,7 +1480,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 31
+        "y": 38
       },
       "hiddenSeries": false,
       "id": 48,
@@ -1393,7 +1579,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 38
+        "y": 45
       },
       "hiddenSeries": false,
       "id": 50,
@@ -1492,7 +1678,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 52
       },
       "hiddenSeries": false,
       "id": 51,
@@ -1583,7 +1769,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 52
+        "y": 59
       },
       "id": 72,
       "panels": [],
@@ -1606,7 +1792,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 53
+        "y": 60
       },
       "hiddenSeries": false,
       "id": 12,
@@ -1702,7 +1888,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 53
+        "y": 60
       },
       "hiddenSeries": false,
       "id": 14,
@@ -1797,7 +1983,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 60
+        "y": 67
       },
       "id": 73,
       "panels": [],
@@ -1820,7 +2006,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 61
+        "y": 68
       },
       "hiddenSeries": false,
       "id": 52,
@@ -1941,7 +2127,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 61
+        "y": 68
       },
       "hiddenSeries": false,
       "id": 54,
@@ -2037,7 +2223,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 68
+        "y": 75
       },
       "hiddenSeries": false,
       "id": 53,
@@ -2136,7 +2322,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 75
+        "y": 82
       },
       "hiddenSeries": false,
       "id": 66,
@@ -2287,7 +2473,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 75
+        "y": 82
       },
       "hiddenSeries": false,
       "id": 68,

--- a/other/metrics/grafana_seaweedfs_heartbeat.json
+++ b/other/metrics/grafana_seaweedfs_heartbeat.json
@@ -721,6 +721,168 @@
           "datasource": "${DS_PROMETHEUS-DEV}",
           "editable": true,
           "error": false,
+          "fill": 1,
+          "grid": {},
+          "id": 84,
+          "fieldConfig": {
+            "defaults": {
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(SeaweedFS_s3_bucket_traffic_received_bytes_total[$__interval])) by (bucket)",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{bucket}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "S3 Bucket Traffic Received",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "decbytes",
+              "logBase": 1,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": false
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_PROMETHEUS-DEV}",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {},
+          "id": 85,
+          "fieldConfig": {
+            "defaults": {
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "span": 6,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(rate(SeaweedFS_s3_bucket_traffic_sent_bytes_total[$__interval])) by (bucket)",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "{{bucket}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "S3 Bucket Traffic Sent",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "decbytes",
+              "logBase": 1,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": false
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_PROMETHEUS-DEV}",
+          "editable": true,
+          "error": false,
           "fill": 0,
           "grid": {},
           "id": 55,

--- a/other/metrics/grafana_seaweedfs_k8s.json
+++ b/other/metrics/grafana_seaweedfs_k8s.json
@@ -266,6 +266,192 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fill": 1,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "hiddenSeries": false,
+      "id": 84,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.1.2",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(SeaweedFS_s3_bucket_traffic_received_bytes_total{namespace=\"$namespace\",service=~\"$service-api\"}[$__interval])) by (bucket)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{bucket}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "S3 Bucket Traffic Received",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbytes",
+          "logBase": 1,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fill": 1,
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "hiddenSeries": false,
+      "id": 85,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "8.1.2",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(SeaweedFS_s3_bucket_traffic_sent_bytes_total{namespace=\"$namespace\",service=~\"$service-api\"}[$__interval])) by (bucket)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 2,
+          "legendFormat": "{{bucket}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "S3 Bucket Traffic Sent",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbytes",
+          "logBase": 1,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
       "datasource": "$DS_PROMETHEUS",
       "editable": true,
       "error": false,
@@ -282,7 +468,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 8
+        "y": 15
       },
       "hiddenSeries": false,
       "id": 68,
@@ -393,7 +579,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 8
+        "y": 15
       },
       "hiddenSeries": false,
       "id": 67,
@@ -504,7 +690,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 8
+        "y": 15
       },
       "hiddenSeries": false,
       "id": 65,
@@ -601,7 +787,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 22
       },
       "id": 55,
       "panels": [],
@@ -630,7 +816,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 16
+        "y": 23
       },
       "hiddenSeries": false,
       "id": 46,
@@ -741,7 +927,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 16
+        "y": 23
       },
       "hiddenSeries": false,
       "id": 49,
@@ -857,7 +1043,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 16
+        "y": 23
       },
       "hiddenSeries": false,
       "id": 66,
@@ -973,7 +1159,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 23
+        "y": 30
       },
       "hiddenSeries": false,
       "id": 2,
@@ -1072,7 +1258,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 30
+        "y": 37
       },
       "id": 56,
       "panels": [],
@@ -1101,7 +1287,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 31
+        "y": 38
       },
       "hiddenSeries": false,
       "id": 47,
@@ -1209,7 +1395,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 31
+        "y": 38
       },
       "hiddenSeries": false,
       "id": 40,
@@ -1312,7 +1498,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 38
+        "y": 45
       },
       "hiddenSeries": false,
       "id": 48,
@@ -1425,7 +1611,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 52
       },
       "hiddenSeries": false,
       "id": 50,
@@ -1530,7 +1716,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 52
+        "y": 59
       },
       "hiddenSeries": false,
       "id": 51,
@@ -1615,7 +1801,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 59
+        "y": 66
       },
       "id": 57,
       "panels": [],
@@ -1644,7 +1830,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 60
+        "y": 67
       },
       "hiddenSeries": false,
       "id": 12,
@@ -1744,7 +1930,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 60
+        "y": 67
       },
       "hiddenSeries": false,
       "id": 14,
@@ -1833,7 +2019,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 67
+        "y": 74
       },
       "id": 58,
       "panels": [],
@@ -1862,7 +2048,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 68
+        "y": 75
       },
       "hiddenSeries": false,
       "id": 52,
@@ -1990,7 +2176,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 68
+        "y": 75
       },
       "hiddenSeries": false,
       "id": 54,
@@ -2090,7 +2276,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 75
+        "y": 82
       },
       "hiddenSeries": false,
       "id": 53,

--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -234,7 +234,7 @@ func (s3a *S3ApiServer) proxyToFiler(w http.ResponseWriter, r *http.Request, des
 	setUserMetadataKeyToLowercase(resp)
 
 	responseStatusCode, bytesTransferred := responseFn(resp, w)
-	BucketTrafficReceived(bytesTransferred, r)
+	BucketTrafficSent(bytesTransferred, r)
 
 	s3err.PostLog(r, responseStatusCode, s3err.ErrNone)
 }

--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -135,7 +135,7 @@ func (s3a *S3ApiServer) HeadObjectHandler(w http.ResponseWriter, r *http.Request
 	s3a.proxyToFiler(w, r, destUrl, false, passThroughResponse)
 }
 
-func (s3a *S3ApiServer) proxyToFiler(w http.ResponseWriter, r *http.Request, destUrl string, isWrite bool, responseFn func(proxyResponse *http.Response, w http.ResponseWriter) (statusCode int)) {
+func (s3a *S3ApiServer) proxyToFiler(w http.ResponseWriter, r *http.Request, destUrl string, isWrite bool, responseFn func(proxyResponse *http.Response, w http.ResponseWriter) (statusCode int, bytesTransferred int64)) {
 
 	glog.V(3).Infof("s3 proxying %s to %s", r.Method, destUrl)
 	start := time.Now()
@@ -190,7 +190,7 @@ func (s3a *S3ApiServer) proxyToFiler(w http.ResponseWriter, r *http.Request, des
 	if r.Method == http.MethodDelete {
 		if resp.StatusCode == http.StatusNotFound {
 			// this is normal
-			responseStatusCode := responseFn(resp, w)
+			responseStatusCode, _ := responseFn(resp, w)
 			s3err.PostLog(r, responseStatusCode, s3err.ErrNone)
 			return
 		}
@@ -202,7 +202,7 @@ func (s3a *S3ApiServer) proxyToFiler(w http.ResponseWriter, r *http.Request, des
 
 	TimeToFirstByte(r.Method, start, r)
 	if resp.Header.Get(s3_constants.SeaweedFSIsDirectoryKey) == "true" {
-		responseStatusCode := responseFn(resp, w)
+		responseStatusCode, _ := responseFn(resp, w)
 		s3err.PostLog(r, responseStatusCode, s3err.ErrNone)
 		return
 	}
@@ -233,7 +233,9 @@ func (s3a *S3ApiServer) proxyToFiler(w http.ResponseWriter, r *http.Request, des
 
 	setUserMetadataKeyToLowercase(resp)
 
-	responseStatusCode := responseFn(resp, w)
+	responseStatusCode, bytesTransferred := responseFn(resp, w)
+	BucketTrafficReceived(bytesTransferred, r)
+
 	s3err.PostLog(r, responseStatusCode, s3err.ErrNone)
 }
 
@@ -246,7 +248,7 @@ func setUserMetadataKeyToLowercase(resp *http.Response) {
 	}
 }
 
-func passThroughResponse(proxyResponse *http.Response, w http.ResponseWriter) (statusCode int) {
+func passThroughResponse(proxyResponse *http.Response, w http.ResponseWriter) (statusCode int, bytesTransferred int64) {
 	for k, v := range proxyResponse.Header {
 		w.Header()[k] = v
 	}
@@ -259,8 +261,9 @@ func passThroughResponse(proxyResponse *http.Response, w http.ResponseWriter) (s
 	w.WriteHeader(statusCode)
 	buf := mem.Allocate(128 * 1024)
 	defer mem.Free(buf)
-	if n, err := io.CopyBuffer(w, proxyResponse.Body, buf); err != nil {
-		glog.V(1).Infof("passthrough response read %d bytes: %v", n, err)
+	bytesTransferred, err := io.CopyBuffer(w, proxyResponse.Body, buf)
+	if err != nil {
+		glog.V(1).Infof("passthrough response read %d bytes: %v", bytesTransferred, err)
 	}
-	return statusCode
+	return statusCode, bytesTransferred
 }

--- a/weed/s3api/s3api_object_handlers_put.go
+++ b/weed/s3api/s3api_object_handlers_put.go
@@ -162,7 +162,7 @@ func (s3a *S3ApiServer) putToFiler(r *http.Request, uploadUrl string, dataReader
 		glog.Errorf("upload to filer error: %v", ret.Error)
 		return "", filerErrorToS3Error(ret.Error)
 	}
-	stats_collect.S3BucketTrafficSentBytes.WithLabelValues(bucket).Add(float64(ret.Size))
+	stats_collect.S3BucketTrafficReceivedBytes.WithLabelValues(bucket).Add(float64(ret.Size))
 	return etag, s3err.ErrNone
 }
 

--- a/weed/s3api/s3api_object_handlers_put.go
+++ b/weed/s3api/s3api_object_handlers_put.go
@@ -17,6 +17,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	weed_server "github.com/seaweedfs/seaweedfs/weed/server"
+	stats_collect "github.com/seaweedfs/seaweedfs/weed/stats"
 )
 
 func (s3a *S3ApiServer) PutObjectHandler(w http.ResponseWriter, r *http.Request) {
@@ -161,7 +162,7 @@ func (s3a *S3ApiServer) putToFiler(r *http.Request, uploadUrl string, dataReader
 		glog.Errorf("upload to filer error: %v", ret.Error)
 		return "", filerErrorToS3Error(ret.Error)
 	}
-
+	stats_collect.S3BucketTrafficSentBytes.WithLabelValues(bucket).Add(float64(ret.Size))
 	return etag, s3err.ErrNone
 }
 

--- a/weed/s3api/s3api_object_handlers_put.go
+++ b/weed/s3api/s3api_object_handlers_put.go
@@ -162,7 +162,7 @@ func (s3a *S3ApiServer) putToFiler(r *http.Request, uploadUrl string, dataReader
 		glog.Errorf("upload to filer error: %v", ret.Error)
 		return "", filerErrorToS3Error(ret.Error)
 	}
-	stats_collect.S3BucketTrafficReceivedBytes.WithLabelValues(bucket).Add(float64(ret.Size))
+	stats_collect.S3BucketTrafficReceivedBytesCounter.WithLabelValues(bucket).Add(float64(ret.Size))
 	return etag, s3err.ErrNone
 }
 

--- a/weed/s3api/stats.go
+++ b/weed/s3api/stats.go
@@ -35,3 +35,8 @@ func TimeToFirstByte(action string, start time.Time, r *http.Request) {
 	stats_collect.S3TimeToFirstByteHistogram.WithLabelValues(action, bucket).Observe(float64(time.Since(start).Milliseconds()))
 	stats_collect.RecordBucketActiveTime(bucket)
 }
+
+func BucketTrafficReceived(bytesTransferred int64, r *http.Request) {
+	bucket, _ := s3_constants.GetBucketAndObject(r)
+	stats_collect.S3BucketTrafficReceivedBytes.WithLabelValues(bucket).Add(float64(bytesTransferred))
+}

--- a/weed/s3api/stats.go
+++ b/weed/s3api/stats.go
@@ -38,5 +38,5 @@ func TimeToFirstByte(action string, start time.Time, r *http.Request) {
 
 func BucketTrafficSent(bytesTransferred int64, r *http.Request) {
 	bucket, _ := s3_constants.GetBucketAndObject(r)
-	stats_collect.S3BucketTrafficSentBytes.WithLabelValues(bucket).Add(float64(bytesTransferred))
+	stats_collect.S3BucketTrafficSentBytesCounter.WithLabelValues(bucket).Add(float64(bytesTransferred))
 }

--- a/weed/s3api/stats.go
+++ b/weed/s3api/stats.go
@@ -36,7 +36,7 @@ func TimeToFirstByte(action string, start time.Time, r *http.Request) {
 	stats_collect.RecordBucketActiveTime(bucket)
 }
 
-func BucketTrafficReceived(bytesTransferred int64, r *http.Request) {
+func BucketTrafficSent(bytesTransferred int64, r *http.Request) {
 	bucket, _ := s3_constants.GetBucketAndObject(r)
-	stats_collect.S3BucketTrafficReceivedBytes.WithLabelValues(bucket).Add(float64(bytesTransferred))
+	stats_collect.S3BucketTrafficSentBytes.WithLabelValues(bucket).Add(float64(bytesTransferred))
 }

--- a/weed/stats/metrics.go
+++ b/weed/stats/metrics.go
@@ -319,6 +319,22 @@ var (
 			Name:      "in_flight_requests",
 			Help:      "Current number of in-flight requests being handled by s3.",
 		}, []string{"type"})
+
+	S3BucketTrafficReceivedBytes = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Subsystem: "s3",
+			Name:      "bucket_traffic_received_bytes",
+			Help:      "Total number of bytes sent from an S3 bucket to clients.",
+		}, []string{"bucket"})
+
+	S3BucketTrafficSentBytes = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Subsystem: "s3",
+			Name:      "bucket_traffic_sent_bytes",
+			Help:      "Total number of bytes received by an S3 bucket from clients.",
+		}, []string{"bucket"})
 )
 
 func init() {
@@ -362,6 +378,8 @@ func init() {
 	Gather.MustRegister(S3RequestHistogram)
 	Gather.MustRegister(S3InFlightRequestsGauge)
 	Gather.MustRegister(S3TimeToFirstByteHistogram)
+	Gather.MustRegister(S3BucketTrafficReceivedBytes)
+	Gather.MustRegister(S3BucketTrafficSentBytes)
 
 	go bucketMetricTTLControl()
 }

--- a/weed/stats/metrics.go
+++ b/weed/stats/metrics.go
@@ -320,20 +320,20 @@ var (
 			Help:      "Current number of in-flight requests being handled by s3.",
 		}, []string{"type"})
 
-	S3BucketTrafficReceivedBytes = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
+	S3BucketTrafficReceivedBytes = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
 			Namespace: Namespace,
 			Subsystem: "s3",
-			Name:      "bucket_traffic_received_bytes",
-			Help:      "Total number of bytes sent from an S3 bucket to clients.",
+			Name:      "bucket_traffic_received_bytes_total",
+			Help:      "Total number of bytes received by an S3 bucket from clients.",
 		}, []string{"bucket"})
 
-	S3BucketTrafficSentBytes = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
+	S3BucketTrafficSentBytes = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
 			Namespace: Namespace,
 			Subsystem: "s3",
-			Name:      "bucket_traffic_sent_bytes",
-			Help:      "Total number of bytes received by an S3 bucket from clients.",
+			Name:      "bucket_traffic_sent_bytes_total",
+			Help:      "Total number of bytes sent from an S3 bucket to clients.",
 		}, []string{"bucket"})
 )
 

--- a/weed/stats/metrics.go
+++ b/weed/stats/metrics.go
@@ -320,7 +320,7 @@ var (
 			Help:      "Current number of in-flight requests being handled by s3.",
 		}, []string{"type"})
 
-	S3BucketTrafficReceivedBytes = prometheus.NewCounterVec(
+	S3BucketTrafficReceivedBytesCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: Namespace,
 			Subsystem: "s3",
@@ -328,7 +328,7 @@ var (
 			Help:      "Total number of bytes received by an S3 bucket from clients.",
 		}, []string{"bucket"})
 
-	S3BucketTrafficSentBytes = prometheus.NewCounterVec(
+	S3BucketTrafficSentBytesCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: Namespace,
 			Subsystem: "s3",
@@ -378,8 +378,8 @@ func init() {
 	Gather.MustRegister(S3RequestHistogram)
 	Gather.MustRegister(S3InFlightRequestsGauge)
 	Gather.MustRegister(S3TimeToFirstByteHistogram)
-	Gather.MustRegister(S3BucketTrafficReceivedBytes)
-	Gather.MustRegister(S3BucketTrafficSentBytes)
+	Gather.MustRegister(S3BucketTrafficReceivedBytesCounter)
+	Gather.MustRegister(S3BucketTrafficSentBytesCounter)
 
 	go bucketMetricTTLControl()
 }


### PR DESCRIPTION
# What problem are we solving?
We added metrics to calculate the sent and received traffic of a bucket, meaning the number of bytes sent to and received from a bucket are counted. There are somethings like that in MinIo and other storages.
https://min.io/docs/minio/container/operations/monitoring/metrics-and-alerts.html#bucket-api

# How are we solving the problem?
By adding metrics and increasing them only if the bytes are transferred to or from the filer successfully

# How is the PR tested?
It is tested locally.
![image](https://github.com/user-attachments/assets/3846ad5f-bcd3-4771-8429-7312c78ed2c5)



# Checks
- [ ] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
