### PR TITLE
allow distro mount command to use disableXAttr

### DIFF
--- a/weed/command/fuse_std.go
+++ b/weed/command/fuse_std.go
@@ -193,6 +193,13 @@ func runFuse(cmd *Command, args []string) bool {
 			} else {
 				panic(fmt.Errorf("readOnly: %s", err))
 			}
+		case "disableXAttr":
+			if parsed, err := strconv.ParseBool(parameter.value); err == nil {
+
+				mountOptions.disableXAttr = &parsed
+			} else {
+				panic(fmt.Errorf("disableXAttr: %s", err))
+			}
 		case "cpuprofile":
 			mountCpuProfile = &parameter.value
 		case "memprofile":


### PR DESCRIPTION
While -disableXAttr works with the 'weed mount' command, disableXAttr doesn't work with the linux mount command (fstab, unit file, distro mount command).

The change simply adds this ability to runFuse()

I built seaweedfs and placed it on to an existing test system and confirmed an entry in /etc/fstab with disableXAttr in the options list worked properly. A test system that sets an ACL then returns 'Operation not supported'.

This resolves issue 6865
