### PR TITLE
Ensure `weed fuse` master process exits after mounted

### DIFF
--- a/weed/command/fuse.go
+++ b/weed/command/fuse.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"os/signal"
 	"strconv"
@@ -108,6 +109,9 @@ func runFuse(cmd *Command, args []string) bool {
 		case "child":
 			masterProcess = false
 			if parsed, err := strconv.ParseInt(parameter.value, 10, 64); err == nil {
+				if parsed > math.MaxInt || parsed <= 0 {
+					panic(fmt.Errorf("parent PID %s is invalid", err))
+				}
 				mountOptions.fuseCommandPid = int(parsed)
 			} else {
 				panic(fmt.Errorf("parent PID %s is invalid", err))

--- a/weed/command/mount.go
+++ b/weed/command/mount.go
@@ -34,6 +34,7 @@ type MountOptions struct {
 	localSocket        *string
 	disableXAttr       *bool
 	extraOptions       []string
+	fuseCommandPid     int
 }
 
 var (
@@ -72,6 +73,7 @@ func init() {
 	mountOptions.debugPort = cmdMount.Flag.Int("debug.port", 6061, "http port for debugging")
 	mountOptions.localSocket = cmdMount.Flag.String("localSocket", "", "default to /tmp/seaweedfs-mount-<mount_dir_hash>.sock")
 	mountOptions.disableXAttr = cmdMount.Flag.Bool("disableXAttr", false, "disable xattr")
+	mountOptions.fuseCommandPid = 0
 
 	mountCpuProfile = cmdMount.Flag.String("cpuprofile", "", "cpu profile output file")
 	mountMemProfile = cmdMount.Flag.String("memprofile", "", "memory profile output file")


### PR DESCRIPTION
# What problem are we solving?

When using a fuse mount that systemd participates in (e.g., using /etc/fstab and converted by systemd-fstab-generator, or an explicit systemd.mount unit), systemd uses the following process to mount:

First it composes arguments for `mount` and invokes. it then monitors `/proc/self/mountinfo`. At this point, if `mount` exits without found the entry in `mountinfo`, the task is marked as failed, says "there is no mount".[^1]

[^1]: https://github.com/systemd/systemd/pull/14234

![old](https://github.com/user-attachments/assets/8c119625-ae18-4f9a-a206-465d22144e6a)

The reason is that, as implemented in PR https://github.com/seaweedfs/seaweedfs/pull/2141, `weed fuse` will fork out a daemon process and the daemon process complete the mount operation and stays to provide fuse translation. After fork, the main process exits immediately and the daemon process may not yet initiated a mountpoint. 

Although systemd will reset the mount point to `mounted` state after it discovers that the daemon process has done the job, the return value and failed state can be confusing to both users and programs relies on `x-systemd.automount`, etc.

# How are we solving the problem?

This PR adds a simple notification mechanism using signals to let the master process wait until the child process have created the mountpoint.

The master process fork the daemon with `-o child={master_pid}` option, and after forking, it will wait for `SIGUSR1`. 

The daemon process will send a SIGUSR1 to master_pid just after fuse has "mounted" onto specified location.

# How is the PR tested?

This PR is tested with following systemd.mount config

`home-victrid-packages.mount`:
```
[Unit]
After=weed-filer.service

[Mount]
What=fuse
Where=/home/victrid/packages
Type=weed
Options=rw,filer='127.0.0.1:6001',filer.path=/buckets/packages/
TimeoutSec=30
```

which will finally call
```bash
(/usr/bin/mount.weed: symbolic link to /usr/bin/weed)
/usr/bin/mount.weed fuse /home/victrid/packages -o rw,filer='127.0.0.1:6001',filer.path=/buckets/packages/
```

# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
