### PR TITLE
Sleep_seconds support for maintenance

### DIFF
--- a/weed/server/master_server.go
+++ b/weed/server/master_server.go
@@ -256,7 +256,9 @@ func (ms *MasterServer) startAdminScripts() {
 	}
 	glog.V(0).Infof("adminScripts: %v", adminScripts)
 
+	v.SetDefault("master.maintenance.sleep_seconds", 0)
 	v.SetDefault("master.maintenance.sleep_minutes", 17)
+	sleepSeconds := v.GetInt("master.maintenance.sleep_seconds")
 	sleepMinutes := v.GetInt("master.maintenance.sleep_minutes")
 
 	scriptLines := strings.Split(adminScripts, "\n")
@@ -283,7 +285,7 @@ func (ms *MasterServer) startAdminScripts() {
 
 	go func() {
 		for {
-			time.Sleep(time.Duration(sleepMinutes) * time.Minute)
+			time.Sleep(time.Duration(sleepMinutes * 60 + sleepSeconds) * time.Second)
 			if ms.Topo.IsLeader() && ms.MasterClient.GetMaster(context.Background()) != "" {
 				shellOptions.FilerAddress = ms.GetOneFiler(cluster.FilerGroupName(*shellOptions.FilerGroup))
 				if shellOptions.FilerAddress == "" {


### PR DESCRIPTION
# What problem are we solving?

Support sleeping for seconds instead of minutes which is useful for e.g. enforcing bucket quotas every 5-10 seconds in low-trust environments.

# How are we solving the problem?

Adding sleep_seconds support

# How is the PR tested?

Have not tested it yet

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
