### PR TITLE
fix: fix the wrong error return value

### DIFF
--- a/weed/server/filer_server_handlers_write_merge.go
+++ b/weed/server/filer_server_handlers_write_merge.go
@@ -58,7 +58,7 @@ func (fs *FilerServer) mergeChunks(so *operation.StorageOption, inputChunks []*f
 	if err != nil {
 		glog.Errorf("Failed to resolve old entry chunks when delete old entry chunks. new: %s, old: %s",
 			mergedChunks, inputChunks)
-		return
+		return mergedChunks, err
 	}
 	fs.filer.DeleteChunksNotRecursive(garbage)
 	return


### PR DESCRIPTION
# What problem are we solving?


Since we have already checked mergeErr before and returned when mergeErr != nil, mergeErr must be nil here. In fact, it should return err, not the default mergeErr.



# How are we solving the problem?



# How is the PR tested?



# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
