### PR TITLE
fix #6733 add s3.ip.bind command line parameter

### DIFF
--- a/weed/command/server.go
+++ b/weed/command/server.go
@@ -156,6 +156,7 @@ func init() {
 	s3Options.allowEmptyFolder = cmdServer.Flag.Bool("s3.allowEmptyFolder", true, "allow empty folders")
 	s3Options.allowDeleteBucketNotEmpty = cmdServer.Flag.Bool("s3.allowDeleteBucketNotEmpty", true, "allow recursive deleting all entries along with bucket")
 	s3Options.localSocket = cmdServer.Flag.String("s3.localSocket", "", "default to /tmp/seaweedfs-s3-<port>.sock")
+	s3Options.bindIp = cmdServer.Flag.String("s3.ip.bind", "", "ip address to bind to. If empty, default to same as -ip.bind option.")
 
 	iamOptions.port = cmdServer.Flag.Int("iam.port", 8111, "iam server http listen port")
 
@@ -218,7 +219,9 @@ func runServer(cmd *Command, args []string) bool {
 	filerOptions.masters = pb.ServerAddresses(*masterOptions.peers).ToServiceDiscovery()
 	filerOptions.ip = serverIp
 	filerOptions.bindIp = serverBindIp
-	s3Options.bindIp = serverBindIp
+	if *s3Options.bindIp == "" {
+		s3Options.bindIp = serverBindIp
+	}
 	iamOptions.ip = serverBindIp
 	iamOptions.masters = masterOptions.peers
 	webdavOptions.ipBind = serverBindIp


### PR DESCRIPTION
# What problem are we solving?

S3 Feature: please add s3.ip.bind command line parameter #6733
( https://github.com/seaweedfs/seaweedfs/issues/6733 )


# How are we solving the problem?

Reas s3.ip.bind command line. If not set default to ip.bind

# How is the PR tested?

weed.exe server -dir=".\data" -ip="127.0.0.1" -filer -s3 -s3.cert.file="certs\public.crt" -s3.key.file="certs\private.key" -s3.config=".\s3.config" -s3.ip.bind="0.0.0.0"
 
process	PID	protocol	local address	local port	state
weed.exe	44212	TCP	127.0.0.1	8080	LISTEN
weed.exe	44212	TCP	0.0.0.0	8333	LISTEN
weed.exe	44212	TCP	::	8333	LISTEN
weed.exe	44212	TCP	127.0.0.1	8888	LISTEN
weed.exe	44212	TCP	127.0.0.1	9333	LISTEN
weed.exe	44212	TCP	127.0.0.1	18080	LISTEN
weed.exe	44212	TCP	0.0.0.0	18333	LISTEN
weed.exe	44212	TCP	::	18333	LISTEN
weed.exe	44212	TCP	127.0.0.1	18888	LISTEN
weed.exe	44212	TCP	127.0.0.1	19333	LISTEN
 
weed.exe server -dir=".\data" -ip="127.0.0.1" -filer -s3 -s3.cert.file="certs\public.crt" -s3.key.file="certs\private.key" -s3.config=".\s3.config" -s3.ip.bind="10.146.2.34"
 
process	PID	protocol	local address	local port	state
weed.exe	69220	TCP	127.0.0.1	8080	LISTEN
weed.exe	69220	TCP	10.146.2.35	8333	LISTEN
weed.exe	69220	TCP	127.0.0.1	8333	LISTEN
weed.exe	69220	TCP	127.0.0.1	8888	LISTEN
weed.exe	69220	TCP	127.0.0.1	9333	LISTEN
weed.exe	69220	TCP	127.0.0.1	18080	LISTEN
weed.exe	69220	TCP	10.146.2.35	18333	LISTEN
weed.exe	69220	TCP	127.0.0.1	18333	LISTEN
weed.exe	69220	TCP	127.0.0.1	18888	LISTEN
weed.exe	69220	TCP	127.0.0.1	19333	LISTEN


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
