### PR TITLE
Fix typos and YAML syntax issues

### DIFF
--- a/k8s/charts/seaweedfs/templates/cosi-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/cosi-deployment.yaml
@@ -173,7 +173,7 @@ spec:
             {{- if .Values.cosi.existingConfigSecret }}
             secretName: {{ .Values.cosi.existingConfigSecret }}
             {{- else }}
-            secretName: seaweedfs-client-cert
+            secretName: seaweedfs-s3-secret
             {{- end }}
         {{- end }}
         {{- if .Values.global.enableSecurity }}

--- a/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer-statefulset.yaml
@@ -173,7 +173,7 @@ spec:
               {{- end }}
               -dirListLimit={{ .Values.filer.dirListLimit }} \
               {{- if .Values.global.enableReplication }}
-              -defaultReplicaPlacement={{ .Values.global.replicationPlacment }} \
+              -defaultReplicaPlacement={{ .Values.global.replicationPlacement }} \
               {{- else }}
               -defaultReplicaPlacement={{ .Values.filer.defaultReplicaPlacement }} \
               {{- end }}

--- a/k8s/charts/seaweedfs/templates/master-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/master-statefulset.yaml
@@ -139,7 +139,7 @@ spec:
               -mdir=/data \
               -ip.bind={{ .Values.master.ipBind }} \
               {{- if .Values.global.enableReplication }}
-              -defaultReplication={{ .Values.global.replicationPlacment }} \
+              -defaultReplication={{ .Values.global.replicationPlacement }} \
               {{- else }}
               -defaultReplication={{ .Values.master.defaultReplication }} \
               {{- end }}

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -27,13 +27,13 @@ global:
     gatewayHost: null
     gatewayPort: null
     additionalLabels: {}
-  # if enabled will use global.replicationPlacment and override master & filer defaultReplicaPlacement config
+  # if enabled will use global.replicationPlacement and override master & filer defaultReplicaPlacement config
   enableReplication: false
   #  replication type is XYZ:
   # X number of replica in other data centers
   # Y number of replica in other racks in the same data center
   # Z number of replica in other servers in the same rack
-  replicationPlacment: "001"
+  replicationPlacement: "001"
   extraEnvironmentVars:
     WEED_CLUSTER_DEFAULT: "sw"
     WEED_CLUSTER_SW_MASTER: "seaweedfs-master.seaweedfs:9333"

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -291,7 +291,7 @@ volume:
   # For each data disk you may use ANY storage-class, example with local-path-provisioner
   # Annotations are optional.
   #  dataDirs:
-  #   - name: data:
+  #   - name: data
   #     type: "persistentVolumeClaim"
   #     size: "24Ti"
   #     storageClass: "local-path-provisioner"


### PR DESCRIPTION
# What problem are we solving?

There are typos and invalid YAML syntax in the Helm chart. Additionally, there is an incorrect default secret name in the COSI deployment (though I'm unsure about this).

# How are we solving the problem?

Fixing YAML syntax errors by removing a trailing `:`,  typos by renaming the default secret name of the COSI deployment and `replicationPlacement` in the global section of the Helm chart values. The latter might be a breaking change for users overriding this value in their values file. We may add the previous `replicationPlacment` value as a fallback.

# How is the PR tested?

Run `helm template --debug` on the chart in `k8s/charts/seaweedfs`.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
