### PR TITLE
Fix url scheme using for forwarded request with changed proto

### DIFF
--- a/weed/s3api/auth_signature_v4.go
+++ b/weed/s3api/auth_signature_v4.go
@@ -719,9 +719,11 @@ func extractHostHeader(r *http.Request) string {
 
 	forwardedHost := r.Header.Get("X-Forwarded-Host")
 	forwardedPort := r.Header.Get("X-Forwarded-Port")
+	forwardedProto := r.Header.Get("X-Forwarded-Proto")
 
 	// If X-Forwarded-Host is set, use that as the host.
 	// If X-Forwarded-Port is set, use that too to form the host.
+	// If X-Forwarded-Proto is set, check if is it default to omit the port.
 	if forwardedHost != "" {
 		extractedHost := forwardedHost
 		host, port, err := net.SplitHostPort(extractedHost)
@@ -731,7 +733,11 @@ func extractHostHeader(r *http.Request) string {
 				forwardedPort = port
 			}
 		}
-		if !isDefaultPort(r.URL.Scheme, forwardedPort) {
+		scheme := r.URL.Scheme
+		if forwardedProto != "" {
+			scheme = forwardedProto
+		}
+		if !isDefaultPort(scheme, forwardedPort) {
 			extractedHost = net.JoinHostPort(extractedHost, forwardedPort)
 		}
 		return extractedHost


### PR DESCRIPTION
# What problem are we solving?
Correct signature calculation in case of proxied request with changed protocol (https -> http for example), more in 
 https://github.com/seaweedfs/seaweedfs/issues/6839


# How are we solving the problem?
Taking into account `X-Forwarded-Proto` header for host extraction in [auth_signature_v4.go](https://github.com/seaweedfs/seaweedfs/blob/7151a54b28518c93af627911c885f20ad931bc8e/weed/s3api/auth_signature_v4.go#L725C2-L738C10)


# How is the PR tested?
I've builded a local image and deployed it into my k3s cluster where I'm using seaweedfs hidden after traefik proxy (https->http).

Then I've checked with tcpdump that recevied request is correct and checked seaweedfs logs, assuring that the default port is not added for https scheme


# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
