### PR TITLE
glog: add in-memory ring buffer with log interceptor

### DIFF
--- a/weed/glog/glog.go
+++ b/weed/glog/glog.go
@@ -467,6 +467,12 @@ type buffer struct {
 
 var logging loggingT
 
+// LogInterceptor, if non-nil, is called for every log line that passes through
+// glog's output path. The callback receives the severity (0=INFO..3=FATAL)
+// and a copy of the formatted log bytes. This hook is used by the logbuffer
+// package to capture log entries into an in-memory ring buffer.
+var LogInterceptor func(severity int32, data []byte)
+
 // setVState sets a consistent state for V logging.
 // l.mu is held.
 func (l *loggingT) setVState(verbosity Level, filter []modulePat, setFilter bool) {
@@ -731,6 +737,9 @@ func (l *loggingT) output(s severity, buf *buffer, file string, line int, alsoTo
 		}
 	}
 	data := buf.Bytes()
+	if fn := LogInterceptor; fn != nil {
+		fn(int32(s), data)
+	}
 	if l.toStderr {
 		os.Stderr.Write(data)
 	} else {
@@ -1271,4 +1280,26 @@ func Exitln(args ...interface{}) {
 func Exitf(format string, args ...interface{}) {
 	atomic.StoreUint32(&fatalNoStacks, 1)
 	logging.printf(fatalLog, format, args...)
+}
+
+// GetVerbosity returns the current V logging verbosity level.
+func GetVerbosity() int32 {
+	return int32(logging.verbosity.get())
+}
+
+// SetVerbosity sets the V logging verbosity level at runtime.
+func SetVerbosity(v int32) {
+	logging.mu.Lock()
+	defer logging.mu.Unlock()
+	logging.setVState(Level(v), logging.vmodule.filter, false)
+}
+
+// GetVModule returns the current -vmodule setting as a string.
+func GetVModule() string {
+	return logging.vmodule.String()
+}
+
+// SetVModule parses and applies a vmodule spec (e.g. "gopher*=3,filer=2").
+func SetVModule(spec string) error {
+	return logging.vmodule.Set(spec)
 }

--- a/weed/logbuffer/entry.go
+++ b/weed/logbuffer/entry.go
@@ -1,0 +1,76 @@
+package logbuffer
+
+import "time"
+
+// LogEntry represents a single parsed log entry stored in the ring buffer.
+type LogEntry struct {
+	Timestamp time.Time `json:"ts"`
+	Level     string    `json:"level"`
+	File      string    `json:"file"`
+	Line      int       `json:"line"`
+	Message   string    `json:"msg"`
+	RequestID string    `json:"request_id,omitempty"`
+}
+
+// Filter defines criteria for querying log entries.
+type Filter struct {
+	Level     string // minimum severity: INFO, WARNING, ERROR, FATAL
+	Limit     int
+	Offset    int
+	Since     time.Time
+	Until     time.Time
+	Pattern   string // regex pattern to match against message
+	File      string // glob pattern to match source file
+	RequestID string
+}
+
+// QueryResult holds the response for a log query.
+type QueryResult struct {
+	Entries []LogEntry `json:"entries"`
+	Total   int        `json:"total"`
+	HasMore bool       `json:"has_more"`
+	Error   string     `json:"error,omitempty"`
+}
+
+// LevelResponse holds the current log level configuration.
+type LevelResponse struct {
+	Verbosity int    `json:"verbosity"`
+	VModule   string `json:"vmodule"`
+}
+
+// LevelChangeRequest holds a request to change log verbosity.
+type LevelChangeRequest struct {
+	Verbosity  *int   `json:"verbosity,omitempty"`
+	TTLMinutes int    `json:"ttl_minutes,omitempty"`
+	VModule    string `json:"vmodule,omitempty"`
+}
+
+// LevelChangeResponse holds the response after changing log verbosity.
+type LevelChangeResponse struct {
+	Previous int    `json:"previous"`
+	Current  int    `json:"current"`
+	RevertAt string `json:"revert_at,omitempty"`
+}
+
+// FileCount represents a source file and how many log entries it generated.
+type FileCount struct {
+	File  string `json:"file"`
+	Count int    `json:"count"`
+}
+
+// ErrorRateResult holds error rate metrics for a time window.
+type ErrorRateResult struct {
+	Window     string  `json:"window"`
+	TotalLogs  int     `json:"total_logs"`
+	ErrorCount int     `json:"error_count"`
+	ErrorRate  float64 `json:"error_rate_percent"`
+}
+
+// StatsResponse is the full response for the /logs/stats endpoint.
+type StatsResponse struct {
+	Buffer      BufferStats     `json:"buffer"`
+	RecentErrs  []LogEntry      `json:"recent_errors"`
+	TopFiles    []FileCount     `json:"top_files"`
+	ErrorRate1m ErrorRateResult `json:"error_rate_1m"`
+	ErrorRate5m ErrorRateResult `json:"error_rate_5m"`
+}

--- a/weed/logbuffer/global.go
+++ b/weed/logbuffer/global.go
@@ -1,0 +1,61 @@
+package logbuffer
+
+import (
+	"sync"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/glog"
+)
+
+var (
+	// Global is the singleton ring buffer instance.
+	// Nil when log buffering is disabled (capacity=0).
+	Global *RingBuffer
+
+	revertMu    sync.Mutex
+	revertTimer *time.Timer
+)
+
+// Init initializes the global log buffer and hooks into glog.
+// Call this at program startup before any logging.
+// A capacity of 0 disables log buffering entirely.
+func Init(capacity int) {
+	if capacity <= 0 {
+		return
+	}
+
+	Global = NewRingBuffer(capacity)
+
+	glog.LogInterceptor = func(level int32, msg []byte) {
+		// Make a copy since glog reuses the buffer
+		copied := make([]byte, len(msg))
+		copy(copied, msg)
+		entry := ParseLogLine(level, copied)
+		Global.Write(entry)
+	}
+}
+
+// SetVerbosityWithTTL changes the glog verbosity and optionally reverts after ttlMinutes.
+// Returns the previous verbosity level.
+func SetVerbosityWithTTL(v int32, ttlMinutes int) (previous int32, revertAt time.Time) {
+	previous = glog.GetVerbosity()
+	glog.SetVerbosity(v)
+
+	revertMu.Lock()
+	defer revertMu.Unlock()
+
+	// Cancel any existing revert timer
+	if revertTimer != nil {
+		revertTimer.Stop()
+		revertTimer = nil
+	}
+
+	if ttlMinutes > 0 {
+		revertAt = time.Now().Add(time.Duration(ttlMinutes) * time.Minute)
+		revertTimer = time.AfterFunc(time.Duration(ttlMinutes)*time.Minute, func() {
+			glog.SetVerbosity(previous)
+		})
+	}
+
+	return previous, revertAt
+}

--- a/weed/logbuffer/parser.go
+++ b/weed/logbuffer/parser.go
@@ -1,0 +1,173 @@
+package logbuffer
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var severityNames = map[byte]string{
+	'I': "INFO",
+	'W': "WARNING",
+	'E': "ERROR",
+	'F': "FATAL",
+}
+
+var severityFromLevel = map[int32]string{
+	0: "INFO",
+	1: "WARNING",
+	2: "ERROR",
+	3: "FATAL",
+}
+
+// yearForMonth resolves the correct year for a log timestamp.
+// glog does not include the year in its header format (mmdd only).
+// If the parsed month is ahead of the current month, we assume the log
+// is from the previous year (e.g., a December log queried in January).
+func yearForMonth(month time.Month) int {
+	now := time.Now()
+	y := now.Year()
+	if month > now.Month()+1 {
+		y--
+	}
+	return y
+}
+
+// jsonLogLine is used only for JSON unmarshaling in ParseLogLine.
+type jsonLogLine struct {
+	Ts    string `json:"ts"`
+	Level string `json:"level"`
+	File  string `json:"file"`
+	Line  int    `json:"line"`
+	Msg   string `json:"msg"`
+}
+
+// ParseLogLine parses a raw glog line into a LogEntry.
+// It auto-detects the format:
+//   - JSON: {"ts":"...","level":"...","file":"...","line":N,"msg":"..."}
+//   - Text: [IWEF]mmdd hh:mm:ss.uuuuuu threadid file:line] msg...
+func ParseLogLine(level int32, raw []byte) LogEntry {
+	entry := LogEntry{
+		Timestamp: time.Now(),
+		Level:     severityFromLevel[level],
+	}
+
+	if len(raw) == 0 {
+		return entry
+	}
+
+	// Auto-detect JSON format (starts with '{')
+	if raw[0] == '{' {
+		return parseJSONLine(level, raw, entry)
+	}
+
+	return parseTextLine(level, raw, entry)
+}
+
+// parseJSONLine handles JSON-formatted glog output.
+func parseJSONLine(level int32, raw []byte, entry LogEntry) LogEntry {
+	var jl jsonLogLine
+	if err := json.Unmarshal(raw, &jl); err != nil {
+		// Fallback: treat as plain message
+		entry.Message = strings.TrimSpace(string(raw))
+		return entry
+	}
+
+	entry.Level = jl.Level
+	entry.File = jl.File
+	entry.Line = jl.Line
+	entry.Message = jl.Msg
+
+	if jl.Ts != "" {
+		if t, err := time.Parse(time.RFC3339Nano, jl.Ts); err == nil {
+			entry.Timestamp = t
+		}
+	}
+
+	// Extract request_id if present in message
+	if strings.HasPrefix(entry.Message, "request_id:") {
+		spaceIdx := strings.Index(entry.Message, " ")
+		if spaceIdx > 0 {
+			entry.RequestID = entry.Message[11:spaceIdx]
+			entry.Message = entry.Message[spaceIdx+1:]
+		}
+	}
+
+	return entry
+}
+
+// parseTextLine handles classic glog text format.
+func parseTextLine(level int32, raw []byte, entry LogEntry) LogEntry {
+	line := string(raw)
+
+	// Minimum valid: "I0318 12:34:56.123456 12345 f:1] m" = 30+ chars
+	if len(line) < 30 {
+		entry.Message = strings.TrimSpace(line)
+		return entry
+	}
+
+	// First char is severity
+	if name, ok := severityNames[line[0]]; ok {
+		entry.Level = name
+	}
+
+	// Parse date: mmdd (chars 1-4)
+	month, _ := strconv.Atoi(line[1:3])
+	day, _ := strconv.Atoi(line[3:5])
+
+	// Parse time: hh:mm:ss.uuuuuu (chars 6-21)
+	if len(line) > 21 && line[5] == ' ' {
+		hour, _ := strconv.Atoi(line[6:8])
+		min, _ := strconv.Atoi(line[9:11])
+		sec, _ := strconv.Atoi(line[12:14])
+		usec, _ := strconv.Atoi(line[15:21])
+
+		m := time.Month(month)
+		entry.Timestamp = time.Date(
+			yearForMonth(m), m, day,
+			hour, min, sec, usec*1000,
+			time.Now().Location(),
+		)
+	}
+
+	// Find the "] " separator that ends the header
+	bracketIdx := strings.Index(line, "] ")
+	if bracketIdx == -1 {
+		bracketIdx = strings.LastIndex(line, "]")
+		if bracketIdx == -1 {
+			entry.Message = strings.TrimSpace(line)
+			return entry
+		}
+	}
+
+	// Parse file:line from the header (between last space before ] and ])
+	header := line[:bracketIdx]
+	lastSpace := strings.LastIndex(header, " ")
+	if lastSpace > 0 {
+		fileLine := header[lastSpace+1:]
+		colonIdx := strings.LastIndex(fileLine, ":")
+		if colonIdx > 0 {
+			entry.File = fileLine[:colonIdx]
+			entry.Line, _ = strconv.Atoi(fileLine[colonIdx+1:])
+		}
+	}
+
+	// Message is everything after "] "
+	if bracketIdx+2 < len(line) {
+		entry.Message = strings.TrimRight(line[bracketIdx+2:], "\n\r")
+	} else if bracketIdx+1 < len(line) {
+		entry.Message = strings.TrimRight(line[bracketIdx+1:], "\n\r")
+	}
+
+	// Extract request_id if present (format: "request_id:XXXXX ...")
+	if strings.HasPrefix(entry.Message, "request_id:") {
+		spaceIdx := strings.Index(entry.Message, " ")
+		if spaceIdx > 0 {
+			entry.RequestID = entry.Message[11:spaceIdx]
+			entry.Message = entry.Message[spaceIdx+1:]
+		}
+	}
+
+	return entry
+}

--- a/weed/logbuffer/parser.go
+++ b/weed/logbuffer/parser.go
@@ -21,6 +21,8 @@ var severityFromLevel = map[int32]string{
 	3: "FATAL",
 }
 
+const requestIDPrefix = "request_id:"
+
 // yearForMonth resolves the correct year for a log timestamp.
 // glog does not include the year in its header format (mmdd only).
 // If the parsed month is ahead of the current month, we assume the log
@@ -46,7 +48,7 @@ type jsonLogLine struct {
 // ParseLogLine parses a raw glog line into a LogEntry.
 // It auto-detects the format:
 //   - JSON: {"ts":"...","level":"...","file":"...","line":N,"msg":"..."}
-//   - Text: [IWEF]mmdd hh:mm:ss.uuuuuu threadid file:line] msg...
+//   - Text: Lmmdd hh:mm:ss.uuuuuu file:line msg (SeaweedFS glog format)
 func ParseLogLine(level int32, raw []byte) LogEntry {
 	entry := LogEntry{
 		Timestamp: time.Now(),
@@ -85,24 +87,18 @@ func parseJSONLine(level int32, raw []byte, entry LogEntry) LogEntry {
 		}
 	}
 
-	// Extract request_id if present in message
-	if strings.HasPrefix(entry.Message, "request_id:") {
-		spaceIdx := strings.Index(entry.Message, " ")
-		if spaceIdx > 0 {
-			entry.RequestID = entry.Message[11:spaceIdx]
-			entry.Message = entry.Message[spaceIdx+1:]
-		}
-	}
-
+	extractRequestID(&entry)
 	return entry
 }
 
-// parseTextLine handles classic glog text format.
+// parseTextLine handles SeaweedFS glog text format.
+// SeaweedFS glog emits: Lmmdd hh:mm:ss.uuuuuu file:line msg
+// (no thread id, no ] bracket — differs from standard glog).
 func parseTextLine(level int32, raw []byte, entry LogEntry) LogEntry {
 	line := string(raw)
 
-	// Minimum valid: "I0318 12:34:56.123456 12345 f:1] m" = 30+ chars
-	if len(line) < 30 {
+	// Minimum valid: "I0318 12:34:56.123456 f:1 m" = 27+ chars
+	if len(line) < 27 {
 		entry.Message = strings.TrimSpace(line)
 		return entry
 	}
@@ -131,43 +127,57 @@ func parseTextLine(level int32, raw []byte, entry LogEntry) LogEntry {
 		)
 	}
 
-	// Find the "] " separator that ends the header
-	bracketIdx := strings.Index(line, "] ")
-	if bracketIdx == -1 {
-		bracketIdx = strings.LastIndex(line, "]")
-		if bracketIdx == -1 {
-			entry.Message = strings.TrimSpace(line)
-			return entry
+	// After the timestamp (22 chars), the rest is "file:line msg"
+	rest := line[22:]
+
+	// SeaweedFS format: file:line msg (no bracket)
+	// Also support standard glog format: threadid file:line] msg
+	if bracketIdx := strings.Index(rest, "] "); bracketIdx >= 0 {
+		// Standard glog format with "]"
+		header := rest[:bracketIdx]
+		lastSpace := strings.LastIndex(header, " ")
+		if lastSpace >= 0 {
+			fileLine := header[lastSpace+1:]
+			colonIdx := strings.LastIndex(fileLine, ":")
+			if colonIdx > 0 {
+				entry.File = fileLine[:colonIdx]
+				entry.Line, _ = strconv.Atoi(fileLine[colonIdx+1:])
+			}
 		}
-	}
-
-	// Parse file:line from the header (between last space before ] and ])
-	header := line[:bracketIdx]
-	lastSpace := strings.LastIndex(header, " ")
-	if lastSpace > 0 {
-		fileLine := header[lastSpace+1:]
-		colonIdx := strings.LastIndex(fileLine, ":")
-		if colonIdx > 0 {
-			entry.File = fileLine[:colonIdx]
-			entry.Line, _ = strconv.Atoi(fileLine[colonIdx+1:])
-		}
-	}
-
-	// Message is everything after "] "
-	if bracketIdx+2 < len(line) {
-		entry.Message = strings.TrimRight(line[bracketIdx+2:], "\n\r")
-	} else if bracketIdx+1 < len(line) {
-		entry.Message = strings.TrimRight(line[bracketIdx+1:], "\n\r")
-	}
-
-	// Extract request_id if present (format: "request_id:XXXXX ...")
-	if strings.HasPrefix(entry.Message, "request_id:") {
-		spaceIdx := strings.Index(entry.Message, " ")
+		entry.Message = strings.TrimRight(rest[bracketIdx+2:], "\n\r")
+	} else {
+		// SeaweedFS format: file:line msg
+		spaceIdx := strings.Index(rest, " ")
 		if spaceIdx > 0 {
-			entry.RequestID = entry.Message[11:spaceIdx]
-			entry.Message = entry.Message[spaceIdx+1:]
+			fileLine := rest[:spaceIdx]
+			colonIdx := strings.LastIndex(fileLine, ":")
+			if colonIdx > 0 {
+				entry.File = fileLine[:colonIdx]
+				entry.Line, _ = strconv.Atoi(fileLine[colonIdx+1:])
+			}
+			entry.Message = strings.TrimRight(rest[spaceIdx+1:], "\n\r")
+		} else {
+			entry.Message = strings.TrimRight(rest, "\n\r")
 		}
 	}
 
+	extractRequestID(&entry)
 	return entry
+}
+
+// extractRequestID extracts request_id prefix from the entry message if present.
+// Format: "request_id:XXXXX rest of message"
+func extractRequestID(entry *LogEntry) {
+	if !strings.HasPrefix(entry.Message, requestIDPrefix) {
+		return
+	}
+	rest := entry.Message[len(requestIDPrefix):]
+	spaceIdx := strings.Index(rest, " ")
+	if spaceIdx > 0 {
+		entry.RequestID = rest[:spaceIdx]
+		entry.Message = rest[spaceIdx+1:]
+	} else if rest != "" {
+		entry.RequestID = strings.TrimSpace(rest)
+		entry.Message = ""
+	}
 }

--- a/weed/logbuffer/parser_test.go
+++ b/weed/logbuffer/parser_test.go
@@ -6,9 +6,11 @@ import (
 	"time"
 )
 
-func TestParseLogLine_FullHeader(t *testing.T) {
-	// Standard glog format: I0318 12:34:56.123456 12345 master_server.go:123] some message
-	raw := []byte("I0318 12:34:56.123456 12345 master_server.go:123] some message\n")
+// ---------- SeaweedFS text format tests ----------
+// SeaweedFS glog format: Lmmdd hh:mm:ss.uuuuuu file:line msg (no threadid, no bracket)
+
+func TestParseLogLine_SeaweedFSFormat(t *testing.T) {
+	raw := []byte("I0318 12:34:56.123456 master_server.go:123 some message\n")
 	entry := ParseLogLine(0, raw)
 
 	if entry.Level != "INFO" {
@@ -31,6 +33,25 @@ func TestParseLogLine_FullHeader(t *testing.T) {
 	}
 }
 
+func TestParseLogLine_StandardGlogFormat(t *testing.T) {
+	// Standard glog with threadid and bracket: Lmmdd hh:mm:ss.uuuuuu threadid file:line] msg
+	raw := []byte("I0318 12:34:56.123456 12345 master_server.go:123] some message\n")
+	entry := ParseLogLine(0, raw)
+
+	if entry.Level != "INFO" {
+		t.Errorf("expected level INFO, got %q", entry.Level)
+	}
+	if entry.File != "master_server.go" {
+		t.Errorf("expected file master_server.go, got %q", entry.File)
+	}
+	if entry.Line != 123 {
+		t.Errorf("expected line 123, got %d", entry.Line)
+	}
+	if entry.Message != "some message" {
+		t.Errorf("expected message 'some message', got %q", entry.Message)
+	}
+}
+
 func TestParseLogLine_AllSeverities(t *testing.T) {
 	tests := []struct {
 		level    int32
@@ -44,7 +65,8 @@ func TestParseLogLine_AllSeverities(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		raw := []byte(string(tt.char) + "0318 12:34:56.123456 12345 test.go:1] msg")
+		// SeaweedFS format (no bracket)
+		raw := []byte(string(tt.char) + "0318 12:34:56.123456 test.go:1 msg")
 		entry := ParseLogLine(tt.level, raw)
 		if entry.Level != tt.wantName {
 			t.Errorf("level %d: expected %q, got %q", tt.level, tt.wantName, entry.Level)
@@ -53,7 +75,8 @@ func TestParseLogLine_AllSeverities(t *testing.T) {
 }
 
 func TestParseLogLine_WithRequestID(t *testing.T) {
-	raw := []byte("I0318 12:34:56.123456 12345 server.go:42] request_id:abc-123 operation completed")
+	// SeaweedFS format
+	raw := []byte("I0318 12:34:56.123456 server.go:42 request_id:abc-123 operation completed")
 	entry := ParseLogLine(0, raw)
 
 	if entry.RequestID != "abc-123" {
@@ -61,6 +84,19 @@ func TestParseLogLine_WithRequestID(t *testing.T) {
 	}
 	if entry.Message != "operation completed" {
 		t.Errorf("expected message 'operation completed', got %q", entry.Message)
+	}
+}
+
+func TestParseLogLine_RequestID_OnlyID(t *testing.T) {
+	// Message is only the request_id with no trailing text
+	raw := []byte("I0318 12:34:56.123456 server.go:42 request_id:abc-123")
+	entry := ParseLogLine(0, raw)
+
+	if entry.RequestID != "abc-123" {
+		t.Errorf("expected request_id 'abc-123', got %q", entry.RequestID)
+	}
+	if entry.Message != "" {
+		t.Errorf("expected empty message, got %q", entry.Message)
 	}
 }
 
@@ -86,36 +122,18 @@ func TestParseLogLine_EmptyLine(t *testing.T) {
 	}
 }
 
-func TestParseLogLine_NoBracket(t *testing.T) {
-	raw := []byte("I0318 12:34:56.123456 12345 server.go:42 no bracket here at all")
-	entry := ParseLogLine(0, raw)
-
-	// Should still extract what it can
-	if entry.Level != "INFO" {
-		t.Errorf("expected INFO, got %q", entry.Level)
-	}
-	// Message should be the full line since no ] separator
-	if entry.Message == "" {
-		t.Error("expected non-empty message for bracketless line")
-	}
-}
-
 func TestParseLogLine_LevelFromInt(t *testing.T) {
-	// When the header char doesn't match but level int32 is provided
-	raw := []byte("X0318 12:34:56.123456 12345 test.go:1] msg")
+	// 'X' is not a known severity char, should keep ERROR from level=2
+	raw := []byte("X0318 12:34:56.123456 test.go:1 msg")
 	entry := ParseLogLine(2, raw)
 
-	// Should use the int32 level since 'X' is not a known severity char
-	// The parser first sets from int32, then overrides from char if valid
-	// 'X' is not valid, so it should keep ERROR from level=2
 	if entry.Level != "ERROR" {
 		t.Errorf("expected ERROR from level int, got %q", entry.Level)
 	}
 }
 
-func TestParseLogLine_MultiLineMessage(t *testing.T) {
-	// Stack traces and multi-line messages
-	raw := []byte("E0318 12:34:56.123456 12345 server.go:42] panic: runtime error")
+func TestParseLogLine_ErrorMessage(t *testing.T) {
+	raw := []byte("E0318 12:34:56.123456 server.go:42 panic: runtime error")
 	entry := ParseLogLine(2, raw)
 
 	if entry.Level != "ERROR" {
@@ -127,7 +145,7 @@ func TestParseLogLine_MultiLineMessage(t *testing.T) {
 }
 
 func TestParseLogLine_TimestampParsing(t *testing.T) {
-	raw := []byte("I1225 23:59:59.999999 12345 test.go:1] christmas")
+	raw := []byte("I1225 23:59:59.999999 test.go:1 christmas")
 	entry := ParseLogLine(0, raw)
 
 	if entry.Timestamp.Month() != time.December {
@@ -141,31 +159,6 @@ func TestParseLogLine_TimestampParsing(t *testing.T) {
 	}
 	if entry.Timestamp.Second() != 59 {
 		t.Errorf("expected second 59, got %d", entry.Timestamp.Second())
-	}
-}
-
-func TestLevelPriority(t *testing.T) {
-	tests := []struct {
-		level string
-		want  int
-	}{
-		{"INFO", 1},
-		{"info", 1},
-		{"WARNING", 2},
-		{"warning", 2},
-		{"ERROR", 3},
-		{"error", 3},
-		{"FATAL", 4},
-		{"fatal", 4},
-		{"UNKNOWN", 0},
-		{"", 0},
-	}
-
-	for _, tt := range tests {
-		got := LevelPriority(tt.level)
-		if got != tt.want {
-			t.Errorf("LevelPriority(%q) = %d, want %d", tt.level, got, tt.want)
-		}
 	}
 }
 
@@ -219,7 +212,6 @@ func TestParseLogLine_JSON_Invalid(t *testing.T) {
 	raw := []byte(`{invalid json}`)
 	entry := ParseLogLine(0, raw)
 
-	// Should fallback gracefully
 	if entry.Message == "" {
 		t.Error("expected non-empty message for invalid JSON")
 	}
@@ -231,14 +223,13 @@ func TestParseLogLine_JSON_EmptyObject(t *testing.T) {
 
 	// Should not panic, fields default to zero values
 	if entry.Level != "INFO" {
-		// Level comes from severityFromLevel[level] fallback
 		t.Logf("level after empty JSON: %q (ok)", entry.Level)
 	}
 }
 
 func TestParseLogLine_AutoDetect(t *testing.T) {
-	// Text format
-	textRaw := []byte("E0319 12:00:00.000000 12345 server.go:42] error happened")
+	// Text format (SeaweedFS)
+	textRaw := []byte("E0319 12:00:00.000000 server.go:42 error happened")
 	textEntry := ParseLogLine(2, textRaw)
 	if textEntry.Level != "ERROR" {
 		t.Errorf("text: expected ERROR, got %q", textEntry.Level)

--- a/weed/logbuffer/parser_test.go
+++ b/weed/logbuffer/parser_test.go
@@ -1,0 +1,264 @@
+package logbuffer
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseLogLine_FullHeader(t *testing.T) {
+	// Standard glog format: I0318 12:34:56.123456 12345 master_server.go:123] some message
+	raw := []byte("I0318 12:34:56.123456 12345 master_server.go:123] some message\n")
+	entry := ParseLogLine(0, raw)
+
+	if entry.Level != "INFO" {
+		t.Errorf("expected level INFO, got %q", entry.Level)
+	}
+	if entry.File != "master_server.go" {
+		t.Errorf("expected file master_server.go, got %q", entry.File)
+	}
+	if entry.Line != 123 {
+		t.Errorf("expected line 123, got %d", entry.Line)
+	}
+	if entry.Message != "some message" {
+		t.Errorf("expected message 'some message', got %q", entry.Message)
+	}
+	if entry.Timestamp.Month() != 3 || entry.Timestamp.Day() != 18 {
+		t.Errorf("expected March 18, got %v", entry.Timestamp)
+	}
+	if entry.Timestamp.Hour() != 12 || entry.Timestamp.Minute() != 34 {
+		t.Errorf("expected 12:34, got %v", entry.Timestamp)
+	}
+}
+
+func TestParseLogLine_AllSeverities(t *testing.T) {
+	tests := []struct {
+		level    int32
+		char     byte
+		wantName string
+	}{
+		{0, 'I', "INFO"},
+		{1, 'W', "WARNING"},
+		{2, 'E', "ERROR"},
+		{3, 'F', "FATAL"},
+	}
+
+	for _, tt := range tests {
+		raw := []byte(string(tt.char) + "0318 12:34:56.123456 12345 test.go:1] msg")
+		entry := ParseLogLine(tt.level, raw)
+		if entry.Level != tt.wantName {
+			t.Errorf("level %d: expected %q, got %q", tt.level, tt.wantName, entry.Level)
+		}
+	}
+}
+
+func TestParseLogLine_WithRequestID(t *testing.T) {
+	raw := []byte("I0318 12:34:56.123456 12345 server.go:42] request_id:abc-123 operation completed")
+	entry := ParseLogLine(0, raw)
+
+	if entry.RequestID != "abc-123" {
+		t.Errorf("expected request_id 'abc-123', got %q", entry.RequestID)
+	}
+	if entry.Message != "operation completed" {
+		t.Errorf("expected message 'operation completed', got %q", entry.Message)
+	}
+}
+
+func TestParseLogLine_ShortLine(t *testing.T) {
+	raw := []byte("short msg")
+	entry := ParseLogLine(0, raw)
+
+	if entry.Message != "short msg" {
+		t.Errorf("expected 'short msg', got %q", entry.Message)
+	}
+	if entry.Level != "INFO" {
+		t.Errorf("expected level fallback INFO, got %q", entry.Level)
+	}
+}
+
+func TestParseLogLine_EmptyLine(t *testing.T) {
+	entry := ParseLogLine(0, []byte(""))
+	if entry.Level != "INFO" {
+		t.Errorf("expected INFO for empty, got %q", entry.Level)
+	}
+	if entry.Message != "" {
+		t.Errorf("expected empty message, got %q", entry.Message)
+	}
+}
+
+func TestParseLogLine_NoBracket(t *testing.T) {
+	raw := []byte("I0318 12:34:56.123456 12345 server.go:42 no bracket here at all")
+	entry := ParseLogLine(0, raw)
+
+	// Should still extract what it can
+	if entry.Level != "INFO" {
+		t.Errorf("expected INFO, got %q", entry.Level)
+	}
+	// Message should be the full line since no ] separator
+	if entry.Message == "" {
+		t.Error("expected non-empty message for bracketless line")
+	}
+}
+
+func TestParseLogLine_LevelFromInt(t *testing.T) {
+	// When the header char doesn't match but level int32 is provided
+	raw := []byte("X0318 12:34:56.123456 12345 test.go:1] msg")
+	entry := ParseLogLine(2, raw)
+
+	// Should use the int32 level since 'X' is not a known severity char
+	// The parser first sets from int32, then overrides from char if valid
+	// 'X' is not valid, so it should keep ERROR from level=2
+	if entry.Level != "ERROR" {
+		t.Errorf("expected ERROR from level int, got %q", entry.Level)
+	}
+}
+
+func TestParseLogLine_MultiLineMessage(t *testing.T) {
+	// Stack traces and multi-line messages
+	raw := []byte("E0318 12:34:56.123456 12345 server.go:42] panic: runtime error")
+	entry := ParseLogLine(2, raw)
+
+	if entry.Level != "ERROR" {
+		t.Errorf("expected ERROR, got %q", entry.Level)
+	}
+	if !strings.Contains(entry.Message, "panic") {
+		t.Errorf("expected message containing 'panic', got %q", entry.Message)
+	}
+}
+
+func TestParseLogLine_TimestampParsing(t *testing.T) {
+	raw := []byte("I1225 23:59:59.999999 12345 test.go:1] christmas")
+	entry := ParseLogLine(0, raw)
+
+	if entry.Timestamp.Month() != time.December {
+		t.Errorf("expected December, got %v", entry.Timestamp.Month())
+	}
+	if entry.Timestamp.Day() != 25 {
+		t.Errorf("expected day 25, got %d", entry.Timestamp.Day())
+	}
+	if entry.Timestamp.Hour() != 23 {
+		t.Errorf("expected hour 23, got %d", entry.Timestamp.Hour())
+	}
+	if entry.Timestamp.Second() != 59 {
+		t.Errorf("expected second 59, got %d", entry.Timestamp.Second())
+	}
+}
+
+func TestLevelPriority(t *testing.T) {
+	tests := []struct {
+		level string
+		want  int
+	}{
+		{"INFO", 1},
+		{"info", 1},
+		{"WARNING", 2},
+		{"warning", 2},
+		{"ERROR", 3},
+		{"error", 3},
+		{"FATAL", 4},
+		{"fatal", 4},
+		{"UNKNOWN", 0},
+		{"", 0},
+	}
+
+	for _, tt := range tests {
+		got := LevelPriority(tt.level)
+		if got != tt.want {
+			t.Errorf("LevelPriority(%q) = %d, want %d", tt.level, got, tt.want)
+		}
+	}
+}
+
+// ---------- JSON format tests ----------
+
+func TestParseLogLine_JSON_Basic(t *testing.T) {
+	raw := []byte(`{"ts":"2026-03-19T15:30:00.123456Z","level":"INFO","file":"server.go","line":42,"msg":"hello world"}`)
+	entry := ParseLogLine(0, raw)
+
+	if entry.Level != "INFO" {
+		t.Errorf("expected INFO, got %q", entry.Level)
+	}
+	if entry.File != "server.go" {
+		t.Errorf("expected server.go, got %q", entry.File)
+	}
+	if entry.Line != 42 {
+		t.Errorf("expected line 42, got %d", entry.Line)
+	}
+	if entry.Message != "hello world" {
+		t.Errorf("expected 'hello world', got %q", entry.Message)
+	}
+	if entry.Timestamp.Year() != 2026 || entry.Timestamp.Month() != 3 {
+		t.Errorf("expected 2026-03, got %v", entry.Timestamp)
+	}
+}
+
+func TestParseLogLine_JSON_AllLevels(t *testing.T) {
+	levels := []string{"INFO", "WARNING", "ERROR", "FATAL"}
+	for _, lvl := range levels {
+		raw := []byte(`{"ts":"2026-03-19T12:00:00Z","level":"` + lvl + `","file":"t.go","line":1,"msg":"x"}`)
+		entry := ParseLogLine(0, raw)
+		if entry.Level != lvl {
+			t.Errorf("expected %s, got %q", lvl, entry.Level)
+		}
+	}
+}
+
+func TestParseLogLine_JSON_WithRequestID(t *testing.T) {
+	raw := []byte(`{"ts":"2026-03-19T12:00:00Z","level":"INFO","file":"t.go","line":1,"msg":"request_id:abc-123 operation done"}`)
+	entry := ParseLogLine(0, raw)
+
+	if entry.RequestID != "abc-123" {
+		t.Errorf("expected request_id 'abc-123', got %q", entry.RequestID)
+	}
+	if entry.Message != "operation done" {
+		t.Errorf("expected 'operation done', got %q", entry.Message)
+	}
+}
+
+func TestParseLogLine_JSON_Invalid(t *testing.T) {
+	raw := []byte(`{invalid json}`)
+	entry := ParseLogLine(0, raw)
+
+	// Should fallback gracefully
+	if entry.Message == "" {
+		t.Error("expected non-empty message for invalid JSON")
+	}
+}
+
+func TestParseLogLine_JSON_EmptyObject(t *testing.T) {
+	raw := []byte(`{}`)
+	entry := ParseLogLine(0, raw)
+
+	// Should not panic, fields default to zero values
+	if entry.Level != "INFO" {
+		// Level comes from severityFromLevel[level] fallback
+		t.Logf("level after empty JSON: %q (ok)", entry.Level)
+	}
+}
+
+func TestParseLogLine_AutoDetect(t *testing.T) {
+	// Text format
+	textRaw := []byte("E0319 12:00:00.000000 12345 server.go:42] error happened")
+	textEntry := ParseLogLine(2, textRaw)
+	if textEntry.Level != "ERROR" {
+		t.Errorf("text: expected ERROR, got %q", textEntry.Level)
+	}
+	if textEntry.File != "server.go" {
+		t.Errorf("text: expected server.go, got %q", textEntry.File)
+	}
+
+	// JSON format
+	jsonRaw := []byte(`{"ts":"2026-03-19T12:00:00Z","level":"ERROR","file":"server.go","line":42,"msg":"error happened"}`)
+	jsonEntry := ParseLogLine(2, jsonRaw)
+	if jsonEntry.Level != "ERROR" {
+		t.Errorf("json: expected ERROR, got %q", jsonEntry.Level)
+	}
+	if jsonEntry.File != "server.go" {
+		t.Errorf("json: expected server.go, got %q", jsonEntry.File)
+	}
+
+	// Both should produce same logical content
+	if textEntry.Message != jsonEntry.Message {
+		t.Errorf("message mismatch: text=%q json=%q", textEntry.Message, jsonEntry.Message)
+	}
+}

--- a/weed/logbuffer/ring.go
+++ b/weed/logbuffer/ring.go
@@ -1,0 +1,398 @@
+package logbuffer
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const defaultCapacity = 10000
+
+// RingBuffer is a thread-safe circular buffer for log entries
+// with support for live subscribers (SSE streaming) and runtime stats.
+type RingBuffer struct {
+	mu      sync.RWMutex
+	entries []LogEntry
+	head    int // next write position
+	count   int
+	cap     int
+
+	subsMu sync.RWMutex
+	subs   map[uint64]chan LogEntry
+	nextID uint64
+
+	// Stats counters (atomic, lock-free reads)
+	totalWritten uint64
+	dropped      uint64 // entries dropped due to slow subscribers
+	infoCount    uint64
+	warnCount    uint64
+	errorCount   uint64
+	fatalCount   uint64
+}
+
+// BufferStats holds runtime statistics about the ring buffer.
+type BufferStats struct {
+	Capacity     int     `json:"capacity"`
+	Used         int     `json:"used"`
+	UsagePercent float64 `json:"usage_percent"`
+	TotalWritten uint64  `json:"total_written"`
+	Dropped      uint64  `json:"dropped"`
+	Subscribers  int     `json:"subscribers"`
+	ByLevel      struct {
+		Info    uint64 `json:"info"`
+		Warning uint64 `json:"warning"`
+		Error   uint64 `json:"error"`
+		Fatal   uint64 `json:"fatal"`
+	} `json:"by_level"`
+}
+
+// NewRingBuffer creates a ring buffer with the given capacity.
+func NewRingBuffer(capacity int) *RingBuffer {
+	if capacity <= 0 {
+		capacity = defaultCapacity
+	}
+	return &RingBuffer{
+		entries: make([]LogEntry, capacity),
+		cap:     capacity,
+		subs:    make(map[uint64]chan LogEntry),
+	}
+}
+
+// Write adds a log entry to the ring buffer and notifies subscribers.
+func (rb *RingBuffer) Write(entry LogEntry) {
+	rb.mu.Lock()
+	rb.entries[rb.head] = entry
+	rb.head = (rb.head + 1) % rb.cap
+	if rb.count < rb.cap {
+		rb.count++
+	}
+	rb.mu.Unlock()
+
+	// Update stats (lock-free)
+	atomic.AddUint64(&rb.totalWritten, 1)
+	switch strings.ToUpper(entry.Level) {
+	case "INFO":
+		atomic.AddUint64(&rb.infoCount, 1)
+	case "WARNING":
+		atomic.AddUint64(&rb.warnCount, 1)
+	case "ERROR":
+		atomic.AddUint64(&rb.errorCount, 1)
+	case "FATAL":
+		atomic.AddUint64(&rb.fatalCount, 1)
+	}
+
+	// Fan-out to SSE subscribers (non-blocking)
+	rb.subsMu.RLock()
+	for _, ch := range rb.subs {
+		select {
+		case ch <- entry:
+		default:
+			// Drop if subscriber is slow — count it
+			atomic.AddUint64(&rb.dropped, 1)
+		}
+	}
+	rb.subsMu.RUnlock()
+}
+
+// Subscribe returns a channel that receives new log entries and an unsubscribe function.
+// The channel has a buffer of 256 entries to handle bursts.
+func (rb *RingBuffer) Subscribe() (<-chan LogEntry, func()) {
+	ch := make(chan LogEntry, 256)
+
+	rb.subsMu.Lock()
+	id := rb.nextID
+	rb.nextID++
+	rb.subs[id] = ch
+	rb.subsMu.Unlock()
+
+	unsubscribe := func() {
+		rb.subsMu.Lock()
+		delete(rb.subs, id)
+		close(ch)
+		rb.subsMu.Unlock()
+	}
+
+	return ch, unsubscribe
+}
+
+// Stats returns a snapshot of the buffer's runtime statistics.
+func (rb *RingBuffer) Stats() BufferStats {
+	rb.mu.RLock()
+	used := rb.count
+	cap_ := rb.cap
+	rb.mu.RUnlock()
+
+	rb.subsMu.RLock()
+	subs := len(rb.subs)
+	rb.subsMu.RUnlock()
+
+	s := BufferStats{
+		Capacity:     cap_,
+		Used:         used,
+		TotalWritten: atomic.LoadUint64(&rb.totalWritten),
+		Dropped:      atomic.LoadUint64(&rb.dropped),
+		Subscribers:  subs,
+	}
+	if cap_ > 0 {
+		s.UsagePercent = float64(used) / float64(cap_) * 100
+	}
+	s.ByLevel.Info = atomic.LoadUint64(&rb.infoCount)
+	s.ByLevel.Warning = atomic.LoadUint64(&rb.warnCount)
+	s.ByLevel.Error = atomic.LoadUint64(&rb.errorCount)
+	s.ByLevel.Fatal = atomic.LoadUint64(&rb.fatalCount)
+	return s
+}
+
+// Query returns log entries matching the given filter.
+// Entries are returned in chronological order (oldest first).
+// Returns an error string in QueryResult if the regex pattern is invalid.
+func (rb *RingBuffer) Query(f Filter) QueryResult {
+	rb.mu.RLock()
+	defer rb.mu.RUnlock()
+
+	if rb.count == 0 {
+		return QueryResult{}
+	}
+
+	// Set defaults
+	limit := f.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	if limit > rb.count {
+		limit = rb.count
+	}
+
+	minLevel := LevelPriority(f.Level)
+
+	var compiledPattern *regexp.Regexp
+	if f.Pattern != "" {
+		var err error
+		compiledPattern, err = regexp.Compile(f.Pattern)
+		if err != nil {
+			return QueryResult{
+				Error: fmt.Sprintf("invalid regex pattern: %v", err),
+			}
+		}
+	}
+
+	// Iterate from oldest to newest
+	start := 0
+	if rb.count == rb.cap {
+		start = rb.head // oldest entry when buffer is full
+	}
+
+	var matched []LogEntry
+	skipped := 0
+	total := 0
+
+	for i := 0; i < rb.count; i++ {
+		idx := (start + i) % rb.cap
+		entry := rb.entries[idx]
+
+		if !matchesFilter(entry, f, minLevel, compiledPattern) {
+			continue
+		}
+
+		total++
+
+		if skipped < f.Offset {
+			skipped++
+			continue
+		}
+
+		if len(matched) < limit {
+			matched = append(matched, entry)
+		}
+	}
+
+	return QueryResult{
+		Entries: matched,
+		Total:   total,
+		HasMore: total > f.Offset+len(matched),
+	}
+}
+
+// Snapshot returns the last N entries (no filtering).
+func (rb *RingBuffer) Snapshot(n int) []LogEntry {
+	rb.mu.RLock()
+	defer rb.mu.RUnlock()
+
+	if n <= 0 || rb.count == 0 {
+		return nil
+	}
+	if n > rb.count {
+		n = rb.count
+	}
+
+	result := make([]LogEntry, n)
+	start := (rb.head - n + rb.cap) % rb.cap
+	for i := 0; i < n; i++ {
+		result[i] = rb.entries[(start+i)%rb.cap]
+	}
+	return result
+}
+
+// RecentErrors returns the last N error/fatal entries for quick diagnosis.
+func (rb *RingBuffer) RecentErrors(n int) []LogEntry {
+	rb.mu.RLock()
+	defer rb.mu.RUnlock()
+
+	if n <= 0 || rb.count == 0 {
+		return nil
+	}
+
+	var result []LogEntry
+	// Walk backwards from newest entry
+	for i := 0; i < rb.count && len(result) < n; i++ {
+		idx := (rb.head - 1 - i + rb.cap) % rb.cap
+		entry := rb.entries[idx]
+		if LevelPriority(entry.Level) >= 3 { // ERROR or FATAL
+			result = append(result, entry)
+		}
+	}
+
+	// Reverse to chronological order (oldest first)
+	for i, j := 0, len(result)-1; i < j; i, j = i+1, j-1 {
+		result[i], result[j] = result[j], result[i]
+	}
+	return result
+}
+
+// TopFiles returns the N source files that generated the most log entries.
+func (rb *RingBuffer) TopFiles(n int) []FileCount {
+	rb.mu.RLock()
+	defer rb.mu.RUnlock()
+
+	counts := make(map[string]int)
+	start := 0
+	if rb.count == rb.cap {
+		start = rb.head
+	}
+	for i := 0; i < rb.count; i++ {
+		idx := (start + i) % rb.cap
+		f := rb.entries[idx].File
+		if f != "" {
+			counts[f]++
+		}
+	}
+
+	// Sort by count descending
+	type kv struct {
+		file  string
+		count int
+	}
+	var sorted []kv
+	for f, c := range counts {
+		sorted = append(sorted, kv{f, c})
+	}
+	for i := 0; i < len(sorted); i++ {
+		for j := i + 1; j < len(sorted); j++ {
+			if sorted[j].count > sorted[i].count {
+				sorted[i], sorted[j] = sorted[j], sorted[i]
+			}
+		}
+	}
+
+	if n > len(sorted) {
+		n = len(sorted)
+	}
+	result := make([]FileCount, n)
+	for i := 0; i < n; i++ {
+		result[i] = FileCount{File: sorted[i].file, Count: sorted[i].count}
+	}
+	return result
+}
+
+// ErrorRate returns error+fatal count in the given time window.
+func (rb *RingBuffer) ErrorRate(window time.Duration) ErrorRateResult {
+	rb.mu.RLock()
+	defer rb.mu.RUnlock()
+
+	cutoff := time.Now().Add(-window)
+	var errors, total int
+
+	start := 0
+	if rb.count == rb.cap {
+		start = rb.head
+	}
+	for i := 0; i < rb.count; i++ {
+		idx := (start + i) % rb.cap
+		entry := rb.entries[idx]
+		if entry.Timestamp.Before(cutoff) {
+			continue
+		}
+		total++
+		p := LevelPriority(entry.Level)
+		if p >= 3 {
+			errors++
+		}
+	}
+
+	var rate float64
+	if total > 0 {
+		rate = float64(errors) / float64(total) * 100
+	}
+
+	return ErrorRateResult{
+		Window:     window.String(),
+		TotalLogs:  total,
+		ErrorCount: errors,
+		ErrorRate:  rate,
+	}
+}
+
+func matchesFilter(entry LogEntry, f Filter, minLevel int, pattern *regexp.Regexp) bool {
+	// Level filter
+	if minLevel > 0 && LevelPriority(entry.Level) < minLevel {
+		return false
+	}
+
+	// Time range
+	if !f.Since.IsZero() && entry.Timestamp.Before(f.Since) {
+		return false
+	}
+	if !f.Until.IsZero() && entry.Timestamp.After(f.Until) {
+		return false
+	}
+
+	// File pattern (glob)
+	if f.File != "" {
+		matched, _ := filepath.Match(f.File, entry.File)
+		if !matched {
+			return false
+		}
+	}
+
+	// Request ID
+	if f.RequestID != "" && entry.RequestID != f.RequestID {
+		return false
+	}
+
+	// Regex pattern on message
+	if pattern != nil && !pattern.MatchString(entry.Message) {
+		return false
+	}
+
+	return true
+}
+
+// LevelPriority converts a level name to a numeric priority for comparisons.
+func LevelPriority(level string) int {
+	switch strings.ToUpper(level) {
+	case "INFO":
+		return 1
+	case "WARNING":
+		return 2
+	case "ERROR":
+		return 3
+	case "FATAL":
+		return 4
+	default:
+		return 0
+	}
+}

--- a/weed/logbuffer/ring.go
+++ b/weed/logbuffer/ring.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -151,6 +152,21 @@ func (rb *RingBuffer) Stats() BufferStats {
 // Entries are returned in chronological order (oldest first).
 // Returns an error string in QueryResult if the regex pattern is invalid.
 func (rb *RingBuffer) Query(f Filter) QueryResult {
+	// Compile regex and compute filter params before acquiring lock
+	// to avoid blocking writers during regex compilation.
+	minLevel := LevelPriority(f.Level)
+
+	var compiledPattern *regexp.Regexp
+	if f.Pattern != "" {
+		var err error
+		compiledPattern, err = regexp.Compile(f.Pattern)
+		if err != nil {
+			return QueryResult{
+				Error: fmt.Sprintf("invalid regex pattern: %v", err),
+			}
+		}
+	}
+
 	rb.mu.RLock()
 	defer rb.mu.RUnlock()
 
@@ -165,19 +181,6 @@ func (rb *RingBuffer) Query(f Filter) QueryResult {
 	}
 	if limit > rb.count {
 		limit = rb.count
-	}
-
-	minLevel := LevelPriority(f.Level)
-
-	var compiledPattern *regexp.Regexp
-	if f.Pattern != "" {
-		var err error
-		compiledPattern, err = regexp.Compile(f.Pattern)
-		if err != nil {
-			return QueryResult{
-				Error: fmt.Sprintf("invalid regex pattern: %v", err),
-			}
-		}
 	}
 
 	// Iterate from oldest to newest
@@ -290,13 +293,9 @@ func (rb *RingBuffer) TopFiles(n int) []FileCount {
 	for f, c := range counts {
 		sorted = append(sorted, kv{f, c})
 	}
-	for i := 0; i < len(sorted); i++ {
-		for j := i + 1; j < len(sorted); j++ {
-			if sorted[j].count > sorted[i].count {
-				sorted[i], sorted[j] = sorted[j], sorted[i]
-			}
-		}
-	}
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].count > sorted[j].count
+	})
 
 	if n > len(sorted) {
 		n = len(sorted)

--- a/weed/logbuffer/ring_test.go
+++ b/weed/logbuffer/ring_test.go
@@ -175,11 +175,15 @@ func TestRingBuffer_QueryInvalidRegex(t *testing.T) {
 	now := time.Now()
 	rb.Write(makeEntry("INFO", "test", now))
 
-	// Invalid regex should return error or no panic
 	result := rb.Query(Filter{Pattern: "[invalid"})
-	// After fix: should return 0 results with no panic
-	if result.Total < 0 {
-		t.Error("query with invalid regex should not panic")
+	if result.Error == "" {
+		t.Error("expected error for invalid regex pattern")
+	}
+	if result.Total != 0 {
+		t.Errorf("expected 0 results for invalid regex, got %d", result.Total)
+	}
+	if len(result.Entries) != 0 {
+		t.Errorf("expected 0 entries for invalid regex, got %d", len(result.Entries))
 	}
 }
 
@@ -611,6 +615,31 @@ func TestRingBuffer_ErrorRate_OutsideWindow(t *testing.T) {
 	}
 }
 
+func TestLevelPriority(t *testing.T) {
+	tests := []struct {
+		level string
+		want  int
+	}{
+		{"INFO", 1},
+		{"info", 1},
+		{"WARNING", 2},
+		{"warning", 2},
+		{"ERROR", 3},
+		{"error", 3},
+		{"FATAL", 4},
+		{"fatal", 4},
+		{"UNKNOWN", 0},
+		{"", 0},
+	}
+
+	for _, tt := range tests {
+		got := LevelPriority(tt.level)
+		if got != tt.want {
+			t.Errorf("LevelPriority(%q) = %d, want %d", tt.level, got, tt.want)
+		}
+	}
+}
+
 func BenchmarkRingBuffer_Write(b *testing.B) {
 	rb := NewRingBuffer(10000)
 	entry := makeEntry("INFO", "benchmark message", time.Now())
@@ -635,7 +664,7 @@ func BenchmarkRingBuffer_Query(b *testing.B) {
 }
 
 func BenchmarkParseLogLine(b *testing.B) {
-	raw := []byte("I0318 12:34:56.123456 12345 master_server.go:123] request_id:abc123 operation completed successfully\n")
+	raw := []byte("I0318 12:34:56.123456 master_server.go:123 request_id:abc123 operation completed successfully\n")
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		ParseLogLine(0, raw)

--- a/weed/logbuffer/ring_test.go
+++ b/weed/logbuffer/ring_test.go
@@ -1,0 +1,643 @@
+package logbuffer
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+func makeEntry(level string, msg string, ts time.Time) LogEntry {
+	return LogEntry{
+		Timestamp: ts,
+		Level:     level,
+		File:      "test.go",
+		Line:      1,
+		Message:   msg,
+	}
+}
+
+func TestNewRingBuffer(t *testing.T) {
+	rb := NewRingBuffer(100)
+	if rb.cap != 100 {
+		t.Errorf("expected capacity 100, got %d", rb.cap)
+	}
+	if rb.count != 0 {
+		t.Errorf("expected count 0, got %d", rb.count)
+	}
+}
+
+func TestNewRingBuffer_DefaultCapacity(t *testing.T) {
+	rb := NewRingBuffer(0)
+	if rb.cap != defaultCapacity {
+		t.Errorf("expected default capacity %d, got %d", defaultCapacity, rb.cap)
+	}
+
+	rb = NewRingBuffer(-1)
+	if rb.cap != defaultCapacity {
+		t.Errorf("expected default capacity for negative, got %d", rb.cap)
+	}
+}
+
+func TestRingBuffer_WriteAndSnapshot(t *testing.T) {
+	rb := NewRingBuffer(5)
+	now := time.Now()
+
+	for i := 0; i < 3; i++ {
+		rb.Write(makeEntry("INFO", fmt.Sprintf("msg-%d", i), now.Add(time.Duration(i)*time.Second)))
+	}
+
+	snap := rb.Snapshot(10)
+	if len(snap) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(snap))
+	}
+	if snap[0].Message != "msg-0" {
+		t.Errorf("expected first entry msg-0, got %q", snap[0].Message)
+	}
+	if snap[2].Message != "msg-2" {
+		t.Errorf("expected last entry msg-2, got %q", snap[2].Message)
+	}
+}
+
+func TestRingBuffer_Wraparound(t *testing.T) {
+	rb := NewRingBuffer(3)
+	now := time.Now()
+
+	// Write 5 entries into buffer of 3 — oldest 2 should be gone
+	for i := 0; i < 5; i++ {
+		rb.Write(makeEntry("INFO", fmt.Sprintf("msg-%d", i), now.Add(time.Duration(i)*time.Second)))
+	}
+
+	if rb.count != 3 {
+		t.Errorf("expected count 3 after wraparound, got %d", rb.count)
+	}
+
+	snap := rb.Snapshot(10)
+	if len(snap) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(snap))
+	}
+	// Should have msg-2, msg-3, msg-4 (oldest first)
+	if snap[0].Message != "msg-2" {
+		t.Errorf("expected msg-2 after wraparound, got %q", snap[0].Message)
+	}
+	if snap[2].Message != "msg-4" {
+		t.Errorf("expected msg-4 as newest, got %q", snap[2].Message)
+	}
+}
+
+func TestRingBuffer_SnapshotEmpty(t *testing.T) {
+	rb := NewRingBuffer(10)
+	snap := rb.Snapshot(5)
+	if snap != nil {
+		t.Errorf("expected nil for empty buffer, got %v", snap)
+	}
+}
+
+func TestRingBuffer_SnapshotZero(t *testing.T) {
+	rb := NewRingBuffer(10)
+	rb.Write(makeEntry("INFO", "msg", time.Now()))
+	snap := rb.Snapshot(0)
+	if snap != nil {
+		t.Errorf("expected nil for n=0, got %v", snap)
+	}
+}
+
+func TestRingBuffer_QueryByLevel(t *testing.T) {
+	rb := NewRingBuffer(100)
+	now := time.Now()
+
+	rb.Write(makeEntry("INFO", "info-msg", now))
+	rb.Write(makeEntry("WARNING", "warn-msg", now.Add(time.Second)))
+	rb.Write(makeEntry("ERROR", "error-msg", now.Add(2*time.Second)))
+
+	result := rb.Query(Filter{Level: "WARNING"})
+	if result.Total != 2 {
+		t.Errorf("expected 2 entries >= WARNING, got %d", result.Total)
+	}
+	for _, e := range result.Entries {
+		if e.Level == "INFO" {
+			t.Error("INFO should be filtered out for WARNING minimum")
+		}
+	}
+}
+
+func TestRingBuffer_QueryByTimeRange(t *testing.T) {
+	rb := NewRingBuffer(100)
+	base := time.Date(2026, 3, 18, 12, 0, 0, 0, time.UTC)
+
+	rb.Write(makeEntry("INFO", "early", base))
+	rb.Write(makeEntry("INFO", "middle", base.Add(5*time.Minute)))
+	rb.Write(makeEntry("INFO", "late", base.Add(10*time.Minute)))
+
+	result := rb.Query(Filter{
+		Since: base.Add(3 * time.Minute),
+		Until: base.Add(7 * time.Minute),
+	})
+	if result.Total != 1 {
+		t.Errorf("expected 1 entry in time range, got %d", result.Total)
+	}
+	if len(result.Entries) > 0 && result.Entries[0].Message != "middle" {
+		t.Errorf("expected 'middle', got %q", result.Entries[0].Message)
+	}
+}
+
+func TestRingBuffer_QueryByPattern(t *testing.T) {
+	rb := NewRingBuffer(100)
+	now := time.Now()
+
+	rb.Write(makeEntry("INFO", "user login successful", now))
+	rb.Write(makeEntry("INFO", "file uploaded", now.Add(time.Second)))
+	rb.Write(makeEntry("ERROR", "user login failed", now.Add(2*time.Second)))
+
+	result := rb.Query(Filter{Pattern: "user login"})
+	if result.Total != 2 {
+		t.Errorf("expected 2 entries matching 'user login', got %d", result.Total)
+	}
+}
+
+func TestRingBuffer_QueryByRegex(t *testing.T) {
+	rb := NewRingBuffer(100)
+	now := time.Now()
+
+	rb.Write(makeEntry("INFO", "request took 150ms", now))
+	rb.Write(makeEntry("INFO", "request took 2500ms", now.Add(time.Second)))
+	rb.Write(makeEntry("INFO", "request took 50ms", now.Add(2*time.Second)))
+
+	// Regex: find requests taking 1000ms+ (4+ digits before 'ms')
+	result := rb.Query(Filter{Pattern: `\d{4,}ms`})
+	if result.Total != 1 {
+		t.Errorf("expected 1 entry with 4+ digit ms, got %d", result.Total)
+	}
+}
+
+func TestRingBuffer_QueryInvalidRegex(t *testing.T) {
+	rb := NewRingBuffer(100)
+	now := time.Now()
+	rb.Write(makeEntry("INFO", "test", now))
+
+	// Invalid regex should return error or no panic
+	result := rb.Query(Filter{Pattern: "[invalid"})
+	// After fix: should return 0 results with no panic
+	if result.Total < 0 {
+		t.Error("query with invalid regex should not panic")
+	}
+}
+
+func TestRingBuffer_QueryByFile(t *testing.T) {
+	rb := NewRingBuffer(100)
+	now := time.Now()
+
+	e1 := makeEntry("INFO", "msg1", now)
+	e1.File = "master_server.go"
+	e2 := makeEntry("INFO", "msg2", now.Add(time.Second))
+	e2.File = "volume_server.go"
+	e3 := makeEntry("INFO", "msg3", now.Add(2*time.Second))
+	e3.File = "master_grpc.go"
+
+	rb.Write(e1)
+	rb.Write(e2)
+	rb.Write(e3)
+
+	result := rb.Query(Filter{File: "master_*"})
+	if result.Total != 2 {
+		t.Errorf("expected 2 entries matching master_*, got %d", result.Total)
+	}
+}
+
+func TestRingBuffer_QueryByRequestID(t *testing.T) {
+	rb := NewRingBuffer(100)
+	now := time.Now()
+
+	e1 := makeEntry("INFO", "step1", now)
+	e1.RequestID = "req-abc"
+	e2 := makeEntry("INFO", "step2", now.Add(time.Second))
+	e2.RequestID = "req-xyz"
+	e3 := makeEntry("INFO", "step3", now.Add(2*time.Second))
+	e3.RequestID = "req-abc"
+
+	rb.Write(e1)
+	rb.Write(e2)
+	rb.Write(e3)
+
+	result := rb.Query(Filter{RequestID: "req-abc"})
+	if result.Total != 2 {
+		t.Errorf("expected 2 entries for req-abc, got %d", result.Total)
+	}
+}
+
+func TestRingBuffer_QueryPagination(t *testing.T) {
+	rb := NewRingBuffer(100)
+	now := time.Now()
+
+	for i := 0; i < 20; i++ {
+		rb.Write(makeEntry("INFO", fmt.Sprintf("msg-%d", i), now.Add(time.Duration(i)*time.Second)))
+	}
+
+	// Page 1: offset=0, limit=5
+	r1 := rb.Query(Filter{Limit: 5, Offset: 0})
+	if len(r1.Entries) != 5 {
+		t.Errorf("page 1: expected 5 entries, got %d", len(r1.Entries))
+	}
+	if r1.Total != 20 {
+		t.Errorf("expected total 20, got %d", r1.Total)
+	}
+	if !r1.HasMore {
+		t.Error("expected HasMore=true for page 1")
+	}
+	if r1.Entries[0].Message != "msg-0" {
+		t.Errorf("expected first entry msg-0, got %q", r1.Entries[0].Message)
+	}
+
+	// Page 2: offset=5, limit=5
+	r2 := rb.Query(Filter{Limit: 5, Offset: 5})
+	if len(r2.Entries) != 5 {
+		t.Errorf("page 2: expected 5 entries, got %d", len(r2.Entries))
+	}
+	if r2.Entries[0].Message != "msg-5" {
+		t.Errorf("expected page 2 first entry msg-5, got %q", r2.Entries[0].Message)
+	}
+
+	// Last page: offset=18, limit=5
+	r3 := rb.Query(Filter{Limit: 5, Offset: 18})
+	if len(r3.Entries) != 2 {
+		t.Errorf("last page: expected 2 entries, got %d", len(r3.Entries))
+	}
+	if r3.HasMore {
+		t.Error("expected HasMore=false for last page")
+	}
+}
+
+func TestRingBuffer_Subscribe(t *testing.T) {
+	rb := NewRingBuffer(100)
+
+	ch, unsub := rb.Subscribe()
+	defer unsub()
+
+	go func() {
+		rb.Write(makeEntry("INFO", "live-msg", time.Now()))
+	}()
+
+	select {
+	case entry := <-ch:
+		if entry.Message != "live-msg" {
+			t.Errorf("expected 'live-msg', got %q", entry.Message)
+		}
+	case <-time.After(2 * time.Second):
+		t.Error("timeout waiting for subscriber message")
+	}
+}
+
+func TestRingBuffer_SubscribeMultiple(t *testing.T) {
+	rb := NewRingBuffer(100)
+
+	ch1, unsub1 := rb.Subscribe()
+	defer unsub1()
+	ch2, unsub2 := rb.Subscribe()
+	defer unsub2()
+
+	rb.Write(makeEntry("INFO", "broadcast", time.Now()))
+
+	for i, ch := range []<-chan LogEntry{ch1, ch2} {
+		select {
+		case entry := <-ch:
+			if entry.Message != "broadcast" {
+				t.Errorf("subscriber %d: expected 'broadcast', got %q", i, entry.Message)
+			}
+		case <-time.After(2 * time.Second):
+			t.Errorf("subscriber %d: timeout", i)
+		}
+	}
+}
+
+func TestRingBuffer_UnsubscribeStopsDelivery(t *testing.T) {
+	rb := NewRingBuffer(100)
+
+	ch, unsub := rb.Subscribe()
+	unsub()
+
+	// Write after unsubscribe — channel should be closed
+	rb.Write(makeEntry("INFO", "after-unsub", time.Now()))
+
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Error("expected channel to be closed after unsubscribe")
+		}
+	case <-time.After(500 * time.Millisecond):
+		// Channel closed, no more data — this is fine
+	}
+}
+
+func TestRingBuffer_ConcurrentWriteAndQuery(t *testing.T) {
+	rb := NewRingBuffer(1000)
+	var wg sync.WaitGroup
+
+	// Concurrent writers
+	for w := 0; w < 5; w++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < 200; i++ {
+				rb.Write(makeEntry("INFO", fmt.Sprintf("w%d-msg-%d", id, i), time.Now()))
+			}
+		}(w)
+	}
+
+	// Concurrent readers
+	for r := 0; r < 3; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 50; i++ {
+				rb.Query(Filter{Limit: 10})
+				rb.Snapshot(5)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// After all writes: 5 writers * 200 = 1000 entries, buffer is 1000
+	if rb.count != 1000 {
+		t.Errorf("expected 1000 entries, got %d", rb.count)
+	}
+}
+
+func TestRingBuffer_QueryCombinedFilters(t *testing.T) {
+	rb := NewRingBuffer(100)
+	base := time.Date(2026, 3, 18, 12, 0, 0, 0, time.UTC)
+
+	e1 := makeEntry("INFO", "user login ok", base)
+	e1.File = "auth.go"
+	e1.RequestID = "req-1"
+
+	e2 := makeEntry("ERROR", "user login failed", base.Add(time.Second))
+	e2.File = "auth.go"
+	e2.RequestID = "req-2"
+
+	e3 := makeEntry("ERROR", "disk full", base.Add(2*time.Second))
+	e3.File = "storage.go"
+	e3.RequestID = "req-3"
+
+	rb.Write(e1)
+	rb.Write(e2)
+	rb.Write(e3)
+
+	// Combine level + file + pattern
+	result := rb.Query(Filter{
+		Level:   "ERROR",
+		File:    "auth*",
+		Pattern: "login",
+	})
+	if result.Total != 1 {
+		t.Errorf("expected 1 combined match, got %d", result.Total)
+	}
+	if len(result.Entries) > 0 && result.Entries[0].Message != "user login failed" {
+		t.Errorf("expected 'user login failed', got %q", result.Entries[0].Message)
+	}
+}
+
+// ---------- Stats / RecentErrors / TopFiles / ErrorRate ----------
+
+func TestRingBuffer_Stats(t *testing.T) {
+	rb := NewRingBuffer(100)
+	now := time.Now()
+
+	rb.Write(makeEntry("INFO", "a", now))
+	rb.Write(makeEntry("INFO", "b", now))
+	rb.Write(makeEntry("WARNING", "c", now))
+	rb.Write(makeEntry("ERROR", "d", now))
+	rb.Write(makeEntry("FATAL", "e", now))
+
+	s := rb.Stats()
+	if s.Capacity != 100 {
+		t.Errorf("expected capacity 100, got %d", s.Capacity)
+	}
+	if s.Used != 5 {
+		t.Errorf("expected used 5, got %d", s.Used)
+	}
+	if s.TotalWritten != 5 {
+		t.Errorf("expected totalWritten 5, got %d", s.TotalWritten)
+	}
+	if s.ByLevel.Info != 2 {
+		t.Errorf("expected 2 info, got %d", s.ByLevel.Info)
+	}
+	if s.ByLevel.Warning != 1 {
+		t.Errorf("expected 1 warning, got %d", s.ByLevel.Warning)
+	}
+	if s.ByLevel.Error != 1 {
+		t.Errorf("expected 1 error, got %d", s.ByLevel.Error)
+	}
+	if s.ByLevel.Fatal != 1 {
+		t.Errorf("expected 1 fatal, got %d", s.ByLevel.Fatal)
+	}
+	if s.UsagePercent != 5.0 {
+		t.Errorf("expected usage 5%%, got %.1f%%", s.UsagePercent)
+	}
+}
+
+func TestRingBuffer_StatsDropped(t *testing.T) {
+	rb := NewRingBuffer(100)
+	ch, unsub := rb.Subscribe()
+	defer unsub()
+
+	// Fill subscriber channel (buffer=256) then overflow
+	for i := 0; i < 300; i++ {
+		rb.Write(makeEntry("INFO", fmt.Sprintf("msg-%d", i), time.Now()))
+	}
+
+	s := rb.Stats()
+	if s.Dropped == 0 {
+		t.Error("expected some dropped entries for slow subscriber")
+	}
+	if s.Subscribers != 1 {
+		t.Errorf("expected 1 subscriber, got %d", s.Subscribers)
+	}
+
+	// Drain to avoid goroutine leak
+	for len(ch) > 0 {
+		<-ch
+	}
+}
+
+func TestRingBuffer_RecentErrors(t *testing.T) {
+	rb := NewRingBuffer(100)
+	now := time.Now()
+
+	rb.Write(makeEntry("INFO", "ok1", now))
+	rb.Write(makeEntry("ERROR", "err1", now.Add(1*time.Second)))
+	rb.Write(makeEntry("INFO", "ok2", now.Add(2*time.Second)))
+	rb.Write(makeEntry("FATAL", "fatal1", now.Add(3*time.Second)))
+	rb.Write(makeEntry("ERROR", "err2", now.Add(4*time.Second)))
+	rb.Write(makeEntry("INFO", "ok3", now.Add(5*time.Second)))
+
+	errs := rb.RecentErrors(10)
+	if len(errs) != 3 {
+		t.Fatalf("expected 3 errors, got %d", len(errs))
+	}
+	// Should be in chronological order
+	if errs[0].Message != "err1" {
+		t.Errorf("expected first error 'err1', got %q", errs[0].Message)
+	}
+	if errs[1].Message != "fatal1" {
+		t.Errorf("expected second error 'fatal1', got %q", errs[1].Message)
+	}
+	if errs[2].Message != "err2" {
+		t.Errorf("expected third error 'err2', got %q", errs[2].Message)
+	}
+}
+
+func TestRingBuffer_RecentErrors_Limit(t *testing.T) {
+	rb := NewRingBuffer(100)
+	now := time.Now()
+
+	for i := 0; i < 10; i++ {
+		rb.Write(makeEntry("ERROR", fmt.Sprintf("err-%d", i), now.Add(time.Duration(i)*time.Second)))
+	}
+
+	errs := rb.RecentErrors(3)
+	if len(errs) != 3 {
+		t.Fatalf("expected 3 errors, got %d", len(errs))
+	}
+	// Should be the 3 MOST RECENT in chrono order
+	if errs[0].Message != "err-7" {
+		t.Errorf("expected err-7, got %q", errs[0].Message)
+	}
+	if errs[2].Message != "err-9" {
+		t.Errorf("expected err-9, got %q", errs[2].Message)
+	}
+}
+
+func TestRingBuffer_RecentErrors_Empty(t *testing.T) {
+	rb := NewRingBuffer(100)
+	errs := rb.RecentErrors(5)
+	if errs != nil {
+		t.Errorf("expected nil for empty buffer, got %v", errs)
+	}
+}
+
+func TestRingBuffer_RecentErrors_NoErrors(t *testing.T) {
+	rb := NewRingBuffer(100)
+	rb.Write(makeEntry("INFO", "ok", time.Now()))
+	rb.Write(makeEntry("WARNING", "warn", time.Now()))
+
+	errs := rb.RecentErrors(5)
+	if len(errs) != 0 {
+		t.Errorf("expected 0 errors when only INFO/WARNING, got %d", len(errs))
+	}
+}
+
+func TestRingBuffer_TopFiles(t *testing.T) {
+	rb := NewRingBuffer(100)
+	now := time.Now()
+
+	// master_server.go: 5 entries
+	for i := 0; i < 5; i++ {
+		e := makeEntry("INFO", "msg", now)
+		e.File = "master_server.go"
+		rb.Write(e)
+	}
+	// volume_server.go: 3 entries
+	for i := 0; i < 3; i++ {
+		e := makeEntry("INFO", "msg", now)
+		e.File = "volume_server.go"
+		rb.Write(e)
+	}
+	// filer.go: 1 entry
+	e := makeEntry("INFO", "msg", now)
+	e.File = "filer.go"
+	rb.Write(e)
+
+	top := rb.TopFiles(2)
+	if len(top) != 2 {
+		t.Fatalf("expected 2 top files, got %d", len(top))
+	}
+	if top[0].File != "master_server.go" || top[0].Count != 5 {
+		t.Errorf("expected master_server.go:5, got %s:%d", top[0].File, top[0].Count)
+	}
+	if top[1].File != "volume_server.go" || top[1].Count != 3 {
+		t.Errorf("expected volume_server.go:3, got %s:%d", top[1].File, top[1].Count)
+	}
+}
+
+func TestRingBuffer_TopFiles_Empty(t *testing.T) {
+	rb := NewRingBuffer(100)
+	top := rb.TopFiles(5)
+	if len(top) != 0 {
+		t.Errorf("expected 0 for empty buffer, got %d", len(top))
+	}
+}
+
+func TestRingBuffer_ErrorRate(t *testing.T) {
+	rb := NewRingBuffer(100)
+	now := time.Now()
+
+	// 8 INFO + 2 ERROR = 20% error rate
+	for i := 0; i < 8; i++ {
+		rb.Write(makeEntry("INFO", "ok", now.Add(-30*time.Second)))
+	}
+	rb.Write(makeEntry("ERROR", "e1", now.Add(-20*time.Second)))
+	rb.Write(makeEntry("FATAL", "f1", now.Add(-10*time.Second)))
+
+	r := rb.ErrorRate(1 * time.Minute)
+	if r.TotalLogs != 10 {
+		t.Errorf("expected 10 total, got %d", r.TotalLogs)
+	}
+	if r.ErrorCount != 2 {
+		t.Errorf("expected 2 errors, got %d", r.ErrorCount)
+	}
+	if r.ErrorRate < 19.9 || r.ErrorRate > 20.1 {
+		t.Errorf("expected ~20%% error rate, got %.1f%%", r.ErrorRate)
+	}
+}
+
+func TestRingBuffer_ErrorRate_NoLogs(t *testing.T) {
+	rb := NewRingBuffer(100)
+	r := rb.ErrorRate(1 * time.Minute)
+	if r.TotalLogs != 0 || r.ErrorRate != 0 {
+		t.Errorf("expected zeros for empty buffer, got total=%d rate=%.1f", r.TotalLogs, r.ErrorRate)
+	}
+}
+
+func TestRingBuffer_ErrorRate_OutsideWindow(t *testing.T) {
+	rb := NewRingBuffer(100)
+	// Write entries 10 minutes ago — outside 1 minute window
+	old := time.Now().Add(-10 * time.Minute)
+	rb.Write(makeEntry("ERROR", "old error", old))
+
+	r := rb.ErrorRate(1 * time.Minute)
+	if r.TotalLogs != 0 {
+		t.Errorf("expected 0 logs in window, got %d", r.TotalLogs)
+	}
+}
+
+func BenchmarkRingBuffer_Write(b *testing.B) {
+	rb := NewRingBuffer(10000)
+	entry := makeEntry("INFO", "benchmark message", time.Now())
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rb.Write(entry)
+	}
+}
+
+func BenchmarkRingBuffer_Query(b *testing.B) {
+	rb := NewRingBuffer(10000)
+	now := time.Now()
+	for i := 0; i < 10000; i++ {
+		rb.Write(makeEntry("INFO", fmt.Sprintf("msg-%d", i), now.Add(time.Duration(i)*time.Millisecond)))
+	}
+
+	f := Filter{Level: "INFO", Limit: 100, Pattern: "msg-5"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rb.Query(f)
+	}
+}
+
+func BenchmarkParseLogLine(b *testing.B) {
+	raw := []byte("I0318 12:34:56.123456 12345 master_server.go:123] request_id:abc123 operation completed successfully\n")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ParseLogLine(0, raw)
+	}
+}

--- a/weed/weed.go
+++ b/weed/weed.go
@@ -13,6 +13,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/seaweedfs/seaweedfs/weed/logbuffer"
 	weed_server "github.com/seaweedfs/seaweedfs/weed/server"
 	"github.com/seaweedfs/seaweedfs/weed/util"
 	flag "github.com/seaweedfs/seaweedfs/weed/util/fla9"
@@ -69,6 +70,11 @@ func main() {
 	}
 
 	flag.Parse()
+
+	// Initialize in-memory log ring buffer (10k entries) for runtime log
+	// querying and SSE streaming. Must be called after flag.Parse() so that
+	// --log_json is already resolved.
+	logbuffer.Init(10000)
 
 	args := flag.Args()
 	if len(args) < 1 {


### PR DESCRIPTION
## Summary

Adds a new `weed/logbuffer` package that captures every glog line into a thread-safe circular ring buffer for runtime log querying and live streaming.

### What's included:

- **LogInterceptor hook** in `glog.output()` — zero-cost when disabled (nil check)
- **Ring buffer** — fixed-capacity circular buffer with `sync.RWMutex` for concurrent read/write safety
- **Dual-mode parser** — auto-detects JSON (`--log_json`) vs classic glog text format
- **Atomic stats counters** — lock-free per-level counts (INFO/WARNING/ERROR/FATAL), total written, dropped
- **Fan-out subscribers** — non-blocking channel delivery for SSE streaming, with drop counting for slow consumers
- **Query engine** — filter by level, time range, file glob, regex pattern, request_id; supports pagination (offset + limit)
- **Utility methods** — `RecentErrors(n)`, `TopFiles(n)`, `ErrorRate(window)`
- **Runtime verbosity control** — `GetVerbosity`/`SetVerbosity`/`GetVModule`/`SetVModule` + `SetVerbosityWithTTL` for temporary debug verbosity that auto-reverts

### Design decisions:

- Buffer initialized after `flag.Parse()` so `--log_json` is resolved
- `LogInterceptor` is a simple `func(int32, []byte)` — no interface, no allocation
- Parser uses `raw[0] == '{'` for O(1) format detection
- All stats use `sync/atomic` for lock-free reads from HTTP handlers

### Files changed:

| File | Change |
|---|---|
| `weed/glog/glog.go` | +LogInterceptor var, hook in output(), +Get/SetVerbosity, +Get/SetVModule |
| `weed/logbuffer/entry.go` | Log entry types and filter/query/stats structs |
| `weed/logbuffer/ring.go` | Ring buffer: Write, Query, Subscribe, Stats, RecentErrors, TopFiles, ErrorRate |
| `weed/logbuffer/parser.go` | Dual-mode log line parser (JSON + text) |
| `weed/logbuffer/global.go` | Global singleton, Init(), SetVerbosityWithTTL |
| `weed/logbuffer/ring_test.go` | 29 unit tests + 3 benchmarks |
| `weed/logbuffer/parser_test.go` | 16 unit tests |
| `weed/weed.go` | +logbuffer.Init(10000) after flag.Parse() |

## Test plan

- [x] `go test ./weed/logbuffer/` — 29 ring buffer tests + 16 parser tests pass
- [x] `go test ./weed/glog/` — existing glog tests unaffected
- [x] `go build ./weed/` — full binary compiles
- [x] `go vet ./weed/glog/ ./weed/logbuffer/` — no issues
- [ ] CI cross-platform validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime controls to get/set verbosity and vmodule without restart.
  * In-memory circular log buffer with querying (filters, pagination, regex, time range).
  * Real-time log streaming via subscriptions.
  * Log analytics: error rates, top files, recent errors, snapshots.
  * Temporary verbosity changes with automatic revert (TTL).

* **Tests**
  * Comprehensive parsing and buffer test suites and benchmarks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->