### PR TITLE
[filer] void panic if s3opt.tlsCACertificate is nill

### DIFF
--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -114,6 +114,7 @@ func init() {
 	filerS3Options.dataCenter = cmdFiler.Flag.String("s3.dataCenter", "", "prefer to read and write to volumes in this data center")
 	filerS3Options.tlsPrivateKey = cmdFiler.Flag.String("s3.key.file", "", "path to the TLS private key file")
 	filerS3Options.tlsCertificate = cmdFiler.Flag.String("s3.cert.file", "", "path to the TLS certificate file")
+	filerS3Options.tlsCACertificate = cmdFiler.Flag.String("s3.cacert.file", "", "path to the TLS CA certificate file")
 	filerS3Options.config = cmdFiler.Flag.String("s3.config", "", "path to the config file")
 	filerS3Options.auditLogConfig = cmdFiler.Flag.String("s3.auditLogConfig", "", "path to the audit log config file")
 	filerS3Options.allowEmptyFolder = cmdFiler.Flag.Bool("s3.allowEmptyFolder", true, "allow empty folders")

--- a/weed/command/s3.go
+++ b/weed/command/s3.go
@@ -312,7 +312,7 @@ func (s3opt *S3Options) startS3Server() bool {
 		}
 
 		caCertPool := x509.NewCertPool()
-		if *s3opt.tlsCACertificate != "" {
+		if s3opt.tlsCACertificate != nil && *s3opt.tlsCACertificate != "" {
 			// load CA certificate file and add it to list of client CAs
 			caCertFile, err := ioutil.ReadFile(*s3opt.tlsCACertificate)
 			if err != nil {


### PR DESCRIPTION
# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/6684

# How are we solving the problem?

Check option if not nill 

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
