### PR TITLE
fix: remove blocking match label

### DIFF
--- a/k8s/charts/seaweedfs/templates/cosi-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/cosi-deployment.yaml
@@ -14,7 +14,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
-      helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: objectstorage-provisioner
   template:


### PR DESCRIPTION
# What problem are we solving?

`matchLabels` are immutable. Thus, matching against the version, which changes with every release, blocks Helm upgrades. To resolve this, the label is removed. See #6090 where this was similarly done.

# How are we solving the problem?

See #6090

# How is the PR tested?

Not tested. Just common sense and copied the solution from #6090.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
