### PR TITLE
[volume] refactor and add metrics for flight upload and download data limit condition

### DIFF
--- a/weed/server/volume_server_handlers_read.go
+++ b/weed/server/volume_server_handlers_read.go
@@ -141,18 +141,29 @@ func (vs *VolumeServer) GetOrHeadHandler(w http.ResponseWriter, r *http.Request)
 	var count int
 	var memoryCost types.Size
 	readOption.AttemptMetaOnly, readOption.MustMetaOnly = shouldAttemptStreamWrite(hasVolume, ext, r)
-	onReadSizeFn := func(size types.Size) {
-		memoryCost = size
-		atomic.AddInt64(&vs.inFlightDownloadDataSize, int64(memoryCost))
+	if vs.concurrentDownloadLimit != 0 {
+		onReadSizeFn := func(size types.Size) {
+			memoryCost = size
+			atomic.AddInt64(&vs.inFlightDownloadDataSize, int64(memoryCost))
+		}
+		if hasVolume {
+			count, err = vs.store.ReadVolumeNeedle(volumeId, n, readOption, onReadSizeFn)
+		} else if hasEcVolume {
+			count, err = vs.store.ReadEcShardNeedle(volumeId, n, onReadSizeFn)
+		}
+	} else {
+		if hasVolume {
+			count, err = vs.store.ReadVolumeNeedle(volumeId, n, readOption, nil)
+		} else if hasEcVolume {
+			count, err = vs.store.ReadEcShardNeedle(volumeId, n, nil)
+		}
 	}
-	if hasVolume {
-		count, err = vs.store.ReadVolumeNeedle(volumeId, n, readOption, onReadSizeFn)
-	} else if hasEcVolume {
-		count, err = vs.store.ReadEcShardNeedle(volumeId, n, onReadSizeFn)
-	}
+
 	defer func() {
-		atomic.AddInt64(&vs.inFlightDownloadDataSize, -int64(memoryCost))
-		vs.inFlightDownloadDataLimitCond.Signal()
+		if vs.concurrentDownloadLimit != 0 {
+			atomic.AddInt64(&vs.inFlightDownloadDataSize, -int64(memoryCost))
+			vs.inFlightDownloadDataLimitCond.Broadcast()
+		}
 	}()
 
 	if err != nil && err != storage.ErrorDeleted && hasVolume {

--- a/weed/stats/metrics.go
+++ b/weed/stats/metrics.go
@@ -278,6 +278,38 @@ var (
 			Help:      "Resource usage",
 		}, []string{"name", "type"})
 
+	VolumeServerConcurrentDownloadLimit = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Subsystem: "volumeServer",
+			Name:      "concurrent_download_limit",
+			Help:      "Limit total concurrent download size.",
+		})
+
+	VolumeServerConcurrentUploadLimit = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Subsystem: "volumeServer",
+			Name:      "concurrent_upload_limit_size",
+			Help:      "Limit total concurrent upload size.",
+		})
+
+	VolumeServerInFlightDownloadSize = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Subsystem: "volumeServer",
+			Name:      "in_flight_download_size",
+			Help:      "In flight total download size.",
+		})
+
+	VolumeServerInFlightUploadSize = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Subsystem: "volumeServer",
+			Name:      "in_flight_upload_size",
+			Help:      "In flight total upload size.",
+		})
+
 	S3RequestCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: Namespace,
@@ -387,6 +419,10 @@ func init() {
 	Gather.MustRegister(VolumeServerReadOnlyVolumeGauge)
 	Gather.MustRegister(VolumeServerDiskSizeGauge)
 	Gather.MustRegister(VolumeServerResourceGauge)
+	Gather.MustRegister(VolumeServerConcurrentDownloadLimit)
+	Gather.MustRegister(VolumeServerConcurrentUploadLimit)
+	Gather.MustRegister(VolumeServerInFlightDownloadSize)
+	Gather.MustRegister(VolumeServerInFlightUploadSize)
 
 	Gather.MustRegister(S3RequestCounter)
 	Gather.MustRegister(S3HandlerCounter)

--- a/weed/stats/metrics_names.go
+++ b/weed/stats/metrics_names.go
@@ -6,6 +6,8 @@ const (
 	// volume server
 	WriteToLocalDisk            = "writeToLocalDisk"
 	WriteToReplicas             = "writeToReplicas"
+	DownloadLimitCond           = "downloadLimitCond"
+	UploadLimitCond             = "uploadLimitCond"
 	ErrorSizeMismatchOffsetSize = "errorSizeMismatchOffsetSize"
 	ErrorSizeMismatch           = "errorSizeMismatch"
 	ErrorCRC                    = "errorCRC"


### PR DESCRIPTION
# What problem are we solving?

It seems that the concurrent Downloads Limit parameter excessively blocks read requests.

Since the limit is set at the maximum disk speed, blocking occurs, and the disk is not loaded, this is possible when reading is actually done from the page cache and perhaps the actual disk utilization should be taken into account


# How are we solving the problem?

In any case, I would like to monitor the inFlightDownloadSize and inFlightUploadSize size metrics
in order to select the optimal size for a specific disk


# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
