### PR TITLE
Addendum to issue #6733

### DIFF
--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -121,6 +121,7 @@ func init() {
 	filerS3Options.localSocket = cmdFiler.Flag.String("s3.localSocket", "", "default to /tmp/seaweedfs-s3-<port>.sock")
 	filerS3Options.tlsCACertificate = cmdFiler.Flag.String("s3.cacert.file", "", "path to the TLS CA certificate file")
 	filerS3Options.tlsVerifyClientCert = cmdFiler.Flag.Bool("s3.tlsVerifyClientCert", false, "whether to verify the client's certificate")
+	filerS3Options.bindIp = cmdFiler.Flag.String("s3.ip.bind", "", "ip address to bind to. If empty, default to same as -ip.bind option.")
 	filerS3Options.idleTimeout = cmdFiler.Flag.Int("s3.idleTimeout", 10, "connection idle seconds")
 
 	// start webdav on filer
@@ -198,7 +199,9 @@ func runFiler(cmd *Command, args []string) bool {
 	startDelay := time.Duration(2)
 	if *filerStartS3 {
 		filerS3Options.filer = &filerAddress
-		filerS3Options.bindIp = f.bindIp
+		if *filerS3Options.bindIp == "" {
+			filerS3Options.bindIp = f.bindIp
+		}
 		filerS3Options.localFilerSocket = f.localSocket
 		if *f.dataCenter != "" && *filerS3Options.dataCenter == "" {
 			filerS3Options.dataCenter = f.dataCenter


### PR DESCRIPTION
# What problem are we solving?

Addendum to issue #6733
While analyzing the issue regarding the idle Timeout parameter (#6746) I noticed that, to keep consistency, it would be necessary to have a “s3.ip.bind” command line parameter in the filer.go as well.  


# How are we solving the problem?

add “s3.ip.bind” to filer.go using "ip.bind" as default.

# How is the PR tested?

weed.exe filer -defaultStoreDir=".\data" -ip="127.0.0.1" -master="127.0.0.1:9333" -s3 -s3.cert.file="certs\public.crt" -s3.key.file="certs\private.key" -s3.config=".\s3.config" -s3.idleTimeout=30 

process PID protocol local address local port state
weed.exe 26404 TCP 127.0.0.1 8888 LISTEN
weed.exe 26404 TCP 127.0.0.1 8333 LISTEN
weed.exe 26404 TCP 127.0.0.1 18888 LISTEN
weed.exe 26404 TCP 127.0.0.1 18333 LISTEN

weed.exe filer -defaultStoreDir=".\data" -ip="127.0.0.1" -master="127.0.0.1:9333" -s3 -s3.cert.file="certs\public.crt" -s3.key.file="certs\private.key" -s3.config=".\s3.config" -s3.idleTimeout=30 -s3.ip.bind="0.0.0.0"

process PID protocol local address local port state
weed.exe 37664 TCP 127.0.0.1 8888 LISTEN
weed.exe 37664 TCP 127.0.0.1 18888 LISTEN
weed.exe 37664 TCP 0.0.0.0 8333 LISTEN
weed.exe 37664 TCP 0.0.0.0 18333 LISTEN
weed.exe 37664 TCP :: 8333 LISTEN
weed.exe 37664 TCP :: 18333 LISTEN

weed.exe filer -defaultStoreDir=".\data" -ip="127.0.0.1" -ip.bind="0.0.0.0" -master="127.0.0.1:9333" -s3 -s3.cert.file="certs\public.crt" -s3.key.file="certs\private.key" -s3.config=".\s3.config" -s3.idleTimeout=30

process PID protocol local address local port state
weed.exe 70184 TCP 0.0.0.0 8333 LISTEN
weed.exe 70184 TCP 0.0.0.0 8888 LISTEN
weed.exe 70184 TCP 0.0.0.0 18333 LISTEN
weed.exe 70184 TCP 0.0.0.0 18888 LISTEN
weed.exe 70184 TCP :: 8333 LISTEN
weed.exe 70184 TCP :: 8888 LISTEN
weed.exe 70184 TCP :: 18333 LISTEN
weed.exe 70184 TCP :: 18888 LISTEN


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
