### PR TITLE
Fixed weed mount reads with jwt.signing.read.key

### DIFF
--- a/weed/filer/filechunk_manifest.go
+++ b/weed/filer/filechunk_manifest.go
@@ -122,7 +122,7 @@ func fetchChunkRange(buffer []byte, lookupFileIdFn wdclient.LookupFileIdFunction
 		glog.Errorf("operation LookupFileId %s failed, err: %v", fileId, err)
 		return 0, err
 	}
-	return util_http.RetriedFetchChunkData(context.Background(), buffer, urlStrings, cipherKey, isGzipped, false, offset)
+	return util_http.RetriedFetchChunkData(context.Background(), buffer, urlStrings, cipherKey, isGzipped, false, offset, fileId)
 }
 
 func retriedStreamFetchChunkData(ctx context.Context, writer io.Writer, urlStrings []string, jwt string, cipherKey []byte, isGzipped bool, isFullChunk bool, offset int64, size int) (err error) {

--- a/weed/filer/reader_cache.go
+++ b/weed/filer/reader_cache.go
@@ -178,7 +178,7 @@ func (s *SingleChunkCacher) startCaching() {
 
 	s.data = mem.Allocate(s.chunkSize)
 
-	_, s.err = util_http.RetriedFetchChunkData(context.Background(), s.data, urlStrings, s.cipherKey, s.isGzipped, true, 0)
+	_, s.err = util_http.RetriedFetchChunkData(context.Background(), s.data, urlStrings, s.cipherKey, s.isGzipped, true, 0, s.chunkFileId)
 	if s.err != nil {
 		mem.Free(s.data)
 		s.data = nil

--- a/weed/filer/stream.go
+++ b/weed/filer/stream.go
@@ -196,7 +196,7 @@ func ReadAll(ctx context.Context, buffer []byte, masterClient *wdclient.MasterCl
 			return err
 		}
 
-		n, err := util_http.RetriedFetchChunkData(ctx, buffer[idx:idx+int(chunkView.ViewSize)], urlStrings, chunkView.CipherKey, chunkView.IsGzipped, chunkView.IsFullChunk(), chunkView.OffsetInChunk)
+		n, err := util_http.RetriedFetchChunkData(ctx, buffer[idx:idx+int(chunkView.ViewSize)], urlStrings, chunkView.CipherKey, chunkView.IsGzipped, chunkView.IsFullChunk(), chunkView.OffsetInChunk, chunkView.FileId)
 		if err != nil {
 			return err
 		}

--- a/weed/util/http/http_global_client_util.go
+++ b/weed/util/http/http_global_client_util.go
@@ -18,6 +18,8 @@ import (
 	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
+
+	"github.com/seaweedfs/seaweedfs/weed/security"
 )
 
 var ErrNotFound = fmt.Errorf("not found")
@@ -452,7 +454,16 @@ func (r *CountingReader) Read(p []byte) (n int, err error) {
 	return n, err
 }
 
-func RetriedFetchChunkData(ctx context.Context, buffer []byte, urlStrings []string, cipherKey []byte, isGzipped bool, isFullChunk bool, offset int64) (n int, err error) {
+func RetriedFetchChunkData(ctx context.Context, buffer []byte, urlStrings []string, cipherKey []byte, isGzipped bool, isFullChunk bool, offset int64, fileId string) (n int, err error) {
+
+	v := util.GetViper()
+	signingKey := v.GetString("jwt.signing.read.key")
+	var jwt security.EncodedJwt
+
+	if signingKey != "" {
+		expiresAfterSec := v.GetInt("jwt.signing.expires_after_seconds")
+		jwt = security.GenJwtForVolumeServer(security.SigningKey(signingKey), expiresAfterSec, fileId)
+	}
 
 	var shouldRetry bool
 
@@ -462,7 +473,7 @@ func RetriedFetchChunkData(ctx context.Context, buffer []byte, urlStrings []stri
 			if strings.Contains(urlString, "%") {
 				urlString = url.PathEscape(urlString)
 			}
-			shouldRetry, err = ReadUrlAsStream(ctx, urlString+"?readDeleted=true", cipherKey, isGzipped, isFullChunk, offset, len(buffer), func(data []byte) {
+			shouldRetry, err = ReadUrlAsStreamAuthenticated(ctx, urlString+"?readDeleted=true", string(security.EncodedJwt(jwt)), cipherKey, isGzipped, isFullChunk, offset, len(buffer), func(data []byte) {
 				if n < len(buffer) {
 					x := copy(buffer[n:], data)
 					n += x


### PR DESCRIPTION
# What problem are we solving?
If you set the `jwt.signing.read.key` parameter in security.toml, you will encounter an “Input/output error” when trying to read a file from weed mount.
`weed mount` logs:
```shell
E0731 21:32:40.395505 reader_at.go:163 fetching chunk &{FileId:1,ceea99843c5c OffsetInChunk:0 ViewSize:13 ViewOffset:0 ChunkSize:13 CipherKey:[] IsGzipped:true ModifiedTsNs:1753984005346050238}: http://192.168.2.41:8080/1,ceea99843c5c?readDeleted=true: 401 Unauthorized
E0731 21:32:40.395534 filehandle_read.go:66 file handle read /shared/test.txt: http://192.168.2.41:8080/1,ceea99843c5c?readDeleted=true: 401 Unauthorized
W0731 21:32:40.395548 weedfs_file_read.go:51 file handle read /shared/test.txt 0: http://192.168.2.41:8080/1,ceea99843c5c?readDeleted=true: 401 Unauthorized
```

Mb fix for #6740.

# How are we solving the problem?

Added JWT token authorization usage to `RetriedFetchChunkData`.

# How is the PR tested?

After making the changes, files from `weed mount` are read without errors. No side effects on other functions were observed.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
