### PR TITLE
Further improve memory usage of `needle_map.CompactMap()`.

### DIFF
--- a/weed/storage/needle_map/compact_map_test.go
+++ b/weed/storage/needle_map/compact_map_test.go
@@ -2,11 +2,12 @@ package needle_map
 
 import (
 	"fmt"
-	"github.com/seaweedfs/seaweedfs/weed/sequence"
-	. "github.com/seaweedfs/seaweedfs/weed/storage/types"
 	"log"
 	"os"
 	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/sequence"
+	. "github.com/seaweedfs/seaweedfs/weed/storage/types"
 )
 
 func TestSnowflakeSequencer(t *testing.T) {
@@ -65,15 +66,15 @@ func TestIssue52(t *testing.T) {
 
 func TestCompactMap(t *testing.T) {
 	m := NewCompactMap()
-	for i := uint32(0); i < 100*batch; i += 2 {
+	for i := uint32(0); i < 100*MaxSectionBucketSize; i += 2 {
 		m.Set(NeedleId(i), ToOffset(int64(i)), Size(i))
 	}
 
-	for i := uint32(0); i < 100*batch; i += 37 {
+	for i := uint32(0); i < 100*MaxSectionBucketSize; i += 37 {
 		m.Delete(NeedleId(i))
 	}
 
-	for i := uint32(0); i < 10*batch; i += 3 {
+	for i := uint32(0); i < 10*MaxSectionBucketSize; i += 3 {
 		m.Set(NeedleId(i), ToOffset(int64(i+11)), Size(i+5))
 	}
 
@@ -83,7 +84,7 @@ func TestCompactMap(t *testing.T) {
 	//		}
 	//	}
 
-	for i := uint32(0); i < 10*batch; i++ {
+	for i := uint32(0); i < 10*MaxSectionBucketSize; i++ {
 		v, ok := m.Get(NeedleId(i))
 		if i%3 == 0 {
 			if !ok {
@@ -103,7 +104,7 @@ func TestCompactMap(t *testing.T) {
 		}
 	}
 
-	for i := uint32(10 * batch); i < 100*batch; i++ {
+	for i := uint32(10 * MaxSectionBucketSize); i < 100*MaxSectionBucketSize; i++ {
 		v, ok := m.Get(NeedleId(i))
 		if i%37 == 0 {
 			if ok && v.Size.IsValid() {


### PR DESCRIPTION
# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/6804

# How are we solving the problem?

As of 2e1506c3, `CompactMap()` now uses variable-size slices as ID buckets.

An unexpected issue is that mostly-ordered needle writes causes these buckets end up mostly filled, but with a lot of unused capacity - and wasted memory. For the current bucket size of 10,000 elements, Golang allocates a capacity of 11,264, or ~12% waste.

This MR ensures that buckets which end up filled are re-sized so their capacity matches size; on average, it improves memory usage by ~10% for mostly ordered needle IDs. A couple `CompactMap()` memory pprofs yielded these averages:

```
v3.87, running weed server: 346.89MB/639.85MB heap, 347.16MB/3.48GB allocs
v3.87, running weed volume: 346.89MB/626.50MB heap
v3.88, running weed server: 468.81MB/751.42MB heap, 1.74GB/4.77GB allocs
v3.88, running weed volume: 468.81MB/764.41MB heap
new, running weed server:   426.21MB/711.50MB heap, 2.16GB/5.20GB allocs
new, running weed volume:   426.21MB/664.94MB heap
```

# How is the PR tested?

Every single existing unit and integration test should pass without issues; the existing API and behavior for CompactMap() is unchanged.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
