### PR TITLE
s3: fix SigV4 permission check

### DIFF
--- a/.github/workflows/test-s3-over-https-using-awscli.yml
+++ b/.github/workflows/test-s3-over-https-using-awscli.yml
@@ -60,14 +60,32 @@ jobs:
         run: |
           aws --no-verify-ssl s3api create-bucket --bucket bucket
 
-      - name: Test PutObject
+      - name: Test Write-only User
         run: |
           set -e
           dd if=/dev/urandom of=generated bs=1M count=2
-          aws --no-verify-ssl s3api put-object --bucket bucket --key test-putobject --body generated
-          aws --no-verify-ssl s3api get-object --bucket bucket --key test-putobject downloaded
+          aws --no-verify-ssl s3api put-object --bucket bucket --key test-obj --body generated
+          if ! aws --no-verify-ssl s3api get-object --bucket bucket --key test-obj downloaded 2>&1 | grep -q AccessDenied; then
+            echo 'GetObject should fail with AccessDenied'
+            exit 1
+          fi
+        env:
+          AWS_ACCESS_KEY_ID: some_access_key4
+          AWS_SECRET_ACCESS_KEY: some_secret_key4
+
+      - name: Test Read-only User
+        run: |
+          set -e
+          if ! aws --no-verify-ssl s3api put-object --bucket bucket --key test-obj --body generated 2>&1 | grep -q AccessDenied; then
+            echo 'PutObject should fail with AccessDenied'
+            exit 1
+          fi
+          aws --no-verify-ssl s3api get-object --bucket bucket --key test-obj downloaded
           diff -q generated downloaded
           rm -f generated downloaded
+        env:
+          AWS_ACCESS_KEY_ID: some_access_key2
+          AWS_SECRET_ACCESS_KEY: some_secret_key2
 
       - name: Test Multi-part Upload
         run: |

--- a/docker/compose/s3.json
+++ b/docker/compose/s3.json
@@ -103,13 +103,25 @@
         "Tagging",
         "Write"
       ]
+    },
+    {
+      "name": "some_write_only_user",
+      "credentials": [
+        {
+          "accessKey": "some_access_key4",
+          "secretKey": "some_secret_key4"
+        }
+      ],
+      "actions": [
+        "Write"
+      ]
     }
   ],
   "accounts": [
-      {
-        "id" : "testid",
-        "displayName": "M. Tester",
-        "emailAddress": "tester@ceph.com"
-      }
-    ]
+    {
+      "id": "testid",
+      "displayName": "M. Tester",
+      "emailAddress": "tester@ceph.com"
+    }
+  ]
 }

--- a/weed/s3api/auth_credentials.go
+++ b/weed/s3api/auth_credentials.go
@@ -56,10 +56,10 @@ type IdentityAccessManagement struct {
 }
 
 type Identity struct {
-	Name        string
-	Account     *Account
-	Credentials []*Credential
-	Actions     []Action
+	Name         string
+	Account      *Account
+	Credentials  []*Credential
+	Actions      []Action
 	PrincipalArn string // ARN for IAM authorization (e.g., "arn:seaweed:iam::user/username")
 }
 
@@ -447,7 +447,7 @@ func (iam *IdentityAccessManagement) authRequest(r *http.Request, action Action)
 		authType = "SigV2"
 	case authTypeStreamingSigned, authTypeSigned, authTypePresigned:
 		glog.V(3).Infof("v4 auth type")
-		identity, s3Err = iam.reqSignatureV4Verify(r)
+		identity, s3Err = iam.reqSignatureV4Verify(r, action)
 		authType = "SigV4"
 	case authTypePostPolicy:
 		glog.V(3).Infof("post policy auth type")

--- a/weed/s3api/s3api_object_handlers_multipart.go
+++ b/weed/s3api/s3api_object_handlers_multipart.go
@@ -306,7 +306,7 @@ func (s3a *S3ApiServer) PutObjectPartHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	dataReader, s3ErrCode := getRequestDataReader(s3a, r)
+	dataReader, s3ErrCode := getRequestDataReader(s3a, r, s3_constants.ACTION_WRITE)
 	if s3ErrCode != s3err.ErrNone {
 		s3err.WriteErrorResponse(w, r, s3ErrCode)
 		return

--- a/weed/s3api/s3api_object_handlers_put.go
+++ b/weed/s3api/s3api_object_handlers_put.go
@@ -98,7 +98,7 @@ func (s3a *S3ApiServer) PutObjectHandler(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
-	dataReader, s3ErrCode := getRequestDataReader(s3a, r)
+	dataReader, s3ErrCode := getRequestDataReader(s3a, r, s3_constants.ACTION_WRITE)
 	if s3ErrCode != s3err.ErrNone {
 		s3err.WriteErrorResponse(w, r, s3ErrCode)
 		return

--- a/weed/s3api/s3api_put_object_helper.go
+++ b/weed/s3api/s3api_put_object_helper.go
@@ -12,7 +12,7 @@ import (
 // authTypeStreamingUnsigned to strip checksum headers and extract the actual data.
 // This fixes issues where chunked data with checksums would be stored incorrectly
 // when IAM is not enabled.
-func getRequestDataReader(s3a *S3ApiServer, r *http.Request) (io.ReadCloser, s3err.ErrorCode) {
+func getRequestDataReader(s3a *S3ApiServer, r *http.Request, action Action) (io.ReadCloser, s3err.ErrorCode) {
 	var s3ErrCode s3err.ErrorCode
 	dataReader := r.Body
 	rAuthType := getRequestAuthType(r)
@@ -23,7 +23,7 @@ func getRequestDataReader(s3a *S3ApiServer, r *http.Request) (io.ReadCloser, s3e
 		case authTypeSignedV2, authTypePresignedV2:
 			_, s3ErrCode = s3a.iam.isReqAuthenticatedV2(r)
 		case authTypePresigned, authTypeSigned:
-			_, s3ErrCode = s3a.iam.reqSignatureV4Verify(r)
+			_, s3ErrCode = s3a.iam.reqSignatureV4Verify(r, action)
 		}
 	} else {
 		switch rAuthType {


### PR DESCRIPTION
# What problem are we solving?

s3 proxy returns AccessDenied, even though the caller only performs reads via read-only access-key.

# How are we solving the problem?

add an action parameter to `reqSignatureV4Verify`

# How is the PR tested?

added some tests

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
