### PR TITLE
Removed unused certificate mounts from helm chart

### DIFF
--- a/k8s/charts/seaweedfs/Chart.yaml
+++ b/k8s/charts/seaweedfs/Chart.yaml
@@ -3,4 +3,4 @@ description: SeaweedFS
 name: seaweedfs
 appVersion: "3.85"
 # Dev note: Trigger a helm chart release by `git tag -a helm-<version>`
-version: 4.0.385
+version: 4.0.386

--- a/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
@@ -248,18 +248,14 @@ spec:
             - name: ca-cert
               readOnly: true
               mountPath: /usr/local/share/ca-certificates/ca/
-            - name: master-cert
-              readOnly: true
-              mountPath: /usr/local/share/ca-certificates/master/
-            - name: volume-cert
-              readOnly: true
-              mountPath: /usr/local/share/ca-certificates/volume/
             - name: filer-cert
               readOnly: true
               mountPath: /usr/local/share/ca-certificates/filer/
+            {{- if .Values.filer.s3.enabled }}
             - name: client-cert
               readOnly: true
               mountPath: /usr/local/share/ca-certificates/client/
+            {{- end }}
             {{- end }}
             {{ tpl .Values.filer.extraVolumeMounts . | nindent 12 | trim }}
           ports:
@@ -367,18 +363,14 @@ spec:
         - name: ca-cert
           secret:
             secretName: {{ template "seaweedfs.name" . }}-ca-cert
-        - name: master-cert
-          secret:
-            secretName: {{ template "seaweedfs.name" . }}-master-cert
-        - name: volume-cert
-          secret:
-            secretName: {{ template "seaweedfs.name" . }}-volume-cert
         - name: filer-cert
           secret:
             secretName: {{ template "seaweedfs.name" . }}-filer-cert
+        {{- if .Values.filer.s3.enabled }}
         - name: client-cert
           secret:
             secretName: {{ template "seaweedfs.name" . }}-client-cert
+        {{- end }}
         {{- end }}
         {{ tpl .Values.filer.extraVolumes . | indent 8 | trim }}
       {{- if .Values.filer.nodeSelector }}

--- a/k8s/charts/seaweedfs/templates/master-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/master-statefulset.yaml
@@ -191,15 +191,6 @@ spec:
             - name: master-cert
               readOnly: true
               mountPath: /usr/local/share/ca-certificates/master/
-            - name: volume-cert
-              readOnly: true
-              mountPath: /usr/local/share/ca-certificates/volume/
-            - name: filer-cert
-              readOnly: true
-              mountPath: /usr/local/share/ca-certificates/filer/
-            - name: client-cert
-              readOnly: true
-              mountPath: /usr/local/share/ca-certificates/client/
             {{- end }}
             {{ tpl .Values.master.extraVolumeMounts . | nindent 12 | trim }}
           ports:
@@ -289,15 +280,6 @@ spec:
         - name: master-cert
           secret:
             secretName: {{ template "seaweedfs.name" . }}-master-cert
-        - name: volume-cert
-          secret:
-            secretName: {{ template "seaweedfs.name" . }}-volume-cert
-        - name: filer-cert
-          secret:
-            secretName: {{ template "seaweedfs.name" . }}-filer-cert
-        - name: client-cert
-          secret:
-            secretName: {{ template "seaweedfs.name" . }}-client-cert
         {{- end }}
         {{ tpl .Values.master.extraVolumes . | indent 8 | trim }}
       {{- if .Values.master.nodeSelector }}

--- a/k8s/charts/seaweedfs/templates/volume-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/volume-statefulset.yaml
@@ -207,18 +207,9 @@ spec:
             - name: ca-cert
               readOnly: true
               mountPath: /usr/local/share/ca-certificates/ca/
-            - name: master-cert
-              readOnly: true
-              mountPath: /usr/local/share/ca-certificates/master/
             - name: volume-cert
               readOnly: true
               mountPath: /usr/local/share/ca-certificates/volume/
-            - name: filer-cert
-              readOnly: true
-              mountPath: /usr/local/share/ca-certificates/filer/
-            - name: client-cert
-              readOnly: true
-              mountPath: /usr/local/share/ca-certificates/client/
             {{- end }}
             {{ tpl .Values.volume.extraVolumeMounts . | nindent 12 | trim }}
           ports:


### PR DESCRIPTION
What problem are we solving?
Fix: #6579

How are we solving the problem?
In the Helm chart, we remove volume and volumeMounts for the certificates that are not used by the statefulset/deployment in question (s3, filer, volume and master).

How is the PR tested?
We ran SeaweedFS in a Kubernetes Cluster with a joint Filer and S3 server in one container, with leveldb2 as the filer storage.
We have a Kyverno policy that restarts pods when their mounted secrets are changed. Then using `cmctl renew` to renew the various certificates, we observed that only the relevant statefulset was restarted. Thereafter we used s3cmd to write to an s3 bucket to prove that the Seaweed cluster was still operational.

Checks
[ ] I have added unit tests if possible.
[ ] I will add related wiki document changes and link to this PR after merging.