### PR TITLE
Filer: fix filer range read

### DIFF
--- a/weed/filer/filechunks.go
+++ b/weed/filer/filechunks.go
@@ -178,7 +178,10 @@ func (cv *ChunkView) Clone() IntervalValue {
 }
 
 func (cv *ChunkView) IsFullChunk() bool {
-	return cv.ViewSize == cv.ChunkSize
+	// Fixed: Only return true if we're reading the ENTIRE chunk from the beginning.
+	// This prevents bandwidth amplification when range requests happen to align 
+	// with chunk boundaries but don't actually want the full chunk.
+	return cv.OffsetInChunk == 0 && cv.ViewSize == cv.ChunkSize
 }
 
 func ViewFromChunks(ctx context.Context, lookupFileIdFn wdclient.LookupFileIdFunctionType, chunks []*filer_pb.FileChunk, offset int64, size int64) (chunkViews *IntervalList[*ChunkView]) {


### PR DESCRIPTION

# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/7056

# How are we solving the problem?

Only return true if we're reading the ENTIRE chunk from the beginning.
This prevents bandwidth amplification when range requests happen to align
with chunk boundaries but don't actually want the full chunk.


# How is the PR tested?

local integration tests

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
