### PR TITLE
added re-generating and writing the Volume UUID if it is empty

### DIFF
--- a/weed/stats/metrics.go
+++ b/weed/stats/metrics.go
@@ -1,7 +1,6 @@
 package stats
 
 import (
-	"log"
 	"net"
 	"net/http"
 	"os"
@@ -436,7 +435,7 @@ func StartMetricsServer(ip string, port int) {
 		return
 	}
 	http.Handle("/metrics", promhttp.HandlerFor(Gather, promhttp.HandlerOpts{}))
-	log.Fatal(http.ListenAndServe(JoinHostPort(ip, port), nil))
+	glog.Fatal(http.ListenAndServe(JoinHostPort(ip, port), nil))
 }
 
 func SourceName(port uint32) string {

--- a/weed/storage/disk_location.go
+++ b/weed/storage/disk_location.go
@@ -40,21 +40,28 @@ type DiskLocation struct {
 
 func GenerateDirUuid(dir string) (dirUuidString string, err error) {
 	glog.V(1).Infof("Getting uuid of volume directory:%s", dir)
-	dirUuidString = ""
 	fileName := dir + "/vol_dir.uuid"
 	if !util.FileExists(fileName) {
-		dirUuid, _ := uuid.NewRandom()
-		dirUuidString = dirUuid.String()
-		writeErr := util.WriteFile(fileName, []byte(dirUuidString), 0644)
-		if writeErr != nil {
-			return "", fmt.Errorf("failed to write uuid to %s : %v", fileName, writeErr)
-		}
+		dirUuidString, err = writeNewUuid(fileName)
 	} else {
 		uuidData, readErr := os.ReadFile(fileName)
 		if readErr != nil {
 			return "", fmt.Errorf("failed to read uuid from %s : %v", fileName, readErr)
 		}
-		dirUuidString = string(uuidData)
+		if len(uuidData) > 0 {
+			dirUuidString = string(uuidData)
+		} else {
+			dirUuidString, err = writeNewUuid(fileName)
+		}
+	}
+	return dirUuidString, err
+}
+
+func writeNewUuid(fileName string) (string, error) {
+	dirUuid, _ := uuid.NewRandom()
+	dirUuidString := dirUuid.String()
+	if err := util.WriteFile(fileName, []byte(dirUuidString), 0644); err != nil {
+		return "", fmt.Errorf("failed to write uuid to %s : %v", fileName, err)
 	}
 	return dirUuidString, nil
 }


### PR DESCRIPTION
# What problem are we solving?
https://github.com/seaweedfs/seaweedfs/issues/4598


# How are we solving the problem?
re-generating and writing the Volume UUID if it is empty


# How is the PR tested?
it was checked on the local stand, all volume servers have a non-empty UUID, otherwise the UUID was re-written to the file.


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
