### PR TITLE
ydb filer improvements

### DIFF
--- a/weed/filer/ydb/ydb_queries.go
+++ b/weed/filer/ydb/ydb_queries.go
@@ -22,19 +22,21 @@ const (
 	deleteQuery = `
 		PRAGMA TablePathPrefix("%v");
 		DECLARE $dir_hash AS int64;
+		DECLARE $directory AS Utf8;
 		DECLARE $name AS Utf8;
 
 		DELETE FROM ` + asql.DEFAULT_TABLE + ` 
-		WHERE dir_hash = $dir_hash AND name = $name;`
+		WHERE dir_hash = $dir_hash AND directory = $directory AND name = $name;`
 
 	findQuery = `
 		PRAGMA TablePathPrefix("%v");
 		DECLARE $dir_hash AS int64;
+		DECLARE $directory AS Utf8;
 		DECLARE $name AS Utf8;
 		
 		SELECT meta
 		FROM ` + asql.DEFAULT_TABLE + ` 
-		WHERE dir_hash = $dir_hash AND name = $name;`
+		WHERE dir_hash = $dir_hash AND directory = $directory AND name = $name;`
 
 	deleteFolderChildrenQuery = `
 		PRAGMA TablePathPrefix("%v");

--- a/weed/filer/ydb/ydb_store.go
+++ b/weed/filer/ydb/ydb_store.go
@@ -277,8 +277,8 @@ func (store *YdbStore) ListDirectoryPrefixedEntries(ctx context.Context, dirPath
 		}
 		rest := limit - entryCount
 		chunkLimit := rest
-		if chunkLimit > defaultMaxListChunk {
-			chunkLimit = defaultMaxListChunk
+		if chunkLimit > int64(store.maxListChunk) {
+			chunkLimit = int64(store.maxListChunk)
 		}
 		var rowCount int64
 

--- a/weed/filer/ydb/ydb_store_kv.go
+++ b/weed/filer/ydb/ydb_store_kv.go
@@ -11,7 +11,6 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/util"
 	"github.com/ydb-platform/ydb-go-sdk/v3/query"
 	"github.com/ydb-platform/ydb-go-sdk/v3/table"
-	"github.com/ydb-platform/ydb-go-sdk/v3/table/result/named"
 	"github.com/ydb-platform/ydb-go-sdk/v3/table/types"
 )
 

--- a/weed/filer/ydb/ydb_store_kv.go
+++ b/weed/filer/ydb/ydb_store_kv.go
@@ -9,6 +9,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/filer/abstract_sql"
 	"github.com/seaweedfs/seaweedfs/weed/util"
+	"github.com/ydb-platform/ydb-go-sdk/v3/query"
 	"github.com/ydb-platform/ydb-go-sdk/v3/table"
 	"github.com/ydb-platform/ydb-go-sdk/v3/table/result/named"
 	"github.com/ydb-platform/ydb-go-sdk/v3/table/types"
@@ -17,40 +18,46 @@ import (
 func (store *YdbStore) KvPut(ctx context.Context, key []byte, value []byte) (err error) {
 	dirStr, dirHash, name := abstract_sql.GenDirAndName(key)
 	fileMeta := FileMeta{dirHash, name, dirStr, value}
-	return store.DB.Table().Do(ctx, func(ctx context.Context, s table.Session) (err error) {
-		_, _, err = s.Execute(ctx, rwTX, *withPragma(&store.tablePathPrefix, upsertQuery),
-			fileMeta.queryParameters(0))
+	return store.DB.Query().Do(ctx, func(ctx context.Context, s query.Session) (err error) {
+		_, err = s.Query(ctx, *withPragma(&store.tablePathPrefix, upsertQuery),
+			query.WithParameters(fileMeta.queryParameters(0)), rwQC)
 		if err != nil {
 			return fmt.Errorf("kv put execute %s: %v", util.NewFullPath(dirStr, name).Name(), err)
 		}
 		return nil
-	})
+	}, query.WithIdempotent())
 }
 
 func (store *YdbStore) KvGet(ctx context.Context, key []byte) (value []byte, err error) {
 	dirStr, dirHash, name := abstract_sql.GenDirAndName(key)
 	valueFound := false
-	err = store.DB.Table().Do(ctx, func(ctx context.Context, s table.Session) error {
-		_, res, err := s.Execute(ctx, roTX, *withPragma(&store.tablePathPrefix, findQuery),
-			table.NewQueryParameters(
+	err = store.DB.Query().Do(ctx, func(ctx context.Context, s query.Session) error {
+		res, err := s.Query(ctx, *withPragma(&store.tablePathPrefix, findQuery),
+			query.WithParameters(table.NewQueryParameters(
 				table.ValueParam("$dir_hash", types.Int64Value(dirHash)),
-				table.ValueParam("$name", types.UTF8Value(name))))
+				table.ValueParam("$directory", types.UTF8Value(dirStr)),
+				table.ValueParam("$name", types.UTF8Value(name)))), roQC)
 		if err != nil {
 			return fmt.Errorf("kv get execute %s: %v", util.NewFullPath(dirStr, name).Name(), err)
 		}
-		defer func() { _ = res.Close() }()
-		if !res.NextResultSet(ctx) || !res.HasNextRow() {
-			return nil
-		}
-		for res.NextRow() {
-			if err := res.ScanNamed(named.OptionalWithDefault("meta", &value)); err != nil {
-				return fmt.Errorf("scanNamed %s : %v", util.NewFullPath(dirStr, name).Name(), err)
+		defer func() { _ = res.Close(ctx) }()
+		for rs, err := range res.ResultSets(ctx) {
+			if err != nil {
+				return err
 			}
-			valueFound = true
-			return nil
+			for row, err := range rs.Rows(ctx) {
+				if err != nil {
+					return err
+				}
+				if err := row.Scan(&value); err != nil {
+					return fmt.Errorf("scan %s : %v", util.NewFullPath(dirStr, name).Name(), err)
+				}
+				valueFound = true
+				return nil
+			}
 		}
-		return res.Err()
-	})
+		return nil
+	}, query.WithIdempotent())
 
 	if !valueFound {
 		return nil, filer.ErrKvNotFound
@@ -61,15 +68,16 @@ func (store *YdbStore) KvGet(ctx context.Context, key []byte) (value []byte, err
 
 func (store *YdbStore) KvDelete(ctx context.Context, key []byte) (err error) {
 	dirStr, dirHash, name := abstract_sql.GenDirAndName(key)
-	return store.DB.Table().Do(ctx, func(ctx context.Context, s table.Session) (err error) {
-		_, _, err = s.Execute(ctx, rwTX, *withPragma(&store.tablePathPrefix, deleteQuery),
-			table.NewQueryParameters(
+	return store.DB.Query().Do(ctx, func(ctx context.Context, s query.Session) (err error) {
+		_, err = s.Query(ctx, *withPragma(&store.tablePathPrefix, deleteQuery),
+			query.WithParameters(table.NewQueryParameters(
 				table.ValueParam("$dir_hash", types.Int64Value(dirHash)),
-				table.ValueParam("$name", types.UTF8Value(name))))
+				table.ValueParam("$directory", types.UTF8Value(dirStr)),
+				table.ValueParam("$name", types.UTF8Value(name)))), rwQC)
 		if err != nil {
 			return fmt.Errorf("kv delete %s: %v", util.NewFullPath(dirStr, name).Name(), err)
 		}
 		return nil
-	})
+	}, query.WithIdempotent())
 
 }

--- a/weed/filer/ydb/ydb_store_test.go
+++ b/weed/filer/ydb/ydb_store_test.go
@@ -13,7 +13,8 @@ func TestStore(t *testing.T) {
 	// to set up local env
 	if false {
 		store := &YdbStore{}
-		store.initialize("/buckets", "grpc://localhost:2136/?database=local", "seaweedfs", true, 10, 50)
+		store.initialize("/buckets", "grpc://localhost:2136/?database=local", "seaweedfs", true, 10, 50,
+			true, 200, true, 5, 1000, 2000)
 		store_test.TestFilerStore(t, store)
 	}
 }


### PR DESCRIPTION
# What problem are we solving?
- partitioning of tables is not used
- an outdated driver is being used
- ydb has a new query api with no restrictions on the length of the list operation, we use the old table
- reading a non-existent bucket would create a table for it
- primary key values were declared optional
- retries were not used
- some operations, in particular deletions, check only on the hash of the directory

# How are we solving the problem?
- added partitioning settings with some default values
- migrated to the new YDB query client and updated the driver
- prevented automatic table creation when reading non-existent buckets
- most of the fields are required (NOT NULL)
- WithIdempotent() for retry in case of problems
- query statements include directory in every case

# How is the PR tested?
load testing on self-hosted ydb cluster
existing tests

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
