### PR TITLE
Remove warning on EC balancing if no replica placement settings are found.

### DIFF
--- a/weed/shell/command_ec_common.go
+++ b/weed/shell/command_ec_common.go
@@ -194,9 +194,6 @@ func parseReplicaPlacementArg(commandEnv *CommandEnv, replicaStr string) (*super
 		fmt.Printf("using master default replica placement %q for EC volumes\n", rp.String())
 	}
 
-	if !rp.HasReplication() {
-		fmt.Printf("WARNING: replica placement type %q is empty!", rp.String())
-	}
 	return rp, nil
 }
 


### PR DESCRIPTION
# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/6474

# How are we solving the problem?

Effectively undoes c9399a68. After ff8bd862, a replica placement type `000` will no longer break
shards re-balancing, so there's no display a warning for them.

# How is the PR tested?

No tests required/impacted.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
