### PR TITLE
stop retry when all nodes have tried it

### DIFF
--- a/weed/filer/filechunk_manifest.go
+++ b/weed/filer/filechunk_manifest.go
@@ -130,7 +130,9 @@ func retriedStreamFetchChunkData(writer io.Writer, urlStrings []string, jwt stri
 	var totalWritten int
 
 	for waitTime := time.Second; waitTime < util.RetryWaitTime; waitTime += waitTime / 2 {
+		retriedCnt := 0
 		for _, urlString := range urlStrings {
+			retriedCnt++
 			var localProcessed int
 			var writeErr error
 			shouldRetry, err = util_http.ReadUrlAsStreamAuthenticated(urlString+"?readDeleted=true", jwt, cipherKey, isGzipped, isFullChunk, offset, size, func(data []byte) {
@@ -160,6 +162,10 @@ func retriedStreamFetchChunkData(writer io.Writer, urlStrings []string, jwt stri
 			} else {
 				break
 			}
+		}
+		// all nodes have tried it
+		if retriedCnt == len(urlStrings) {
+			break
 		}
 		if err != nil && shouldRetry {
 			glog.V(0).Infof("retry reading in %v", waitTime)


### PR DESCRIPTION
# What problem are we solving?
When all replicas fail to download, retries should be stopped because there may be serious issues with the cluster. Continuing to retry would only result in unnecessary resource consumption for the cluster.

# How are we solving the problem?
Stop retrying when all nodes have failed to retry.


# How is the PR tested?
test in my cluster


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
