### PR TITLE
fix: make replica count configurable in all-in-one deployment

### DIFF
--- a/k8s/charts/seaweedfs/templates/all-in-one-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/all-in-one-deployment.yaml
@@ -15,7 +15,7 @@ metadata:
     {{- toYaml .Values.allInOne.annotations | nindent 4 }}
   {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.allInOne.replicas | default 1 }}
   strategy:
     type: Recreate
   selector:


### PR DESCRIPTION
# What problem are we solving?
- https://github.com/seaweedfs/seaweedfs/issues/7108

# How are we solving the problem?
- Passing through replica count from `allInOne`
- Setting a default in-line to 1 so that the change is backwards compatible/non-breaking

# How is the PR tested?
I deployed to kubernetes.

# Checks
- [ ] <del>I have added unit tests if possible.</del> 
- [ ] <del>I will add related wiki document changes and link to this PR after merging.</del> 
I _believe_ these are non-applicable to helm chart changes. Please let me know if not.