### PR TITLE
Fix volume ttl

### DIFF
--- a/weed/storage/needle/volume_ttl.go
+++ b/weed/storage/needle/volume_ttl.go
@@ -44,7 +44,48 @@ func ReadTTL(ttlString string) (*TTL, error) {
 	}
 	count, err := strconv.Atoi(string(countBytes))
 	unit := toStoredByte(unitByte)
-	return &TTL{Count: byte(count), Unit: unit}, err
+	return fitTtlCount(count, unit), err
+}
+
+func fitTtlCount(count int, unit byte) *TTL {
+	seconds := ToSeconds(count, unit)
+	if seconds == 0 {
+		return EMPTY_TTL
+	}
+	if seconds%(3600*24*365) == 0 && seconds/(3600*24*365) < 256 {
+		return &TTL{Count: byte(seconds / (3600 * 24 * 365)), Unit: Year}
+	}
+	if seconds%(3600*24*30) == 0 && seconds/(3600*24*30) < 256 {
+		return &TTL{Count: byte(seconds / (3600 * 24 * 30)), Unit: Month}
+	}
+	if seconds%(3600*24*7) == 0 && seconds/(3600*24*7) < 256 {
+		return &TTL{Count: byte(seconds / (3600 * 24 * 7)), Unit: Week}
+	}
+	if seconds%(3600*24) == 0 && seconds/(3600*24) < 256 {
+		return &TTL{Count: byte(seconds / (3600 * 24)), Unit: Day}
+	}
+	if seconds%(3600) == 0 && seconds/(3600) < 256 {
+		return &TTL{Count: byte(seconds / (3600)), Unit: Hour}
+	}
+	if seconds/60 < 256 {
+		return &TTL{Count: byte(seconds / 60), Unit: Minute}
+	}
+	if seconds/(3600) < 256 {
+		return &TTL{Count: byte(seconds / (3600)), Unit: Hour}
+	}
+	if seconds/(3600*24) < 256 {
+		return &TTL{Count: byte(seconds / (3600 * 24)), Unit: Day}
+	}
+	if seconds/(3600*24*7) < 256 {
+		return &TTL{Count: byte(seconds / (3600 * 24 * 7)), Unit: Week}
+	}
+	if seconds/(3600*24*30) < 256 {
+		return &TTL{Count: byte(seconds / (3600 * 24 * 30)), Unit: Month}
+	}
+	if seconds/(3600*24*365) < 256 {
+		return &TTL{Count: byte(seconds / (3600 * 24 * 365)), Unit: Year}
+	}
+	return EMPTY_TTL
 }
 
 // read stored bytes to a ttl
@@ -104,21 +145,25 @@ func (t *TTL) String() string {
 }
 
 func (t *TTL) ToSeconds() uint64 {
-	switch t.Unit {
+	return ToSeconds(int(t.Count), t.Unit)
+}
+
+func ToSeconds(count int, unit byte) uint64 {
+	switch unit {
 	case Empty:
 		return 0
 	case Minute:
-		return uint64(t.Count) * 60
+		return uint64(count) * 60
 	case Hour:
-		return uint64(t.Count) * 60 * 60
+		return uint64(count) * 60 * 60
 	case Day:
-		return uint64(t.Count) * 60 * 24 * 60
+		return uint64(count) * 60 * 24 * 60
 	case Week:
-		return uint64(t.Count) * 60 * 24 * 7 * 60
+		return uint64(count) * 60 * 24 * 7 * 60
 	case Month:
-		return uint64(t.Count) * 60 * 24 * 30 * 60
+		return uint64(count) * 60 * 24 * 30 * 60
 	case Year:
-		return uint64(t.Count) * 60 * 24 * 365 * 60
+		return uint64(count) * 60 * 24 * 365 * 60
 	}
 	return 0
 }

--- a/weed/storage/needle/volume_ttl_test.go
+++ b/weed/storage/needle/volume_ttl_test.go
@@ -35,6 +35,16 @@ func TestTTLReadWrite(t *testing.T) {
 		t.Errorf("50d ttl:%v", ttl)
 	}
 
+	ttl, _ = ReadTTL("365d")
+	if ttl.Minutes() != 365*24*60 {
+		t.Errorf("365d ttl:%v", ttl)
+	}
+
+	ttl, _ = ReadTTL("730d")
+	if ttl.Minutes() != 730*24*60 {
+		t.Errorf("730d ttl:%v", ttl)
+	}
+
 	ttl, _ = ReadTTL("5w")
 	if ttl.Minutes() != 5*7*24*60 {
 		t.Errorf("5w ttl:%v", ttl)


### PR DESCRIPTION
# What problem are we solving?
issues repoted here: https://github.com/seaweedfs/seaweedfs/issues/6682


# How are we solving the problem?
Add fitTtlCount to fit ttl into suitable unit, avoiding overflow from int to byte when count > 256


# How is the PR tested?
By manually tested with aws-cmd, buckets Expiration Days from 1to 1000;
When retrieving the bucket lifecycle configuration, if the set expiration days are not integer multiples of weeks, months, or years, a minor precision loss may occur. This is because the TTL conversion will round to the nearest suitable cycle while ensuring the count value remains under 256. However, this is generally acceptable in practice, as long-term expiration settings typically prioritize coarse-grained units (e.g., months or years) over exact day counts.


# Checks
- [✅] I have added unit tests if possible.
- [ - ] I will add related wiki document changes and link to this PR after merging.
