### PR TITLE
Improve safety for weed shell's `ec.encode`.

### DIFF
--- a/weed/shell/command_ec_common.go
+++ b/weed/shell/command_ec_common.go
@@ -134,6 +134,14 @@ func NewErrorWaitGroup(maxConcurrency int) *ErrorWaitGroup {
 	}
 }
 
+func (ewg *ErrorWaitGroup) Reset() {
+	close(ewg.wgSem)
+
+	ewg.wg = &sync.WaitGroup{}
+	ewg.wgSem = make(chan bool, ewg.maxConcurrency)
+	ewg.errors = nil
+}
+
 func (ewg *ErrorWaitGroup) Add(f ErrorWaitGroupTask) {
 	if ewg.maxConcurrency <= 1 {
 		// Keep run order deterministic when parallelization is off


### PR DESCRIPTION
# What problem are we solving?

The current logic for `ec.encode` is:

1. EC shards for a volume are generated and added to a single server.
2. The original volume is deleted.
3. EC shards get re-balanced across the entire topology.

There's a small, but real, possibility of losing data between 2 and 3, if the underlying volume storage/server/rack/DC happens to fail.

# How are we solving the problem?

As a fix, this MR reworks `ec.encode` so:

  * Newly created EC shards are spread across all locations for the source volume.
  * Source volumes are deleted only _after_ EC shards are converted and balanced.

# How is the PR tested?

Existing functional/units tests should pass without failures after this change.

# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
