### PR TITLE
fix: s3 return BadDigest

### DIFF
--- a/weed/s3api/chunked_reader_v4.go
+++ b/weed/s3api/chunked_reader_v4.go
@@ -386,7 +386,6 @@ func (cr *s3ChunkedReader) Read(buf []byte) (n int, err error) {
 			computedChecksum := cr.checkSumWriter.Sum(nil)
 			base64Checksum := base64.StdEncoding.EncodeToString(computedChecksum)
 			if string(extractedChecksum) != base64Checksum {
-				// TODO: Return BadDigest
 				glog.V(3).Infof("payload checksum '%s' does not match provided checksum '%s'", base64Checksum, string(extractedChecksum))
 				cr.err = errors.New("payload checksum does not match")
 				return 0, cr.err

--- a/weed/s3api/chunked_reader_v4.go
+++ b/weed/s3api/chunked_reader_v4.go
@@ -379,7 +379,7 @@ func (cr *s3ChunkedReader) Read(buf []byte) (n int, err error) {
 			if extractedCheckSumAlgorithm.String() != cr.checkSumAlgorithm {
 				errorMessage := fmt.Sprintf("checksum algorithm in trailer '%s' does not match the one advertised in the header '%s'", extractedCheckSumAlgorithm.String(), cr.checkSumAlgorithm)
 				glog.V(3).Info(errorMessage)
-				cr.err = errors.New(errorMessage)
+				cr.err = errors.New(s3err.ErrMsgChecksumAlgorithmMismatch)
 				return 0, cr.err
 			}
 
@@ -387,7 +387,7 @@ func (cr *s3ChunkedReader) Read(buf []byte) (n int, err error) {
 			base64Checksum := base64.StdEncoding.EncodeToString(computedChecksum)
 			if string(extractedChecksum) != base64Checksum {
 				glog.V(3).Infof("payload checksum '%s' does not match provided checksum '%s'", base64Checksum, string(extractedChecksum))
-				cr.err = errors.New("payload checksum does not match")
+				cr.err = errors.New(s3err.ErrMsgPayloadChecksumMismatch)
 				return 0, cr.err
 			}
 
@@ -448,7 +448,7 @@ func (cr *s3ChunkedReader) Read(buf []byte) (n int, err error) {
 			newSignature := cr.getChunkSignature(hashedChunk)
 			if !compareSignatureV4(cr.chunkSignature, newSignature) {
 				// Chunk signature doesn't match we return signature does not match.
-				cr.err = errors.New("chunk signature does not match")
+				cr.err = errors.New(s3err.ErrMsgChunkSignatureMismatch)
 				return 0, cr.err
 			}
 			// Newly calculated signature becomes the seed for the next chunk

--- a/weed/s3api/s3api_object_handlers_put.go
+++ b/weed/s3api/s3api_object_handlers_put.go
@@ -143,6 +143,9 @@ func (s3a *S3ApiServer) putToFiler(r *http.Request, uploadUrl string, dataReader
 
 	if postErr != nil {
 		glog.Errorf("post to filer: %v", postErr)
+		if strings.Contains(postErr.Error(), "checksum") {
+			return "", s3err.ErrInvalidDigest
+		}
 		return "", s3err.ErrInternalError
 	}
 	defer resp.Body.Close()

--- a/weed/s3api/s3api_object_handlers_put.go
+++ b/weed/s3api/s3api_object_handlers_put.go
@@ -143,7 +143,7 @@ func (s3a *S3ApiServer) putToFiler(r *http.Request, uploadUrl string, dataReader
 
 	if postErr != nil {
 		glog.Errorf("post to filer: %v", postErr)
-		if strings.Contains(postErr.Error(), "checksum") {
+		if strings.Contains(postErr.Error(), s3err.ErrMsgPayloadChecksumMismatch) {
 			return "", s3err.ErrInvalidDigest
 		}
 		return "", s3err.ErrInternalError

--- a/weed/s3api/s3err/s3api_errors.go
+++ b/weed/s3api/s3err/s3api_errors.go
@@ -112,6 +112,13 @@ const (
 	ErrNoSuchTagSet
 )
 
+// Error message constants for checksum validation
+const (
+	ErrMsgPayloadChecksumMismatch   = "payload checksum does not match"
+	ErrMsgChunkSignatureMismatch    = "chunk signature does not match"
+	ErrMsgChecksumAlgorithmMismatch = "checksum algorithm mismatch"
+)
+
 // error code to APIError structure, these fields carry respective
 // descriptions for all the error responses.
 var errorCodeResponse = map[ErrorCode]APIError{


### PR DESCRIPTION
# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/6713

# How are we solving the problem?
replace  `We encountered an internal error, please try again.` to `The Content-Md5 you specified did not match what we received`

# How is the PR tested?

localy
before 
```
aws --endpoint-url https://filer01.dev:8443 s3 cp /tmp/test.txt s3://test/test.txt --ca-bundle GolandProjects/seaweedfs/docker/compose/tls/SeaweedFS_CA.crt --checksum-algorithm CRC64NVME
upload failed: ../../tmp/test.txt to s3://test/test.txt An error occurred (InternalError) when calling the PutObject operation (reached max retries: 2): We encountered an internal error, please try again.
```

after
```
aws --endpoint-url https://filer01.dev:8443 s3 cp /tmp/test.txt s3://test/test.txt --ca-bundle /Users/whitefox/GolandProjects/seaweedfs/docker/compose/tls/SeaweedFS_CA.crt --checksum-algorithm CRC64NVME
upload failed: ../../tmp/test.txt to s3://test/test.txt An error occurred (InvalidDigest) when calling the PutObject operation: The Content-Md5 you specified is not valid.
```
# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
