### PR TITLE
feat/fix: add s3.cacert.file/tlsVerifyClientCert to filer command

### DIFF
--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -119,6 +119,8 @@ func init() {
 	filerS3Options.allowEmptyFolder = cmdFiler.Flag.Bool("s3.allowEmptyFolder", true, "allow empty folders")
 	filerS3Options.allowDeleteBucketNotEmpty = cmdFiler.Flag.Bool("s3.allowDeleteBucketNotEmpty", true, "allow recursive deleting all entries along with bucket")
 	filerS3Options.localSocket = cmdFiler.Flag.String("s3.localSocket", "", "default to /tmp/seaweedfs-s3-<port>.sock")
+	filerS3Options.tlsCACertificate = cmdFiler.Flag.String("s3.cacert.file", "", "path to the TLS CA certificate file")
+	filerS3Options.tlsVerifyClientCert = cmdFiler.Flag.Bool("s3.tlsVerifyClientCert", false, "whether to verify the client's certificate")
 
 	// start webdav on filer
 	filerStartWebDav = cmdFiler.Flag.Bool("webdav", false, "whether to start webdav gateway")


### PR DESCRIPTION
This prevent crash filler with nil pointer dereference as s3 expect this parameters.

New two parameters are added to filer command - copy of s3 parameters:
- s3.cacert.file - path to the TLS CA certificate file
- s3.tlsVerifyClientCert - whether to verify the client's certificate

# What problem are we solving?

When S3 is started within filler - crash with nil pointer deference because this parameters are not set = nil.

# How are we solving the problem?

Missing parameter are copied from s3 to filler command.

# How is the PR tested?

Start filler with -s3 -> no crash.
Start filler with -s3 and  -s3.cacert.file and - s3.tlsVerifyClientCert  -> check is s3 endpoint require certificates from cacerf file and certificate is require.


# Checks
- [-] I have added unit tests if possible.
- [-] I will add related wiki document changes and link to this PR after merging.
