### PR TITLE
S3 API: unsigned streaming (no cred) but chunks contain signatures

### DIFF
--- a/weed/s3api/chunked_bug_reproduction_test.go
+++ b/weed/s3api/chunked_bug_reproduction_test.go
@@ -1,0 +1,142 @@
+package s3api
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
+)
+
+// TestChunkedEncodingMixedFormat tests the fix for GitHub issue #6847
+// where AWS SDKs send mixed format: unsigned streaming headers but signed chunk data
+func TestChunkedEncodingMixedFormat(t *testing.T) {
+	expectedContent := "hello world\n"
+
+	// Create the problematic mixed format payload:
+	// - Unsigned streaming headers (STREAMING-UNSIGNED-PAYLOAD-TRAILER)
+	// - But chunk data contains chunk-signature headers
+	mixedFormatPayload := "c;chunk-signature=347f6c62acd95b7c6ae18648776024a9e8cd6151184a5e777ea8e1d9b4e45b3c\r\n" +
+		"hello world\n\r\n" +
+		"0;chunk-signature=1a99b7790b8db0f4bfc048c8802056c3179d561e40c073167e79db5f1a6af4b2\r\n" +
+		"x-amz-checksum-crc32:rwg7LQ==\r\n" +
+		"\r\n"
+
+	// Create HTTP request with unsigned streaming headers
+	req, _ := http.NewRequest("PUT", "/test-bucket/test-object", bytes.NewReader([]byte(mixedFormatPayload)))
+	req.Header.Set("x-amz-content-sha256", "STREAMING-UNSIGNED-PAYLOAD-TRAILER")
+	req.Header.Set("x-amz-trailer", "x-amz-checksum-crc32")
+
+	// Process through SeaweedFS chunked reader
+	iam := setupTestIAM()
+	reader, errCode := iam.newChunkedReader(req)
+
+	if errCode != s3err.ErrNone {
+		t.Fatalf("Failed to create chunked reader: %v", errCode)
+	}
+
+	// Read the content
+	actualContent, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("Failed to read content: %v", err)
+	}
+
+	// Should correctly extract just the content, ignoring chunk signatures
+	if string(actualContent) != expectedContent {
+		t.Errorf("Mixed format handling failed. Expected: %q, Got: %q", expectedContent, string(actualContent))
+	}
+}
+
+// createProblematicChunkedPayload creates the exact chunked payload from the GitHub issue
+// This simulates what newer AWS SDKs actually send with STREAMING-UNSIGNED-PAYLOAD-TRAILER
+func createProblematicChunkedPayload(content string) string {
+	// For unsigned streaming, chunks should NOT have chunk-signature headers
+	contentHex := fmt.Sprintf("%x", len(content))
+
+	// First chunk with content (no chunk-signature for unsigned streaming)
+	chunk1 := fmt.Sprintf("%s\r\n%s\r\n", contentHex, content)
+
+	// Final chunk (0-length) with trailer
+	finalChunk := "0\r\n" +
+		"x-amz-checksum-crc32:rwg7LQ==\r\n" +
+		"\r\n"
+
+	return chunk1 + finalChunk
+}
+
+// createChunkedRequest creates an HTTP request with chunked encoding headers
+func createChunkedRequest(payload string) *http.Request {
+	req, _ := http.NewRequest("PUT", "/test-bucket/test-object", bytes.NewReader([]byte(payload)))
+
+	// Set headers that trigger chunked processing
+	req.Header.Set("x-amz-content-sha256", "STREAMING-UNSIGNED-PAYLOAD-TRAILER")
+	req.Header.Set("x-amz-trailer", "x-amz-checksum-crc32")
+	req.Header.Set("Content-Encoding", "aws-chunked")
+	req.Header.Set("x-amz-decoded-content-length", "12") // length of "hello world\n"
+
+	return req
+}
+
+// setupTestIAM creates a test IAM instance using the same pattern as existing tests
+func setupTestIAM() *IdentityAccessManagement {
+	iam := &IdentityAccessManagement{}
+	return iam
+}
+
+// Standalone test to reproduce without relying on testing framework
+func ReproduceChunkedEncodingBugStandalone() {
+	fmt.Println("=== Reproducing Chunked Encoding Bug (Standalone) ===")
+
+	// This simulates the exact payload that AWS SDK sends with chunked encoding
+	// Based on the error message from the GitHub issue
+	expectedContent := "hello world\n"
+
+	// Create chunked payload similar to what AWS SDK sends
+	chunkedPayload := createProblematicChunkedPayload(expectedContent)
+
+	fmt.Printf("Input chunked payload:\n%s\n", chunkedPayload)
+	fmt.Printf("Expected output: %q\n", expectedContent)
+
+	// Create HTTP request that triggers the bug
+	req := createChunkedRequest(chunkedPayload)
+
+	// Process through SeaweedFS chunked reader
+	iam := setupTestIAM()
+	reader, errCode := iam.newChunkedReader(req)
+
+	if errCode != s3err.ErrNone {
+		fmt.Printf("ERROR: Failed to create chunked reader: %v\n", errCode)
+		return
+	}
+
+	// Read the content
+	actualContent, err := io.ReadAll(reader)
+	if err != nil {
+		fmt.Printf("ERROR: Failed to read content: %v\n", err)
+		return
+	}
+
+	fmt.Printf("Actual output: %q\n", string(actualContent))
+
+	// Check if the bug is present
+	if string(actualContent) == expectedContent {
+		fmt.Println("✅ PASS: Content correctly stripped of chunk headers")
+	} else {
+		fmt.Println("❌ FAIL: Bug reproduced - chunk headers included in content!")
+		fmt.Printf("Expected: %q\n", expectedContent)
+		fmt.Printf("Got:      %q\n", string(actualContent))
+
+		if strings.Contains(string(actualContent), "chunk-signature") {
+			fmt.Println("   🐛 Contains chunk-signature headers")
+		}
+		if strings.Contains(string(actualContent), "x-amz-checksum") {
+			fmt.Println("   🐛 Contains x-amz-checksum headers")
+		}
+		if strings.Contains(string(actualContent), "x-amz-trailer-signature") {
+			fmt.Println("   🐛 Contains x-amz-trailer-signature headers")
+		}
+	}
+}

--- a/weed/s3api/chunked_reader_v4.go
+++ b/weed/s3api/chunked_reader_v4.go
@@ -534,9 +534,10 @@ func readChunkLine(b *bufio.Reader) ([]byte, error) {
 	if err != nil {
 		// We always know when EOF is coming.
 		// If the caller asked for a line, there should be a line.
-		if err == io.EOF {
+		switch err {
+		case io.EOF:
 			err = io.ErrUnexpectedEOF
-		} else if err == bufio.ErrBufferFull {
+		case bufio.ErrBufferFull:
 			err = errLineTooLong
 		}
 		return nil, err

--- a/weed/s3api/chunked_reader_v4.go
+++ b/weed/s3api/chunked_reader_v4.go
@@ -440,23 +440,44 @@ func (cr *s3ChunkedReader) Read(buf []byte) (n int, err error) {
 				continue
 			}
 		case verifyChunk:
-			// Calculate the hashed chunk.
-			hashedChunk := hex.EncodeToString(cr.chunkSHA256Writer.Sum(nil))
-			// Calculate the chunk signature.
-			newSignature := cr.getChunkSignature(hashedChunk)
-			if !compareSignatureV4(cr.chunkSignature, newSignature) {
-				// Chunk signature doesn't match we return signature does not match.
-				cr.err = errors.New(s3err.ErrMsgChunkSignatureMismatch)
-				return 0, cr.err
-			}
-			// Newly calculated signature becomes the seed for the next chunk
-			// this follows the chaining.
-			cr.seedSignature = newSignature
-			cr.chunkSHA256Writer.Reset()
-			if cr.lastChunk {
-				cr.state = eofChunk
+			// Check if we have credentials for signature verification
+			// This handles the case where we have unsigned streaming (no cred) but chunks contain signatures
+			//
+			// BUG FIX for GitHub issue #6847:
+			// Some AWS SDK versions (Java 3.7.412+, .NET 4.0.0-preview.6+) send mixed format:
+			// - HTTP headers indicate unsigned streaming (STREAMING-UNSIGNED-PAYLOAD-TRAILER)
+			// - But chunk data contains chunk-signature headers (normally only for signed streaming)
+			// This causes a nil pointer dereference when trying to verify signatures without credentials
+			if cr.cred == nil {
+				// For unsigned streaming, we should not verify chunk signatures even if they are present
+				// This fixes the bug where AWS SDKs send chunk signatures with unsigned streaming headers
+				glog.V(3).Infof("Skipping chunk signature verification for unsigned streaming")
+				cr.chunkSHA256Writer.Reset()
+				if cr.lastChunk {
+					cr.state = eofChunk
+				} else {
+					cr.state = readChunkHeader
+				}
 			} else {
-				cr.state = readChunkHeader
+				// Normal signed streaming - verify the chunk signature
+				// Calculate the hashed chunk.
+				hashedChunk := hex.EncodeToString(cr.chunkSHA256Writer.Sum(nil))
+				// Calculate the chunk signature.
+				newSignature := cr.getChunkSignature(hashedChunk)
+				if !compareSignatureV4(cr.chunkSignature, newSignature) {
+					// Chunk signature doesn't match we return signature does not match.
+					cr.err = errors.New(s3err.ErrMsgChunkSignatureMismatch)
+					return 0, cr.err
+				}
+				// Newly calculated signature becomes the seed for the next chunk
+				// this follows the chaining.
+				cr.seedSignature = newSignature
+				cr.chunkSHA256Writer.Reset()
+				if cr.lastChunk {
+					cr.state = eofChunk
+				} else {
+					cr.state = readChunkHeader
+				}
 			}
 		case eofChunk:
 			return n, io.EOF


### PR DESCRIPTION
…chunks contain signatures

Some AWS SDK versions (Java 3.7.412+, .NET 4.0.0-preview.6+) send mixed format:
- HTTP headers indicate unsigned streaming (STREAMING-UNSIGNED-PAYLOAD-TRAILER)
- But chunk data contains chunk-signature headers (normally only for signed streaming)

This causes a nil pointer dereference when trying to verify signatures without credentials

# How are we solving the problem?

Check if we have credentials for signature verification
This handles the case where we have unsigned streaming (no cred) but chunks contain signatures

# How is the PR tested?

Unit test.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
