### PR TITLE
Nit: fix missing newline on EC balancing warnings regarding replica settings

### DIFF
--- a/weed/shell/command_ec_common.go
+++ b/weed/shell/command_ec_common.go
@@ -195,7 +195,7 @@ func parseReplicaPlacementArg(commandEnv *CommandEnv, replicaStr string) (*super
 	}
 
 	if !rp.HasReplication() {
-		fmt.Printf("WARNING: replica placement type %q is empty!", rp.String())
+		fmt.Printf("WARNING: replica placement type %q is empty!\n", rp.String())
 	}
 	return rp, nil
 }


### PR DESCRIPTION
# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/6474

# How are we solving the problem?

Fix a missing newline on warnings for missing replica settings at EC rebalancing time.

See 79136812.

# How is the PR tested?

No testing required.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
