### PR TITLE
fix: volume.list volume info output not in order

### DIFF
--- a/weed/shell/command_volume_list.go
+++ b/weed/shell/command_volume_list.go
@@ -190,7 +190,7 @@ func (c *commandVolumeList) writeDiskInfo(writer io.Writer, t *master_pb.DiskInf
 		diskType = types.HddType
 	}
 	slices.SortFunc(t.VolumeInfos, func(a, b *master_pb.VolumeInformationMessage) int {
-		return int(a.Id - b.Id)
+		return int(a.Id) - int(b.Id)
 	})
 	volumeInfosFound := false
 	for _, vi := range t.VolumeInfos {


### PR DESCRIPTION
# What problem are we solving?

For a long time, the `volume.list` output is not ordered.

# How are we solving the problem?

It's because integer overflow in the compare func of `slices.SortFunc`. The `a.Id` & `b.Id` are uint32, which will give a large number when a < b due to integer underflow. The correct writing should be `int(a.Id) - int(b.Id)`

# How is the PR tested?

Tested by hand


# Checks
- [x] I have added unit tests if possible. (not needed)
- [x] I will add related wiki document changes and link to this PR after merging. (not need)
