### PR TITLE
Fixes shell output formatting from piped input (#6629)

### DIFF
--- a/weed/command/shell.go
+++ b/weed/command/shell.go
@@ -1,9 +1,8 @@
 package command
 
 import (
-	"fmt"
+	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb"
-
 	"github.com/seaweedfs/seaweedfs/weed/security"
 	"github.com/seaweedfs/seaweedfs/weed/shell"
 	"github.com/seaweedfs/seaweedfs/weed/util"
@@ -59,7 +58,7 @@ func runShell(command *Command, args []string) bool {
 		filerAddress = viper.GetString("cluster." + cluster + ".filer")
 	}
 	shellOptions.FilerAddress = pb.ServerAddress(filerAddress)
-	fmt.Printf("master: %s filer: %s\n", *shellOptions.Masters, shellOptions.FilerAddress)
+	glog.V(1).Infof("master: %s filer: %s\n", *shellOptions.Masters, shellOptions.FilerAddress)
 
 	shell.RunShell(shellOptions)
 

--- a/weed/shell/shell_liner.go
+++ b/weed/shell/shell_liner.go
@@ -75,14 +75,14 @@ func RunShell(options ShellOptions) {
 		}
 	}
 
+	stat, _ := os.Stdin.Stat()
+	var prefix string
+	if (stat.Mode() & os.ModeCharDevice) == 0 {
+		prefix = ""
+	} else {
+		prefix = "> "
+	}
 	for {
-		stat, _ := os.Stdin.Stat()
-		var prefix string
-		if (stat.Mode() & os.ModeCharDevice) == 0 {
-			prefix = ""
-		} else {
-			prefix = "> "
-		}
 		cmd, err := line.Prompt(prefix)
 		if err != nil {
 			if err != io.EOF {
@@ -92,8 +92,11 @@ func RunShell(options ShellOptions) {
 		}
 
 		for _, c := range util.StringSplit(cmd, ";") {
-			glog.V(0).Infof("%s%s", "> ", cmd)
-			fmt.Printf("%s%s\n", "> ", cmd)
+			if c == "" {
+				break
+			}
+			glog.V(0).Infof("%s%s", "> ", c)
+			fmt.Printf("%s%s\n", "> ", c)
 			if processEachCmd(reg, c, commandEnv) {
 				return
 			}


### PR DESCRIPTION
**Caveat** First bit of golang so be ruthless.

* Removed prompt prefix from all output
* Added shell errors to output
* modified -v 0|1 stderr levels for readability.

Piped shell command input now reults in the following;

```
> du
block:   0	logical size:         0	/
> ls
> configure
{
  "version":  0,
  "locations":  []
}
> du
block:   0	logical size:         0	/
> rm non_existant
rm: /non_existant: filer: no entry is found in filer store
> collection.list
collection:"example1"	volumeCount:7	size:224	fileCount:1	deletedBytes:0	deletion:0
collection:"example2"	volumeCount:1	size:176	fileCount:1	deletedBytes:0	deletion:0
Total 2 collections.
> du
block:   0	logical size:         0	/
> volume.fsck
error: need to run "lock" first to continue
```

logging @ 1
```bash
➜ cat test.shell.txt | ./weed -v 1 shell > log-dev.txt 
I0612 01:35:08.297192 config.go:53 Reading : Config File "security" Not Found in "[/home/jack/go/seaweedfs/weed /home/jack/.seaweedfs /usr/local/etc/seaweedfs /etc/seaweedfs]"
I0612 01:35:08.298388 config.go:53 Reading : Config File "shell" Not Found in "[/home/jack/go/seaweedfs/weed /home/jack/.seaweedfs /usr/local/etc/seaweedfs /etc/seaweedfs]"
I0612 01:35:08.298414 shell.go:61 master: localhost:9333 filer:
I0612 01:35:08.298624 masterclient.go:135 .adminShell masterClient bootstraps with masters {[localhost:9333] <nil>}
I0612 01:35:08.298644 masterclient.go:193 .adminShell masterClient Connecting to master localhost:9333
I0612 01:35:08.301354 masterclient.go:218 .adminShell masterClient Connected to localhost:9333
I0612 01:35:08.302054 masterclient.go:230 master localhost:9333 redirected to leader 192.168.1.30:9333
I0612 01:35:08.302360 masterclient.go:193 .adminShell masterClient Connecting to master 192.168.1.30:9333
I0612 01:35:08.303573 masterclient.go:218 .adminShell masterClient Connected to 192.168.1.30:9333
I0612 01:35:08.304051 masterclient.go:318 updateVidMap(DefaultDataCenter) .adminShell: 192.168.1.30:8080 volume add: 8, del: 0, add ec: 0 del ec: 0 .I0612 01:35:08.462317 shell_liner.go:71 master: localhost:9333
I0612 01:35:08.462377 shell_liner.go:73 filers: [192.168.1.30:8888]
I0612 01:35:08.462453 shell_liner.go:95 > du
I0612 01:35:08.466448 shell_liner.go:95 > ls
I0612 01:35:08.467931 shell_liner.go:95 > configure
I0612 01:35:08.469149 shell_liner.go:95 > du
I0612 01:35:08.470993 shell_liner.go:95 > rm non_existant
I0612 01:35:08.472030 shell_liner.go:95 > collection.list
I0612 01:35:08.475073 shell_liner.go:95 > du
I0612 01:35:08.476472 shell_liner.go:95 > volume.fsck I0612 01:35:08.476597 shell_liner.go:129 error: need to run "lock" first to continue
```

logging@0
```bash
➜ cat test.shell.txt | ./weed -v 0 shell > log-dev.txt
I0612 01:35:34.824293 masterclient.go:230 master localhost:9333 redirected to leader 192.168.1.30:9333 .I0612 01:35:35.015470 shell_liner.go:71 master: localhost:9333
I0612 01:35:35.015502 shell_liner.go:73 filers: [192.168.1.30:8888]
I0612 01:35:35.015541 shell_liner.go:95 > du
I0612 01:35:35.018682 shell_liner.go:95 > ls
I0612 01:35:35.019540 shell_liner.go:95 > configure
I0612 01:35:35.020113 shell_liner.go:95 > du
I0612 01:35:35.020796 shell_liner.go:95 > rm non_existant
I0612 01:35:35.021235 shell_liner.go:95 > collection.list
I0612 01:35:35.022664 shell_liner.go:95 > du
I0612 01:35:35.023514 shell_liner.go:95 > volume.fsck
I0612 01:35:35.023658 shell_liner.go:129 error: need to run "lock" first to continue
```

Reference test file test.shell.txt:

```
du
ls
configure
du
rm non_existant
collection.list
du
volume.fsck
```

# What problem are we solving?

One Issue inside #6629 where liner.prompt was UI prefix "> " even when stdin is taking pipe input.

# How are we solving the problem?

Still parse the input via liner except no prompt hint.

# How is the PR tested?

Manually by included report.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
