### PR TITLE
fix: consider EC shard count in volume.balance capacity calculation

### DIFF
--- a/weed/shell/command_volume_balance.go
+++ b/weed/shell/command_volume_balance.go
@@ -225,16 +225,6 @@ func capacityByMaxVolumeCount(diskType types.DiskType) CapacityFunc {
 		if !found {
 			return 0
 		}
-		return float64(diskInfo.MaxVolumeCount)
-	}
-}
-
-func capacityByMaxVolumeCountWithEc(diskType types.DiskType) CapacityFunc {
-	return func(info *master_pb.DataNodeInfo) float64 {
-		diskInfo, found := info.DiskInfos[string(diskType)]
-		if !found {
-			return 0
-		}
 		var ecShardCount int
 		for _, ecShardInfo := range diskInfo.EcShardInfos {
 			ecShardCount += erasure_coding.ShardBits(ecShardInfo.EcIndexBits).ShardIdCount()
@@ -297,7 +287,7 @@ func sortWritableVolumes(volumes []*master_pb.VolumeInformationMessage) {
 func balanceSelectedVolume(commandEnv *CommandEnv, diskType types.DiskType, volumeReplicas map[uint32][]*VolumeReplica, nodes []*Node, sortCandidatesFn func(volumes []*master_pb.VolumeInformationMessage), applyBalancing bool) (err error) {
 	selectedVolumeCount, volumeMaxCount := 0, float64(0)
 	var nodesWithCapacity []*Node
-	capacityFunc := capacityByMaxVolumeCountWithEc(diskType)
+	capacityFunc := capacityByMaxVolumeCount(diskType)
 	for _, dn := range nodes {
 		selectedVolumeCount += len(dn.selectedVolumes)
 		capacity := capacityFunc(dn.info)


### PR DESCRIPTION
# What problem are we solving?

**Related Issues:** Fixes #7033 

When using `volume.balance` command in clusters with erasure coding (EC) volumes enabled, the operation fails with "no space left" error. This occurs because the balance strategy's capacity calculation doesn't account for EC shard usage, leading to incorrect load ratio calculations.

The `capacityByMaxVolumeCount` function only returns `MaxVolumeCount` without considering EC volume usage:

```go
func capacityByMaxVolumeCount(diskType types.DiskType) CapacityFunc {
    return func(info *master_pb.DataNodeInfo) float64 {
        diskInfo, found := info.DiskInfos[string(diskType)]
        if !found {
            return 0
        }
        return float64(diskInfo.MaxVolumeCount)  // Only considers MaxVolumeCount
    }
}
```

This causes nodes with many EC volumes to be misjudged as "low load" and selected as targets for volume movement, even though they actually have no remaining capacity.

# How are we solving the problem?

Added a new `capacityByMaxVolumeCountWithEc` function that properly accounts for EC shard usage:

```go
func capacityByMaxVolumeCountWithEc(diskType types.DiskType) CapacityFunc {
    return func(info *master_pb.DataNodeInfo) float64 {
        diskInfo, found := info.DiskInfos[string(diskType)]
        if !found {
            return 0
        }
        var ecShardCount int
        for _, ecShardInfo := range diskInfo.EcShardInfos {
            ecShardCount += erasure_coding.ShardBits(ecShardInfo.EcIndexBits).ShardIdCount()
        }
        return float64(diskInfo.MaxVolumeCount) - float64(ecShardCount)/erasure_coding.DataShardsCount
    }
}
```

**Changes Made:**
1. Added new capacity function `capacityByMaxVolumeCountWithEc` that subtracts EC shard usage from available capacity
2. Updated `balanceSelectedVolume` to use the new capacity function
3. Maintained backward compatibility - the original `capacityByMaxVolumeCount` function remains unchanged

# How is the PR tested?

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.