### PR TITLE
Make `weed-fuse` compatible with systemd-based mount

### DIFF
--- a/weed/command/fuse_std.go
+++ b/weed/command/fuse_std.go
@@ -205,6 +205,17 @@ func runFuse(cmd *Command, args []string) bool {
 			}
 		case "fusermount.path":
 			fusermountPath = parameter.value
+		case "ignoreMounted":
+			if parsed, err := strconv.ParseBool(parameter.value); err == nil {
+				mountOptions.ignoreMounted = &parsed
+			} else {
+				panic(fmt.Errorf("ignoreMounted: %s", err))
+			}
+		case "_netdev":
+			// _netdev is used for systemd/fstab parser to signify that this is a network mount but systemd
+			// mount sometimes can't strip them off. Meanwhile, fuse3 would refuse to run with _netdev, we
+			// strip them here if it fails to be stripped by the caller.
+			//(See https://github.com/seaweedfs/seaweedfs/wiki/fstab/948a70df5c0d9d2d27561b96de53bde07a29d2db)
 		default:
 			t := parameter.name
 			if parameter.value != "true" {
@@ -227,15 +238,21 @@ func runFuse(cmd *Command, args []string) bool {
 
 		c := make(chan os.Signal, 1)
 		signal.Notify(c, syscall.SIGTERM)
+		signal.Notify(c, syscall.SIGINT)
+		signal.Notify(c, syscall.SIGCHLD)
 
 		attr := os.ProcAttr{}
 		attr.Env = os.Environ()
+		// The child process should inherit our FDs
+		attr.Files = []*os.File{os.Stdin, os.Stdout, os.Stderr}
 
 		child, err := os.StartProcess(arg0, argv, &attr)
 
 		if err != nil {
 			panic(fmt.Errorf("master process can not start child process: %s", err))
 		}
+
+		childPid := child.Pid
 
 		err = child.Release()
 
@@ -244,8 +261,21 @@ func runFuse(cmd *Command, args []string) bool {
 		}
 
 		select {
-		case <-c:
-			return true
+		case sig := <-c:
+			signal.Stop(c)
+			switch sig {
+			case syscall.SIGTERM:
+				// This is the signal sent by child process to exit
+				return true
+			case syscall.SIGINT:
+				// User pressed Ctrl+C, we should pass the signal to the child process
+				_ = syscall.Kill(childPid, syscall.SIGINT)
+				return false
+			case syscall.SIGCHLD:
+				// Child exits without success.
+				return false
+			}
+			return false
 		}
 	}
 

--- a/weed/command/mount.go
+++ b/weed/command/mount.go
@@ -35,6 +35,7 @@ type MountOptions struct {
 	disableXAttr       *bool
 	extraOptions       []string
 	fuseCommandPid     int
+	ignoreMounted      *bool
 }
 
 var (
@@ -73,6 +74,7 @@ func init() {
 	mountOptions.debugPort = cmdMount.Flag.Int("debug.port", 6061, "http port for debugging")
 	mountOptions.localSocket = cmdMount.Flag.String("localSocket", "", "default to /tmp/seaweedfs-mount-<mount_dir_hash>.sock")
 	mountOptions.disableXAttr = cmdMount.Flag.Bool("disableXAttr", false, "disable xattr")
+	mountOptions.ignoreMounted = cmdMount.Flag.Bool("ignoreMounted", false, "Don't check if the mount point is already mounted, ignore any existing mounts")
 	mountOptions.fuseCommandPid = 0
 
 	mountCpuProfile = cmdMount.Flag.String("cpuprofile", "", "cpu profile output file")

--- a/weed/command/mount_darwin.go
+++ b/weed/command/mount_darwin.go
@@ -1,5 +1,5 @@
 package command
 
-func checkMountPointAvailable(dir string) bool {
+func checkMountPointAvailable(dir string, ignoreMounted bool) bool {
 	return true
 }

--- a/weed/command/mount_linux.go
+++ b/weed/command/mount_linux.go
@@ -136,18 +136,18 @@ func parseInfoFile(r io.Reader) ([]*Info, error) {
 	return out, nil
 }
 
-func checkMountPointAvailable(dir string) bool {
+func checkMountPointAvailable(dir string, ignoreMounted bool) bool {
 	mountPoint := dir
 	if mountPoint != "/" && strings.HasSuffix(mountPoint, "/") {
 		mountPoint = mountPoint[0 : len(mountPoint)-1]
 	}
 
-	if mounted, err := mounted(mountPoint); err != nil || mounted {
-		if err != nil {
-			glog.Errorf("check %s: %v", mountPoint, err)
-		}
+	mounted, err := mounted(mountPoint)
+
+	if err != nil {
+		glog.Errorf("check %s: %v", mountPoint, err)
 		return false
 	}
 
-	return true
+	return !mounted || ignoreMounted
 }

--- a/weed/command/mount_std.go
+++ b/weed/command/mount_std.go
@@ -158,7 +158,7 @@ func RunMount(option *MountOptions, umask os.FileMode) bool {
 	}
 
 	// Ensure target mount point availability
-	if isValid := checkMountPointAvailable(dir); !isValid {
+	if isValid := checkMountPointAvailable(dir, *option.ignoreMounted); !isValid {
 		glog.Fatalf("Target mount point is not available: %s, please check!", dir)
 		return true
 	}


### PR DESCRIPTION
# What problem are we solving?
Currently, weed does not work well with systemd-based mount, including `systemd-fstab-generator` and `systemd.mount`/`systemd.automount`:
https://github.com/seaweedfs/seaweedfs/wiki/fstab/948a70df5c0d9d2d27561b96de53bde07a29d2db

The previous PR #6809 has fixed the problem quote
> No matter what systemd options (nofail, x-systemd.device-timeout, x-systemd.mount-timeout, etc.) you add to /etc/fstab, you won’t be able to make systemd.mount(5) handle the mount properly. You will always get an error when starting mount unit, even though the filesystem ends up being mounted.

and this PR fixes others, making such as `_netdev`, `systemd-fstab-generator`, and `x-systemd.automount` to work again. 

# How are we solving the problem?

`x-systemd.automount` don't work because automount will mount a `autofs` to be a placeholder and triggering the actual mount over the same mountpoint when being accessed. 
e.g.
```
systemd-1 on /home/victrid/packages type autofs (rw,relatime,fd=114,uid=1000,gid=1000,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=66576660)
127.0.0.1:6001:/buckets/packages/ on /home/victrid/packages type fuse.seaweedfs (rw,nosuid,nodev,relatime,user_id=0,group_id=0,default_permissions,allow_other,max_read=1048576)
```
The default behavior throws error when mountpoint is occupied. We added an `ignoreMounted` field to change the behavior and should be specified in fstab/systemd.mount if used along with systemd automount.

The `_netdev` is removed from command line, as:

> The _netdev results in errors like:
> 
> kernel: fuse: Unknown parameter '_netdev'
> 
> p.s. Not sure if it’s related. (systemd 255.6)

while `_netdev` itself is used to make the mount unit belongs to `remote-fs.target` (otherwise it belongs to `local-fs.target`) and we can't remove them from mount options. The `weed fuse` command will remove it as it will have no effect when fuse takes place.

We also changed the signal handling on SIGINT/SIGCHLD and file descriptor inheriting to improve debugging.


# How is the PR tested?

We mount it with the following /etc/fstab entry:

```
fuse /home/victrid/packages weed rw,noauto,_netdev,x-systemd.mount-timeout=120,x-systemd.automount,x-systemd.idle-timeout=300,filer='127.0.0.1:6001',filer.path=/buckets/packages/,ignoreMounted 0 0
```

which in turn generates following systemd unit:

```
# Automatically generated by systemd-fstab-generator

[Unit]
Documentation=man:fstab(5) man:systemd-fstab-generator(8)
SourcePath=/etc/fstab
Before=remote-fs.target

[Mount]
What=fuse
Where=/home/victrid/packages
Type=weed
TimeoutSec=2min
Options=rw,noauto,_netdev,x-systemd.mount-timeout=120,x-systemd.automount,x-systemd.idle-timeout=300,filer='127.0.0.1:6001',filer.path=/buckets/packages/,ignoreMounted
```

```
# Automatically generated by systemd-fstab-generator

[Unit]
SourcePath=/etc/fstab
Documentation=man:fstab(5) man:systemd-fstab-generator(8)

[Automount]
Where=/home/victrid/packages
TimeoutIdleSec=5min
```

This is also tested with static mount/automount unit files:
```
[Unit]
After=weed-filer.service

[Mount]
What=fuse
Where=/home/victrid/packages
Type=weed
Options=rw,filer='127.0.0.1:6001',filer.path=/buckets/packages/,ignoreMounted
TimeoutSec=30
```

```
[Automount]
Where=/home/victrid/packages
TimeoutIdleSec=30
```

TODO: I'll further check whether mount on boot still works with systemd-integrated system.

# Checks
- [ ] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
