### PR TITLE
Add metrics for uploaded and deleted s3 objects

### DIFF
--- a/weed/s3api/s3api_object_handlers_delete.go
+++ b/weed/s3api/s3api_object_handlers_delete.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	stats_collect "github.com/seaweedfs/seaweedfs/weed/stats"
 	"github.com/seaweedfs/seaweedfs/weed/util"
 )
 
@@ -56,6 +57,7 @@ func (s3a *S3ApiServer) DeleteObjectHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	stats_collect.S3DeletedObjectsCounter.WithLabelValues(bucket).Inc()
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -174,6 +176,7 @@ func (s3a *S3ApiServer) DeleteMultipleObjectsHandler(w http.ResponseWriter, r *h
 		deleteResp.DeletedObjects = deletedObjects
 	}
 	deleteResp.Errors = deleteErrors
+	stats_collect.S3DeletedObjectsCounter.WithLabelValues(bucket).Add(float64(len(deletedObjects)))
 
 	writeSuccessResponseXML(w, r, deleteResp)
 

--- a/weed/s3api/s3api_object_handlers_multipart.go
+++ b/weed/s3api/s3api_object_handlers_multipart.go
@@ -15,7 +15,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
 	weed_server "github.com/seaweedfs/seaweedfs/weed/server"
-
+	stats_collect "github.com/seaweedfs/seaweedfs/weed/stats"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
 )
@@ -91,6 +91,7 @@ func (s3a *S3ApiServer) CompleteMultipartUploadHandler(w http.ResponseWriter, r 
 		s3err.WriteErrorResponse(w, r, errCode)
 		return
 	}
+	stats_collect.S3UploadedObjectsCounter.WithLabelValues(bucket).Inc()
 
 	writeSuccessResponseXML(w, r, response)
 

--- a/weed/s3api/s3api_object_handlers_put.go
+++ b/weed/s3api/s3api_object_handlers_put.go
@@ -102,6 +102,7 @@ func (s3a *S3ApiServer) PutObjectHandler(w http.ResponseWriter, r *http.Request)
 
 		setEtag(w, etag)
 	}
+	stats_collect.S3UploadedObjectsCounter.WithLabelValues(bucket).Inc()
 
 	writeSuccessResponseEmpty(w, r)
 }

--- a/weed/stats/metrics.go
+++ b/weed/stats/metrics.go
@@ -335,6 +335,22 @@ var (
 			Name:      "bucket_traffic_sent_bytes_total",
 			Help:      "Total number of bytes sent from an S3 bucket to clients.",
 		}, []string{"bucket"})
+
+	S3DeletedObjectsCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: "s3",
+			Name:      "deleted_objects",
+			Help:      "Number of objects deleted in each bucket.",
+		}, []string{"bucket"})
+
+	S3UploadedObjectsCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: "s3",
+			Name:      "uploaded_objects",
+			Help:      "Number of objects uploaded in each bucket.",
+		}, []string{"bucket"})
 )
 
 func init() {
@@ -380,6 +396,8 @@ func init() {
 	Gather.MustRegister(S3TimeToFirstByteHistogram)
 	Gather.MustRegister(S3BucketTrafficReceivedBytesCounter)
 	Gather.MustRegister(S3BucketTrafficSentBytesCounter)
+	Gather.MustRegister(S3DeletedObjectsCounter)
+	Gather.MustRegister(S3UploadedObjectsCounter)
 
 	go bucketMetricTTLControl()
 }


### PR DESCRIPTION
# What problem are we solving?
Two metrics for deleted and uploaded objects in S3 per bucket are added in this pull request.



# How are we solving the problem?
By adding two counter metrics and increasing them in PutObjectHandler, CompleteMultipartUploadHandler, DeleteMultipleObjectsHandler, DeleteObjectHandler handlers.



# How is the PR tested?
It was tested locally.


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
