### PR TITLE
bump depdency-review-action 4.3.0 -> 4.3.2

### DIFF
--- a/.github/workflows/depsreview.yml
+++ b/.github/workflows/depsreview.yml
@@ -11,4 +11,4 @@ jobs:
       - name: 'Checkout Repository'
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@0659a74c94536054bfa5aeb92241f70d680cc78e
+        uses: actions/dependency-review-action@0c155c5e8556a497adf53f2c18edabf945ed8e70


### PR DESCRIPTION
# What problem are we solving?

attempt to fix failing dependency-review workflow due to the below error.

Error: Invalid purl: version must be percent-encoded

# How are we solving the problem?

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
