### PR TITLE
Helm: Support map format for image pull secrets

### DIFF
--- a/k8s/charts/seaweedfs/templates/_helpers.tpl
+++ b/k8s/charts/seaweedfs/templates/_helpers.tpl
@@ -134,14 +134,17 @@ Inject extra environment vars in the format key:value, if populated
 
 {{/* Return the proper imagePullSecrets */}}
 {{- define "seaweedfs.imagePullSecrets" -}}
-{{- if .Values.global.imagePullSecrets }}
-{{- if kindIs "string" .Values.global.imagePullSecrets }}
+{{- with .Values.global.imagePullSecrets }}
 imagePullSecrets:
-  - name: {{ .Values.global.imagePullSecrets }}
-{{- else }}
-imagePullSecrets:
-{{- range .Values.global.imagePullSecrets }}
+{{- if kindIs "string" . }}
   - name: {{ . }}
+{{- else }}
+{{- range . }}
+  {{- if kindIs "string" . }}
+  - name: {{ . }}
+  {{- else }}
+  - {{ toYaml . }}
+  {{- end}}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
# What problem are we solving?

The seaweedfs gets the image pull secrets from the global variables of the charts. This section applies to all subcharts of a helm chart. This is a problem for us, as charts have conflicting formats for the secret:
* some, like seaweed want strings with the secret names
* others take objects

# How are we solving the problem?

This PR changes the chart so it takes all three formats:
* a single string
* a list of strings
* a list of objects (these are rendered directly to yaml)

# How is the PR tested?

* I've tested that all three formats are rendered correctly


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
