### PR TITLE
fix missing support for .Values.global.repository

### DIFF
--- a/k8s/charts/seaweedfs/templates/shared/_helpers.tpl
+++ b/k8s/charts/seaweedfs/templates/shared/_helpers.tpl
@@ -100,7 +100,7 @@ Inject extra environment vars in the format key:value, if populated
 {{- $name := .Values.global.imageName | toString -}}
 {{- $tag := default .Chart.AppVersion .Values.image.tag  | toString -}}
 {{- if $repositoryName -}}
-{{-   $name = printf "%s/%s" (trimSuffix "/" $repositoryName) (last (splitList "/" $name)) -}}
+{{-   $name = printf "%s/%s" (trimSuffix "/" $repositoryName) (base $name) -}}
 {{- end -}}
 {{- if $registryName -}}
 {{-   printf "%s/%s:%s" $registryName $name $tag -}}

--- a/k8s/charts/seaweedfs/templates/shared/_helpers.tpl
+++ b/k8s/charts/seaweedfs/templates/shared/_helpers.tpl
@@ -96,7 +96,7 @@ Inject extra environment vars in the format key:value, if populated
 {{/* Computes the container image name for all components (if they are not overridden) */}}
 {{- define "common.image" -}}
 {{- $registryName := default .Values.image.registry .Values.global.registry | toString -}}
-{{- $repositoryName := .Values.image.repository | toString -}}
+{{- $repositoryName := default .Values.image.repository .Values.global.repository | toString -}}
 {{- $name := .Values.global.imageName | toString -}}
 {{- $tag := default .Chart.AppVersion .Values.image.tag  | toString -}}
 {{- if $registryName -}}

--- a/k8s/charts/seaweedfs/templates/shared/_helpers.tpl
+++ b/k8s/charts/seaweedfs/templates/shared/_helpers.tpl
@@ -99,10 +99,13 @@ Inject extra environment vars in the format key:value, if populated
 {{- $repositoryName := default .Values.image.repository .Values.global.repository | toString -}}
 {{- $name := .Values.global.imageName | toString -}}
 {{- $tag := default .Chart.AppVersion .Values.image.tag  | toString -}}
+{{- if $repositoryName -}}
+{{-   $name = printf "%s/%s" (trimSuffix "/" $repositoryName) (last (splitList "/" $name)) -}}
+{{- end -}}
 {{- if $registryName -}}
-{{- printf "%s/%s%s:%s" $registryName $repositoryName $name $tag -}}
+{{-   printf "%s/%s:%s" $registryName $name $tag -}}
 {{- else -}}
-{{- printf "%s%s:%s" $repositoryName $name $tag -}}
+{{-   printf "%s:%s" $name $tag -}}
 {{- end -}}
 {{- end -}}
 

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -3,6 +3,7 @@
 global:
   createClusterRole: true
   registry: ""
+  # if repository is set, it overrides the namespace part of imageName
   repository: ""
   imageName: chrislusf/seaweedfs
   imagePullPolicy: IfNotPresent


### PR DESCRIPTION
# What problem are we solving?

being able to override registry, repository, and image name separately

# How are we solving the problem?

implementing the missing "default" value with global reference

# How is the PR tested?

local testing with `helm template`

# Checks
- [x] I have added unit tests if possible.
  _AFAICT there are no unit tests for the Helm chart_
- [x] I will add related wiki document changes and link to this PR after merging.
  _I found no relevant existing Helm documentation_