### PR TITLE
worker: add compaction task type with configurable empty-volume deletion

### DIFF
--- a/weed/admin/dash/config_persistence.go
+++ b/weed/admin/dash/config_persistence.go
@@ -26,12 +26,13 @@ const (
 	ConfigSubdir = "conf"
 
 	// Configuration file names (protobuf binary)
-	MaintenanceConfigFile     = "maintenance.pb"
-	VacuumTaskConfigFile      = "task_vacuum.pb"
-	ECTaskConfigFile          = "task_erasure_coding.pb"
-	BalanceTaskConfigFile     = "task_balance.pb"
-	ReplicationTaskConfigFile = "task_replication.pb"
-	CompactionTaskConfigFile  = "task_compaction.pb"
+	MaintenanceConfigFile        = "maintenance.pb"
+	VacuumTaskConfigFile         = "task_vacuum.pb"
+	ECTaskConfigFile             = "task_erasure_coding.pb"
+	BalanceTaskConfigFile        = "task_balance.pb"
+	ReplicationTaskConfigFile    = "task_replication.pb"
+	CompactionTaskConfigFile     = "task_compaction.pb"
+	CompactionTaskFullConfigFile = "task_compaction_full.json" // carries all fields
 
 	// JSON reference files
 	MaintenanceConfigJSONFile     = "maintenance.json"
@@ -159,7 +160,7 @@ func (cp *ConfigPersistence) LoadMaintenanceConfig() (*MaintenanceConfig, error)
 		var config MaintenanceConfig
 		if err := proto.Unmarshal(configData, &config); err == nil {
 			// Always populate policy from separate task configuration files
-			config.Policy = buildPolicyFromTaskConfigs()
+			config.Policy = cp.buildPolicyFromTaskConfigs()
 			return &config, nil
 		}
 	}
@@ -629,9 +630,59 @@ func (cp *ConfigPersistence) loadTaskConfig(filename string, config proto.Messag
 	return nil
 }
 
-// SaveCompactionTaskPolicy saves the compaction task policy to a protobuf file.
+// SaveCompactionTaskPolicy saves the compaction task policy to a protobuf file
+// and also updates the full JSON config so that DeleteEmptyEnabled and
+// QuietForSeconds survive the round-trip.
 func (cp *ConfigPersistence) SaveCompactionTaskPolicy(policy *worker_pb.TaskPolicy) error {
-	return cp.saveTaskConfig(CompactionTaskConfigFile, policy)
+	if err := cp.saveTaskConfig(CompactionTaskConfigFile, policy); err != nil {
+		return err
+	}
+	// Merge base policy fields into the full JSON config.
+	existing := delete_empty.NewDefaultConfig()
+	if full, err := cp.LoadCompactionConfig(); err == nil && full != nil {
+		existing = full
+	}
+	existing.Enabled = policy.Enabled
+	existing.MaxConcurrent = int(policy.MaxConcurrent)
+	existing.ScanIntervalSeconds = int(policy.RepeatIntervalSeconds)
+	if policy.CheckIntervalSeconds > 0 {
+		existing.QuietForSeconds = int(policy.CheckIntervalSeconds)
+	}
+	_ = cp.SaveCompactionConfig(existing) // best-effort
+	return nil
+}
+
+// SaveCompactionConfig saves the full compaction config (all fields) as JSON.
+func (cp *ConfigPersistence) SaveCompactionConfig(cfg *delete_empty.Config) error {
+	if cp.dataDir == "" {
+		return fmt.Errorf("no data directory specified, cannot save compaction config")
+	}
+	confDir := filepath.Join(cp.dataDir, ConfigSubdir)
+	if err := os.MkdirAll(confDir, ConfigDirPermissions); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal compaction config: %w", err)
+	}
+	return os.WriteFile(filepath.Join(confDir, CompactionTaskFullConfigFile), data, ConfigFilePermissions)
+}
+
+// LoadCompactionConfig loads the full compaction config (all fields) from JSON.
+func (cp *ConfigPersistence) LoadCompactionConfig() (*delete_empty.Config, error) {
+	if cp.dataDir == "" {
+		return nil, os.ErrNotExist
+	}
+	path := filepath.Join(cp.dataDir, ConfigSubdir, CompactionTaskFullConfigFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var cfg delete_empty.Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal compaction full config: %w", err)
+	}
+	return &cfg, nil
 }
 
 // LoadCompactionTaskPolicy loads the compaction task policy from disk.
@@ -679,7 +730,7 @@ func (cp *ConfigPersistence) SaveTaskPolicy(taskType string, policy *worker_pb.T
 		return cp.SaveBalanceTaskPolicy(policy)
 	case "replication":
 		return cp.SaveReplicationTaskPolicy(policy)
-	case "compaction":
+	case "compaction", "delete_empty": // delete_empty is a deprecated alias
 		return cp.SaveCompactionTaskPolicy(policy)
 	}
 	return fmt.Errorf("unknown task type: %s", taskType)
@@ -735,7 +786,7 @@ func (cp *ConfigPersistence) GetConfigInfo() map[string]interface{} {
 }
 
 // buildPolicyFromTaskConfigs loads task configurations from separate files and builds a MaintenancePolicy
-func buildPolicyFromTaskConfigs() *worker_pb.MaintenancePolicy {
+func (cp *ConfigPersistence) buildPolicyFromTaskConfigs() *worker_pb.MaintenancePolicy {
 	policy := &worker_pb.MaintenancePolicy{
 		GlobalMaxConcurrent:          4,
 		DefaultRepeatIntervalSeconds: 6 * 3600,  // 6 hours in seconds
@@ -794,13 +845,13 @@ func buildPolicyFromTaskConfigs() *worker_pb.MaintenancePolicy {
 		}
 	}
 
-	// Load compaction task configuration
-	if deConfig := delete_empty.LoadConfigFromPersistence(nil); deConfig != nil {
+	// Load compaction task configuration (pass cp so LoadCompactionConfig is used)
+	if deConfig := delete_empty.LoadConfigFromPersistence(cp); deConfig != nil {
 		policy.TaskPolicies["compaction"] = &worker_pb.TaskPolicy{
 			Enabled:               deConfig.Enabled,
 			MaxConcurrent:         int32(deConfig.MaxConcurrent),
 			RepeatIntervalSeconds: int32(deConfig.ScanIntervalSeconds),
-			CheckIntervalSeconds:  int32(deConfig.ScanIntervalSeconds),
+			CheckIntervalSeconds:  int32(deConfig.QuietForSeconds),
 		}
 	}
 

--- a/weed/admin/dash/config_persistence.go
+++ b/weed/admin/dash/config_persistence.go
@@ -845,14 +845,11 @@ func (cp *ConfigPersistence) buildPolicyFromTaskConfigs() *worker_pb.Maintenance
 		}
 	}
 
-	// Load compaction task configuration (pass cp so LoadCompactionConfig is used)
+	// Load compaction task configuration (pass cp so LoadCompactionConfig is used).
+	// Use ToTaskPolicy() so the CheckIntervalSeconds → QuietForSeconds contract
+	// is honoured without duplicating the field mapping here.
 	if deConfig := delete_empty.LoadConfigFromPersistence(cp); deConfig != nil {
-		policy.TaskPolicies["compaction"] = &worker_pb.TaskPolicy{
-			Enabled:               deConfig.Enabled,
-			MaxConcurrent:         int32(deConfig.MaxConcurrent),
-			RepeatIntervalSeconds: int32(deConfig.ScanIntervalSeconds),
-			CheckIntervalSeconds:  int32(deConfig.QuietForSeconds),
-		}
+		policy.TaskPolicies["compaction"] = deConfig.ToTaskPolicy()
 	}
 
 	glog.V(1).Infof("Built maintenance policy from separate task configs - %d task policies loaded", len(policy.TaskPolicies))

--- a/weed/admin/dash/config_persistence.go
+++ b/weed/admin/dash/config_persistence.go
@@ -31,7 +31,7 @@ const (
 	ECTaskConfigFile          = "task_erasure_coding.pb"
 	BalanceTaskConfigFile     = "task_balance.pb"
 	ReplicationTaskConfigFile = "task_replication.pb"
-	DeleteEmptyTaskConfigFile = "task_delete_empty.pb"
+	CompactionTaskConfigFile  = "task_compaction.pb"
 
 	// JSON reference files
 	MaintenanceConfigJSONFile     = "maintenance.json"
@@ -39,7 +39,7 @@ const (
 	ECTaskConfigJSONFile          = "task_erasure_coding.json"
 	BalanceTaskConfigJSONFile     = "task_balance.json"
 	ReplicationTaskConfigJSONFile = "task_replication.json"
-	DeleteEmptyTaskConfigJSONFile = "task_delete_empty.json"
+	CompactionTaskConfigJSONFile  = "task_compaction.json"
 
 	// Task persistence subdirectories and settings
 	TasksSubdir       = "tasks"
@@ -629,15 +629,15 @@ func (cp *ConfigPersistence) loadTaskConfig(filename string, config proto.Messag
 	return nil
 }
 
-// SaveDeleteEmptyTaskPolicy saves complete delete_empty task policy to protobuf file
-func (cp *ConfigPersistence) SaveDeleteEmptyTaskPolicy(policy *worker_pb.TaskPolicy) error {
-	return cp.saveTaskConfig(DeleteEmptyTaskConfigFile, policy)
+// SaveCompactionTaskPolicy saves the compaction task policy to a protobuf file.
+func (cp *ConfigPersistence) SaveCompactionTaskPolicy(policy *worker_pb.TaskPolicy) error {
+	return cp.saveTaskConfig(CompactionTaskConfigFile, policy)
 }
 
-// LoadDeleteEmptyTaskPolicy loads the delete_empty task policy from disk.
-// Since delete_empty config is not yet a typed oneof in TaskPolicy proto,
+// LoadCompactionTaskPolicy loads the compaction task policy from disk.
+// Since compaction config is not yet a typed oneof in TaskPolicy proto,
 // we persist only the base policy fields (enabled, concurrency, interval).
-func (cp *ConfigPersistence) LoadDeleteEmptyTaskPolicy() (*worker_pb.TaskPolicy, error) {
+func (cp *ConfigPersistence) LoadCompactionTaskPolicy() (*worker_pb.TaskPolicy, error) {
 	defaultPolicy := &worker_pb.TaskPolicy{
 		Enabled:               true,
 		MaxConcurrent:         1,
@@ -649,22 +649,22 @@ func (cp *ConfigPersistence) LoadDeleteEmptyTaskPolicy() (*worker_pb.TaskPolicy,
 		return defaultPolicy, nil
 	}
 
-	configPath := filepath.Join(cp.dataDir, ConfigSubdir, DeleteEmptyTaskConfigFile)
+	configPath := filepath.Join(cp.dataDir, ConfigSubdir, CompactionTaskConfigFile)
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
 		return defaultPolicy, nil
 	}
 
 	configData, err := os.ReadFile(configPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read delete_empty task config file: %w", err)
+		return nil, fmt.Errorf("failed to read compaction task config file: %w", err)
 	}
 
 	var policy worker_pb.TaskPolicy
 	if err := proto.Unmarshal(configData, &policy); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal delete_empty task configuration: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal compaction task configuration: %w", err)
 	}
 
-	glog.V(1).Infof("Loaded delete_empty task policy from %s", configPath)
+	glog.V(1).Infof("Loaded compaction task policy from %s", configPath)
 	return &policy, nil
 }
 
@@ -679,8 +679,8 @@ func (cp *ConfigPersistence) SaveTaskPolicy(taskType string, policy *worker_pb.T
 		return cp.SaveBalanceTaskPolicy(policy)
 	case "replication":
 		return cp.SaveReplicationTaskPolicy(policy)
-	case "delete_empty":
-		return cp.SaveDeleteEmptyTaskPolicy(policy)
+	case "compaction":
+		return cp.SaveCompactionTaskPolicy(policy)
 	}
 	return fmt.Errorf("unknown task type: %s", taskType)
 }
@@ -794,9 +794,9 @@ func buildPolicyFromTaskConfigs() *worker_pb.MaintenancePolicy {
 		}
 	}
 
-	// Load delete_empty task configuration
+	// Load compaction task configuration
 	if deConfig := delete_empty.LoadConfigFromPersistence(nil); deConfig != nil {
-		policy.TaskPolicies["delete_empty"] = &worker_pb.TaskPolicy{
+		policy.TaskPolicies["compaction"] = &worker_pb.TaskPolicy{
 			Enabled:               deConfig.Enabled,
 			MaxConcurrent:         int32(deConfig.MaxConcurrent),
 			RepeatIntervalSeconds: int32(deConfig.ScanIntervalSeconds),

--- a/weed/admin/dash/config_persistence.go
+++ b/weed/admin/dash/config_persistence.go
@@ -14,6 +14,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb/worker_pb"
 	"github.com/seaweedfs/seaweedfs/weed/worker/tasks/balance"
+	"github.com/seaweedfs/seaweedfs/weed/worker/tasks/delete_empty"
 	"github.com/seaweedfs/seaweedfs/weed/worker/tasks/erasure_coding"
 	"github.com/seaweedfs/seaweedfs/weed/worker/tasks/vacuum"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -30,6 +31,7 @@ const (
 	ECTaskConfigFile          = "task_erasure_coding.pb"
 	BalanceTaskConfigFile     = "task_balance.pb"
 	ReplicationTaskConfigFile = "task_replication.pb"
+	DeleteEmptyTaskConfigFile = "task_delete_empty.pb"
 
 	// JSON reference files
 	MaintenanceConfigJSONFile     = "maintenance.json"
@@ -37,6 +39,7 @@ const (
 	ECTaskConfigJSONFile          = "task_erasure_coding.json"
 	BalanceTaskConfigJSONFile     = "task_balance.json"
 	ReplicationTaskConfigJSONFile = "task_replication.json"
+	DeleteEmptyTaskConfigJSONFile = "task_delete_empty.json"
 
 	// Task persistence subdirectories and settings
 	TasksSubdir       = "tasks"
@@ -626,6 +629,45 @@ func (cp *ConfigPersistence) loadTaskConfig(filename string, config proto.Messag
 	return nil
 }
 
+// SaveDeleteEmptyTaskPolicy saves complete delete_empty task policy to protobuf file
+func (cp *ConfigPersistence) SaveDeleteEmptyTaskPolicy(policy *worker_pb.TaskPolicy) error {
+	return cp.saveTaskConfig(DeleteEmptyTaskConfigFile, policy)
+}
+
+// LoadDeleteEmptyTaskPolicy loads the delete_empty task policy from disk.
+// Since delete_empty config is not yet a typed oneof in TaskPolicy proto,
+// we persist only the base policy fields (enabled, concurrency, interval).
+func (cp *ConfigPersistence) LoadDeleteEmptyTaskPolicy() (*worker_pb.TaskPolicy, error) {
+	defaultPolicy := &worker_pb.TaskPolicy{
+		Enabled:               true,
+		MaxConcurrent:         1,
+		RepeatIntervalSeconds: 6 * 3600,
+		CheckIntervalSeconds:  6 * 3600,
+	}
+
+	if cp.dataDir == "" {
+		return defaultPolicy, nil
+	}
+
+	configPath := filepath.Join(cp.dataDir, ConfigSubdir, DeleteEmptyTaskConfigFile)
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		return defaultPolicy, nil
+	}
+
+	configData, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read delete_empty task config file: %w", err)
+	}
+
+	var policy worker_pb.TaskPolicy
+	if err := proto.Unmarshal(configData, &policy); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal delete_empty task configuration: %w", err)
+	}
+
+	glog.V(1).Infof("Loaded delete_empty task policy from %s", configPath)
+	return &policy, nil
+}
+
 // SaveTaskPolicy generic dispatcher for task persistence
 func (cp *ConfigPersistence) SaveTaskPolicy(taskType string, policy *worker_pb.TaskPolicy) error {
 	switch taskType {
@@ -637,6 +679,8 @@ func (cp *ConfigPersistence) SaveTaskPolicy(taskType string, policy *worker_pb.T
 		return cp.SaveBalanceTaskPolicy(policy)
 	case "replication":
 		return cp.SaveReplicationTaskPolicy(policy)
+	case "delete_empty":
+		return cp.SaveDeleteEmptyTaskPolicy(policy)
 	}
 	return fmt.Errorf("unknown task type: %s", taskType)
 }
@@ -747,6 +791,16 @@ func buildPolicyFromTaskConfigs() *worker_pb.MaintenancePolicy {
 					MinServerCount:     int32(balanceConfig.MinServerCount),
 				},
 			},
+		}
+	}
+
+	// Load delete_empty task configuration
+	if deConfig := delete_empty.LoadConfigFromPersistence(nil); deConfig != nil {
+		policy.TaskPolicies["delete_empty"] = &worker_pb.TaskPolicy{
+			Enabled:               deConfig.Enabled,
+			MaxConcurrent:         int32(deConfig.MaxConcurrent),
+			RepeatIntervalSeconds: int32(deConfig.ScanIntervalSeconds),
+			CheckIntervalSeconds:  int32(deConfig.ScanIntervalSeconds),
 		}
 	}
 
@@ -1094,6 +1148,9 @@ func (cp *ConfigPersistence) loadTaskStateLocked(taskID string) (*maintenance.Ma
 
 	// Convert protobuf to maintenance task
 	task := cp.protobufToMaintenanceTask(taskStateFile.Task)
+	if task == nil {
+		return nil, fmt.Errorf("task state file %s has no task data", taskID)
+	}
 
 	glog.V(2).Infof("Loaded task state for task %s from %s", taskID, taskFilePath)
 	return task, nil
@@ -1224,6 +1281,9 @@ func (cp *ConfigPersistence) maintenanceTaskToProtobuf(task *maintenance.Mainten
 
 // protobufToMaintenanceTask converts protobuf format to MaintenanceTask
 func (cp *ConfigPersistence) protobufToMaintenanceTask(pbTask *worker_pb.MaintenanceTaskData) *maintenance.MaintenanceTask {
+	if pbTask == nil {
+		return nil
+	}
 	task := &maintenance.MaintenanceTask{
 		ID:              pbTask.Id,
 		Type:            maintenance.MaintenanceTaskType(pbTask.Type),

--- a/weed/admin/maintenance/maintenance_manager.go
+++ b/weed/admin/maintenance/maintenance_manager.go
@@ -9,6 +9,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb/worker_pb"
 	"github.com/seaweedfs/seaweedfs/weed/worker/tasks/balance"
+	"github.com/seaweedfs/seaweedfs/weed/worker/tasks/delete_empty"
 	"github.com/seaweedfs/seaweedfs/weed/worker/tasks/erasure_coding"
 	"github.com/seaweedfs/seaweedfs/weed/worker/tasks/vacuum"
 )
@@ -70,6 +71,15 @@ func buildPolicyFromTaskConfigs() *worker_pb.MaintenancePolicy {
 					MinServerCount:     int32(balanceConfig.MinServerCount),
 				},
 			},
+		}
+	}
+
+	if deConfig := delete_empty.LoadConfigFromPersistence(nil); deConfig != nil {
+		policy.TaskPolicies["delete_empty"] = &worker_pb.TaskPolicy{
+			Enabled:               deConfig.Enabled,
+			MaxConcurrent:         int32(deConfig.MaxConcurrent),
+			RepeatIntervalSeconds: int32(deConfig.ScanIntervalSeconds),
+			CheckIntervalSeconds:  int32(deConfig.ScanIntervalSeconds),
 		}
 	}
 

--- a/weed/admin/maintenance/maintenance_manager.go
+++ b/weed/admin/maintenance/maintenance_manager.go
@@ -74,14 +74,11 @@ func buildPolicyFromTaskConfigs() *worker_pb.MaintenancePolicy {
 		}
 	}
 
-	// Load compaction task configuration (task type: "compaction")
+	// Load compaction task configuration (task type: "compaction").
+	// Use ToTaskPolicy() so the CheckIntervalSeconds → QuietForSeconds
+	// contract is honoured without duplicating the mapping here.
 	if deConfig := delete_empty.LoadConfigFromPersistence(nil); deConfig != nil {
-		policy.TaskPolicies["compaction"] = &worker_pb.TaskPolicy{
-			Enabled:               deConfig.Enabled,
-			MaxConcurrent:         int32(deConfig.MaxConcurrent),
-			RepeatIntervalSeconds: int32(deConfig.ScanIntervalSeconds),
-			CheckIntervalSeconds:  int32(deConfig.ScanIntervalSeconds),
-		}
+		policy.TaskPolicies["compaction"] = deConfig.ToTaskPolicy()
 	}
 
 	glog.V(1).Infof("Built maintenance policy from separate task configs - %d task policies loaded", len(policy.TaskPolicies))

--- a/weed/admin/maintenance/maintenance_manager.go
+++ b/weed/admin/maintenance/maintenance_manager.go
@@ -74,8 +74,9 @@ func buildPolicyFromTaskConfigs() *worker_pb.MaintenancePolicy {
 		}
 	}
 
+	// Load compaction task configuration (task type: "compaction")
 	if deConfig := delete_empty.LoadConfigFromPersistence(nil); deConfig != nil {
-		policy.TaskPolicies["delete_empty"] = &worker_pb.TaskPolicy{
+		policy.TaskPolicies["compaction"] = &worker_pb.TaskPolicy{
 			Enabled:               deConfig.Enabled,
 			MaxConcurrent:         int32(deConfig.MaxConcurrent),
 			RepeatIntervalSeconds: int32(deConfig.ScanIntervalSeconds),

--- a/weed/admin/maintenance/maintenance_worker.go
+++ b/weed/admin/maintenance/maintenance_worker.go
@@ -14,6 +14,7 @@ import (
 
 	// Import task packages to trigger their auto-registration
 	_ "github.com/seaweedfs/seaweedfs/weed/worker/tasks/balance"
+	_ "github.com/seaweedfs/seaweedfs/weed/worker/tasks/delete_empty"
 	_ "github.com/seaweedfs/seaweedfs/weed/worker/tasks/erasure_coding"
 	_ "github.com/seaweedfs/seaweedfs/weed/worker/tasks/vacuum"
 )

--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -25,6 +25,7 @@ import (
 
 	// Import task packages to trigger their auto-registration
 	_ "github.com/seaweedfs/seaweedfs/weed/worker/tasks/balance"
+	_ "github.com/seaweedfs/seaweedfs/weed/worker/tasks/delete_empty"
 	_ "github.com/seaweedfs/seaweedfs/weed/worker/tasks/erasure_coding"
 	_ "github.com/seaweedfs/seaweedfs/weed/worker/tasks/vacuum"
 )

--- a/weed/pb/worker.proto
+++ b/weed/pb/worker.proto
@@ -181,6 +181,12 @@ message ReplicationTaskParams {
   bool verify_consistency = 2;            // Verify replica consistency after creation
 }
 
+// DeleteEmptyTaskParams for deleting empty volumes
+// NOTE: add field 13 to TaskParams.task_params oneof after proto regeneration
+message DeleteEmptyTaskParams {
+  int32 quiet_for_seconds = 1;            // Minimum quiet time before deletion (default: 86400)
+}
+
 // TaskUpdate reports task progress
 message TaskUpdate {
   string task_id = 1;

--- a/weed/pb/worker.proto
+++ b/weed/pb/worker.proto
@@ -112,6 +112,7 @@ message TaskParams {
     BalanceTaskParams balance_params = 11;
     ReplicationTaskParams replication_params = 12;
     EcBalanceTaskParams ec_balance_params = 13;
+    DeleteEmptyTaskParams delete_empty_params = 14;
   }
 }
 
@@ -181,8 +182,7 @@ message ReplicationTaskParams {
   bool verify_consistency = 2;            // Verify replica consistency after creation
 }
 
-// DeleteEmptyTaskParams for deleting empty volumes
-// NOTE: add field 13 to TaskParams.task_params oneof after proto regeneration
+// DeleteEmptyTaskParams carries runtime parameters for a single compaction task.
 message DeleteEmptyTaskParams {
   int32 quiet_for_seconds = 1;            // Minimum quiet time before deletion (default: 86400)
 }
@@ -315,7 +315,17 @@ message TaskPolicy {
     BalanceTaskConfig balance_config = 7;
     ReplicationTaskConfig replication_config = 8;
     EcBalanceTaskConfig ec_balance_config = 9;
+    DeleteEmptyTaskConfig compaction_config = 10;
   }
+}
+
+// DeleteEmptyTaskConfig contains compaction-specific policy configuration.
+// TODO: regenerate worker_pb/worker.pb.go after this proto change so that
+// TaskPolicy.GetCompactionConfig() and full binary marshaling work.
+message DeleteEmptyTaskConfig {
+  bool delete_empty_enabled = 1;  // Whether to delete zero-byte volumes
+  int32 quiet_for_seconds = 2;    // Minimum idle time before deletion (default: 86400)
+
 }
 
 // Task-specific configuration messages

--- a/weed/worker/tasks/delete_empty/config.go
+++ b/weed/worker/tasks/delete_empty/config.go
@@ -60,17 +60,17 @@ func LoadConfigFromPersistence(configPersistence interface{}) *Config {
 	cfg := NewDefaultConfig()
 
 	if persistence, ok := configPersistence.(interface {
-		LoadDeleteEmptyTaskPolicy() (*worker_pb.TaskPolicy, error)
+		LoadCompactionTaskPolicy() (*worker_pb.TaskPolicy, error)
 	}); ok {
-		if policy, err := persistence.LoadDeleteEmptyTaskPolicy(); err == nil && policy != nil {
+		if policy, err := persistence.LoadCompactionTaskPolicy(); err == nil && policy != nil {
 			if err := cfg.FromTaskPolicy(policy); err == nil {
-				glog.V(1).Infof("Loaded delete_empty configuration from persistence")
+				glog.V(1).Infof("Loaded compaction configuration from persistence")
 				return cfg
 			}
 		}
 	}
 
-	glog.V(1).Infof("Using default delete_empty configuration")
+	glog.V(1).Infof("Using default compaction configuration")
 	return cfg
 }
 

--- a/weed/worker/tasks/delete_empty/config.go
+++ b/weed/worker/tasks/delete_empty/config.go
@@ -33,18 +33,21 @@ func NewDefaultConfig() *Config {
 }
 
 // ToTaskPolicy converts configuration to a TaskPolicy protobuf message.
-// Delete-empty config is stored via the generic policy fields; typed config
-// support requires proto regeneration (see worker.proto TODO).
+// QuietForSeconds is stored in CheckIntervalSeconds so it survives a
+// proto round-trip. DeleteEmptyEnabled is persisted via the full JSON
+// config (SaveCompactionConfig / LoadCompactionConfig); see worker.proto
+// TODO for the tracked typed-oneof approach.
 func (c *Config) ToTaskPolicy() *worker_pb.TaskPolicy {
 	return &worker_pb.TaskPolicy{
 		Enabled:               c.Enabled,
 		MaxConcurrent:         int32(c.MaxConcurrent),
 		RepeatIntervalSeconds: int32(c.ScanIntervalSeconds),
-		CheckIntervalSeconds:  int32(c.ScanIntervalSeconds),
+		CheckIntervalSeconds:  int32(c.QuietForSeconds),
 	}
 }
 
-// FromTaskPolicy loads base fields from a TaskPolicy protobuf message
+// FromTaskPolicy loads fields from a TaskPolicy protobuf message.
+// QuietForSeconds is recovered from CheckIntervalSeconds.
 func (c *Config) FromTaskPolicy(policy *worker_pb.TaskPolicy) error {
 	if policy == nil {
 		return nil
@@ -52,13 +55,29 @@ func (c *Config) FromTaskPolicy(policy *worker_pb.TaskPolicy) error {
 	c.Enabled = policy.Enabled
 	c.MaxConcurrent = int(policy.MaxConcurrent)
 	c.ScanIntervalSeconds = int(policy.RepeatIntervalSeconds)
+	if policy.CheckIntervalSeconds > 0 {
+		c.QuietForSeconds = int(policy.CheckIntervalSeconds)
+	}
 	return nil
 }
 
-// LoadConfigFromPersistence loads configuration from the persistence layer if available
+// LoadConfigFromPersistence loads configuration from the persistence layer if available.
+// It first tries a full JSON config (which carries all fields including
+// DeleteEmptyEnabled) and falls back to the base TaskPolicy proto.
 func LoadConfigFromPersistence(configPersistence interface{}) *Config {
-	cfg := NewDefaultConfig()
+	// Prefer the full JSON config — it carries DeleteEmptyEnabled and
+	// QuietForSeconds without requiring proto regeneration.
+	if persistence, ok := configPersistence.(interface {
+		LoadCompactionConfig() (*Config, error)
+	}); ok {
+		if cfg, err := persistence.LoadCompactionConfig(); err == nil && cfg != nil {
+			glog.V(1).Infof("Loaded compaction configuration from full JSON config")
+			return cfg
+		}
+	}
 
+	// Fallback: load from base TaskPolicy proto (QuietForSeconds via check_interval_seconds)
+	cfg := NewDefaultConfig()
 	if persistence, ok := configPersistence.(interface {
 		LoadCompactionTaskPolicy() (*worker_pb.TaskPolicy, error)
 	}); ok {

--- a/weed/worker/tasks/delete_empty/config.go
+++ b/weed/worker/tasks/delete_empty/config.go
@@ -1,0 +1,139 @@
+package delete_empty
+
+import (
+	"github.com/seaweedfs/seaweedfs/weed/admin/config"
+	"github.com/seaweedfs/seaweedfs/weed/glog"
+	"github.com/seaweedfs/seaweedfs/weed/pb/worker_pb"
+	"github.com/seaweedfs/seaweedfs/weed/worker/tasks/base"
+)
+
+// Config holds compaction task settings, including the optional
+// "delete empty volumes" sub-operation.
+type Config struct {
+	base.BaseConfig
+	// DeleteEmptyEnabled controls whether the compaction task will delete
+	// volumes that contain no needle data (size == superblock header only).
+	DeleteEmptyEnabled bool `json:"delete_empty_enabled"`
+	// QuietForSeconds is how long a volume must be unmodified before it is
+	// considered safe to delete. Only used when DeleteEmptyEnabled is true.
+	QuietForSeconds int `json:"quiet_for_seconds"`
+}
+
+// NewDefaultConfig creates a new default compaction configuration
+func NewDefaultConfig() *Config {
+	return &Config{
+		BaseConfig: base.BaseConfig{
+			Enabled:             true,
+			ScanIntervalSeconds: 6 * 60 * 60, // 6 hours
+			MaxConcurrent:       1,
+		},
+		DeleteEmptyEnabled: true,
+		QuietForSeconds:    24 * 60 * 60, // 24 hours
+	}
+}
+
+// ToTaskPolicy converts configuration to a TaskPolicy protobuf message.
+// Delete-empty config is stored via the generic policy fields; typed config
+// support requires proto regeneration (see worker.proto TODO).
+func (c *Config) ToTaskPolicy() *worker_pb.TaskPolicy {
+	return &worker_pb.TaskPolicy{
+		Enabled:               c.Enabled,
+		MaxConcurrent:         int32(c.MaxConcurrent),
+		RepeatIntervalSeconds: int32(c.ScanIntervalSeconds),
+		CheckIntervalSeconds:  int32(c.ScanIntervalSeconds),
+	}
+}
+
+// FromTaskPolicy loads base fields from a TaskPolicy protobuf message
+func (c *Config) FromTaskPolicy(policy *worker_pb.TaskPolicy) error {
+	if policy == nil {
+		return nil
+	}
+	c.Enabled = policy.Enabled
+	c.MaxConcurrent = int(policy.MaxConcurrent)
+	c.ScanIntervalSeconds = int(policy.RepeatIntervalSeconds)
+	return nil
+}
+
+// LoadConfigFromPersistence loads configuration from the persistence layer if available
+func LoadConfigFromPersistence(configPersistence interface{}) *Config {
+	cfg := NewDefaultConfig()
+
+	if persistence, ok := configPersistence.(interface {
+		LoadDeleteEmptyTaskPolicy() (*worker_pb.TaskPolicy, error)
+	}); ok {
+		if policy, err := persistence.LoadDeleteEmptyTaskPolicy(); err == nil && policy != nil {
+			if err := cfg.FromTaskPolicy(policy); err == nil {
+				glog.V(1).Infof("Loaded delete_empty configuration from persistence")
+				return cfg
+			}
+		}
+	}
+
+	glog.V(1).Infof("Using default delete_empty configuration")
+	return cfg
+}
+
+// GetConfigSpec returns the configuration schema for compaction tasks
+func GetConfigSpec() base.ConfigSpec {
+	return base.ConfigSpec{
+		Fields: []*config.Field{
+			{
+				Name:         "enabled",
+				JSONName:     "enabled",
+				Type:         config.FieldTypeBool,
+				DefaultValue: true,
+				Required:     false,
+				DisplayName:  "Enable Compaction",
+				Description:  "Whether volume compaction tasks should run automatically",
+				HelpText:     "Master switch for all compaction operations",
+				InputType:    "checkbox",
+				CSSClasses:   "form-check-input",
+			},
+			{
+				Name:         "scan_interval_seconds",
+				JSONName:     "scan_interval_seconds",
+				Type:         config.FieldTypeInterval,
+				DefaultValue: 6 * 60 * 60,
+				MinValue:     60 * 60,
+				MaxValue:     7 * 24 * 60 * 60,
+				Required:     true,
+				DisplayName:  "Scan Interval",
+				Description:  "How often to scan volumes for compaction candidates",
+				HelpText:     "The system will scan volumes at this interval",
+				Placeholder:  "6",
+				Unit:         config.UnitHours,
+				InputType:    "interval",
+				CSSClasses:   "form-control",
+			},
+			{
+				Name:         "delete_empty_enabled",
+				JSONName:     "delete_empty_enabled",
+				Type:         config.FieldTypeBool,
+				DefaultValue: true,
+				Required:     false,
+				DisplayName:  "Delete Empty Volumes",
+				Description:  "Delete volumes that contain no data (zero-byte buckets)",
+				HelpText:     "Removes volumes whose on-disk size equals the superblock header only. Requires Compaction to be enabled.",
+				InputType:    "checkbox",
+				CSSClasses:   "form-check-input",
+			},
+			{
+				Name:         "quiet_for_seconds",
+				JSONName:     "quiet_for_seconds",
+				Type:         config.FieldTypeInterval,
+				DefaultValue: 24 * 60 * 60,
+				MinValue:     60 * 60,
+				MaxValue:     7 * 24 * 60 * 60,
+				Required:     true,
+				DisplayName:  "Empty Volume Quiet Period",
+				Description:  "Only delete empty volumes that have not been modified for this duration",
+				HelpText:     "Prevents deletion of freshly allocated volumes that may still receive data",
+				Placeholder:  "24",
+				Unit:         config.UnitHours,
+				InputType:    "interval",
+				CSSClasses:   "form-control",
+			},
+		},
+	}
+}

--- a/weed/worker/tasks/delete_empty/config_test.go
+++ b/weed/worker/tasks/delete_empty/config_test.go
@@ -67,8 +67,9 @@ func TestConfig_ToTaskPolicy_RoundTrip(t *testing.T) {
 	if policy.RepeatIntervalSeconds != 7200 {
 		t.Errorf("Expected RepeatIntervalSeconds=7200, got %d", policy.RepeatIntervalSeconds)
 	}
-	if policy.CheckIntervalSeconds != 7200 {
-		t.Errorf("Expected CheckIntervalSeconds=7200, got %d", policy.CheckIntervalSeconds)
+	// CheckIntervalSeconds now carries QuietForSeconds (12 h = 43200 s)
+	if policy.CheckIntervalSeconds != 12*3600 {
+		t.Errorf("Expected CheckIntervalSeconds=%d (QuietForSeconds), got %d", 12*3600, policy.CheckIntervalSeconds)
 	}
 
 	// Round-trip: policy → config
@@ -84,6 +85,9 @@ func TestConfig_ToTaskPolicy_RoundTrip(t *testing.T) {
 	}
 	if restored.ScanIntervalSeconds != original.ScanIntervalSeconds {
 		t.Errorf("ScanIntervalSeconds mismatch: %d vs %d", restored.ScanIntervalSeconds, original.ScanIntervalSeconds)
+	}
+	if restored.QuietForSeconds != original.QuietForSeconds {
+		t.Errorf("QuietForSeconds mismatch: %d vs %d", restored.QuietForSeconds, original.QuietForSeconds)
 	}
 }
 

--- a/weed/worker/tasks/delete_empty/config_test.go
+++ b/weed/worker/tasks/delete_empty/config_test.go
@@ -1,0 +1,125 @@
+package delete_empty
+
+import (
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/worker/tasks/base"
+)
+
+func TestNewDefaultConfig(t *testing.T) {
+	cfg := NewDefaultConfig()
+	if cfg == nil {
+		t.Fatal("NewDefaultConfig returned nil")
+	}
+	if !cfg.Enabled {
+		t.Error("Default config should be enabled")
+	}
+	if !cfg.DeleteEmptyEnabled {
+		t.Error("Default config should have DeleteEmptyEnabled=true")
+	}
+	if cfg.QuietForSeconds != 24*60*60 {
+		t.Errorf("Expected QuietForSeconds=86400, got %d", cfg.QuietForSeconds)
+	}
+	if cfg.ScanIntervalSeconds != 6*60*60 {
+		t.Errorf("Expected ScanIntervalSeconds=21600, got %d", cfg.ScanIntervalSeconds)
+	}
+	if cfg.MaxConcurrent != 1 {
+		t.Errorf("Expected MaxConcurrent=1, got %d", cfg.MaxConcurrent)
+	}
+}
+
+func TestConfig_IsEnabled(t *testing.T) {
+	cfg := NewDefaultConfig()
+	if !cfg.IsEnabled() {
+		t.Error("Expected IsEnabled()=true")
+	}
+	cfg.SetEnabled(false)
+	if cfg.IsEnabled() {
+		t.Error("Expected IsEnabled()=false after SetEnabled(false)")
+	}
+	cfg.SetEnabled(true)
+	if !cfg.IsEnabled() {
+		t.Error("Expected IsEnabled()=true after SetEnabled(true)")
+	}
+}
+
+func TestConfig_ToTaskPolicy_RoundTrip(t *testing.T) {
+	original := &Config{
+		BaseConfig: base.BaseConfig{
+			Enabled:             true,
+			ScanIntervalSeconds: 7200,
+			MaxConcurrent:       2,
+		},
+		DeleteEmptyEnabled: true,
+		QuietForSeconds:    12 * 3600,
+	}
+
+	policy := original.ToTaskPolicy()
+	if policy == nil {
+		t.Fatal("ToTaskPolicy returned nil")
+	}
+	if !policy.Enabled {
+		t.Error("Expected policy.Enabled=true")
+	}
+	if policy.MaxConcurrent != 2 {
+		t.Errorf("Expected MaxConcurrent=2, got %d", policy.MaxConcurrent)
+	}
+	if policy.RepeatIntervalSeconds != 7200 {
+		t.Errorf("Expected RepeatIntervalSeconds=7200, got %d", policy.RepeatIntervalSeconds)
+	}
+	if policy.CheckIntervalSeconds != 7200 {
+		t.Errorf("Expected CheckIntervalSeconds=7200, got %d", policy.CheckIntervalSeconds)
+	}
+
+	// Round-trip: policy → config
+	restored := NewDefaultConfig()
+	if err := restored.FromTaskPolicy(policy); err != nil {
+		t.Fatalf("FromTaskPolicy error: %v", err)
+	}
+	if restored.Enabled != original.Enabled {
+		t.Errorf("Enabled mismatch: %v vs %v", restored.Enabled, original.Enabled)
+	}
+	if restored.MaxConcurrent != original.MaxConcurrent {
+		t.Errorf("MaxConcurrent mismatch: %d vs %d", restored.MaxConcurrent, original.MaxConcurrent)
+	}
+	if restored.ScanIntervalSeconds != original.ScanIntervalSeconds {
+		t.Errorf("ScanIntervalSeconds mismatch: %d vs %d", restored.ScanIntervalSeconds, original.ScanIntervalSeconds)
+	}
+}
+
+func TestConfig_FromTaskPolicy_Nil(t *testing.T) {
+	cfg := NewDefaultConfig()
+	// nil policy should not error and should leave config unchanged
+	if err := cfg.FromTaskPolicy(nil); err != nil {
+		t.Errorf("FromTaskPolicy(nil) should not error, got: %v", err)
+	}
+	if !cfg.Enabled {
+		t.Error("Enabled should remain true after nil policy")
+	}
+}
+
+func TestConfig_Validate(t *testing.T) {
+	cfg := NewDefaultConfig()
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("Default config should be valid, got: %v", err)
+	}
+}
+
+func TestGetConfigSpec(t *testing.T) {
+	spec := GetConfigSpec()
+	if len(spec.Fields) == 0 {
+		t.Error("ConfigSpec should have at least one field")
+	}
+
+	fieldNames := make(map[string]bool)
+	for _, f := range spec.Fields {
+		fieldNames[f.JSONName] = true
+	}
+
+	required := []string{"enabled", "scan_interval_seconds", "delete_empty_enabled", "quiet_for_seconds"}
+	for _, name := range required {
+		if !fieldNames[name] {
+			t.Errorf("ConfigSpec missing required field: %s", name)
+		}
+	}
+}

--- a/weed/worker/tasks/delete_empty/delete_empty_task.go
+++ b/weed/worker/tasks/delete_empty/delete_empty_task.go
@@ -1,0 +1,130 @@
+package delete_empty
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/glog"
+	"github.com/seaweedfs/seaweedfs/weed/operation"
+	"github.com/seaweedfs/seaweedfs/weed/pb"
+	"github.com/seaweedfs/seaweedfs/weed/pb/volume_server_pb"
+	"github.com/seaweedfs/seaweedfs/weed/pb/worker_pb"
+	"github.com/seaweedfs/seaweedfs/weed/worker/types"
+	"github.com/seaweedfs/seaweedfs/weed/worker/types/base"
+	"google.golang.org/grpc"
+)
+
+// DeleteEmptyTask deletes a single empty volume from a volume server.
+// It only proceeds if the volume is still empty at execution time (onlyEmpty=true),
+// so it is safe to run concurrently with write traffic.
+type DeleteEmptyTask struct {
+	*base.BaseTask
+	server         string
+	volumeID       uint32
+	collection     string
+	grpcDialOption grpc.DialOption
+}
+
+// NewDeleteEmptyTask creates a new delete_empty task instance
+func NewDeleteEmptyTask(id string, server string, volumeID uint32, collection string, grpcDialOption grpc.DialOption) *DeleteEmptyTask {
+	return &DeleteEmptyTask{
+		BaseTask:       base.NewBaseTask(id, types.TaskTypeDeleteEmpty),
+		server:         server,
+		volumeID:       volumeID,
+		collection:     collection,
+		grpcDialOption: grpcDialOption,
+	}
+}
+
+// Execute implements the Task interface
+func (t *DeleteEmptyTask) Execute(ctx context.Context, params *worker_pb.TaskParams) error {
+	if params == nil {
+		return fmt.Errorf("task parameters are required")
+	}
+
+	t.GetLogger().WithFields(map[string]interface{}{
+		"volume_id":  t.volumeID,
+		"server":     t.server,
+		"collection": t.collection,
+	}).Info("Starting delete_empty task")
+
+	t.ReportProgress(10.0)
+
+	if err := t.verifyVolumeIsEmpty(ctx); err != nil {
+		return err
+	}
+
+	t.ReportProgress(50.0)
+
+	if err := t.deleteVolume(ctx); err != nil {
+		return err
+	}
+
+	t.ReportProgress(100.0)
+	glog.Infof("DELETE_EMPTY: successfully deleted empty volume %d from %s", t.volumeID, t.server)
+	return nil
+}
+
+// Validate implements the Task interface
+func (t *DeleteEmptyTask) Validate(params *worker_pb.TaskParams) error {
+	if params == nil {
+		return fmt.Errorf("task parameters are required")
+	}
+	if params.VolumeId != t.volumeID {
+		return fmt.Errorf("volume ID mismatch: expected %d, got %d", t.volumeID, params.VolumeId)
+	}
+	if len(params.Sources) == 0 {
+		return fmt.Errorf("at least one source is required")
+	}
+	return nil
+}
+
+// EstimateTime implements the Task interface
+func (t *DeleteEmptyTask) EstimateTime(_ *worker_pb.TaskParams) time.Duration {
+	return 5 * time.Second
+}
+
+// verifyVolumeIsEmpty re-checks the volume size before deletion to guard
+// against a race where new data arrived between detection and execution.
+func (t *DeleteEmptyTask) verifyVolumeIsEmpty(ctx context.Context) error {
+	return operation.WithVolumeServerClient(false, pb.ServerAddress(t.server), t.grpcDialOption,
+		func(client volume_server_pb.VolumeServerClient) error {
+			checkCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+			defer cancel()
+
+			resp, err := client.VacuumVolumeCheck(checkCtx, &volume_server_pb.VacuumVolumeCheckRequest{
+				VolumeId: t.volumeID,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to check volume %d status: %w", t.volumeID, err)
+			}
+
+			// A truly empty volume has garbage ratio 0 and the shell command
+			// uses Size <= SuperBlockSize. We re-verify by checking that
+			// GarbageRatio is 0 and the volume reports no data (gRPC check is
+			// a reasonable proxy; the real guard is onlyEmpty=true in delete).
+			glog.V(2).Infof("DELETE_EMPTY: pre-delete check on volume %d: garbage_ratio=%.4f", t.volumeID, resp.GarbageRatio)
+			return nil
+		})
+}
+
+// deleteVolume calls VolumeDelete with onlyEmpty=true so the server will
+// refuse to delete the volume if it has received data since detection.
+func (t *DeleteEmptyTask) deleteVolume(ctx context.Context) error {
+	return operation.WithVolumeServerClient(false, pb.ServerAddress(t.server), t.grpcDialOption,
+		func(client volume_server_pb.VolumeServerClient) error {
+			deleteCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+			defer cancel()
+
+			_, err := client.VolumeDelete(deleteCtx, &volume_server_pb.VolumeDeleteRequest{
+				VolumeId:  t.volumeID,
+				OnlyEmpty: true,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to delete empty volume %d from %s: %w", t.volumeID, t.server, err)
+			}
+
+			return nil
+		})
+}

--- a/weed/worker/tasks/delete_empty/delete_empty_task.go
+++ b/weed/worker/tasks/delete_empty/delete_empty_task.go
@@ -47,7 +47,7 @@ func (t *DeleteEmptyTask) Execute(ctx context.Context, params *worker_pb.TaskPar
 		"volume_id":  t.volumeID,
 		"server":     t.server,
 		"collection": t.collection,
-	}).Info("Starting delete_empty task")
+	}).Info("Starting compaction task")
 
 	t.ReportProgress(10.0)
 
@@ -62,7 +62,7 @@ func (t *DeleteEmptyTask) Execute(ctx context.Context, params *worker_pb.TaskPar
 	}
 
 	t.ReportProgress(100.0)
-	glog.Infof("DELETE_EMPTY: successfully deleted empty volume %d from %s", t.volumeID, t.server)
+	glog.Infof("COMPACTION: successfully deleted empty volume %d from %s", t.volumeID, t.server)
 	return nil
 }
 
@@ -100,11 +100,13 @@ func (t *DeleteEmptyTask) verifyVolumeIsEmpty(ctx context.Context) error {
 				return fmt.Errorf("failed to check volume %d status: %w", t.volumeID, err)
 			}
 
-			// A truly empty volume has garbage ratio 0 and the shell command
-			// uses Size <= SuperBlockSize. We re-verify by checking that
-			// GarbageRatio is 0 and the volume reports no data (gRPC check is
-			// a reasonable proxy; the real guard is onlyEmpty=true in delete).
-			glog.V(2).Infof("DELETE_EMPTY: pre-delete check on volume %d: garbage_ratio=%.4f", t.volumeID, resp.GarbageRatio)
+			// Re-verify the volume is still empty: a non-zero GarbageRatio means
+			// the volume has received data since detection. Abort to be safe;
+			// the real server-side guard is onlyEmpty=true in VolumeDelete.
+			glog.V(2).Infof("COMPACTION: pre-delete check on volume %d: garbage_ratio=%.4f", t.volumeID, resp.GarbageRatio)
+			if resp.GarbageRatio > 0 {
+				return fmt.Errorf("pre-delete check failed: volume %d is not empty (garbage_ratio=%.4f)", t.volumeID, resp.GarbageRatio)
+			}
 			return nil
 		})
 }

--- a/weed/worker/tasks/delete_empty/detection.go
+++ b/weed/worker/tasks/delete_empty/detection.go
@@ -1,0 +1,97 @@
+package delete_empty
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/glog"
+	"github.com/seaweedfs/seaweedfs/weed/pb/worker_pb"
+	"github.com/seaweedfs/seaweedfs/weed/worker/tasks/base"
+	"github.com/seaweedfs/seaweedfs/weed/worker/types"
+)
+
+// superBlockSize is the minimum size of a volume file (just the header).
+// A volume at exactly this size has no needle data — it is empty.
+const superBlockSize = 8
+
+// Detection implements the detection logic for compaction tasks.
+// When DeleteEmptyEnabled is set it selects volumes whose on-disk size equals
+// the superblock header (i.e. FileCount == 0) and that have not been modified
+// within the configured quiet period, to avoid deleting freshly allocated volumes.
+func Detection(metrics []*types.VolumeHealthMetrics, clusterInfo *types.ClusterInfo, config base.TaskConfig) ([]*types.TaskDetectionResult, error) {
+	if !config.IsEnabled() {
+		return nil, nil
+	}
+
+	cfg := config.(*Config)
+
+	if !cfg.DeleteEmptyEnabled {
+		glog.V(2).Infof("COMPACTION: delete-empty-volumes is disabled, skipping")
+		return nil, nil
+	}
+
+	quietFor := time.Duration(cfg.QuietForSeconds) * time.Second
+	now := time.Now()
+
+	var results []*types.TaskDetectionResult
+
+	for _, metric := range metrics {
+		if metric.Size > superBlockSize {
+			continue
+		}
+		if metric.LastModified.IsZero() {
+			continue
+		}
+		if now.Sub(metric.LastModified) < quietFor {
+			glog.V(3).Infof("COMPACTION: skipping volume %d on %s — modified %v ago (quiet period: %v)",
+				metric.VolumeID, metric.Server, now.Sub(metric.LastModified).Truncate(time.Minute), quietFor)
+			continue
+		}
+
+		if clusterInfo != nil && clusterInfo.ActiveTopology != nil {
+			if clusterInfo.ActiveTopology.HasAnyTask(metric.VolumeID) {
+				glog.V(2).Infof("COMPACTION: skipping volume %d, task already exists in ActiveTopology", metric.VolumeID)
+				continue
+			}
+		}
+
+		taskID := fmt.Sprintf("compaction_vol_%d_%d", metric.VolumeID, now.Unix())
+
+		result := &types.TaskDetectionResult{
+			TaskID:     taskID,
+			TaskType:   types.TaskTypeCompaction,
+			VolumeID:   metric.VolumeID,
+			Server:     metric.Server,
+			Collection: metric.Collection,
+			Priority:   types.TaskPriorityLow,
+			Reason:     "Volume is empty and has been quiet for the configured period",
+			ScheduleAt: now,
+			TypedParams: &worker_pb.TaskParams{
+				TaskId:     taskID,
+				VolumeId:   metric.VolumeID,
+				Collection: metric.Collection,
+				VolumeSize: metric.Size,
+				Sources: []*worker_pb.TaskSource{
+					{
+						Node:          metric.ServerAddress,
+						VolumeId:      metric.VolumeID,
+						EstimatedSize: metric.Size,
+						DataCenter:    metric.DataCenter,
+						Rack:          metric.Rack,
+					},
+				},
+			},
+		}
+
+		glog.V(1).Infof("COMPACTION: detected empty volume %d on %s (collection: %q, last modified: %v ago)",
+			metric.VolumeID, metric.Server, metric.Collection, now.Sub(metric.LastModified).Truncate(time.Minute))
+
+		results = append(results, result)
+	}
+
+	if len(results) == 0 && len(metrics) > 0 {
+		glog.V(1).Infof("COMPACTION: no empty volumes found among %d volumes (quiet period: %v)", len(metrics), quietFor)
+	}
+
+	return results, nil
+}

--- a/weed/worker/tasks/delete_empty/detection.go
+++ b/weed/worker/tasks/delete_empty/detection.go
@@ -48,14 +48,16 @@ func Detection(metrics []*types.VolumeHealthMetrics, clusterInfo *types.ClusterI
 			continue
 		}
 
+		// Build a per-replica task ID so each replica of an empty volume
+		// gets its own compaction task without ID collisions.
+		taskID := fmt.Sprintf("compaction_%d_%s_%d", metric.VolumeID, metric.ServerAddress, now.Unix())
+
 		if clusterInfo != nil && clusterInfo.ActiveTopology != nil {
 			if clusterInfo.ActiveTopology.HasAnyTask(metric.VolumeID) {
-				glog.V(2).Infof("COMPACTION: skipping volume %d, task already exists in ActiveTopology", metric.VolumeID)
+				glog.V(2).Infof("COMPACTION: skipping volume %d on %s, task already exists in ActiveTopology", metric.VolumeID, metric.ServerAddress)
 				continue
 			}
 		}
-
-		taskID := fmt.Sprintf("compaction_vol_%d_%d", metric.VolumeID, now.Unix())
 
 		result := &types.TaskDetectionResult{
 			TaskID:     taskID,

--- a/weed/worker/tasks/delete_empty/detection_test.go
+++ b/weed/worker/tasks/delete_empty/detection_test.go
@@ -1,0 +1,380 @@
+package delete_empty
+
+import (
+	"testing"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/admin/topology"
+	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
+	"github.com/seaweedfs/seaweedfs/weed/worker/tasks/base"
+	"github.com/seaweedfs/seaweedfs/weed/worker/types"
+)
+
+func defaultDetectionConfig() *Config {
+	return &Config{
+		BaseConfig: base.BaseConfig{
+			Enabled:             true,
+			ScanIntervalSeconds: 3600,
+			MaxConcurrent:       1,
+		},
+		DeleteEmptyEnabled: true,
+		QuietForSeconds:    3600, // 1 hour for tests
+	}
+}
+
+// emptyVolume returns a VolumeHealthMetrics for an empty volume quiet for > 1 hour.
+func emptyVolume(id uint32, server string) *types.VolumeHealthMetrics {
+	return &types.VolumeHealthMetrics{
+		VolumeID:      id,
+		Server:        server,
+		ServerAddress: server + ":8080",
+		DiskType:      "hdd",
+		Collection:    "",
+		Size:          0,
+		LastModified:  time.Now().Add(-2 * time.Hour),
+	}
+}
+
+// buildTopologyWithVolumes creates a minimal ActiveTopology for the given metrics.
+func buildTopologyWithVolumes(metrics []*types.VolumeHealthMetrics) *topology.ActiveTopology {
+	at := topology.NewActiveTopology(0)
+
+	volumesByServer := make(map[string][]*master_pb.VolumeInformationMessage)
+	for _, m := range metrics {
+		volumesByServer[m.Server] = append(volumesByServer[m.Server], &master_pb.VolumeInformationMessage{
+			Id:   m.VolumeID,
+			Size: m.Size,
+		})
+	}
+
+	var nodes []*master_pb.DataNodeInfo
+	seen := make(map[string]bool)
+	for _, m := range metrics {
+		if seen[m.Server] {
+			continue
+		}
+		seen[m.Server] = true
+		nodes = append(nodes, &master_pb.DataNodeInfo{
+			Id:      m.Server,
+			Address: m.Server + ":8080",
+			DiskInfos: map[string]*master_pb.DiskInfo{
+				"hdd": {
+					Type:           "hdd",
+					DiskId:         1,
+					VolumeInfos:    volumesByServer[m.Server],
+					MaxVolumeCount: 1000,
+				},
+			},
+		})
+	}
+
+	at.UpdateTopology(&master_pb.TopologyInfo{
+		DataCenterInfos: []*master_pb.DataCenterInfo{
+			{
+				Id: "dc1",
+				RackInfos: []*master_pb.RackInfo{
+					{Id: "rack1", DataNodeInfos: nodes},
+				},
+			},
+		},
+	})
+	return at
+}
+
+func clusterInfo(metrics []*types.VolumeHealthMetrics) *types.ClusterInfo {
+	return &types.ClusterInfo{
+		ActiveTopology: buildTopologyWithVolumes(metrics),
+	}
+}
+
+// --- Tests ---
+
+func TestDetection_DetectsEmptyVolume(t *testing.T) {
+	vol := emptyVolume(42, "server-1")
+	metrics := []*types.VolumeHealthMetrics{vol}
+
+	results, err := Detection(metrics, clusterInfo(metrics), defaultDetectionConfig())
+	if err != nil {
+		t.Fatalf("Detection error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("Expected 1 detection result, got %d", len(results))
+	}
+	if results[0].VolumeID != 42 {
+		t.Errorf("Expected VolumeID=42, got %d", results[0].VolumeID)
+	}
+	if results[0].TaskType != types.TaskTypeCompaction {
+		t.Errorf("Expected TaskType=%s, got %s", types.TaskTypeDeleteEmpty, results[0].TaskType)
+	}
+	if results[0].Priority != types.TaskPriorityLow {
+		t.Errorf("Expected PriorityLow, got %v", results[0].Priority)
+	}
+	if results[0].TypedParams == nil {
+		t.Fatal("TypedParams must not be nil")
+	}
+	if len(results[0].TypedParams.Sources) == 0 {
+		t.Error("TypedParams.Sources must not be empty")
+	}
+	if results[0].TypedParams.Sources[0].Node != "server-1:8080" {
+		t.Errorf("Expected source node server-1:8080, got %s", results[0].TypedParams.Sources[0].Node)
+	}
+}
+
+func TestDetection_SkipsNonEmptyVolume(t *testing.T) {
+	vol := &types.VolumeHealthMetrics{
+		VolumeID:     10,
+		Server:       "server-1",
+		Size:         1024 * 1024,
+		LastModified: time.Now().Add(-2 * time.Hour),
+	}
+	metrics := []*types.VolumeHealthMetrics{vol}
+
+	results, err := Detection(metrics, clusterInfo(metrics), defaultDetectionConfig())
+	if err != nil {
+		t.Fatalf("Detection error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("Expected 0 results for non-empty volume, got %d", len(results))
+	}
+}
+
+func TestDetection_SkipsSuperBlockSizePlusOne(t *testing.T) {
+	vol := &types.VolumeHealthMetrics{
+		VolumeID:     11,
+		Server:       "server-1",
+		Size:         superBlockSize + 1,
+		LastModified: time.Now().Add(-2 * time.Hour),
+	}
+	metrics := []*types.VolumeHealthMetrics{vol}
+
+	results, err := Detection(metrics, clusterInfo(metrics), defaultDetectionConfig())
+	if err != nil {
+		t.Fatalf("Detection error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("Expected 0 results for size=%d, got %d", superBlockSize+1, len(results))
+	}
+}
+
+func TestDetection_SkipsRecentlyModifiedVolume(t *testing.T) {
+	vol := &types.VolumeHealthMetrics{
+		VolumeID:     20,
+		Server:       "server-1",
+		Size:         0,
+		LastModified: time.Now().Add(-10 * time.Minute), // too recent
+	}
+	metrics := []*types.VolumeHealthMetrics{vol}
+
+	results, err := Detection(metrics, clusterInfo(metrics), defaultDetectionConfig())
+	if err != nil {
+		t.Fatalf("Detection error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("Expected 0 results for recently modified volume, got %d", len(results))
+	}
+}
+
+func TestDetection_SkipsZeroLastModified(t *testing.T) {
+	vol := &types.VolumeHealthMetrics{
+		VolumeID: 30,
+		Server:   "server-1",
+		Size:     0,
+		// LastModified is zero value
+	}
+	metrics := []*types.VolumeHealthMetrics{vol}
+
+	results, err := Detection(metrics, clusterInfo(metrics), defaultDetectionConfig())
+	if err != nil {
+		t.Fatalf("Detection error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("Expected 0 results for zero LastModified, got %d", len(results))
+	}
+}
+
+func TestDetection_DeleteEmptyDisabledReturnsNil(t *testing.T) {
+	cfg := defaultDetectionConfig()
+	cfg.DeleteEmptyEnabled = false
+
+	vol := emptyVolume(55, "server-1")
+	metrics := []*types.VolumeHealthMetrics{vol}
+
+	results, err := Detection(metrics, clusterInfo(metrics), cfg)
+	if err != nil {
+		t.Fatalf("Detection error: %v", err)
+	}
+	if results != nil {
+		t.Errorf("Expected nil results when DeleteEmptyEnabled=false, got %v", results)
+	}
+}
+
+func TestDetection_DisabledConfigReturnsNil(t *testing.T) {
+	cfg := defaultDetectionConfig()
+	cfg.Enabled = false
+
+	vol := emptyVolume(50, "server-1")
+	metrics := []*types.VolumeHealthMetrics{vol}
+
+	results, err := Detection(metrics, clusterInfo(metrics), cfg)
+	if err != nil {
+		t.Fatalf("Detection error: %v", err)
+	}
+	if results != nil {
+		t.Errorf("Expected nil results for disabled config, got %v", results)
+	}
+}
+
+func TestDetection_MultipeEmptyVolumes(t *testing.T) {
+	metrics := []*types.VolumeHealthMetrics{
+		emptyVolume(100, "server-1"),
+		emptyVolume(101, "server-1"),
+		emptyVolume(102, "server-2"),
+		{
+			VolumeID:     103,
+			Server:       "server-2",
+			Size:         512 * 1024, // not empty
+			LastModified: time.Now().Add(-2 * time.Hour),
+		},
+	}
+
+	results, err := Detection(metrics, clusterInfo(metrics), defaultDetectionConfig())
+	if err != nil {
+		t.Fatalf("Detection error: %v", err)
+	}
+	if len(results) != 3 {
+		t.Errorf("Expected 3 results (3 empty, 1 skipped), got %d", len(results))
+	}
+
+	// Verify no duplicates
+	seen := make(map[uint32]bool)
+	for _, r := range results {
+		if seen[r.VolumeID] {
+			t.Errorf("Duplicate VolumeID %d in results", r.VolumeID)
+		}
+		seen[r.VolumeID] = true
+	}
+}
+
+func TestDetection_SkipsVolumeWithExistingTask(t *testing.T) {
+	metrics := []*types.VolumeHealthMetrics{
+		emptyVolume(200, "server-1"),
+		emptyVolume(201, "server-1"),
+	}
+
+	at := buildTopologyWithVolumes(metrics)
+	err := at.AddPendingTask(topology.TaskSpec{
+		TaskID:       "existing-200",
+		TaskType:     topology.TaskTypeBalance,
+		VolumeID:     200,
+		VolumeSize:   0,
+		Sources:      []topology.TaskSourceSpec{{ServerID: "server-1", DiskID: 1}},
+		Destinations: []topology.TaskDestinationSpec{{ServerID: "server-1", DiskID: 2}},
+	})
+	if err != nil {
+		t.Fatalf("AddPendingTask failed: %v", err)
+	}
+
+	ci := &types.ClusterInfo{ActiveTopology: at}
+	results, err := Detection(metrics, ci, defaultDetectionConfig())
+	if err != nil {
+		t.Fatalf("Detection error: %v", err)
+	}
+
+	// Volume 200 has pending task → skipped; 201 should still be detected
+	if len(results) != 1 {
+		t.Fatalf("Expected 1 result (vol 201 only), got %d", len(results))
+	}
+	if results[0].VolumeID != 201 {
+		t.Errorf("Expected VolumeID=201, got %d", results[0].VolumeID)
+	}
+}
+
+func TestDetection_NilClusterInfo(t *testing.T) {
+	vol := emptyVolume(300, "server-1")
+	metrics := []*types.VolumeHealthMetrics{vol}
+
+	// Should not panic with nil clusterInfo
+	results, err := Detection(metrics, nil, defaultDetectionConfig())
+	if err != nil {
+		t.Fatalf("Detection error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("Expected 1 result with nil clusterInfo, got %d", len(results))
+	}
+}
+
+func TestDetection_EmptyMetricsSlice(t *testing.T) {
+	results, err := Detection(nil, nil, defaultDetectionConfig())
+	if err != nil {
+		t.Fatalf("Detection error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("Expected 0 results for empty metrics, got %d", len(results))
+	}
+}
+
+func TestDetection_QuietPeriodBoundary(t *testing.T) {
+	cfg := defaultDetectionConfig()
+	cfg.QuietForSeconds = 3600 // 1 hour
+
+	// Just before the quiet period – should NOT be detected (Age < quietFor)
+	tooRecent := &types.VolumeHealthMetrics{
+		VolumeID:     400,
+		Server:       "server-1",
+		Size:         0,
+		LastModified: time.Now().Add(-time.Hour + time.Second),
+	}
+	// Exactly at and past boundary – should be detected (Age >= quietFor)
+	atBoundary := &types.VolumeHealthMetrics{
+		VolumeID:     401,
+		Server:       "server-1",
+		Size:         0,
+		LastModified: time.Now().Add(-time.Hour),
+	}
+	pastLimit := &types.VolumeHealthMetrics{
+		VolumeID:     402,
+		Server:       "server-1",
+		Size:         0,
+		LastModified: time.Now().Add(-time.Hour - time.Second),
+	}
+
+	metrics := []*types.VolumeHealthMetrics{tooRecent, atBoundary, pastLimit}
+	results, err := Detection(metrics, clusterInfo(metrics), cfg)
+	if err != nil {
+		t.Fatalf("Detection error: %v", err)
+	}
+
+	seen := make(map[uint32]bool)
+	for _, r := range results {
+		seen[r.VolumeID] = true
+	}
+
+	if seen[400] {
+		t.Errorf("Volume 400 (too recent) should not be detected")
+	}
+	if !seen[401] {
+		t.Errorf("Volume 401 (exactly at boundary) should be detected")
+	}
+	if !seen[402] {
+		t.Errorf("Volume 402 (past quiet period) should be detected")
+	}
+}
+
+func TestDetection_TaskIDUnique(t *testing.T) {
+	metrics := []*types.VolumeHealthMetrics{
+		emptyVolume(500, "server-1"),
+		emptyVolume(501, "server-1"),
+	}
+
+	results, err := Detection(metrics, clusterInfo(metrics), defaultDetectionConfig())
+	if err != nil {
+		t.Fatalf("Detection error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("Expected 2 results, got %d", len(results))
+	}
+
+	if results[0].TaskID == results[1].TaskID {
+		t.Errorf("Task IDs should be unique: both are %q", results[0].TaskID)
+	}
+}

--- a/weed/worker/tasks/delete_empty/register.go
+++ b/weed/worker/tasks/delete_empty/register.go
@@ -77,6 +77,11 @@ func UpdateConfigFromPersistence(configPersistence interface{}) error {
 	}
 
 	globalTaskDef.Config = newConfig
+	// Sync the runtime scheduling fields read by GenericDetector/GenericScheduler
+	// so that persisted changes to intervals and concurrency take effect.
+	globalTaskDef.ScanInterval = time.Duration(newConfig.ScanIntervalSeconds) * time.Second
+	globalTaskDef.MaxConcurrent = newConfig.MaxConcurrent
+	globalTaskDef.RepeatInterval = time.Duration(newConfig.ScanIntervalSeconds) * time.Second
 	glog.V(1).Infof("Updated compaction task configuration from persistence")
 	return nil
 }

--- a/weed/worker/tasks/delete_empty/register.go
+++ b/weed/worker/tasks/delete_empty/register.go
@@ -1,0 +1,78 @@
+package delete_empty
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/glog"
+	"github.com/seaweedfs/seaweedfs/weed/pb/worker_pb"
+	"github.com/seaweedfs/seaweedfs/weed/security"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+	"github.com/seaweedfs/seaweedfs/weed/worker/tasks"
+	"github.com/seaweedfs/seaweedfs/weed/worker/tasks/base"
+	"github.com/seaweedfs/seaweedfs/weed/worker/types"
+)
+
+var globalTaskDef *base.TaskDefinition
+
+func init() {
+	RegisterDeleteEmptyTask()
+	tasks.AutoRegisterConfigUpdater(types.TaskTypeCompaction, UpdateConfigFromPersistence)
+}
+
+// RegisterDeleteEmptyTask registers the delete_empty task with the worker architecture
+func RegisterDeleteEmptyTask() {
+	cfg := NewDefaultConfig()
+	dialOpt := security.LoadClientTLS(util.GetViper(), "grpc.worker")
+
+	taskDef := &base.TaskDefinition{
+		Type:         types.TaskTypeCompaction,
+		Name:         "compaction",
+		DisplayName:  "Volume Compaction",
+		Description:  "Compaction operations for volumes, including deletion of empty (zero-byte) volumes",
+		Icon:         "fas fa-compress-alt text-info",
+		Capabilities: []string{"compaction", "storage"},
+
+		Config:     cfg,
+		ConfigSpec: GetConfigSpec(),
+		CreateTask: func(params *worker_pb.TaskParams) (types.Task, error) {
+			if params == nil {
+				return nil, fmt.Errorf("task parameters are required")
+			}
+			if len(params.Sources) == 0 {
+				return nil, fmt.Errorf("at least one source is required for compaction task")
+			}
+			return NewDeleteEmptyTask(
+				fmt.Sprintf("compaction-%d", params.VolumeId),
+				params.Sources[0].Node,
+				params.VolumeId,
+				params.Collection,
+				dialOpt,
+			), nil
+		},
+		DetectionFunc:  Detection,
+		ScanInterval:   6 * time.Hour,
+		SchedulingFunc: Scheduling,
+		MaxConcurrent:  1,
+		RepeatInterval: 6 * time.Hour,
+	}
+
+	globalTaskDef = taskDef
+	base.RegisterTask(taskDef)
+}
+
+// UpdateConfigFromPersistence updates the compaction configuration from persistence
+func UpdateConfigFromPersistence(configPersistence interface{}) error {
+	if globalTaskDef == nil {
+		return fmt.Errorf("compaction task not registered")
+	}
+
+	newConfig := LoadConfigFromPersistence(configPersistence)
+	if newConfig == nil {
+		return fmt.Errorf("failed to load configuration from persistence")
+	}
+
+	globalTaskDef.Config = newConfig
+	glog.V(1).Infof("Updated compaction task configuration from persistence")
+	return nil
+}

--- a/weed/worker/tasks/delete_empty/register.go
+++ b/weed/worker/tasks/delete_empty/register.go
@@ -42,8 +42,12 @@ func RegisterDeleteEmptyTask() {
 			if len(params.Sources) == 0 {
 				return nil, fmt.Errorf("at least one source is required for compaction task")
 			}
+			taskID := params.TaskId
+			if taskID == "" {
+				taskID = fmt.Sprintf("compaction-%d", params.VolumeId)
+			}
 			return NewDeleteEmptyTask(
-				fmt.Sprintf("compaction-%d", params.VolumeId),
+				taskID,
 				params.Sources[0].Node,
 				params.VolumeId,
 				params.Collection,

--- a/weed/worker/tasks/delete_empty/scheduling.go
+++ b/weed/worker/tasks/delete_empty/scheduling.go
@@ -1,0 +1,34 @@
+package delete_empty
+
+import (
+	"github.com/seaweedfs/seaweedfs/weed/worker/tasks/base"
+	"github.com/seaweedfs/seaweedfs/weed/worker/types"
+)
+
+// Scheduling implements the scheduling logic for compaction tasks
+func Scheduling(task *types.TaskInput, runningTasks []*types.TaskInput, availableWorkers []*types.WorkerData, config base.TaskConfig) bool {
+	cfg := config.(*Config)
+
+	runningCount := 0
+	for _, runningTask := range runningTasks {
+		if runningTask.Type == types.TaskTypeCompaction {
+			runningCount++
+		}
+	}
+
+	if runningCount >= cfg.MaxConcurrent {
+		return false
+	}
+
+	for _, worker := range availableWorkers {
+		if worker.CurrentLoad < worker.MaxConcurrent {
+			for _, capability := range worker.Capabilities {
+				if capability == types.TaskTypeCompaction {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}

--- a/weed/worker/tasks/delete_empty/scheduling_test.go
+++ b/weed/worker/tasks/delete_empty/scheduling_test.go
@@ -1,0 +1,150 @@
+package delete_empty
+
+import (
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/worker/tasks/base"
+	"github.com/seaweedfs/seaweedfs/weed/worker/types"
+)
+
+func makeWorker(id string, hasCapability bool, currentLoad, maxConcurrent int) *types.WorkerData {
+	caps := []types.TaskType{}
+	if hasCapability {
+		caps = append(caps, types.TaskTypeCompaction)
+	}
+	return &types.WorkerData{
+		ID:            id,
+		Status:        "active",
+		Capabilities:  caps,
+		CurrentLoad:   currentLoad,
+		MaxConcurrent: maxConcurrent,
+	}
+}
+
+func makeCompactionTask() *types.TaskInput {
+	return makeTask(types.TaskTypeCompaction)
+}
+
+func makeTask(taskType types.TaskType) *types.TaskInput {
+	return &types.TaskInput{
+		Type: taskType,
+	}
+}
+
+func schedulingConfig(maxConcurrent int) *Config {
+	return &Config{
+		BaseConfig: base.BaseConfig{
+			Enabled:       true,
+			MaxConcurrent: maxConcurrent,
+		},
+		QuietForSeconds: 3600,
+	}
+}
+
+func TestScheduling_AvailableWorkerWithCapability(t *testing.T) {
+	task := makeCompactionTask()
+	workers := []*types.WorkerData{
+		makeWorker("worker-1", true, 0, 2),
+	}
+
+	result := Scheduling(task, nil, workers, schedulingConfig(1))
+	if !result {
+		t.Error("Expected Scheduling=true with capable idle worker")
+	}
+}
+
+func TestScheduling_NoWorkersWithCapability(t *testing.T) {
+	task := makeCompactionTask()
+	workers := []*types.WorkerData{
+		makeWorker("worker-1", false, 0, 2), // no delete_empty capability
+	}
+
+	result := Scheduling(task, nil, workers, schedulingConfig(1))
+	if result {
+		t.Error("Expected Scheduling=false when no worker has capability")
+	}
+}
+
+func TestScheduling_WorkerAtCapacity(t *testing.T) {
+	task := makeCompactionTask()
+	workers := []*types.WorkerData{
+		makeWorker("worker-1", true, 2, 2), // CurrentLoad == MaxConcurrent
+	}
+
+	result := Scheduling(task, nil, workers, schedulingConfig(1))
+	if result {
+		t.Error("Expected Scheduling=false when worker is at capacity")
+	}
+}
+
+func TestScheduling_AtConcurrencyLimit(t *testing.T) {
+	task := makeCompactionTask()
+	// Already running 1 compaction task, config max is 1
+	running := []*types.TaskInput{
+		makeCompactionTask(),
+	}
+	workers := []*types.WorkerData{
+		makeWorker("worker-1", true, 0, 4),
+	}
+
+	result := Scheduling(task, running, workers, schedulingConfig(1))
+	if result {
+		t.Error("Expected Scheduling=false when at concurrency limit (1/1)")
+	}
+}
+
+func TestScheduling_BelowConcurrencyLimit(t *testing.T) {
+	task := makeCompactionTask()
+	// 1 running, max is 2 → still room
+	running := []*types.TaskInput{
+		makeCompactionTask(),
+	}
+	workers := []*types.WorkerData{
+		makeWorker("worker-1", true, 0, 4),
+	}
+
+	result := Scheduling(task, running, workers, schedulingConfig(2))
+	if !result {
+		t.Error("Expected Scheduling=true when below concurrency limit (1/2)")
+	}
+}
+
+func TestScheduling_OtherTaskTypesDoNotCountAgainstLimit(t *testing.T) {
+	task := makeTask(types.TaskTypeDeleteEmpty)
+	// Running vacuum tasks should not count against delete_empty limit
+	running := []*types.TaskInput{
+		makeTask(types.TaskTypeVacuum),
+		makeTask(types.TaskTypeBalance),
+	}
+	workers := []*types.WorkerData{
+		makeWorker("worker-1", true, 0, 4),
+	}
+
+	result := Scheduling(task, running, workers, schedulingConfig(1))
+	if !result {
+		t.Error("Expected Scheduling=true: other task types don't count against delete_empty limit")
+	}
+}
+
+func TestScheduling_NoWorkers(t *testing.T) {
+	task := makeCompactionTask()
+
+	result := Scheduling(task, nil, nil, schedulingConfig(1))
+	if result {
+		t.Error("Expected Scheduling=false with no workers")
+	}
+}
+
+func TestScheduling_MultipleWorkers_OnlyOneCapable(t *testing.T) {
+	task := makeCompactionTask()
+	workers := []*types.WorkerData{
+		makeWorker("worker-1", false, 0, 4),
+		makeWorker("worker-2", false, 0, 4),
+		makeWorker("worker-3", true, 1, 4), // capable and has room
+	}
+
+	result := Scheduling(task, nil, workers, schedulingConfig(2))
+	if !result {
+		t.Error("Expected Scheduling=true: worker-3 is capable and has room")
+	}
+}

--- a/weed/worker/types/task_types.go
+++ b/weed/worker/types/task_types.go
@@ -16,6 +16,10 @@ const (
 	TaskTypeBalance       TaskType = "balance"
 	TaskTypeReplication   TaskType = "replication"
 	TaskTypeECBalance     TaskType = "ec_balance"
+	TaskTypeCompaction    TaskType = "compaction"
+
+	// TaskTypeDeleteEmpty is deprecated: use TaskTypeCompaction instead.
+	TaskTypeDeleteEmpty = TaskTypeCompaction
 )
 
 // TaskStatus represents the status of a maintenance task

--- a/weed/worker/worker.go
+++ b/weed/worker/worker.go
@@ -16,6 +16,7 @@ import (
 
 	// Import task packages to trigger their auto-registration
 	_ "github.com/seaweedfs/seaweedfs/weed/worker/tasks/balance"
+	_ "github.com/seaweedfs/seaweedfs/weed/worker/tasks/delete_empty"
 	_ "github.com/seaweedfs/seaweedfs/weed/worker/tasks/erasure_coding"
 	_ "github.com/seaweedfs/seaweedfs/weed/worker/tasks/vacuum"
 )


### PR DESCRIPTION
## Summary

Introduce a new **compaction** worker task that periodically identifies and removes volumes containing no needle data (on-disk size ≤ superblock header = 8 bytes).

This is complementary to the existing **vacuum** task:
- **Vacuum** reclaims space inside volumes by compacting out deleted needles.
- **Compaction** removes volumes that are entirely empty and have been idle long enough to be considered safe to delete.

The implementation follows the same worker-task framework as vacuum and balance, reusing `base.RegisterTask` for automatic UI, scheduling, and detection registration.

---

## New package: `weed/worker/tasks/delete_empty` (task type: `compaction`)

### Detection (`detection.go`)
- Scans `VolumeHealthMetrics` for volumes with `size <= 8` (superblock header only)
- Skips volumes with a zero `LastModified` timestamp
- Skips volumes modified within the configurable **quiet period** (default 24 h) to avoid racing with freshly allocated volumes
- Skips volumes that already have a pending task in `ActiveTopology`

### Scheduling (`scheduling.go`)
- Enforces a configurable `MaxConcurrent` limit (default 1)
- Only schedules onto workers advertising the `compaction` capability

### Execution (`delete_empty_task.go`)
- Calls `VolumeDelete` gRPC on the volume server
- Verifies the volume is still empty immediately before deletion to prevent accidental data loss

### Configuration (surfaced in admin UI automatically via `GenericUIProvider`)

| Field | Default | Description |
|---|---|---|
| `enabled` | `true` | Master switch for compaction tasks |
| `scan_interval_seconds` | 6 h | How often to scan for candidates |
| `delete_empty_enabled` | `true` | Toggle for the empty-volume sub-operation |
| `quiet_for_seconds` | 24 h | Minimum idle time before a volume is eligible |

---

## Changes to existing files

- **`weed/worker/types/task_types.go`** — add `TaskTypeCompaction = "compaction"`; `TaskTypeDeleteEmpty` kept as a deprecated alias
- **`weed/worker/worker.go`**, **`weed/command/mini.go`**, **`weed/admin/maintenance/maintenance_worker.go`** — blank imports to trigger `init()` registration
- **`weed/admin/maintenance/maintenance_manager.go`** — wire compaction config loading
- **`weed/admin/dash/config_persistence.go`** — `SaveCompactionTaskPolicy` / `LoadCompactionTaskPolicy` persistence helpers
- **`weed/pb/worker.proto`** — stub `DeleteEmptyTaskParams` / `DeleteEmptyTaskConfig` messages (proto regeneration deferred; base policy fields cover current needs)

---

## Tests (27 passing)

| File | Cases | Coverage |
|---|---|---|
| `detection_test.go` | 13 | empty/non-empty volumes, quiet-period boundary, nil cluster info, existing-task skip, master+sub toggle disabled |
| `scheduling_test.go` | 8 | concurrency limits, capability checks, multi-worker |
| `config_test.go` | 6 | defaults, enable/disable, policy round-trip, ConfigSpec field presence |

```
ok  github.com/seaweedfs/seaweedfs/weed/worker/tasks/delete_empty  (27 tests)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automatic "compaction" (delete-empty) maintenance task that detects and removes idle empty volumes, with configurable quiet period, scheduling, and concurrency; config UI/spec and persistence support added so compaction settings can be viewed, saved, and loaded.

* **Tests**
  * Added unit tests covering compaction config, detection, and scheduling behavior.

* **Bug Fixes**
  * Improved robustness and error handling when loading task state and missing/absent compaction configs; sensible defaults applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->