### PR TITLE
fix: S3 Feature: please add s3.idleTimeout command line parameter #6746

### DIFF
--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -121,6 +121,7 @@ func init() {
 	filerS3Options.localSocket = cmdFiler.Flag.String("s3.localSocket", "", "default to /tmp/seaweedfs-s3-<port>.sock")
 	filerS3Options.tlsCACertificate = cmdFiler.Flag.String("s3.cacert.file", "", "path to the TLS CA certificate file")
 	filerS3Options.tlsVerifyClientCert = cmdFiler.Flag.Bool("s3.tlsVerifyClientCert", false, "whether to verify the client's certificate")
+	filerS3Options.idleTimeout = cmdFiler.Flag.Int("s3.idleTimeout", 10, "connection idle seconds")
 
 	// start webdav on filer
 	filerStartWebDav = cmdFiler.Flag.Bool("webdav", false, "whether to start webdav gateway")

--- a/weed/command/server.go
+++ b/weed/command/server.go
@@ -157,6 +157,7 @@ func init() {
 	s3Options.allowDeleteBucketNotEmpty = cmdServer.Flag.Bool("s3.allowDeleteBucketNotEmpty", true, "allow recursive deleting all entries along with bucket")
 	s3Options.localSocket = cmdServer.Flag.String("s3.localSocket", "", "default to /tmp/seaweedfs-s3-<port>.sock")
 	s3Options.bindIp = cmdServer.Flag.String("s3.ip.bind", "", "ip address to bind to. If empty, default to same as -ip.bind option.")
+	s3Options.idleTimeout = cmdServer.Flag.Int("s3.idleTimeout", 10, "connection idle seconds")
 
 	iamOptions.port = cmdServer.Flag.Int("iam.port", 8111, "iam server http listen port")
 


### PR DESCRIPTION
# What problem are we solving?

Issue #6746: S3 Feature: please add s3.idleTimeout command line parameter
 ( https://github.com/seaweedfs/seaweedfs/issues/6746 )

# How are we solving the problem?

Following the command line parameter scheme, I have adde "idleTimeout" parameter to the S3 standalone and "s3.idleTimeout" to the server and filer options. I have kept the default value 10

# How is the PR tested?

weed s3 without idleTimeout parameter:
time telnet 127.0.0.1 8333
Connected to 127.0.0.1. 
telnet: Connection closed by foreign host
real    10.030
user    0.15000
sys     0.000
weed s3 with -idleTimeout=20:
time telnet 127.0.0.1 8333
Connected to 127.0.0.1.
telnet: Connection closed by foreign host
real    20.033
user    0.000
sys     0.000
weed server with filer and s3 API without idleTimeout parameter:
time telnet 127.0.0.1 8333
Connected to 127.0.0.1.
telnet: Connection closed by foreign host
real    10.031
user    0.000
sys     0.30000
weed server with filer and s3 API with -s3.idleTime=30:
time telnet 127.0.0.1 8333
Connected to 127.0.0.1.
telnet: Connection closed by foreign host
real    30.034
user    0.000
sys     0.61000
weed filer with s3 API without idleTimeout parameter:
> time telnet 127.0.0.1 8333
Connected to 127.0.0.1.
telnet: Connection closed by foreign host
real    10.034
user    0.000
sys     0.15000
weed filer with s3 API with -s3.idleTimeout=30:
time telnet 127.0.0.1 8333
Connected to 127.0.0.1.
telnet: Connection closed by foreign host
real    30.032
user    0.15000
sys     0.46000
 

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
