### PR TITLE
Use the correct constant when computing the offset in SearchNeedleFromSortedIndex

### DIFF
--- a/weed/storage/erasure_coding/ec_volume.go
+++ b/weed/storage/erasure_coding/ec_volume.go
@@ -3,14 +3,13 @@ package erasure_coding
 import (
 	"errors"
 	"fmt"
-	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"math"
 	"os"
+	"slices"
 	"sync"
 	"time"
 
-	"slices"
-
+	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/volume_server_pb"
@@ -263,7 +262,7 @@ func SearchNeedleFromSortedIndex(ecxFile *os.File, ecxFileSize int64, needleId t
 		key, offset, size = idx.IdxFileEntry(buf)
 		if key == needleId {
 			if processNeedleFn != nil {
-				err = processNeedleFn(ecxFile, m*types.NeedleHeaderSize)
+				err = processNeedleFn(ecxFile, m*types.NeedleMapEntrySize)
 			}
 			return
 		}


### PR DESCRIPTION
# What problem are we solving?

`NeedleHeaderSize` happens to have the same size as `NeedleMapEntrySize`, except when running the 5 bytes offset variant of Seaweedfs, because it does not contain OffsetSize. This causes ECX corruption on deletes, due to the drifting offset computation (offset is always computed on a basis of 16 bytes per record instead of 17 bytes).


# How are we solving the problem?

Using the correct constant.

# How is the PR tested?

None for now

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
