### PR TITLE
omit http and https ports when using X-Forwarded-Port

### DIFF
--- a/weed/s3api/auth_signature_v4.go
+++ b/weed/s3api/auth_signature_v4.go
@@ -710,7 +710,7 @@ func extractHostHeader(r *http.Request) string {
 	// If X-Forwarded-Port is set, use that too to form the host.
 	if forwardedHost != "" {
 		extractedHost := forwardedHost
-		if forwardedPort != "" {
+		if forwardedPort != "" && forwardedPort != "80" && forwardedPort != "443" {
 			extractedHost = forwardedHost + ":" + forwardedPort
 		}
 		return extractedHost


### PR DESCRIPTION
The S3 clients tend to omit them when signing the request, and so the server should too