### PR TITLE
fix: restore deletion audit of individual objects

### DIFF
--- a/docker/compose/fluent.conf
+++ b/docker/compose/fluent.conf
@@ -1,0 +1,8 @@
+<source>
+  @type forward
+  port 24224
+</source>
+
+<match **>
+  @type stdout  # Output logs to container's stdout (visible via `docker logs`)
+</match>

--- a/docker/compose/local-auditlog-compose.yml
+++ b/docker/compose/local-auditlog-compose.yml
@@ -19,7 +19,9 @@ services:
     depends_on:
       - fluent
   fluent:
-    image: fluent/fluentd:v1.14
+    image: fluent/fluentd:v1.17
+    volumes:
+      - ./fluent.conf:/fluentd/etc/fluent.conf
     ports:
       - 24224:24224
   #s3tests:

--- a/weed/s3api/s3err/audit_fluent.go
+++ b/weed/s3api/s3err/audit_fluent.go
@@ -3,12 +3,13 @@ package s3err
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/fluent/fluent-logger-golang/fluent"
-	"github.com/seaweedfs/seaweedfs/weed/glog"
-	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 	"net/http"
 	"os"
 	"time"
+
+	"github.com/fluent/fluent-logger-golang/fluent"
+	"github.com/seaweedfs/seaweedfs/weed/glog"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 )
 
 type AccessLogExtend struct {


### PR DESCRIPTION
- auditing deleting individual records restored
- added logging output to stdout of fluent container for convenient manual testing

# What problem are we solving?
audit deleting individual key does not work


# How are we solving the problem?
I returned the missing code block


# How is the PR tested?
built a new version and tested it locally


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
