### PR TITLE
fix: bucket-hook fails with gnu wget

### DIFF
--- a/weed/command/master.go
+++ b/weed/command/master.go
@@ -192,7 +192,7 @@ func startMaster(masterOption MasterOptions, masterWhiteList []string) {
 		}
 	}
 	ms.SetRaftServer(raftServer)
-	r.HandleFunc("/cluster/status", raftServer.StatusHandler).Methods(http.MethodGet)
+	r.HandleFunc("/cluster/status", raftServer.StatusHandler).Methods(http.MethodGet, http.MethodHead)
 	r.HandleFunc("/cluster/healthz", raftServer.HealthzHandler).Methods(http.MethodGet, http.MethodHead)
 	if *masterOption.raftHashicorp {
 		r.HandleFunc("/raft/stats", raftServer.StatsRaftHandler).Methods(http.MethodGet)


### PR DESCRIPTION
# What problem are we solving?

Alternative to https://github.com/seaweedfs/seaweedfs/pull/6520

When we change the base image to one with GNU Wget, the call to `http://seaweedfs-master.seaweedfs:9333/cluster/status` fails because it does not implement the HTTP HEAD method.

the issue:

```
root@tmp-shell:/# wget --version
GNU Wget 1.21.2 built on linux-gnu.
root@tmp-shell:/# wget --spider http://seaweedfs-master.seaweedfs:9333/cluster/status && echo "exit $?"
Spider mode enabled. Check if remote file exists.
--2025-02-07 00:26:52--  http://seaweedfs-master.seaweedfs:9333/cluster/status
Resolving seaweedfs-master.seaweedfs (seaweedfs-master.seaweedfs)... 10.244.97.67
Connecting to seaweedfs-master.seaweedfs (seaweedfs-master.seaweedfs)|10.244.97.67|:9333... connected.
HTTP request sent, awaiting response... 405 Method Not Allowed
Remote file does not exist -- broken link!!!
```

Apologies for our atypical use case.

# How are we solving the problem?



# How is the PR tested?

Manual

with the fix:

```
/data # wget
BusyBox v1.37.0 (2024-09-30 10:39:57 UTC) multi-call binary.
...
/data # wget -O - http://seaweedfs-master.seaweedfs:9333/cluster/status && echo "exit $?"
Connecting to seaweedfs-master.seaweedfs:9333 (10.244.97.67:9333)
writing to stdout
-                    100% |********************************************************|    96  0:00:00 ETA
written to stdout
exit 0
```

```
root@tmp-shell:/# wget --version
GNU Wget 1.21.2 built on linux-gnu.
root@tmp-shell:/# wget -O - http://seaweedfs-master.seaweedfs:9333/cluster/status && echo "exit $?"
--2025-02-07 00:26:22--  http://seaweedfs-master.seaweedfs:9333/cluster/status
Resolving seaweedfs-master.seaweedfs (seaweedfs-master.seaweedfs)... 10.244.97.67
Connecting to seaweedfs-master.seaweedfs (seaweedfs-master.seaweedfs)|10.244.97.67|:9333... connected.
HTTP request sent, awaiting response... 200 OK
Length: 96 [application/json]
Saving to: 'STDOUT'

-                           0%[                                      ]       0  --.-KB/s               {-                         100%[=====================================>]      96  --.-KB/s    in 0s

2025-02-07 00:26:22 (12.3 MB/s) - written to stdout [96/96]

exit 0
```


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
