### PR TITLE
Commit files to WORM automatically

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -155,6 +155,7 @@ require (
 	go.uber.org/atomic v1.11.0
 	golang.org/x/sync v0.10.0
 	google.golang.org/grpc/security/advancedtls v1.0.0
+	k8s.io/utils v0.0.0-20241210054802-24370beab758
 )
 
 require (
@@ -244,6 +245,7 @@ require (
 	github.com/gofrs/flock v0.8.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.1 // indirect
+	github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db // indirect
 	github.com/google/s2a-go v0.1.8 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
@@ -286,6 +288,8 @@ require (
 	github.com/ncw/swift/v2 v2.0.3 // indirect
 	github.com/nxadm/tail v1.4.11 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
+	github.com/onsi/ginkgo/v2 v2.21.0 // indirect
+	github.com/onsi/gomega v1.35.1 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/oracle/oci-go-sdk/v65 v65.69.2 // indirect
 	github.com/panjf2000/ants/v2 v2.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1062,8 +1062,8 @@ github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
-github.com/google/pprof v0.0.0-20240509144519-723abb6459b7 h1:velgFPYr1X9TDwLIfkV7fWqsFlf7TeP11M/7kPd/dVI=
-github.com/google/pprof v0.0.0-20240509144519-723abb6459b7/go.mod h1:kf6iHlnVGwgKolg33glAes7Yg/8iWP8ukqeldJSO7jw=
+github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgYQBbFN4U4JNXUNYpxael3UzMyo=
+github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/s2a-go v0.1.8 h1:zZDs9gcbt9ZPLV0ndSyQk6Kacx2g/X+SKYovpnz3SMM=
 github.com/google/s2a-go v0.1.8/go.mod h1:6iNWHTpQ+nfNRN5E00MSdfDwVesa8hhS32PhPO8deJA=
@@ -1334,11 +1334,11 @@ github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
-github.com/onsi/ginkgo/v2 v2.17.3 h1:oJcvKpIb7/8uLpDDtnQuf18xVnwKp8DTD7DQ6gTd/MU=
-github.com/onsi/ginkgo/v2 v2.17.3/go.mod h1:nP2DPOQoNsQmsVyv5rDA8JkXQoCs6goXIvr/PRJ1eCc=
+github.com/onsi/ginkgo/v2 v2.21.0 h1:7rg/4f3rB88pb5obDgNZrNHrQ4e6WpjonchcpuBRnZM=
+github.com/onsi/ginkgo/v2 v2.21.0/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
-github.com/onsi/gomega v1.33.1 h1:dsYjIxxSR755MDmKVsaFQTE22ChNBcuuTWgkUDSubOk=
-github.com/onsi/gomega v1.33.1/go.mod h1:U4R44UsT+9eLIaYRB2a5qajjtQYn0hauxvRm16AVYg0=
+github.com/onsi/gomega v1.35.1 h1:Cwbd75ZBPxFSuZ6T+rN/WCb/gOc6YgFBXLlZLhC7Ds4=
+github.com/onsi/gomega v1.35.1/go.mod h1:PvZbdDc8J6XJEpDK4HCuRBm8a6Fzp9/DmhC9C7yFlog=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
@@ -2474,6 +2474,8 @@ honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.1.3/go.mod h1:NgwopIslSNH47DimFoV78dnkksY2EFtX0ajyb3K/las=
+k8s.io/utils v0.0.0-20241210054802-24370beab758 h1:sdbE21q2nlQtFh65saZY+rRM6x6aJJI8IUa1AmH/qa0=
+k8s.io/utils v0.0.0-20241210054802-24370beab758/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 lukechampine.com/uint128 v1.1.1/go.mod h1:c4eWIwlEGaxC/+H1VguhU4PHXNWDCDMUlWdIWl2j1gk=
 lukechampine.com/uint128 v1.2.0/go.mod h1:c4eWIwlEGaxC/+H1VguhU4PHXNWDCDMUlWdIWl2j1gk=
 modernc.org/b v1.0.0 h1:vpvqeyp17ddcQWF29Czawql4lDdABCDRbXRAS4+aF2o=

--- a/weed/filer/filer_conf.go
+++ b/weed/filer/filer_conf.go
@@ -171,6 +171,17 @@ func (fc *FilerConf) GetCollectionTtls(collection string) (ttls map[string]strin
 	return ttls
 }
 
+func (fc *FilerConf) GetWORMPaths() []string {
+	var res []string
+	fc.rules.Walk(func(key []byte, value *filer_pb.FilerConf_PathConf) bool {
+		if value.Worm {
+			res = append(res, value.LocationPrefix)
+		}
+		return true
+	})
+	return res
+}
+
 // merge if values in b is not empty, merge them into a
 func mergePathConf(a, b *filer_pb.FilerConf_PathConf) {
 	a.Collection = util.Nvl(b.Collection, a.Collection)

--- a/weed/filer/worm_auto_commit.go
+++ b/weed/filer/worm_auto_commit.go
@@ -1,0 +1,194 @@
+package filer
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/glog"
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+	"github.com/seaweedfs/seaweedfs/weed/util/queue"
+	"github.com/seaweedfs/seaweedfs/weed/util/workqueue"
+	"k8s.io/utils/clock"
+)
+
+func (f *Filer) maybeCommitAsWORM(entry *Entry) {
+	if entry.WORMEnforcedAtTsNs > 0 {
+		return
+	}
+
+	f.wormAutoCommitController.AddItem(entryItem{fullPath: entry.FullPath, mtime: entry.Mtime})
+}
+
+func (f *Filer) StartWormAutoCommitControllerInBackground(ctx context.Context) error {
+	controller := newWormAutoCommitController(f, nil)
+	err := controller.loopAllWORMPaths(ctx)
+	if err != nil {
+		glog.Errorf("Failed to loop all WORM paths: %v", err)
+		return err
+	}
+
+	f.wormAutoCommitController = controller
+	go controller.Run(ctx, 3)
+
+	return nil
+}
+
+type entryItem struct {
+	fullPath util.FullPath
+	mtime    time.Time
+}
+
+func (i entryItem) Compare(other queue.Item) int {
+	o := other.(entryItem)
+	// if i is before o, it should be processed first
+	return i.mtime.Compare(o.mtime) * -1
+}
+
+func (i entryItem) GetUniqueID() string {
+	return string(i.fullPath)
+}
+
+var _ queue.Item = entryItem{}
+
+type wormAutoCommitController struct {
+	queue workqueue.DelayingInterface
+	clock clock.WithTicker
+	filer *Filer
+}
+
+func newWormAutoCommitController(filer *Filer, ck clock.WithTicker) *wormAutoCommitController {
+	if ck == nil {
+		ck = clock.RealClock{}
+	}
+
+	return &wormAutoCommitController{
+		queue: workqueue.NewDelayingQueueWithConfig(workqueue.DelayingQueueConfig{Clock: ck}),
+		clock: ck,
+		filer: filer,
+	}
+}
+
+func (s *wormAutoCommitController) AddItem(item queue.Item) {
+	s.queue.Add(item)
+}
+
+func (s *wormAutoCommitController) loopAllWORMPaths(ctx context.Context) error {
+	paths := s.filer.FilerConf.GetWORMPaths()
+	for _, path := range paths {
+		if err := s.loopPath(ctx, util.FullPath(path)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *wormAutoCommitController) loopPath(ctx context.Context, path util.FullPath) error {
+	lastFileName := ""
+	for {
+		entries, hasMore, err := s.filer.ListDirectoryEntries(ctx, path, lastFileName, false, 1024, "", "", "")
+		if err != nil {
+			return err
+		}
+
+		for _, entry := range entries {
+			lastFileName = entry.Name()
+			if entry.IsDirectory() {
+				err = s.loopPath(ctx, entry.FullPath)
+				if err != nil {
+					return err
+				}
+			} else {
+				if entry.WORMEnforcedAtTsNs == 0 {
+					s.AddItem(entryItem{fullPath: entry.FullPath, mtime: entry.Mtime})
+				}
+			}
+		}
+		if !hasMore {
+			break
+		}
+	}
+
+	return nil
+}
+
+func (s *wormAutoCommitController) Run(ctx context.Context, workers int) {
+	defer s.queue.ShutDown()
+
+	glog.Infof("Starting wormAutoCommitController, workers: %d", workers)
+	defer glog.Info("Stopping wormAutoCommitController")
+
+	for i := 0; i < workers; i++ {
+		go s.worker(ctx)
+	}
+
+	<-ctx.Done()
+}
+
+func (s *wormAutoCommitController) worker(ctx context.Context) {
+	for s.processNextWorkItem(ctx) {
+	}
+}
+
+func (s *wormAutoCommitController) processNextWorkItem(ctx context.Context) bool {
+	key, closed := s.queue.Get()
+	if closed {
+		return false
+	}
+	defer s.queue.Done(key)
+
+	err := s.process(ctx, key.(entryItem).fullPath)
+	if err != nil {
+		glog.Errorf("Failed to process %s, try it again: %v", key, err)
+		s.queue.AddAfter(key, 100*time.Millisecond)
+	}
+
+	return true
+}
+
+func (s *wormAutoCommitController) process(ctx context.Context, fullPath util.FullPath) error {
+	yes, entry, err := s.enforceNow(ctx, fullPath)
+	if err != nil {
+		return err
+	} else if !yes {
+		return nil
+	}
+
+	glog.Infof("the time elapsed since the entry's mtime is more than its grace period, WORM is enforced, entry: %s, mtime: %s", fullPath, entry.Mtime)
+	entry.WORMEnforcedAtTsNs = s.clock.Now().UnixNano()
+
+	// update the entry
+	return s.filer.CreateEntry(ctx, entry, false, false, nil, false, s.filer.MaxFilenameLength)
+}
+
+func (s *wormAutoCommitController) enforceNow(ctx context.Context, fullPath util.FullPath) (bool, *Entry, error) {
+	rule := s.filer.FilerConf.MatchStorageRule(string(fullPath))
+	if !rule.Worm {
+		return false, nil, nil
+	}
+
+	entry, err := s.filer.FindEntry(ctx, fullPath)
+	if err != nil {
+		if errors.Is(err, filer_pb.ErrNotFound) {
+			return false, nil, nil
+		}
+
+		return false, nil, err
+	}
+
+	// grace period is already set
+	if entry.WORMEnforcedAtTsNs > 0 {
+		return false, nil, nil
+	}
+
+	silentTime := s.clock.Now().Sub(entry.Mtime)
+	if silentTime >= time.Duration(rule.WormGracePeriodSeconds)*time.Second {
+		return true, entry, nil
+	}
+
+	s.queue.AddAfter(entryItem{mtime: entry.Mtime, fullPath: fullPath}, time.Duration(rule.WormGracePeriodSeconds)*time.Second-silentTime)
+
+	return false, nil, nil
+}

--- a/weed/server/filer_server.go
+++ b/weed/server/filer_server.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"os/signal"
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/stats"
@@ -104,6 +106,11 @@ type FilerServer struct {
 }
 
 func NewFilerServer(defaultMux, readonlyMux *http.ServeMux, option *FilerOption) (fs *FilerServer, err error) {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	go func() {
+		<-ctx.Done()
+		stop()
+	}()
 
 	v := util.GetViper()
 	signingKey := v.GetString("jwt.filer_signing.key")
@@ -159,7 +166,7 @@ func NewFilerServer(defaultMux, readonlyMux *http.ServeMux, option *FilerOption)
 	fs.checkWithMaster()
 
 	go stats.LoopPushingMetric("filer", string(fs.option.Host), fs.metricsAddress, fs.metricsIntervalSec)
-	go fs.filer.KeepMasterClientConnected(context.Background())
+	go fs.filer.KeepMasterClientConnected(ctx)
 
 	if !util.LoadConfiguration("filer", false) {
 		v.SetDefault("leveldb2.enabled", true)
@@ -195,7 +202,7 @@ func NewFilerServer(defaultMux, readonlyMux *http.ServeMux, option *FilerOption)
 		readonlyMux.HandleFunc("/", fs.filerGuard.WhiteList(fs.readonlyFilerHandler))
 	}
 
-	existingNodes := fs.filer.ListExistingPeerUpdates(context.Background())
+	existingNodes := fs.filer.ListExistingPeerUpdates(ctx)
 	startFromTime := time.Now().Add(-filer.LogFlushInterval)
 	if isFresh {
 		glog.V(0).Infof("%s bootstrap from peers %+v", option.Host, existingNodes)
@@ -208,6 +215,11 @@ func NewFilerServer(defaultMux, readonlyMux *http.ServeMux, option *FilerOption)
 	fs.filer.LoadFilerConf()
 
 	fs.filer.LoadRemoteStorageConfAndMapping()
+
+	err = fs.filer.StartWormAutoCommitControllerInBackground(ctx)
+	if err != nil {
+		glog.Fatalf("Failed to start WORM auto commit controller: %v", err)
+	}
 
 	grace.OnReload(fs.Reload)
 	grace.OnInterrupt(func() {

--- a/weed/util/queue/error.go
+++ b/weed/util/queue/error.go
@@ -1,0 +1,16 @@
+package queue
+
+import "errors"
+
+var (
+	// ErrDisposed is returned when an operation is performed on a disposed
+	// queue.
+	ErrDisposed = errors.New(`queue: disposed`)
+
+	// ErrTimeout is returned when an applicable queue operation times out.
+	ErrTimeout = errors.New(`queue: poll timed out`)
+
+	// ErrEmptyQueue is returned when an non-applicable queue operation was called
+	// due to the queue's empty item state
+	ErrEmptyQueue = errors.New(`queue: empty queue`)
+)

--- a/weed/util/queue/mock_test.go
+++ b/weed/util/queue/mock_test.go
@@ -1,0 +1,21 @@
+package queue
+
+import (
+	"strconv"
+)
+
+type mockItem int
+
+func (mi mockItem) Compare(other Item) int {
+	omi := other.(mockItem)
+	if mi > omi {
+		return 1
+	} else if mi == omi {
+		return 0
+	}
+	return -1
+}
+
+func (mi mockItem) GetUniqueID() string {
+	return strconv.Itoa(int(mi))
+}

--- a/weed/util/queue/priority_queue.go
+++ b/weed/util/queue/priority_queue.go
@@ -1,0 +1,245 @@
+package queue
+
+import "sync"
+
+type Empty struct{}
+
+// Item is an item that can be added to the priority queue.
+type Item interface {
+	// Compare returns a bool that can be used to determine
+	// ordering in the priority queue.  Assuming the queue
+	// is in ascending order, this should return > logic.
+	// Return 1 to indicate this object is greater than the
+	//  other logic, 0 to indicate equality, and -1 to indicate
+	// less than others.
+	Compare(other Item) int
+	GetUniqueID() string
+}
+
+type priorityItems []Item
+
+func (items *priorityItems) swap(i, j int) {
+	(*items)[i], (*items)[j] = (*items)[j], (*items)[i]
+}
+
+func (items *priorityItems) pop() Item {
+	size := len(*items)
+
+	// Move last leaf to root, and 'pop' the last item.
+	items.swap(size-1, 0)
+	item := (*items)[size-1] // Item to return.
+	(*items)[size-1], *items = nil, (*items)[:size-1]
+
+	// 'Bubble down' to restore heap property.
+	index := 0
+	childL, childR := 2*index+1, 2*index+2
+	for len(*items) > childL {
+		child := childL
+		if len(*items) > childR && (*items)[childR].Compare((*items)[childL]) < 0 {
+			child = childR
+		}
+
+		if (*items)[child].Compare((*items)[index]) < 0 {
+			items.swap(index, child)
+
+			index = child
+			childL, childR = 2*index+1, 2*index+2
+		} else {
+			break
+		}
+	}
+
+	return item
+}
+
+func (items *priorityItems) get(number int) []Item {
+	returnItems := make([]Item, 0, number)
+	for i := 0; i < number; i++ {
+		if len(*items) == 0 {
+			break
+		}
+
+		returnItems = append(returnItems, items.pop())
+	}
+
+	return returnItems
+}
+
+func (items *priorityItems) push(item Item) {
+	// Stick the item as the end of the last level.
+	*items = append(*items, item)
+
+	// 'Bubble up' to restore heap property.
+	index := len(*items) - 1
+	parent := int((index - 1) / 2)
+	for parent >= 0 && (*items)[parent].Compare(item) > 0 {
+		items.swap(index, parent)
+
+		index = parent
+		parent = int((index - 1) / 2)
+	}
+}
+
+// PriorityQueue is similar to queue except that it takes
+// items that implement the Item interface and adds them
+// to the queue in priority order.
+type PriorityQueue struct {
+	waiters         waiters
+	items           priorityItems
+	itemMap         map[string]Empty
+	lock            sync.Mutex
+	disposeLock     sync.Mutex
+	disposed        bool
+	allowDuplicates bool
+}
+
+// Put adds items to the queue.
+func (pq *PriorityQueue) Put(items ...Item) error {
+	if len(items) == 0 {
+		return nil
+	}
+
+	pq.lock.Lock()
+	defer pq.lock.Unlock()
+
+	if pq.disposed {
+		return ErrDisposed
+	}
+
+	for _, item := range items {
+		if pq.allowDuplicates {
+			pq.items.push(item)
+		} else if _, ok := pq.itemMap[item.GetUniqueID()]; !ok {
+			pq.itemMap[item.GetUniqueID()] = Empty{}
+			pq.items.push(item)
+		}
+	}
+
+	for {
+		sema := pq.waiters.get()
+		if sema == nil {
+			break
+		}
+
+		sema.response.Add(1)
+		sema.ready <- true
+		sema.response.Wait()
+		if len(pq.items) == 0 {
+			break
+		}
+	}
+
+	return nil
+}
+
+// Get retrieves items from the queue.  If the queue is empty,
+// this call blocks until the next item is added to the queue.  This
+// will attempt to retrieve number of items.
+func (pq *PriorityQueue) Get(number int) ([]Item, error) {
+	if number < 1 {
+		return nil, nil
+	}
+
+	pq.lock.Lock()
+
+	if pq.disposed {
+		pq.lock.Unlock()
+		return nil, ErrDisposed
+	}
+
+	var items []Item
+
+	// Remove references to popped items.
+	deleteItems := func(items []Item) {
+		for _, item := range items {
+			delete(pq.itemMap, item.GetUniqueID())
+		}
+	}
+
+	if len(pq.items) == 0 {
+		sema := newSema()
+		pq.waiters.put(sema)
+		pq.lock.Unlock()
+
+		<-sema.ready
+
+		if pq.Disposed() {
+			return nil, ErrDisposed
+		}
+
+		items = pq.items.get(number)
+		if !pq.allowDuplicates {
+			deleteItems(items)
+		}
+		sema.response.Done()
+		return items, nil
+	}
+
+	items = pq.items.get(number)
+	deleteItems(items)
+	pq.lock.Unlock()
+	return items, nil
+}
+
+// Peek will look at the next item without removing it from the queue.
+func (pq *PriorityQueue) Peek() Item {
+	pq.lock.Lock()
+	defer pq.lock.Unlock()
+	if len(pq.items) > 0 {
+		return pq.items[0]
+	}
+	return nil
+}
+
+// Empty returns a bool indicating if there are any items left
+// in the queue.
+func (pq *PriorityQueue) Empty() bool {
+	pq.lock.Lock()
+	defer pq.lock.Unlock()
+
+	return len(pq.items) == 0
+}
+
+// Len returns a number indicating how many items are in the queue.
+func (pq *PriorityQueue) Len() int {
+	pq.lock.Lock()
+	defer pq.lock.Unlock()
+
+	return len(pq.items)
+}
+
+// Disposed returns a bool indicating if this queue has been disposed.
+func (pq *PriorityQueue) Disposed() bool {
+	pq.disposeLock.Lock()
+	defer pq.disposeLock.Unlock()
+
+	return pq.disposed
+}
+
+// Dispose will prevent any further reads/writes to this queue
+// and frees available resources.
+func (pq *PriorityQueue) Dispose() {
+	pq.lock.Lock()
+	defer pq.lock.Unlock()
+
+	pq.disposeLock.Lock()
+	defer pq.disposeLock.Unlock()
+
+	pq.disposed = true
+	for _, waiter := range pq.waiters {
+		waiter.response.Add(1)
+		waiter.ready <- true
+	}
+
+	pq.items = nil
+	pq.waiters = nil
+}
+
+// NewPriorityQueue is the constructor for a priority queue.
+func NewPriorityQueue(hint int, allowDuplicates bool) *PriorityQueue {
+	return &PriorityQueue{
+		items:           make(priorityItems, 0, hint),
+		itemMap:         make(map[string]Empty, hint),
+		allowDuplicates: allowDuplicates,
+	}
+}

--- a/weed/util/queue/priority_queue_test.go
+++ b/weed/util/queue/priority_queue_test.go
@@ -1,0 +1,255 @@
+/*
+Copyright 2014 Workiva, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPriorityPut(t *testing.T) {
+	q := NewPriorityQueue(1, false)
+
+	q.Put(mockItem(2))
+
+	assert.Len(t, q.items, 1)
+	assert.Equal(t, mockItem(2), q.items[0])
+
+	q.Put(mockItem(1))
+
+	if !assert.Len(t, q.items, 2) {
+		return
+	}
+	assert.Equal(t, mockItem(1), q.items[0])
+	assert.Equal(t, mockItem(2), q.items[1])
+}
+
+func TestPriorityGet(t *testing.T) {
+	q := NewPriorityQueue(1, false)
+
+	q.Put(mockItem(2))
+	result, err := q.Get(2)
+	if !assert.Nil(t, err) {
+		return
+	}
+
+	if !assert.Len(t, result, 1) {
+		return
+	}
+
+	assert.Equal(t, mockItem(2), result[0])
+	assert.Len(t, q.items, 0)
+
+	q.Put(mockItem(2))
+	q.Put(mockItem(1))
+
+	result, err = q.Get(1)
+	if !assert.Nil(t, err) {
+		return
+	}
+
+	if !assert.Len(t, result, 1) {
+		return
+	}
+
+	assert.Equal(t, mockItem(1), result[0])
+	assert.Len(t, q.items, 1)
+
+	result, err = q.Get(2)
+	if !assert.Nil(t, err) {
+		return
+	}
+
+	if !assert.Len(t, result, 1) {
+		return
+	}
+
+	assert.Equal(t, mockItem(2), result[0])
+}
+
+func TestAddEmptyPriorityPut(t *testing.T) {
+	q := NewPriorityQueue(1, false)
+
+	q.Put()
+
+	assert.Len(t, q.items, 0)
+}
+
+func TestPriorityGetNonPositiveNumber(t *testing.T) {
+	q := NewPriorityQueue(1, false)
+
+	q.Put(mockItem(1))
+
+	result, err := q.Get(0)
+	if !assert.Nil(t, err) {
+		return
+	}
+
+	assert.Len(t, result, 0)
+
+	result, err = q.Get(-1)
+	if !assert.Nil(t, err) {
+		return
+	}
+
+	assert.Len(t, result, 0)
+}
+
+func TestPriorityEmpty(t *testing.T) {
+	q := NewPriorityQueue(1, false)
+	assert.True(t, q.Empty())
+
+	q.Put(mockItem(1))
+
+	assert.False(t, q.Empty())
+}
+
+func TestPriorityGetEmpty(t *testing.T) {
+	q := NewPriorityQueue(1, false)
+
+	go func() {
+		q.Put(mockItem(1))
+	}()
+
+	result, err := q.Get(1)
+	if !assert.Nil(t, err) {
+		return
+	}
+
+	if !assert.Len(t, result, 1) {
+		return
+	}
+	assert.Equal(t, mockItem(1), result[0])
+}
+
+func TestMultiplePriorityGetEmpty(t *testing.T) {
+	q := NewPriorityQueue(1, false)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	results := make([][]Item, 2)
+
+	go func() {
+		wg.Done()
+		local, _ := q.Get(1)
+		results[0] = local
+		wg.Done()
+	}()
+
+	go func() {
+		wg.Done()
+		local, _ := q.Get(1)
+		results[1] = local
+		wg.Done()
+	}()
+
+	wg.Wait()
+	wg.Add(2)
+
+	q.Put(mockItem(1), mockItem(3), mockItem(2))
+	wg.Wait()
+
+	if !assert.Len(t, results[0], 1) || !assert.Len(t, results[1], 1) {
+		return
+	}
+
+	assert.True(
+		t, (results[0][0] == mockItem(1) && results[1][0] == mockItem(2)) ||
+			results[0][0] == mockItem(2) && results[1][0] == mockItem(1),
+	)
+}
+
+func TestEmptyPriorityGetWithDispose(t *testing.T) {
+	q := NewPriorityQueue(1, false)
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	var err error
+	go func() {
+		wg.Done()
+		_, err = q.Get(1)
+		wg.Done()
+	}()
+
+	wg.Wait()
+	wg.Add(1)
+
+	q.Dispose()
+
+	wg.Wait()
+
+	assert.IsType(t, ErrDisposed, err)
+}
+
+func TestPriorityGetPutDisposed(t *testing.T) {
+	q := NewPriorityQueue(1, false)
+	q.Dispose()
+
+	_, err := q.Get(1)
+	assert.IsType(t, ErrDisposed, err)
+
+	err = q.Put(mockItem(1))
+	assert.IsType(t, ErrDisposed, err)
+}
+
+func BenchmarkPriorityQueue(b *testing.B) {
+	q := NewPriorityQueue(b.N, false)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	i := 0
+
+	go func() {
+		for {
+			q.Get(1)
+			i++
+			if i == b.N {
+				wg.Done()
+				break
+			}
+		}
+	}()
+
+	for i := 0; i < b.N; i++ {
+		q.Put(mockItem(i))
+	}
+
+	wg.Wait()
+}
+
+func TestPriorityPeek(t *testing.T) {
+	q := NewPriorityQueue(1, false)
+	q.Put(mockItem(1))
+
+	assert.Equal(t, mockItem(1), q.Peek())
+}
+
+func TestInsertDuplicate(t *testing.T) {
+	q := NewPriorityQueue(1, false)
+	q.Put(mockItem(1))
+	q.Put(mockItem(1))
+
+	assert.Equal(t, 1, q.Len())
+}
+
+func TestAllowDuplicates(t *testing.T) {
+	q := NewPriorityQueue(2, true)
+	q.Put(mockItem(1))
+	q.Put(mockItem(1))
+
+	assert.Equal(t, 2, q.Len())
+}

--- a/weed/util/queue/queue.go
+++ b/weed/util/queue/queue.go
@@ -1,0 +1,50 @@
+package queue
+
+import (
+	"sync"
+)
+
+type waiters []*sema
+
+func (w *waiters) get() *sema {
+	if len(*w) == 0 {
+		return nil
+	}
+
+	sema := (*w)[0]
+	copy((*w)[0:], (*w)[1:])
+	(*w)[len(*w)-1] = nil // or the zero value of T
+	*w = (*w)[:len(*w)-1]
+	return sema
+}
+
+func (w *waiters) put(sema *sema) {
+	*w = append(*w, sema)
+}
+
+func (w *waiters) remove(sema *sema) {
+	if len(*w) == 0 {
+		return
+	}
+	// build new slice, copy all except sema
+	ws := *w
+	newWs := make(waiters, 0, len(*w))
+	for i := range ws {
+		if ws[i] != sema {
+			newWs = append(newWs, ws[i])
+		}
+	}
+	*w = newWs
+}
+
+type sema struct {
+	ready    chan bool
+	response *sync.WaitGroup
+}
+
+func newSema() *sema {
+	return &sema{
+		ready:    make(chan bool, 1),
+		response: &sync.WaitGroup{},
+	}
+}

--- a/weed/util/queue/queue_test.go
+++ b/weed/util/queue/queue_test.go
@@ -1,0 +1,69 @@
+package queue
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWaiters(t *testing.T) {
+	s1, s2, s3, s4 := newSema(), newSema(), newSema(), newSema()
+
+	w := waiters{}
+	assert.Len(t, w, 0)
+
+	//
+	// test put()
+	w.put(s1)
+	assert.Equal(t, waiters{s1}, w)
+
+	w.put(s2)
+	w.put(s3)
+	w.put(s4)
+	assert.Equal(t, waiters{s1, s2, s3, s4}, w)
+
+	//
+	// test remove()
+	//
+	// remove from middle
+	w.remove(s2)
+	assert.Equal(t, waiters{s1, s3, s4}, w)
+
+	// remove non-existing element
+	w.remove(s2)
+	assert.Equal(t, waiters{s1, s3, s4}, w)
+
+	// remove from beginning
+	w.remove(s1)
+	assert.Equal(t, waiters{s3, s4}, w)
+
+	// remove from end
+	w.remove(s4)
+	assert.Equal(t, waiters{s3}, w)
+
+	// remove last element
+	w.remove(s3)
+	assert.Empty(t, w)
+
+	// remove non-existing element
+	w.remove(s3)
+	assert.Empty(t, w)
+
+	//
+	// test get()
+	//
+	// start with 3 elements in list
+	w.put(s1)
+	w.put(s2)
+	w.put(s3)
+	assert.Equal(t, waiters{s1, s2, s3}, w)
+
+	// get() returns each item in insertion order
+	assert.Equal(t, s1, w.get())
+	assert.Equal(t, s2, w.get())
+	w.put(s4) // interleave a put(), item should go to the end
+	assert.Equal(t, s3, w.get())
+	assert.Equal(t, s4, w.get())
+	assert.Empty(t, w)
+	assert.Nil(t, w.get())
+}

--- a/weed/util/workqueue/delaying_queue.go
+++ b/weed/util/workqueue/delaying_queue.go
@@ -1,0 +1,279 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workqueue
+
+import (
+	"container/heap"
+	"sync"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/util/queue"
+	"k8s.io/utils/clock"
+)
+
+// DelayingInterface is an Interface that can Add an item at a later time. This makes it easier to
+// requeue items after failures without ending up in a hot-loop.
+type DelayingInterface interface {
+	Interface
+	// AddAfter adds an item to the workqueue after the indicated duration has passed
+	AddAfter(item queue.Item, duration time.Duration)
+}
+
+// DelayingQueueConfig specifies optional configurations to customize a DelayingInterface.
+type DelayingQueueConfig struct {
+	// Clock optionally allows injecting a real or fake clock for testing purposes.
+	Clock clock.WithTicker
+
+	// Queue optionally allows injecting custom queue Interface instead of the default one.
+	Queue Interface
+}
+
+// NewDelayingQueue constructs a new workqueue with delayed queuing ability.
+func NewDelayingQueue() DelayingInterface {
+	return NewDelayingQueueWithConfig(DelayingQueueConfig{})
+}
+
+// NewDelayingQueueWithConfig constructs a new workqueue with options to
+// customize different properties.
+func NewDelayingQueueWithConfig(config DelayingQueueConfig) DelayingInterface {
+	if config.Clock == nil {
+		config.Clock = clock.RealClock{}
+	}
+
+	if config.Queue == nil {
+		config.Queue = New()
+	}
+
+	return newDelayingQueue(config.Clock, config.Queue)
+}
+
+func newDelayingQueue(clock clock.WithTicker, q Interface) *delayingType {
+	ret := &delayingType{
+		Interface:       q,
+		clock:           clock,
+		heartbeat:       clock.NewTicker(maxWait),
+		stopCh:          make(chan struct{}),
+		waitingForAddCh: make(chan *waitFor, 1000),
+	}
+
+	go ret.waitingLoop()
+	return ret
+}
+
+// delayingType wraps an Interface and provides delayed re-enquing
+type delayingType struct {
+	Interface
+
+	// clock tracks time for delayed firing
+	clock clock.Clock
+
+	// stopCh lets us signal a shutdown to the waiting loop
+	stopCh chan struct{}
+	// stopOnce guarantees we only signal shutdown a single time
+	stopOnce sync.Once
+
+	// heartbeat ensures we wait no more than maxWait before firing
+	heartbeat clock.Ticker
+
+	// waitingForAddCh is a buffered channel that feeds waitingForAdd
+	waitingForAddCh chan *waitFor
+}
+
+// waitFor holds the data to add and the time it should be added
+type waitFor struct {
+	data    queue.Item
+	readyAt time.Time
+	// index in the priority queue (heap)
+	index int
+}
+
+// waitForPriorityQueue implements a priority queue for waitFor items.
+//
+// waitForPriorityQueue implements heap.Interface. The item occurring next in
+// time (i.e., the item with the smallest readyAt) is at the root (index 0).
+// Peek returns this minimum item at index 0. Pop returns the minimum item after
+// it has been removed from the queue and placed at index Len()-1 by
+// container/heap. Push adds an item at index Len(), and container/heap
+// percolates it into the correct location.
+type waitForPriorityQueue []*waitFor
+
+func (pq waitForPriorityQueue) Len() int {
+	return len(pq)
+}
+func (pq waitForPriorityQueue) Less(i, j int) bool {
+	return pq[i].readyAt.Before(pq[j].readyAt)
+}
+func (pq waitForPriorityQueue) Swap(i, j int) {
+	pq[i], pq[j] = pq[j], pq[i]
+	pq[i].index = i
+	pq[j].index = j
+}
+
+// Push adds an item to the queue. Push should not be called directly; instead,
+// use `heap.Push`.
+func (pq *waitForPriorityQueue) Push(x interface{}) {
+	n := len(*pq)
+	item := x.(*waitFor)
+	item.index = n
+	*pq = append(*pq, item)
+}
+
+// Pop removes an item from the queue. Pop should not be called directly;
+// instead, use `heap.Pop`.
+func (pq *waitForPriorityQueue) Pop() interface{} {
+	n := len(*pq)
+	item := (*pq)[n-1]
+	item.index = -1
+	*pq = (*pq)[0:(n - 1)]
+	return item
+}
+
+// Peek returns the item at the beginning of the queue, without removing the
+// item or otherwise mutating the queue. It is safe to call directly.
+func (pq waitForPriorityQueue) Peek() interface{} {
+	return pq[0]
+}
+
+// ShutDown stops the queue. After the queue drains, the returned shutdown bool
+// on Get() will be true. This method may be invoked more than once.
+func (q *delayingType) ShutDown() {
+	q.stopOnce.Do(func() {
+		q.Interface.ShutDown()
+		close(q.stopCh)
+		q.heartbeat.Stop()
+	})
+}
+
+// AddAfter adds the given item to the work queue after the given delay
+func (q *delayingType) AddAfter(item queue.Item, duration time.Duration) {
+	// don't add if we're already shutting down
+	if q.ShuttingDown() {
+		return
+	}
+
+	// immediately add things with no delay
+	if duration <= 0 {
+		q.Add(item)
+		return
+	}
+
+	select {
+	case <-q.stopCh:
+		// unblock if ShutDown() is called
+	case q.waitingForAddCh <- &waitFor{data: item, readyAt: q.clock.Now().Add(duration)}:
+	}
+}
+
+// maxWait keeps a max bound on the wait time. It's just insurance against weird things happening.
+// Checking the queue every 10 seconds isn't expensive and we know that we'll never end up with an
+// expired item sitting for more than 10 seconds.
+const maxWait = 10 * time.Second
+
+// waitingLoop runs until the workqueue is shutdown and keeps a check on the list of items to be added.
+func (q *delayingType) waitingLoop() {
+
+	// Make a placeholder channel to use when there are no items in our list
+	never := make(<-chan time.Time)
+
+	// Make a timer that expires when the item at the head of the waiting queue is ready
+	var nextReadyAtTimer clock.Timer
+
+	waitingForQueue := &waitForPriorityQueue{}
+	heap.Init(waitingForQueue)
+
+	waitingEntryByData := map[any]*waitFor{}
+
+	for {
+		if q.Interface.ShuttingDown() {
+			return
+		}
+
+		now := q.clock.Now()
+
+		// Add ready entries
+		for waitingForQueue.Len() > 0 {
+			entry := waitingForQueue.Peek().(*waitFor)
+			if entry.readyAt.After(now) {
+				break
+			}
+
+			entry = heap.Pop(waitingForQueue).(*waitFor)
+			q.Add(entry.data)
+			delete(waitingEntryByData, entry.data)
+		}
+
+		// Set up a wait for the first item's readyAt (if one exists)
+		nextReadyAt := never
+		if waitingForQueue.Len() > 0 {
+			if nextReadyAtTimer != nil {
+				nextReadyAtTimer.Stop()
+			}
+			entry := waitingForQueue.Peek().(*waitFor)
+			nextReadyAtTimer = q.clock.NewTimer(entry.readyAt.Sub(now))
+			nextReadyAt = nextReadyAtTimer.C()
+		}
+
+		select {
+		case <-q.stopCh:
+			return
+
+		case <-q.heartbeat.C():
+			// continue the loop, which will add ready items
+
+		case <-nextReadyAt:
+			// continue the loop, which will add ready items
+
+		case waitEntry := <-q.waitingForAddCh:
+			if waitEntry.readyAt.After(q.clock.Now()) {
+				insert(waitingForQueue, waitingEntryByData, waitEntry)
+			} else {
+				q.Add(waitEntry.data)
+			}
+
+			drained := false
+			for !drained {
+				select {
+				case waitEntry := <-q.waitingForAddCh:
+					if waitEntry.readyAt.After(q.clock.Now()) {
+						insert(waitingForQueue, waitingEntryByData, waitEntry)
+					} else {
+						q.Add(waitEntry.data)
+					}
+				default:
+					drained = true
+				}
+			}
+		}
+	}
+}
+
+// insert adds the entry to the priority queue, or updates the readyAt if it already exists in the queue
+func insert(q *waitForPriorityQueue, knownEntries map[any]*waitFor, entry *waitFor) {
+	// if the entry already exists, update the time only if it would cause the item to be queued sooner
+	existing, exists := knownEntries[entry.data]
+	if exists {
+		if existing.readyAt.After(entry.readyAt) {
+			existing.readyAt = entry.readyAt
+			heap.Fix(q, existing.index)
+		}
+
+		return
+	}
+
+	heap.Push(q, entry)
+	knownEntries[entry.data] = entry
+}

--- a/weed/util/workqueue/queue.go
+++ b/weed/util/workqueue/queue.go
@@ -1,0 +1,163 @@
+package workqueue
+
+import (
+	"sync"
+
+	"github.com/seaweedfs/seaweedfs/weed/util/queue"
+)
+
+type Interface interface {
+	Add(item queue.Item)
+	Len() int
+	Get() (item queue.Item, shutdown bool)
+	Done(item queue.Item)
+	ShutDown()
+	ShuttingDown() bool
+	Processing(item queue.Item) bool
+}
+
+type Queue struct {
+	*queue.PriorityQueue
+}
+
+// Put adds an item to the queue.
+func (q *Queue) Put(item queue.Item) error {
+	return q.PriorityQueue.Put(item)
+}
+
+func (q *Queue) ShutDown() {
+	q.PriorityQueue.Dispose()
+}
+
+// Get retrieves an item from the queue. If the queue is empty,
+// this call blocks until the next item is added to the queue.
+func (q *Queue) Get() (item queue.Item, closed bool) {
+	res, err := q.PriorityQueue.Get(1)
+	if err != nil {
+		return nil, true
+	}
+
+	return res[0], false
+}
+
+// New constructs a new work queue.
+func New() *Type {
+	return newQueue()
+}
+
+func newQueue() *Type {
+	t := &Type{
+		processing: make(map[string]queue.Empty),
+		cond:       sync.NewCond(&sync.Mutex{}),
+		queue:      &Queue{PriorityQueue: queue.NewPriorityQueue(100, false)},
+	}
+
+	return t
+}
+
+// Type is a work queue (see the package comment).
+type Type struct {
+	// queue defines the order in which we will work on items. Every
+	// element of queue should not in the processing set.
+	queue *Queue
+
+	// Things that are currently being processed are in the processing set.
+	// These things may be simultaneously in the dirty set. When we finish
+	// processing something and remove it from this set, we'll check if
+	// it's in the dirty set, and if so, add it to the queue.
+	processing map[string]queue.Empty
+
+	cond *sync.Cond
+
+	shuttingDown bool
+}
+
+// Add marks item as needing processing.
+func (q *Type) Add(item queue.Item) {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+	if q.shuttingDown {
+		return
+	}
+
+	if _, ok := q.processing[item.GetUniqueID()]; ok {
+		return
+	}
+
+	_ = q.queue.Put(item)
+
+	q.cond.Signal()
+}
+
+// Len returns the current queue length, for informational purposes only. You
+// shouldn't e.g. gate a call to Add() or Get() on Len() being a particular
+// value, that can't be synchronized properly.
+func (q *Type) Len() int {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+	return q.queue.Len()
+}
+
+// Get blocks until it can return an item to be processed. If shutdown = true,
+// the caller should end their goroutine. You must call Done with item when you
+// have finished processing it.
+func (q *Type) Get() (item queue.Item, shutdown bool) {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+	for q.queue.Len() == 0 && !q.shuttingDown {
+		q.cond.Wait()
+	}
+	if q.queue.Len() == 0 {
+		// We must be shutting down.
+		return nil, true
+	}
+
+	item, closed := q.queue.Get()
+	if closed {
+		return nil, true
+	}
+
+	q.processing[item.GetUniqueID()] = queue.Empty{}
+
+	return item, false
+}
+
+// Done marks item as done processing.
+func (q *Type) Done(item queue.Item) {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+
+	delete(q.processing, item.GetUniqueID())
+	if len(q.processing) == 0 {
+		q.cond.Signal()
+	}
+}
+
+// ShutDown will cause q to ignore all new items added to it and
+// immediately instruct the worker goroutines to exit.
+func (q *Type) ShutDown() {
+	q.shutdown()
+}
+
+func (q *Type) shutdown() {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+	q.shuttingDown = true
+	q.cond.Broadcast()
+}
+
+func (q *Type) ShuttingDown() bool {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+
+	return q.shuttingDown
+}
+
+func (q *Type) Processing(item queue.Item) bool {
+	q.cond.L.Lock()
+	defer q.cond.L.Unlock()
+
+	_, ok := q.processing[item.GetUniqueID()]
+
+	return ok
+}


### PR DESCRIPTION
# What problem are we solving?

This pr implements the WORM auto-commit feature mentioned in this pr: https://github.com/seaweedfs/seaweedfs/pull/6404

# How are we solving the problem?

1. create a queue and several workers to handle the auto-commit logic
2. when a file is created or updated, send it to the queue if it is worm enabled
3. one of the worker will pick the file from the queue, check if it should be committed right now. If yes, commit it by setting WORMEnforcedAtTsNs field, if no, re-add it to the queue later
4. when filer starts, loop all worm paths to find the files which need to commit and send them to the queue.

about the queue:
1. it is a priority queue, file with old mtime will be handled first
2. it ensures that one file can only be added once, if the file is processing, new add reqest will be dropped, if the file is in the queue, it will be replaced by new add request

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
