### PR TITLE
Rewrite `needle_map.CompactMap()` for more efficient memory usage

### DIFF
--- a/weed/storage/needle_map/compact_map.go
+++ b/weed/storage/needle_map/compact_map.go
@@ -98,13 +98,12 @@ func (cs *CompactSection) setOverflowEntry(skey SectionalNeedleId, offset Offset
 	})
 	if insertCandidate != len(cs.overflow) && cs.overflow[insertCandidate].Key == needleValue.Key {
 		cs.overflow[insertCandidate] = needleValue
-	} else {
-		cs.overflow = append(cs.overflow, needleValue)
-		for i := len(cs.overflow) - 1; i > insertCandidate; i-- {
-			cs.overflow[i] = cs.overflow[i-1]
-		}
-		cs.overflow[insertCandidate] = needleValue
+		return
 	}
+
+	cs.overflow = append(cs.overflow, needleValue)
+	copy(cs.overflow[insertCandidate+1:], cs.overflow[insertCandidate:])
+	cs.overflow[insertCandidate] = needleValue
 }
 
 func (cs *CompactSection) findOverflowEntry(key SectionalNeedleId) (nv SectionalNeedleValue, found bool) {

--- a/weed/storage/needle_map/compact_map_test.go
+++ b/weed/storage/needle_map/compact_map_test.go
@@ -150,7 +150,7 @@ func TestOverflow(t *testing.T) {
 		t.Fatalf("expecting 5 entries now: %+v", cs.overflow)
 	}
 
-	_, x, _ := cs.findOverflowEntry(5)
+	x, _ := cs.findOverflowEntry(5)
 	if x.Key != 5 {
 		t.Fatalf("expecting entry 5 now: %+v", x)
 	}


### PR DESCRIPTION
# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/6804

# How are we solving the problem?

`CompactMap()` relies on fixed-size storage buckets of 10,000 elements, and a separate storage for overflow (i.e. out of order) needle IDs. The problem is that most of that fixed storage bucket space ends up allocated but never used; this is particularly true for out-of-order needle IDs, but happens also with perfectly ordered needle writes.

This MR reworks `CompactMap()` so:

- Underlying data structures are simplified.
- Needle buckets are now variable-size slices instead of fixed-size arrays.
- Data handling is performed via optimized built-in functions such as `copy()` instead of ad-hoc loops.
- `if` and `for` sections are unrolled, whenever possible.

The result is a dramatic improvement in memory usage, at the cost of slightly increased memory fragmentation - whose impact will be entirely platform-dependent. 

https://github.com/seaweedfs/seaweedfs/issues/6804 has more details, but this MR improves memory usage of `weed` processes by ~95% in best-case scenarios, and ~99% in worst-case scenarios, with no measurable performance impact.

# How is the PR tested?

Every single existing unit and integration test should pass without issues; the existing API and behavior for `CompactMap()` is unchanged.

# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
