### PR TITLE
Add JWT authentication to fs.mergeVolumes command

### DIFF
--- a/weed/shell/command_fs_merge_volumes.go
+++ b/weed/shell/command_fs_merge_volumes.go
@@ -10,10 +10,12 @@ import (
 	"sort"
 	"strings"
 
+	"slices"
+
+	"github.com/seaweedfs/seaweedfs/weed/security"
 	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
 	"github.com/seaweedfs/seaweedfs/weed/wdclient"
 	"golang.org/x/exp/maps"
-	"slices"
 
 	"github.com/seaweedfs/seaweedfs/weed/operation"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
@@ -341,6 +343,14 @@ func moveChunk(chunk *filer_pb.FileChunk, toVolumeId needle.VolumeId, masterClie
 		return err
 	}
 
+	v := util.GetViper()
+	signingKey := v.GetString("jwt.signing.key")
+	var jwt security.EncodedJwt
+	if signingKey != "" {
+		expiresAfterSec := v.GetInt("jwt.signing.expires_after_seconds")
+		jwt = security.GenJwtForVolumeServer(security.SigningKey(signingKey), expiresAfterSec, toFid.String())
+	}
+
 	_, err, _ = uploader.Upload(reader, &operation.UploadOption{
 		UploadUrl:         uploadURL,
 		Filename:          filename,
@@ -349,6 +359,7 @@ func moveChunk(chunk *filer_pb.FileChunk, toVolumeId needle.VolumeId, masterClie
 		MimeType:          contentType,
 		PairMap:           nil,
 		Md5:               md5,
+		Jwt:               security.EncodedJwt(jwt),
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
# What problem are we solving?
Currently, the fs.mergeVolumes command does not work when jwt.signing.key is set. This issue arises because the JWT token is not passed to UploaderOptions during the chunk upload process to another volume. In this pull request (PR), we have added the necessary changes to ensure that the fs.mergeVolumes command functions correctly when security is enabled.

Current error:
![image](https://github.com/user-attachments/assets/6514794d-2b57-4e47-abac-6f5c107633e4)


# How are we solving the problem?

By generating a JWT token using security.GenJwtForVolumeServer and passing it to Uploader.

# How is the PR tested?
This PR was tested locally, by generating numerous chunks and merging them.


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
