### PR TITLE
Populate bucket_traffic_received_bytes_total metric

### DIFF
--- a/weed/s3api/s3api_object_handlers_put.go
+++ b/weed/s3api/s3api_object_handlers_put.go
@@ -362,7 +362,7 @@ func (s3a *S3ApiServer) putToFiler(r *http.Request, uploadUrl string, dataReader
 		return "", filerErrorToS3Error(ret.Error), ""
 	}
 
-	stats_collect.RecordBucketActiveTime(bucket)
+	BucketTrafficReceived(ret.Size, r)
 
 	// Return the SSE type determined by the unified handler
 	return etag, s3err.ErrNone, sseResult.SSEType

--- a/weed/s3api/stats.go
+++ b/weed/s3api/stats.go
@@ -37,6 +37,12 @@ func TimeToFirstByte(action string, start time.Time, r *http.Request) {
 	stats_collect.RecordBucketActiveTime(bucket)
 }
 
+func BucketTrafficReceived(bytesReceived int64, r *http.Request) {
+	bucket, _ := s3_constants.GetBucketAndObject(r)
+	stats_collect.RecordBucketActiveTime(bucket)
+	stats_collect.S3BucketTrafficReceivedBytesCounter.WithLabelValues(bucket).Add(float64(bytesReceived))
+}
+
 func BucketTrafficSent(bytesTransferred int64, r *http.Request) {
 	bucket, _ := s3_constants.GetBucketAndObject(r)
 	stats_collect.RecordBucketActiveTime(bucket)


### PR DESCRIPTION
# What problem are we solving?
Currently, `SeaweedFS_bucket_traffic_received_bytes_total` stays unpopulated with data and it's graph in is empty in Grafana.


# How are we solving the problem?
New function BucketTrafficReceived (similar to BucketTrafficSent) is called in s3api_object_handlers_put.go#putToFiler called after file being successfully uploaded into Filer.


# How is the PR tested?
Via modified for tests `make benchmark`


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
