### PR TITLE
revert part of d8c574a5ef1a811f9a0d447097d9edfcc0c1d84c

### DIFF
--- a/weed/storage/volume_write.go
+++ b/weed/storage/volume_write.go
@@ -122,7 +122,7 @@ func (v *Volume) writeNeedle2(n *needle.Needle, checkCookie bool, fsync bool) (o
 		n.Ttl = v.Ttl
 	}
 
-	if fsync {
+	if !fsync {
 		return v.syncWrite(n, checkCookie)
 	} else {
 		asyncRequest := needle.NewAsyncRequest(n, true)


### PR DESCRIPTION
# What problem are we solving?

d8c574a5ef1a811f9a0d447097d9edfcc0c1d84c mistakenly treat fsync as the same sync write requests.


# How are we solving the problem?

set fsync correctly

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
