### PR TITLE
Minor fix for the `CompactMap()` performance test.

### DIFF
--- a/weed/storage/needle_map/compact_map_perf_test.go
+++ b/weed/storage/needle_map/compact_map_perf_test.go
@@ -16,7 +16,7 @@ import (
 To see the memory usage:
 
 go test -run TestMemoryUsage
-The TotalAlloc section shows the memory increase for each iteration.
+The Alloc section shows the in-use memory increase for each iteration.
 
 go test -run TestMemoryUsage -memprofile=mem.out
 go tool pprof --alloc_space needle.test mem.out
@@ -81,7 +81,7 @@ func PrintMemUsage(totalRowCount uint64) {
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m)
 	// For info on each, see: https://golang.org/pkg/runtime/#MemStats
-	fmt.Printf("Each %.2f Bytes", float64(m.TotalAlloc)/float64(totalRowCount))
+	fmt.Printf("Each %.02f Bytes", float64(m.Alloc)/float64(totalRowCount))
 	fmt.Printf("\tAlloc = %v MiB", bToMb(m.Alloc))
 	fmt.Printf("\tTotalAlloc = %v MiB", bToMb(m.TotalAlloc))
 	fmt.Printf("\tSys = %v MiB", bToMb(m.Sys))


### PR DESCRIPTION
# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/6804

# How are we solving the problem?

Per-entry memory usage for `CompactMap()` is based on `TotalAllocs`, which is incorrect, as that value measures a cumulative of heap usage - and won't decrease when objects are freeed.

`Allocs` is instead an accurate representation of actual memory usage at the time metrics are reported. This change allows to better evaluate memory impact for `CompactMap` changes.

# How is the PR tested?

No functional/unit tests are affected.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
