### PR TITLE
fix(filer): add missing return after KvDelete in KvPut with empty value

### DIFF
--- a/weed/server/filer_grpc_server_kv.go
+++ b/weed/server/filer_grpc_server_kv.go
@@ -30,6 +30,7 @@ func (fs *FilerServer) KvPut(ctx context.Context, req *filer_pb.KvPutRequest) (*
 		if err := fs.filer.Store.KvDelete(ctx, req.Key); err != nil {
 			return &filer_pb.KvPutResponse{Error: err.Error()}, nil
 		}
+		return &filer_pb.KvPutResponse{}, nil
 	}
 
 	err := fs.filer.Store.KvPut(ctx, req.Key, req.Value)


### PR DESCRIPTION
# What problem are we solving?
When KvPut receives an empty value, it should delete the key and return immediately
Previously, the function would call KvDelete but then continue execution and call KvPut with the empty value, recreating the entry that was just deleted

# How are we solving the problem?
Added missing return statement after successful KvDelete operation

# How is the PR tested?
Manual testing with grpcurl commands sending empty values to `KvPut`
`grpcurl -plaintext -d '{"key":"dGVzdGtleQ==", "value":""}' localhost:18888 filer_pb.SeaweedFiler/KvPut`
Verified that keys are properly deleted and not recreated

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
