### PR TITLE
chore: remove default replica count for all-in-one deployment

### DIFF
--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -1088,7 +1088,6 @@ allInOne:
   enabled: false
   imageOverride: null
   restartPolicy: Always
-  replicas: 1
 
   # Core configuration
   idleTimeout: 30  # Connection idle seconds


### PR DESCRIPTION
# What problem are we solving?

This was removed because by design the all-in-one configuration will only support one pod in a deployment set.


# How are we solving the problem?
Removing the value from `values.yaml` that doesn't do anything.


# How is the PR tested?
It doesn't need to be, it's only a removal.


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
