### PR TITLE
FUSE Mount: resolve memory leak in Read method goroutine (#7270)

### DIFF
--- a/weed/mount/weedfs_file_read.go
+++ b/weed/mount/weedfs_file_read.go
@@ -49,10 +49,14 @@ func (wfs *WFS) Read(cancel <-chan struct{}, in *fuse.ReadIn, buff []byte) (fuse
 
 	// Create a context that will be cancelled when the cancel channel receives a signal
 	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+	
 	go func() {
 		select {
 		case <-cancel:
 			cancelFunc()
+		case <-ctx.Done():
+			// Context already cancelled, exit goroutine
 		}
 	}()
 


### PR DESCRIPTION


# What problem are we solving?

#7270

# How are we solving the problem?
* Add defer cancelFunc() to ensure context is always cancelled
* Add ctx.Done() case in goroutine select to prevent goroutine leak
* Fixes memory accumulation issue where goroutines were not properly cleaned up

# How is the PR tested?

Over the weekend, I conducted read/write/verify/delete tests using the method described in the issue note, and during the 65+ hours of testing without any incidents, the memory usage did not increase as shown below.

* https://github.com/seaweedfs/seaweedfs/issues/7258#issuecomment-3317421174

<img width="881" height="157" alt="스크린샷 2025-09-29 오전 10 48 11" src="https://github.com/user-attachments/assets/c3839570-a629-484d-acdd-d64ef961edce" />


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
