### PR TITLE
fix(admin): resolve login redirect loop in admin interface (#7272)

### DIFF
--- a/weed/command/admin.go
+++ b/weed/command/admin.go
@@ -198,6 +198,13 @@ func startAdminServer(ctx context.Context, options AdminOptions) error {
 		return fmt.Errorf("failed to generate session key: %w", err)
 	}
 	store := cookie.NewStore(sessionKeyBytes)
+
+	// Configure session options to ensure cookies are properly saved
+	store.Options(sessions.Options{
+		Path:   "/",
+		MaxAge: 3600 * 24, // 24 hours
+	})
+
 	r.Use(sessions.Sessions("admin-session", store))
 
 	// Static files - serve from embedded filesystem


### PR DESCRIPTION
Fixes #7272

# What problem are we solving?
The admin interface login functionality has a redirect loop issue where users entering correct credentials are continuously redirected back to the login page instead of accessing the admin dashboard.

See the issue in https://github.com/seaweedfs/seaweedfs/issues/7272

# How are we solving the problem?
- Configure proper cookie session options in admin server:
  * Set Path, MaxAge attributes
  * Ensure session cookies are correctly saved and retrieved


# How is the PR tested?
Tested on Chrome, Firefox, and Edge.
Verified cookie behavior is consistent across browsers
# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
