### PR TITLE
feat: use disk tag from helm chart

### DIFF
--- a/k8s/charts/seaweedfs/templates/volume/volume-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/volume/volume-statefulset.yaml
@@ -179,6 +179,9 @@ spec:
                 {{- if $volume.id }}
                 -id={{ $volume.id }} \
                 {{- end }}
+                {{- if $volume.diskType }}
+                -disk={{ $volume.diskType }} \
+                {{- end }}
                 -ip.bind={{ $volume.ipBind }} \
                 -readMode={{ $volume.readMode }} \
                 {{- if $volume.whiteList }}

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -408,6 +408,10 @@ volume:
   # Volume server's data center name
   dataCenter: null
 
+  # Volume server's disk type [hdd|ssd|<tag>]
+  # Use "hdd" for hard drives, "ssd" for solid state drives, or a custom tag
+  diskType: null
+
   # Redirect moved or non-local volumes. (default proxy)
   readMode: proxy
 


### PR DESCRIPTION
# What problem are we solving?

The Helm chart doesn't expose the `-disk` parameter to configure a volume server's disk type.

# How are we solving the problem?

Added `diskType` field to the volume configuration in `values.yaml` (similar to existing `dataCenter`, `rack`, and `id` fields) and updated the volume StatefulSet template to pass the `-disk` parameter when `diskType` is specified.

# How is the PR tested?

Deploy the chart with `diskType: ssd` or `diskType: nvme` configured in values and verify volume servers report the correct disk type instead of defaulting to "hdd".

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added disk type configuration for Volume servers, enabling administrators to specify storage types (hdd, ssd, or custom tags) for optimized performance. The optional configuration is fully backward compatible and does not affect existing deployments when not configured.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->