### PR TITLE
clear cache directory when mount exits

### DIFF
--- a/weed/command/mount_std.go
+++ b/weed/command/mount_std.go
@@ -284,5 +284,7 @@ func RunMount(option *MountOptions, umask os.FileMode) bool {
 
 	server.Serve()
 
+	seaweedFileSystem.ClearCacheDir()
+
 	return true
 }

--- a/weed/mount/weedfs.go
+++ b/weed/mount/weedfs.go
@@ -224,6 +224,12 @@ func (wfs *WFS) getCurrentFiler() pb.ServerAddress {
 	return wfs.option.FilerAddresses[i]
 }
 
+func (wfs *WFS) ClearCacheDir() {
+	wfs.metaCache.Shutdown()
+	os.RemoveAll(wfs.option.getUniqueCacheDirForWrite())
+	os.RemoveAll(wfs.option.getUniqueCacheDirForRead())
+}
+
 func (option *Option) setupUniqueCacheDirectory() {
 	cacheUniqueId := util.Md5String([]byte(option.MountDirectory + string(option.FilerAddresses[0]) + option.FilerMountRootPath + util.Version()))[0:8]
 	option.uniqueCacheDirForRead = path.Join(option.CacheDirForRead, cacheUniqueId)


### PR DESCRIPTION
# What problem are we solving?

clear cache directory when mount exits. 
fix the issue:  https://github.com/seaweedfs/seaweedfs/issues/6604

# How are we solving the problem?

Add the code that clearing the cache directory when fuse mount exits

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
