### PR TITLE
fix(filer-ui): support folder creation with JWT token in URL

### DIFF
--- a/weed/server/filer_ui/filer.html
+++ b/weed/server/filer_ui/filer.html
@@ -315,7 +315,7 @@
         if (dirName == null || dirName == '') {
             return;
         }
-        var baseUrl = window.location.href;
+        var baseUrl = window.location.origin + window.location.pathname;
         if (!baseUrl.endsWith('/')) {
             baseUrl += '/';
         }
@@ -323,6 +323,7 @@
         if (!url.endsWith('/')) {
             url += '/';
         }
+        url += window.location.search;
         var xhr = new XMLHttpRequest();
         xhr.open('POST', url, false);
         xhr.setRequestHeader('Content-Type', '');


### PR DESCRIPTION
# What problem are we solving?
When accessing the Filer UI with a JWT token provided in the URL query string (e.g., ?jwt=token), the Create Folder action fails because the token is lost during the request.

# How are we solving the problem?
Update the handleCreateDir function in filer.html:

- Construct baseUrl using window.location.origin + window.location.pathname.
- Append the original query string (window.location.search) to preserve parameters such as the JWT token.

This ensures folder creation works properly when the Filer UI is accessed with ?jwt=....
