### PR TITLE
Fix mysql tls enable

### DIFF
--- a/weed/command/scaffold/filer.toml
+++ b/weed/command/scaffold/filer.toml
@@ -54,6 +54,10 @@ enabled = false
 # dsn will take priority over "hostname, port, username, password, database".
 # [username[:password]@][protocol[(address)]]/dbname[?param1=value1&...&paramN=valueN]
 dsn = "root@tcp(localhost:3306)/seaweedfs?collation=utf8mb4_bin"
+enable_tls = false
+ca_crt = ""                # ca.crt dir when enable_tls set true
+client_crt = ""            # mysql client.crt dir when enable_tls set true
+client_key = ""            # mysql client.key dir when enable_tls set true
 hostname = "localhost"
 port = 3306
 username = "root"

--- a/weed/filer/mysql/mysql_store.go
+++ b/weed/filer/mysql/mysql_store.go
@@ -69,7 +69,6 @@ func (store *MysqlStore) initialize(dsn string, upsertQuery string, enableUpsert
 	}
 
 	if enableTls {
-		// 1. 加载 CA 证书（验证服务器证书）
 		rootCertPool := x509.NewCertPool()
 		pem, err := os.ReadFile(caCrtDir)
 		if err != nil {


### PR DESCRIPTION
# What problem are we solving?
#6806
https://github.com/seaweedfs/seaweedfs/issues/6806


# How are we solving the problem?
add enable_tls to filer.toml and use crypto to handle mysql tls


# How is the PR tested?
by testing under the case:
1.use old filer.toml and run weed filer
2.weed scaffold filer.toml and check the new properties
3.use the new filer.toml to start weed filer and successfully connect to mysql with tls


# Checks
- [✅] I have added unit tests if possible.
- [✅] I will add related wiki document changes and link to this PR after merging.
