### PR TITLE
Fix volume annotations in volume-servicemonitor.yaml

### DIFF
--- a/k8s/charts/seaweedfs/templates/volume/volume-servicemonitor.yaml
+++ b/k8s/charts/seaweedfs/templates/volume/volume-servicemonitor.yaml
@@ -21,9 +21,9 @@ metadata:
     {{- with $.Values.global.monitoring.additionalLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-{{- if $volume.annotations }}
+{{- with $volume.annotations }}
   annotations:
-    {{- toYaml $volume.annotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
 {{- end }}
 spec:
   endpoints:

--- a/k8s/charts/seaweedfs/templates/volume/volume-servicemonitor.yaml
+++ b/k8s/charts/seaweedfs/templates/volume/volume-servicemonitor.yaml
@@ -21,9 +21,9 @@ metadata:
     {{- with $.Values.global.monitoring.additionalLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-{{- if .Values.volume.annotations }}
+{{- if $volume.annotations }}
   annotations:
-    {{- toYaml .Values.volume.annotations | nindent 4 }}
+    {{- toYaml $volume.annotations | nindent 4 }}
 {{- end }}
 spec:
   endpoints:


### PR DESCRIPTION
# What problem are we solving?

dereferencing .Values.volume.annotations directly fails when using Flux helm controller.

"seaweedfs/templates/volume/volume-servicemonitor.yaml" at <.Values.volume.annotations>: nil pointer evaluating interface {}.volume"}

# How are we solving the problem?

Use `$volume.annotations` instead of `.Values.volume.annotations`

# How is the PR tested?

Manually, locally

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
