### PR TITLE
`ec.encode`: Display a warning on EC balancing if no replica placement settings are found.

### DIFF
--- a/weed/storage/super_block/replica_placement.go
+++ b/weed/storage/super_block/replica_placement.go
@@ -45,6 +45,10 @@ func NewReplicaPlacementFromByte(b byte) (*ReplicaPlacement, error) {
 	return NewReplicaPlacementFromString(fmt.Sprintf("%03d", b))
 }
 
+func (rp *ReplicaPlacement) HasReplication() bool {
+	return rp.DiffDataCenterCount != 0 || rp.DiffRackCount != 0 || rp.SameRackCount != 0
+}
+
 func (a *ReplicaPlacement) Equals(b *ReplicaPlacement) bool {
 	if a == nil || b == nil {
 		return false

--- a/weed/storage/super_block/replica_placement_test.go
+++ b/weed/storage/super_block/replica_placement_test.go
@@ -12,3 +12,32 @@ func TestReplicaPlacementSerialDeserial(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestReplicaPlacementHasReplication(t *testing.T) {
+	testCases := []struct {
+		name             string
+		replicaPlacement string
+		want             bool
+	}{
+		{"empty replica placement", "", false},
+		{"no replication", "000", false},
+		{"same rack replication", "100", true},
+		{"diff rack replication", "020", true},
+		{"DC replication", "003", true},
+		{"full replication", "155", true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rp, err := NewReplicaPlacementFromString(tc.replicaPlacement)
+			if err != nil {
+				t.Errorf("failed to initialize ReplicaPlacement: %v", err)
+				return
+			}
+
+			if got, want := rp.HasReplication(), tc.want; got != want {
+				t.Errorf("expected %v, got %v", want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/6474

# How are we solving the problem?

This PR increases the visibility of configuration holes which can cause `ec.encode` to become no-op.

# How is the PR tested?

Added unit tests for new `super_block.ReplicaPlacement` methods.

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
