### PR TITLE
chore: keep master statefulSet chart up-to-date

### DIFF
--- a/k8s/charts/seaweedfs/Chart.yaml
+++ b/k8s/charts/seaweedfs/Chart.yaml
@@ -3,4 +3,4 @@ description: SeaweedFS
 name: seaweedfs
 appVersion: "3.91"
 # Dev note: Trigger a helm chart release by `git tag -a helm-<version>`
-version: 4.0.391
+version: 4.0.392

--- a/k8s/charts/seaweedfs/templates/master-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/master-statefulset.yaml
@@ -164,8 +164,20 @@ spec:
               {{- if .Values.master.disableHttp }}
               -disableHttp \
               {{- end }}
-              {{- if .Values.master.pulseSeconds }}
-              -pulseSeconds={{ .Values.master.pulseSeconds }} \
+              {{- if .Values.master.resumeState }}
+              -resumeState \
+              {{- end }}
+              {{- if .Values.master.raftHashicorp }}
+              -raftHashicorp \
+              {{- end }}
+              {{- if .Values.master.raftBootstrap }}
+              -raftBootstrap \
+              {{- end }}
+              {{- if .Values.master.electionTimeout }}
+              -electionTimeout={{ .Values.master.electionTimeout }} \
+              {{- end }}
+              {{- if .Values.master.heartbeatInterval }}
+              -heartbeatInterval={{ .Values.master.heartbeatInterval }} \
               {{- end }}
               {{- if .Values.master.garbageThreshold }}
               -garbageThreshold={{ .Values.master.garbageThreshold }} \

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -61,8 +61,6 @@ master:
   volumePreallocate: false
   volumeSizeLimitMB: 1000
   loggingOverrideLevel: null
-  # number of seconds between heartbeats, default 5
-  pulseSeconds: null
   # threshold to vacuum and reclaim spaces, default 0.3 (30%)
   garbageThreshold: null
   # Prometheus push interval in seconds, default 15
@@ -75,6 +73,18 @@ master:
 
   # Disable http request, only gRpc operations are allowed
   disableHttp: false
+
+  # Resume previous state on start master server
+  resumeState: false
+  # Use Hashicorp Raft
+  raftHashicorp: false
+  # Whether to bootstrap the Raft cluster. Only use it when use Hashicorp Raft
+  raftBootstrap: false
+
+  # election timeout of master servers
+  electionTimeout: "10s"
+  # heartbeat interval of master servers, and will be randomly multiplied by [1, 1.25)
+  heartbeatInterval: "300ms"
 
   # Custom command line arguments to add to the master command
   # Example to fix IPv6 metrics connectivity issues:


### PR DESCRIPTION
# What problem are we solving?
This patch adds some missing master options to the helm chart of master statefulSet.


# How are we solving the problem?
Lifting the master options from `master.go` to the chart


# How is the PR tested?
Tested by editing the master statefulSet in an existing k8s cluster
```
kg sts seaweedfs-master -oyaml
...
      - command:
        - /bin/sh
        - -ec
        - |
          exec /usr/bin/weed \
          -logtostderr=true \
          -v=1 \
          master \
          -port=9333 \
          -mdir=/data \
          -ip.bind=0.0.0.0 \
          -defaultReplication=000 \
          -metricsPort=9324 \
          -volumeSizeLimitMB=1000 \
          -raftHashicorp \
          -raftBootstrap \
          -electionTimeout="5s" \
          -heartbeatInterval="500ms" \
          -ip=${POD_NAME}.${SEAWEEDFS_FULLNAME}-master.vmsp-platform \
          -peers=${SEAWEEDFS_FULLNAME}-master-0.${SEAWEEDFS_FULLNAME}-master.vmsp-platform:9333,${SEAWEEDFS_FULLNAME}-master-1.${SEAWEEDFS_FULLNAME}-master.vmsp-platform:9333,${SEAWEEDFS_FULLNAME}-master-2.${SEAWEEDFS_FULLNAME}-master.vmsp-platform:9333
...

```



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
