### PR TITLE
S3 API: simpler way to start s3 with credentials

### DIFF
--- a/weed/command/s3.go
+++ b/weed/command/s3.go
@@ -160,6 +160,19 @@ var cmdS3 = &Command{
   ]
 }
 
+	Alternatively, you can use environment variables to set admin credentials
+	without requiring a configuration file:
+
+	WEED_S3_ADMIN_USER=admin_user WEED_S3_ADMIN_PASSWORD=admin_password weed s3
+
+	This will create a default admin identity with full Admin permissions.
+ 	  * The admin access key is from WEED_S3_ADMIN_USER.
+	  * The admin secret key is from WEED_S3_ADMIN_PASSWORD.
+	
+	The environment variables are always loaded when both are set, regardless
+	of whether a configuration file is provided. If an identity with the same
+	name already exists, the environment variable credentials will be skipped.
+
 `,
 }
 

--- a/weed/command/s3.go
+++ b/weed/command/s3.go
@@ -163,15 +163,12 @@ var cmdS3 = &Command{
 	Alternatively, you can use environment variables to set admin credentials
 	without requiring a configuration file:
 
-	WEED_S3_ADMIN_USER=admin_user WEED_S3_ADMIN_PASSWORD=admin_password weed s3
+	AWS_ACCESS_KEY_ID=access_key AWS_SECRET_ACCESS_KEY=secret_key weed s3
 
 	This will create a default admin identity with full Admin permissions.
- 	  * The admin access key is from WEED_S3_ADMIN_USER.
-	  * The admin secret key is from WEED_S3_ADMIN_PASSWORD.
-	
 	The environment variables are always loaded when both are set, regardless
 	of whether a configuration file is provided. If an identity with the same
-	name already exists, the environment variable credentials will be skipped.
+	access key already exists, the environment variable credentials will be skipped.
 
 `,
 }

--- a/weed/command/s3.go
+++ b/weed/command/s3.go
@@ -160,15 +160,13 @@ var cmdS3 = &Command{
   ]
 }
 
-	Alternatively, you can use environment variables to set admin credentials
-	without requiring a configuration file:
+	Alternatively, you can use environment variables to supplement admin credentials:
 
-	AWS_ACCESS_KEY_ID=access_key AWS_SECRET_ACCESS_KEY=secret_key weed s3
+	AWS_ACCESS_KEY_ID=your_access_key AWS_SECRET_ACCESS_KEY=your_secret_key weed s3
 
-	This will create a default admin identity with full Admin permissions.
-	The environment variables are always loaded when both are set, regardless
-	of whether a configuration file is provided. If an identity with the same
-	access key already exists, the environment variable credentials will be skipped.
+	This will add admin credentials from environment variables to any existing
+	configuration. Environment variables are added after loading file/filer 
+	configurations and are skipped if the same access key already exists.
 
 `,
 }

--- a/weed/s3api/auth_credentials.go
+++ b/weed/s3api/auth_credentials.go
@@ -145,7 +145,7 @@ func NewIdentityAccessManagementWithStore(option *S3ApiServerOption, explicitSto
 	}
 
 	// Then, add admin credentials from environment variables if available
-	// This ensures environment variables take precedence and supplement existing config
+// This supplements the configuration by adding admin credentials from environment variables if they don't already exist.
 	accessKeyId := os.Getenv("AWS_ACCESS_KEY_ID")
 	secretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
 

--- a/weed/s3api/auth_credentials.go
+++ b/weed/s3api/auth_credentials.go
@@ -153,19 +153,8 @@ func NewIdentityAccessManagementWithStore(option *S3ApiServerOption, explicitSto
 		glog.V(0).Infof("Adding S3 admin credentials from AWS environment variables")
 
 		// Check if an identity with this access key already exists
-		accessKeyExists := false
 		iam.m.RLock()
-		for _, identity := range iam.identities {
-			for _, cred := range identity.Credentials {
-				if cred.AccessKey == accessKeyId {
-					accessKeyExists = true
-					break
-				}
-			}
-			if accessKeyExists {
-				break
-			}
-		}
+		_, accessKeyExists := iam.accessKeyIdent[accessKeyId]
 		iam.m.RUnlock()
 
 		if !accessKeyExists {


### PR DESCRIPTION
# What problem are we solving?

starting s3 needs a configuration file, which is not so convenient.

# How are we solving the problem?

Simplest way to start and use the object store server:
```
export AWS_ACCESS_KEY_ID=admin_access
export AWS_SECRET_ACCESS_KEY=admin_secret
weed server -s3 -dir=/tmp/dir
```

These should work too:
```
AWS_ACCESS_KEY_ID=admin_access AWS_SECRET_ACCESS_KEY=admin_secret weed s3
AWS_ACCESS_KEY_ID=admin_access AWS_SECRET_ACCESS_KEY=admin_secret weed filer -s3
```
# How is the PR tested?

Manual.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
