### PR TITLE
Client disconnects create context cancelled errors, 500x errors and Filer lookup failures

### DIFF
--- a/weed/filer/stream.go
+++ b/weed/filer/stream.go
@@ -141,12 +141,26 @@ func PrepareStreamContentWithThrottler(ctx context.Context, masterClient wdclien
 		var urlStrings []string
 		var err error
 		for _, backoff := range getLookupFileIdBackoffSchedule {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			urlStrings, err = masterClient.GetLookupFileIdFunction()(ctx, chunkView.FileId)
 			if err == nil && len(urlStrings) > 0 {
 				break
 			}
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			glog.V(4).InfofCtx(ctx, "waiting for chunk: %s", chunkView.FileId)
-			time.Sleep(backoff)
+			timer := time.NewTimer(backoff)
+			select {
+			case <-ctx.Done():
+				if !timer.Stop() {
+					<-timer.C
+				}
+				return nil, ctx.Err()
+			case <-timer.C:
+			}
 		}
 		if err != nil {
 			glog.V(1).InfofCtx(ctx, "operation LookupFileId %s failed, err: %v", chunkView.FileId, err)

--- a/weed/filer/stream.go
+++ b/weed/filer/stream.go
@@ -179,6 +179,13 @@ func PrepareStreamContentWithThrottler(ctx context.Context, masterClient wdclien
 			jwt := jwtFunc(chunkView.FileId)
 			written, err := retriedStreamFetchChunkData(ctx, writer, urlStrings, jwt, chunkView.CipherKey, chunkView.IsGzipped, chunkView.IsFullChunk(), chunkView.OffsetInChunk, int(chunkView.ViewSize))
 
+			// Try catching disconnecting clients
+			if err != nil {
+				if ctx.Err() != nil {
+					return err 
+				}
+			}
+
 			// If read failed, try to invalidate cache and re-lookup
 			if err != nil && written == 0 {
 				if invalidator, ok := masterClient.(CacheInvalidator); ok {

--- a/weed/filer/stream.go
+++ b/weed/filer/stream.go
@@ -179,11 +179,8 @@ func PrepareStreamContentWithThrottler(ctx context.Context, masterClient wdclien
 			jwt := jwtFunc(chunkView.FileId)
 			written, err := retriedStreamFetchChunkData(ctx, writer, urlStrings, jwt, chunkView.CipherKey, chunkView.IsGzipped, chunkView.IsFullChunk(), chunkView.OffsetInChunk, int(chunkView.ViewSize))
 
-			// Try catching disconnecting clients
-			if err != nil {
-				if ctx.Err() != nil {
-					return err 
-				}
+			if err != nil && ctx.Err() != nil {
+				return ctx.Err()
 			}
 
 			// If read failed, try to invalidate cache and re-lookup

--- a/weed/filer/stream_failover_test.go
+++ b/weed/filer/stream_failover_test.go
@@ -1,6 +1,7 @@
 package filer
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
@@ -171,5 +172,39 @@ func TestRetryLogicSkipsSameUrls(t *testing.T) {
 	// Different URLs should return false (and thus allow retry)
 	if urlSlicesEqual(sameUrls, differentUrls) {
 		t.Error("Expected different URLs to not be equal")
+	}
+}
+
+func TestCanceledStreamSkipsCacheInvalidation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	fileId := "3,canceled"
+
+	mock := &mockMasterClient{
+		lookupFunc: func(ctx context.Context, fid string) ([]string, error) {
+			return []string{"http://server:8080"}, nil
+		},
+	}
+
+	chunks := []*filer_pb.FileChunk{
+		{
+			FileId: fileId,
+			Offset: 0,
+			Size:   10,
+		},
+	}
+
+	streamFn, err := PrepareStreamContentWithThrottler(ctx, mock, noJwtFunc, chunks, 0, 10, 0)
+	if err != nil {
+		t.Fatalf("PrepareStreamContentWithThrottler failed: %v", err)
+	}
+
+	cancel()
+
+	err = streamFn(&bytes.Buffer{})
+	if err != context.Canceled {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if len(mock.invalidatedFileIds) != 0 {
+		t.Fatalf("expected no cache invalidation on cancellation, got %v", mock.invalidatedFileIds)
 	}
 }

--- a/weed/filer/stream_failover_test.go
+++ b/weed/filer/stream_failover_test.go
@@ -3,7 +3,9 @@ package filer
 import (
 	"bytes"
 	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/wdclient"
@@ -206,5 +208,74 @@ func TestCanceledStreamSkipsCacheInvalidation(t *testing.T) {
 	}
 	if len(mock.invalidatedFileIds) != 0 {
 		t.Fatalf("expected no cache invalidation on cancellation, got %v", mock.invalidatedFileIds)
+	}
+}
+
+func TestPrepareStreamContentSkipsLookupWhenContextAlreadyCanceled(t *testing.T) {
+	oldSchedule := getLookupFileIdBackoffSchedule
+	getLookupFileIdBackoffSchedule = []time.Duration{time.Millisecond}
+	t.Cleanup(func() {
+		getLookupFileIdBackoffSchedule = oldSchedule
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	lookupCalls := 0
+	mock := &mockMasterClient{
+		lookupFunc: func(ctx context.Context, fileId string) ([]string, error) {
+			lookupCalls++
+			return nil, errors.New("lookup should not run")
+		},
+	}
+
+	chunks := []*filer_pb.FileChunk{
+		{
+			FileId: "3,precanceled",
+			Offset: 0,
+			Size:   10,
+		},
+	}
+
+	_, err := PrepareStreamContentWithThrottler(ctx, mock, noJwtFunc, chunks, 0, 10, 0)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if lookupCalls != 0 {
+		t.Fatalf("expected no lookup calls after cancellation, got %d", lookupCalls)
+	}
+}
+
+func TestPrepareStreamContentStopsLookupRetriesAfterContextCancellation(t *testing.T) {
+	oldSchedule := getLookupFileIdBackoffSchedule
+	getLookupFileIdBackoffSchedule = []time.Duration{time.Millisecond, time.Millisecond, time.Millisecond}
+	t.Cleanup(func() {
+		getLookupFileIdBackoffSchedule = oldSchedule
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	lookupCalls := 0
+	mock := &mockMasterClient{
+		lookupFunc: func(ctx context.Context, fileId string) ([]string, error) {
+			lookupCalls++
+			cancel()
+			return nil, context.Canceled
+		},
+	}
+
+	chunks := []*filer_pb.FileChunk{
+		{
+			FileId: "3,cancel-during-lookup",
+			Offset: 0,
+			Size:   10,
+		},
+	}
+
+	_, err := PrepareStreamContentWithThrottler(ctx, mock, noJwtFunc, chunks, 0, 10, 0)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if lookupCalls != 1 {
+		t.Fatalf("expected lookup retries to stop after cancellation, got %d calls", lookupCalls)
 	}
 }

--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -27,6 +27,8 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/util/mem"
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // corsHeaders defines the CORS headers that need to be preserved
@@ -249,8 +251,12 @@ func newStreamErrorWithResponse(err error) *StreamError {
 	return &StreamError{Err: err, ResponseWritten: true}
 }
 
+func isCanceledStreamingError(err error) bool {
+	return errors.Is(err, context.Canceled) || status.Code(err) == codes.Canceled
+}
+
 func shouldWriteStreamingErrorResponse(err error) bool {
-	return err != nil && !errors.Is(err, context.Canceled)
+	return err != nil && !isCanceledStreamingError(err)
 }
 
 func mimeDetect(r *http.Request, dataReader io.Reader) io.ReadCloser {
@@ -885,7 +891,7 @@ func (s3a *S3ApiServer) GetObjectHandler(w http.ResponseWriter, r *http.Request)
 	streamTime = time.Since(tStream)
 	if err != nil {
 		switch {
-		case errors.Is(err, context.Canceled):
+		case isCanceledStreamingError(err):
 			glog.V(3).Infof("GetObjectHandler: client disconnected while streaming %s/%s: %v", bucket, object, err)
 			return
 		case errors.Is(err, context.DeadlineExceeded):
@@ -1040,7 +1046,7 @@ func (s3a *S3ApiServer) streamFromVolumeServers(w http.ResponseWriter, r *http.R
 	resolvedChunks, _, err := filer.ResolveChunkManifest(ctx, lookupFileIdFn, chunks, offset, offset+size)
 	chunkResolveTime = time.Since(tChunkResolve)
 	if err != nil {
-		if errors.Is(err, context.Canceled) {
+		if isCanceledStreamingError(err) {
 			glog.V(3).Infof("streamFromVolumeServers: request canceled while resolving chunks: %v", err)
 			return err
 		}
@@ -1068,7 +1074,7 @@ func (s3a *S3ApiServer) streamFromVolumeServers(w http.ResponseWriter, r *http.R
 	)
 	streamPrepTime = time.Since(tStreamPrep)
 	if err != nil {
-		if errors.Is(err, context.Canceled) {
+		if isCanceledStreamingError(err) {
 			glog.V(3).Infof("streamFromVolumeServers: request canceled while preparing stream: %v", err)
 			return err
 		}
@@ -1117,7 +1123,7 @@ func (s3a *S3ApiServer) streamFromVolumeServers(w http.ResponseWriter, r *http.R
 	}
 	if err != nil {
 		switch {
-		case errors.Is(err, context.Canceled):
+		case isCanceledStreamingError(err):
 			// Client disconnected mid-stream (e.g. Nginx upstream timeout, browser cancel) - expected
 			glog.V(3).Infof("streamFromVolumeServers: client disconnected after writing %d bytes: %v", cw.written, err)
 		case errors.Is(err, context.DeadlineExceeded):

--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -249,6 +249,10 @@ func newStreamErrorWithResponse(err error) *StreamError {
 	return &StreamError{Err: err, ResponseWritten: true}
 }
 
+func shouldWriteStreamingErrorResponse(err error) bool {
+	return err != nil && !errors.Is(err, context.Canceled)
+}
+
 func mimeDetect(r *http.Request, dataReader io.Reader) io.ReadCloser {
 	mimeBuffer := make([]byte, 512)
 	size, _ := dataReader.Read(mimeBuffer)
@@ -880,7 +884,15 @@ func (s3a *S3ApiServer) GetObjectHandler(w http.ResponseWriter, r *http.Request)
 	err = s3a.streamFromVolumeServersWithSSE(w, r, objectEntryForSSE, primarySSEType, bucket, object, versionId)
 	streamTime = time.Since(tStream)
 	if err != nil {
-		glog.Errorf("GetObjectHandler: failed to stream %s/%s from volume servers: %v", bucket, object, err)
+		switch {
+		case errors.Is(err, context.Canceled):
+			glog.V(3).Infof("GetObjectHandler: client disconnected while streaming %s/%s: %v", bucket, object, err)
+			return
+		case errors.Is(err, context.DeadlineExceeded):
+			glog.Warningf("GetObjectHandler: deadline exceeded while streaming %s/%s: %v", bucket, object, err)
+		default:
+			glog.Errorf("GetObjectHandler: failed to stream %s/%s from volume servers: %v", bucket, object, err)
+		}
 		// Check if the streaming function already wrote an HTTP response
 		var streamErr *StreamError
 		if errors.As(err, &streamErr) && streamErr.ResponseWritten {
@@ -892,7 +904,7 @@ func (s3a *S3ApiServer) GetObjectHandler(w http.ResponseWriter, r *http.Request)
 		// Check if error is due to volume server rate limiting (HTTP 429)
 		if errors.Is(err, util_http.ErrTooManyRequests) {
 			s3err.WriteErrorResponse(w, r, s3err.ErrRequestBytesExceed)
-		} else {
+		} else if shouldWriteStreamingErrorResponse(err) {
 			s3err.WriteErrorResponse(w, r, s3err.ErrInternalError)
 		}
 		return
@@ -1028,7 +1040,15 @@ func (s3a *S3ApiServer) streamFromVolumeServers(w http.ResponseWriter, r *http.R
 	resolvedChunks, _, err := filer.ResolveChunkManifest(ctx, lookupFileIdFn, chunks, offset, offset+size)
 	chunkResolveTime = time.Since(tChunkResolve)
 	if err != nil {
-		glog.Errorf("streamFromVolumeServers: failed to resolve chunks: %v", err)
+		if errors.Is(err, context.Canceled) {
+			glog.V(3).Infof("streamFromVolumeServers: request canceled while resolving chunks: %v", err)
+			return err
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			glog.Warningf("streamFromVolumeServers: request deadline exceeded while resolving chunks: %v", err)
+		} else {
+			glog.Errorf("streamFromVolumeServers: failed to resolve chunks: %v", err)
+		}
 		// Write S3-compliant XML error response
 		s3err.WriteErrorResponse(w, r, s3err.ErrInternalError)
 		return newStreamErrorWithResponse(fmt.Errorf("failed to resolve chunks: %v", err))
@@ -1048,7 +1068,15 @@ func (s3a *S3ApiServer) streamFromVolumeServers(w http.ResponseWriter, r *http.R
 	)
 	streamPrepTime = time.Since(tStreamPrep)
 	if err != nil {
-		glog.Errorf("streamFromVolumeServers: failed to prepare stream: %v", err)
+		if errors.Is(err, context.Canceled) {
+			glog.V(3).Infof("streamFromVolumeServers: request canceled while preparing stream: %v", err)
+			return err
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			glog.Warningf("streamFromVolumeServers: request deadline exceeded while preparing stream: %v", err)
+		} else {
+			glog.Errorf("streamFromVolumeServers: failed to prepare stream: %v", err)
+		}
 		// Write S3-compliant XML error response
 		s3err.WriteErrorResponse(w, r, s3err.ErrInternalError)
 		return newStreamErrorWithResponse(fmt.Errorf("failed to prepare stream: %v", err))

--- a/weed/s3api/s3api_stream_error_test.go
+++ b/weed/s3api/s3api_stream_error_test.go
@@ -1,0 +1,48 @@
+package s3api
+
+import (
+	"context"
+	"testing"
+)
+
+func TestShouldWriteStreamingErrorResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "context canceled",
+			err:      context.Canceled,
+			expected: false,
+		},
+		{
+			name:     "wrapped context canceled",
+			err:      &StreamError{Err: context.Canceled},
+			expected: false,
+		},
+		{
+			name:     "deadline exceeded",
+			err:      context.DeadlineExceeded,
+			expected: true,
+		},
+		{
+			name:     "wrapped deadline exceeded",
+			err:      &StreamError{Err: context.DeadlineExceeded},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldWriteStreamingErrorResponse(tt.err); got != tt.expected {
+				t.Fatalf("shouldWriteStreamingErrorResponse(%v) = %v, want %v", tt.err, got, tt.expected)
+			}
+		})
+	}
+}

--- a/weed/s3api/s3api_stream_error_test.go
+++ b/weed/s3api/s3api_stream_error_test.go
@@ -3,6 +3,9 @@ package s3api
 import (
 	"context"
 	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestShouldWriteStreamingErrorResponse(t *testing.T) {
@@ -24,6 +27,16 @@ func TestShouldWriteStreamingErrorResponse(t *testing.T) {
 		{
 			name:     "wrapped context canceled",
 			err:      &StreamError{Err: context.Canceled},
+			expected: false,
+		},
+		{
+			name:     "grpc canceled",
+			err:      status.Error(codes.Canceled, "client connection is closing"),
+			expected: false,
+		},
+		{
+			name:     "wrapped grpc canceled",
+			err:      &StreamError{Err: status.Error(codes.Canceled, "client connection is closing")},
 			expected: false,
 		},
 		{


### PR DESCRIPTION
Client disconnects create context cancelled errors and Filer lookup failures

# What problem are we solving?

There are 500x errors within metrics and responses

<img width="1972" height="1066" alt="image" src="https://github.com/user-attachments/assets/e56962ff-2ff7-480d-ac20-4beb1aeb8b0d" />



My guess is that cancelled GET-requests contexts are not handled properly 
This results in "Internal error" in logs and metrics
Also this results in lots of logs of failed Filers even though they are fine


```
I0330 16:12:48.237349 filer_pb_helper.go:165 read /buckets/marketdata.all/2026/02/02/BinanceSwap.oregon/PAXGUSDT.dat: rpc error: code = Canceled desc = grpc: the client connection is closing
E0330 16:12:48.238522 s3api_object_handlers.go:888 GetObjectHandler: failed to stream marketdata.all/2026/02/02/BinanceSwap.oregon/PAXGUSDT.dat from volume servers: read chunk: context canceled
I0330 16:12:48.238722 s3api_object_handlers.go:612 GET TTFB PROFILE marketdata.all/2026/02/02/BinanceSwap.oregon/PAXGUSDT.dat: total=5.625824ms | conditional=1.542µs, versioning=5.42µs, entryFetch=0s, stream=0s

<Error><Code>InternalError</Code><Message>We encountered an internal error, please try again.</Message><Resource>/marketdata.all/2026/02/02/BinanceSwap.oregon/PAXGUSDT.dat</Resource><RequestId>1774887168238644243</RequestId><Key>2026/02/02/BinanceSwap.oregon/PAXGUSDT.dat</Key><BucketName>marketdata.all</BucketName></Error>
```
(last line is an actual weed s3 log)

The file is definitely there, so it is not a broken file problem, but some "connection handling" one.

```
root@srv0519 ~ # /srv/mc cp s3-md/marketdata.all//2026/02/02/BinanceSwap.oregon/PAXGUSDT.dat ./
...anceSwap.oregon/PAXGUSDT.dat: 444.84 MiB / 444.84 MiB ┃▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓┃ 171.23 MiB/s 2s
```

I can definitely add that there were no failures of servers, HDD-drives, or network issues while observing this behaviour. 

# How are we solving the problem?

I have a guess that we should check for context cancellation before checking other Filers for the same cancelled request.
I'm positive this might fix the cascade of failed filer requests that happens after this cancellation.
Yet I'm not sure whether this will help with handling the issue of **"  'the client connection is closing' IS NOT a 500 error"**

I0330 16:12:48.238617 s3api_handlers.go:63 WithFilerClient: skipping unhealthy filer srv0803.qb.loc:8888
I0330 16:12:48.238624 s3api_handlers.go:63 WithFilerClient: skipping unhealthy filer srv0536.qb.loc:8888
I0330 16:12:48.238628 s3api_handlers.go:63 WithFilerClient: skipping unhealthy filer srv0802.qb.loc:8888
I0330 16:12:48.238558 s3api_handlers.go:63 WithFilerClient: skipping unhealthy filer srv0586.qb.loc:8888
I0330 16:12:48.238563 s3api_handlers.go:63 WithFilerClient: skipping unhealthy filer srv0580.qb.loc:8888
I0330 16:12:48.238567 s3api_handlers.go:63 WithFilerClient: skipping unhealthy filer srv0519.qb.loc:8888
I0330 16:12:48.238595 s3api_handlers.go:63 WithFilerClient: skipping unhealthy filer srv0584.qb.loc:8888
I0330 16:12:48.238571 s3api_handlers.go:63 WithFilerClient: skipping unhealthy filer srv0585.qb.loc:8888
I0330 16:12:48.238591 s3api_handlers.go:63 WithFilerClient: skipping unhealthy filer srv0528.qb.loc:8888
I0330 16:12:48.238576 s3api_handlers.go:63 WithFilerClient: skipping unhealthy filer srv0521.qb.loc:8888
I0330 16:12:48.238580 s3api_handlers.go:63 WithFilerClient: skipping unhealthy filer srv0550.qb.loc:8888
I0330 16:12:48.238583 s3api_handlers.go:63 WithFilerClient: skipping unhealthy filer srv0549.qb.loc:8888
I0330 16:12:48.238587 s3api_handlers.go:63 WithFilerClient: skipping unhealthy filer srv0534.qb.loc:8888
I0330 16:12:48.238598 s3api_handlers.go:63 WithFilerClient: skipping unhealthy filer srv0587.qb.loc:8888


# How is the PR tested?

I didn't test these changes and I'm not really sure that proposed lines are the correct ones.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming operations now cancel more promptly when requested via context cancellation.
  * S3 API improved to avoid writing error responses for client cancellations.
  * Enhanced logging distinction between client cancellations and timeout errors.

* **Tests**
  * Added comprehensive test coverage for context cancellation scenarios in streaming operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->