### PR TITLE
fix command_volume_tier_upload bug

### DIFF
--- a/weed/shell/command_volume_tier_upload.go
+++ b/weed/shell/command_volume_tier_upload.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/seaweedfs/seaweedfs/weed/storage/types"
 	"io"
 	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/storage/types"
 
 	"github.com/seaweedfs/seaweedfs/weed/pb"
 
@@ -15,6 +16,8 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/operation"
 	"github.com/seaweedfs/seaweedfs/weed/pb/volume_server_pb"
 	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
+
+	"github.com/seaweedfs/seaweedfs/weed/wdclient"
 )
 
 func init() {
@@ -110,9 +113,37 @@ func (c *commandVolumeTierUpload) Do(args []string, commandEnv *CommandEnv, writ
 
 func doVolumeTierUpload(commandEnv *CommandEnv, writer io.Writer, collection string, vid needle.VolumeId, dest string, keepLocalDatFile bool) (err error) {
 	// find volume location
-	existingLocations, found := commandEnv.MasterClient.GetLocationsClone(uint32(vid))
-	if !found {
-		return fmt.Errorf("volume %d not found", vid)
+	topoInfo, _, err := collectTopologyInfo(commandEnv, 0)
+	if err != nil {
+		return fmt.Errorf("collect topology info: %v", err)
+	}
+
+	var existingLocations []wdclient.Location
+	for _, dc := range topoInfo.DataCenterInfos {
+		for _, rack := range dc.RackInfos {
+			for _, dn := range rack.DataNodeInfos {
+				for _, disk := range dn.DiskInfos {
+					for _, vi := range disk.VolumeInfos {
+						if needle.VolumeId(vi.Id) == vid && (collection == "" || vi.Collection == collection) {
+							fmt.Printf("find volume %d from Url:%s, GrpcPort:%d, DC:%s\n", vid, dn.Id, dn.GrpcPort, dc.Id)
+							existingLocations = append(existingLocations, wdclient.Location{
+								Url:        dn.Id,
+								PublicUrl:  dn.Id,
+								GrpcPort:   int(dn.GrpcPort),
+								DataCenter: dc.Id,
+							})
+						}
+					}
+				}
+			}
+		}
+	}
+
+	if len(existingLocations) == 0 {
+		if collection == "" {
+			return fmt.Errorf("volume %d not found", vid)
+		}
+		return fmt.Errorf("volume %d not found in collection %s", vid, collection)
 	}
 
 	err = markVolumeReplicasWritable(commandEnv.option.GrpcDialOption, vid, existingLocations, false, false)
@@ -135,7 +166,7 @@ func doVolumeTierUpload(commandEnv *CommandEnv, writer io.Writer, collection str
 		if i == 0 {
 			continue
 		}
-		fmt.Printf("delete volume %d from %s\n", vid, location.Url)
+		fmt.Printf("delete volume %d from Url:%s\n", vid, location.Url)
 		err = deleteVolume(commandEnv.option.GrpcDialOption, vid, location.ServerAddress(), false)
 		if err != nil {
 			return fmt.Errorf("deleteVolume %s volume %d: %v", location.Url, vid, err)


### PR DESCRIPTION


# What problem are we solving?
We identified two volumes sharing identical volume_ids across separate collections. Following execution of the volume_tier_upload command:​​

✅ ​​Collection A​​: Data was successfully tiered to S3 storage
❌ ​​Collection B​​: Data underwent unintended deletion
​​Impact​​: Permanent and unrecoverable data loss


# How are we solving the problem?

Before performing data deletion, filter all locations under the same collection as the input parameters to prevent accidental deletion.​

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
