### PR TITLE
Fixes files with TTL can not be read in a mounted folder

### DIFF
--- a/weed/mount/meta_cache/meta_cache.go
+++ b/weed/mount/meta_cache/meta_cache.go
@@ -119,7 +119,7 @@ func (mc *MetaCache) FindEntry(ctx context.Context, fp util.FullPath) (entry *fi
 	if err != nil {
 		return nil, err
 	}
-	if entry.TtlSec > 0 && entry.Crtime.Add(time.Duration(entry.TtlSec)).Before(time.Now()) {
+	if entry.TtlSec > 0 && entry.Crtime.Add(time.Duration(entry.TtlSec)*time.Second).Before(time.Now()) {
 		return nil, filer_pb.ErrNotFound
 	}
 	mc.mapIdFromFilerToLocal(entry)


### PR DESCRIPTION
# What problem are we solving?

Fixes files with TTL cannot be read from a mounted folder.
Similar problem with #6621. 

## Reproducing Procedure

```bash
# Start SeaweedFS service with master, volume and filer.
weed server -filer &
# Mount a FUSE volume.
weed mount -dir=/somefolder &
# Upload a text file with TTL.
curl -F --file=@somefile.txt http://localhost:8888/somefile?ttl=1m
# Check if the file is listed.
ls /somefolder
# Check whether the file can be read.
cat /somefoler/somefile.txt
```
An error message is displayed saying no such file when a user tries to read the file.

# How are we solving the problem?

`MetaCache` checks if an entry has expired in the `FindEntry` method. When checking whether the entry has expired by comparing the current time with the expiration time, the conversion of TTL to seconds was missing. Adding `time.Second` unit solves this problem.

# How is the PR tested?

Same procedure to reproduce the problem was used.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
