### PR TITLE
CI: replace sed patch with heredoc Python to fix indentation in s3tests

### DIFF
--- a/.github/workflows/s3tests.yml
+++ b/.github/workflows/s3tests.yml
@@ -393,9 +393,37 @@ jobs:
           echo "All SeaweedFS components are ready!"
           cd ../s3-tests
           sed -i "s/assert prefixes == \['foo%2B1\/', 'foo\/', 'quux%20ab\/'\]/assert prefixes == \['foo\/', 'foo%2B1\/', 'quux%20ab\/'\]/" s3tests_boto3/functional/test_s3.py
-          # Fix bucket creation conflicts in versioning tests by replacing _create_objects calls
-          sed -i 's/bucket_name = _create_objects(bucket_name=bucket_name,keys=key_names)/# Use the existing bucket for object creation\n    client = get_client()\n    for key in key_names:\n        client.put_object(Bucket=bucket_name, Body=key, Key=key)/' s3tests_boto3/functional/test_s3.py
-          sed -i 's/bucket = _create_objects(bucket_name=bucket_name, keys=key_names)/# Use the existing bucket for object creation\n    client = get_client()\n    for key in key_names:\n        client.put_object(Bucket=bucket_name, Body=key, Key=key)/' s3tests_boto3/functional/test_s3.py
+          # Fix bucket creation conflicts using Python for proper indentation handling
+          python3 -c "
+            import re
+            import sys
+            
+            try:
+                # Read the file
+                with open('s3tests_boto3/functional/test_s3.py', 'r') as f:
+                    content = f.read()
+            
+                # Fix the _create_objects replacements with proper indentation
+                # Pattern 1: bucket_name = _create_objects(...)
+                pattern1 = r'(\s+)bucket_name = _create_objects\(bucket_name=bucket_name,\s*keys=key_names\)'
+                replacement1 = r'\1# Use the existing bucket for object creation\n\1client = get_client()\n\1for key in key_names:\n\1    client.put_object(Bucket=bucket_name, Body=key, Key=key)\n\1bucket_name = bucket_name'
+                
+                # Pattern 2: bucket = _create_objects(...)
+                pattern2 = r'(\s+)bucket = _create_objects\(bucket_name=bucket_name,\s*keys=key_names\)'
+                replacement2 = r'\1# Use the existing bucket for object creation\n\1client = get_client()\n\1for key in key_names:\n\1    client.put_object(Bucket=bucket_name, Body=key, Key=key)\n\1bucket = bucket_name'
+                
+                content = re.sub(pattern1, replacement1, content)
+                content = re.sub(pattern2, replacement2, content)
+            
+                # Write the file back
+                with open('s3tests_boto3/functional/test_s3.py', 'w') as f:
+                    f.write(content)
+                
+                print('Successfully fixed test file')
+            except Exception as e:
+                print(f'Warning: Could not fix test file: {e}', file=sys.stderr)
+                # Continue anyway - the original issue may not affect our specific tests
+          "
           # Create and update s3tests.conf to use port 8001
           cp ../docker/compose/s3tests.conf ../docker/compose/s3tests-versioning.conf
           sed -i 's/port = 8000/port = 8001/g' ../docker/compose/s3tests-versioning.conf

--- a/.github/workflows/s3tests.yml
+++ b/.github/workflows/s3tests.yml
@@ -394,36 +394,41 @@ jobs:
           cd ../s3-tests
           sed -i "s/assert prefixes == \['foo%2B1\/', 'foo\/', 'quux%20ab\/'\]/assert prefixes == \['foo\/', 'foo%2B1\/', 'quux%20ab\/'\]/" s3tests_boto3/functional/test_s3.py
           # Fix bucket creation conflicts using Python for proper indentation handling
-          python3 -c "
-            import re
-            import sys
-            
-            try:
-                # Read the file
-                with open('s3tests_boto3/functional/test_s3.py', 'r') as f:
-                    content = f.read()
-            
-                # Fix the _create_objects replacements with proper indentation
-                # Pattern 1: bucket_name = _create_objects(...)
-                pattern1 = r'(\s+)bucket_name = _create_objects\(bucket_name=bucket_name,\s*keys=key_names\)'
-                replacement1 = r'\1# Use the existing bucket for object creation\n\1client = get_client()\n\1for key in key_names:\n\1    client.put_object(Bucket=bucket_name, Body=key, Key=key)\n\1bucket_name = bucket_name'
-                
-                # Pattern 2: bucket = _create_objects(...)
-                pattern2 = r'(\s+)bucket = _create_objects\(bucket_name=bucket_name,\s*keys=key_names\)'
-                replacement2 = r'\1# Use the existing bucket for object creation\n\1client = get_client()\n\1for key in key_names:\n\1    client.put_object(Bucket=bucket_name, Body=key, Key=key)\n\1bucket = bucket_name'
-                
-                content = re.sub(pattern1, replacement1, content)
-                content = re.sub(pattern2, replacement2, content)
-            
-                # Write the file back
-                with open('s3tests_boto3/functional/test_s3.py', 'w') as f:
-                    f.write(content)
-                
-                print('Successfully fixed test file')
-            except Exception as e:
-                print(f'Warning: Could not fix test file: {e}', file=sys.stderr)
-                # Continue anyway - the original issue may not affect our specific tests
-          "
+          python3 - <<'PY'
+          import re, sys, io
+
+          path = 's3tests_boto3/functional/test_s3.py'
+          try:
+              with io.open(path, 'r', encoding='utf-8') as f:
+                  content = f.read()
+
+              # Pattern 1: bucket_name = _create_objects(...)
+              pattern1 = r'(\s+)bucket_name = _create_objects\(bucket_name=bucket_name,\s*keys=key_names\)'
+              replacement1 = (r'\1# Use the existing bucket for object creation\n'
+                              r'\1client = get_client()\n'
+                              r'\1for key in key_names:\n'
+                              r'\1    client.put_object(Bucket=bucket_name, Body=key, Key=key)\n'
+                              r'\1bucket_name = bucket_name')
+
+              # Pattern 2: bucket = _create_objects(...)
+              pattern2 = r'(\s+)bucket = _create_objects\(bucket_name=bucket_name,\s*keys=key_names\)'
+              replacement2 = (r'\1# Use the existing bucket for object creation\n'
+                              r'\1client = get_client()\n'
+                              r'\1for key in key_names:\n'
+                              r'\1    client.put_object(Bucket=bucket_name, Body=key, Key=key)\n'
+                              r'\1bucket = bucket_name')
+
+              content = re.sub(pattern1, replacement1, content)
+              content = re.sub(pattern2, replacement2, content)
+
+              with io.open(path, 'w', encoding='utf-8') as f:
+                  f.write(content)
+
+              print('Successfully fixed test file')
+          except Exception as e:
+              print('Warning: Could not fix test file: %s' % e, file=sys.stderr)
+              # Continue anyway - the original issue may not affect our specific tests
+          PY
           # Create and update s3tests.conf to use port 8001
           cp ../docker/compose/s3tests.conf ../docker/compose/s3tests-versioning.conf
           sed -i 's/port = 8000/port = 8001/g' ../docker/compose/s3tests-versioning.conf


### PR DESCRIPTION
# What problem are we solving?
- The original workflow used sed to inject multi-line Python into `s3tests_boto3/functional/test_s3.py`, which produced malformed indentation and caused `IndentationError` during runs.
- See original snippet in upstream workflow for context: `https://github.com/seaweedfs/seaweedfs/blob/master/.github/workflows/s3tests.yml`.

# How are we solving the problem?
- Replace the sed-based replacements with a heredoc Python script that:
  - Reads `s3tests_boto3/functional/test_s3.py`.
  - Uses regex with captured leading whitespace to preserve correct Python indentation.
  - Writes the modified file back safely.
- This avoids YAML/shell escaping pitfalls and ensures valid Python indentation.

# How is the PR tested?
- Executed the updated step in the GitHub Actions workflow; tests proceed without `IndentationError`.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.