### PR TITLE
fix: error info size bug in command_fs_merge_volumes.go

### DIFF
--- a/weed/shell/command_fs_merge_volumes.go
+++ b/weed/shell/command_fs_merge_volumes.go
@@ -90,7 +90,7 @@ func (c *commandFsMergeVolumes) Do(args []string, commandEnv *CommandEnv, writer
 				"volume %d (%d MB) cannot merge into volume %d (%d MB_ due to volume size limit (%d MB)",
 				fromVolumeId, fromSize/1024/1024,
 				toVolumeId, toSize/1024/1024,
-				c.volumeSizeLimit/1024/102,
+				c.volumeSizeLimit/1024/1024,
 			)
 		}
 	}


### PR DESCRIPTION
fix: error info size bug in command_fs_merge_volumes.go

# What problem are we solving?

a log bug in command_fs_merge_volumes.go

# How are we solving the problem?

modified.

# How is the PR tested?

N/A

# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
