### PR TITLE
Fixes files with TTL are not listed in a mounted folder.

### DIFF
--- a/weed/mount/meta_cache/meta_cache.go
+++ b/weed/mount/meta_cache/meta_cache.go
@@ -147,7 +147,7 @@ func (mc *MetaCache) ListDirectoryEntries(ctx context.Context, dirPath util.Full
 	}
 
 	_, err := mc.localStore.ListDirectoryEntries(ctx, dirPath, startFileName, includeStartFile, limit, func(entry *filer.Entry) bool {
-		if entry.TtlSec > 0 && entry.Crtime.Add(time.Duration(entry.TtlSec)).Before(time.Now()) {
+		if entry.TtlSec > 0 && entry.Crtime.Add(time.Duration(entry.TtlSec)*time.Second).Before(time.Now()) {
 			return true
 		}
 		mc.mapIdFromFilerToLocal(entry)


### PR DESCRIPTION
# What problem are we solving?

Files uploaded with TTL are not listed in a mounted volume.

## Reproducing Procedure

```bash
# Start SeaweedFS service with master, volume and filer.
weed server -filer &
# Mount a FUSE volume.
weed mount -dir=/somefolder &
# Upload a file with TTL.
curl -F --file=@somefile http://localhost:8888/somefile?ttl=1m
# Check if the file is listed.
ls /somefolder
```
No somefile in the /somefolder folder.

# How are we solving the problem?

`MetaCache` checks if directory entries have expired in the `ListDirectoryEntries` method. When checking if an entry has expired by comparing the current time with the expiration time, the conversion of TTL to seconds was missing. Adding `time.Second` unit solves this problem.

# How is the PR tested?

Same procedure to reproduce the problem was used.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
