### PR TITLE
fix call writeJsonError with a nil value error after check another err

### DIFF
--- a/weed/server/filer_server_handlers_tagging.go
+++ b/weed/server/filer_server_handlers_tagging.go
@@ -45,7 +45,7 @@ func (fs *FilerServer) PutTaggingHandler(w http.ResponseWriter, r *http.Request)
 
 	if dbErr := fs.filer.CreateEntry(ctx, existingEntry, false, false, nil, false, fs.filer.MaxFilenameLength); dbErr != nil {
 		glog.V(0).Infof("failing to update %s tagging : %v", path, dbErr)
-		writeJsonError(w, r, http.StatusInternalServerError, err)
+		writeJsonError(w, r, http.StatusInternalServerError, dbErr)
 		return
 	}
 
@@ -111,7 +111,7 @@ func (fs *FilerServer) DeleteTaggingHandler(w http.ResponseWriter, r *http.Reque
 
 	if dbErr := fs.filer.CreateEntry(ctx, existingEntry, false, false, nil, false, fs.filer.MaxFilenameLength); dbErr != nil {
 		glog.V(0).Infof("failing to delete %s tagging : %v", path, dbErr)
-		writeJsonError(w, r, http.StatusInternalServerError, err)
+		writeJsonError(w, r, http.StatusInternalServerError, dbErr)
 		return
 	}
 


### PR DESCRIPTION
# What problem are we solving?

the dbErr != nil and err is nil

when call writeJsonError with a nil value error, it may panic when call `err.Error()`

https://github.com/seaweedfs/seaweedfs/blob/669a3917af5afafbe12586e8ff2007980d0ab77d/weed/server/common.go#L117-L122


# How are we solving the problem?

use the correct err

# How is the PR tested?


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
