### PR TITLE
+-Add content length to filer's requests

### DIFF
--- a/weed/s3api/s3api_object_handlers_put.go
+++ b/weed/s3api/s3api_object_handlers_put.go
@@ -129,6 +129,7 @@ func (s3a *S3ApiServer) putToFiler(r *http.Request, uploadUrl string, dataReader
 		query.Add("collection", s3a.getCollectionName(bucket))
 		proxyReq.URL.RawQuery = query.Encode()
 	}
+	proxyReq.ContentLength = r.ContentLength
 
 	for header, values := range r.Header {
 		for _, value := range values {


### PR DESCRIPTION
# What problem are we solving?
Currently, the concurrent upload limit is not applied in the filer because the result of the getContentLength function in the filer is always 0 – unlike in the VolumeServer where it behaves correctly. Consequently, the filer cannot limit incoming requests.

The reason for this issue is that in the putToFiler function, requests headers will automatically be changed by go clinet. The client changes Transfer Encoding to chunked. As a result, the Content-Length header is deleted. One way to avoid this is to set the Content-Length header directly. It also improved the latency between s3 and filer.

# How are we solving the problem?
By setting Content-Length equal to the request passed to the putToFiler function.

# How is the PR tested?
It is tested locally and also within our Kubernetes system with a large number of requests.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
