### PR TITLE
added a check for the nil value when requesting FindEntry.

### DIFF
--- a/weed/filer/filer.go
+++ b/weed/filer/filer.go
@@ -3,11 +3,12 @@ package filer
 import (
 	"context"
 	"fmt"
-	"github.com/seaweedfs/seaweedfs/weed/s3api/s3bucket"
 	"os"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3bucket"
 
 	"github.com/seaweedfs/seaweedfs/weed/cluster/lock_manager"
 
@@ -289,7 +290,7 @@ func (f *Filer) ensureParentDirectoryEntry(ctx context.Context, entry *Entry, di
 		glog.V(2).Infof("create directory: %s %v", dirPath, dirEntry.Mode)
 		mkdirErr := f.Store.InsertEntry(ctx, dirEntry)
 		if mkdirErr != nil {
-			if _, err := f.FindEntry(ctx, util.FullPath(dirPath)); err == filer_pb.ErrNotFound {
+			if fEntry, err := f.FindEntry(ctx, util.FullPath(dirPath)); err == filer_pb.ErrNotFound || fEntry == nil {
 				glog.V(3).Infof("mkdir %s: %v", dirPath, mkdirErr)
 				return fmt.Errorf("mkdir %s: %v", dirPath, mkdirErr)
 			}


### PR DESCRIPTION
# What problem are we solving?
Because from the Cassandra store, we get errors not only "filer_pb.ErrNotFound" , we may have missed some other errors related to issues in cassandra\scylla. This does not guarantee that we will create the parent directories at the moment.


# How are we solving the problem?
In addition to errors when requesting, cassandra store will also return the nil value for the Entry during the "FindEntry" request. This will help fix the problem and stop further directory creation, as some of them may be skipped due to unhandled errors.


# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
