### PR TITLE
feat(filer): TouchAccessTime handler + atime flags (server wiring) [2/2]

### DIFF
--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -81,6 +81,9 @@ type FilerOptions struct {
 	exposeDirectoryData       *bool
 	tusBasePath               *string
 	s3ConfigFile              *string // optional path to static S3 identity config
+	atimeMode                 *string
+	atimeRelatimeThreshold    *time.Duration
+	atimePaths                *string
 	// shutdownCtx, when non-nil, tells startFiler to gracefully shut down its
 	// HTTP/gRPC servers once the ctx is cancelled. Used by integration tests
 	// and by weed mini; nil for standalone weed filer.
@@ -88,6 +91,25 @@ type FilerOptions struct {
 	// gracefulStopTimeout caps how long startFiler waits for gRPC graceful
 	// stop before forcing the server to stop. Zero means the default of 10s.
 	gracefulStopTimeout time.Duration
+}
+
+// buildAtimePolicy resolves the configured atime policy with safe defaults
+// when the embedding command (e.g. weed mini, integration tests) has not
+// registered the optional atime flags.
+func (fo *FilerOptions) buildAtimePolicy() (*filer.AtimePolicy, error) {
+	mode := string(filer.AtimeModeOff)
+	if fo.atimeMode != nil {
+		mode = *fo.atimeMode
+	}
+	threshold := filer.DefaultRelatimeThreshold
+	if fo.atimeRelatimeThreshold != nil {
+		threshold = *fo.atimeRelatimeThreshold
+	}
+	var paths string
+	if fo.atimePaths != nil {
+		paths = *fo.atimePaths
+	}
+	return filer.NewAtimePolicy(mode, threshold, filer.ParsePathPrefixes(paths))
 }
 
 func init() {
@@ -123,6 +145,9 @@ func init() {
 	f.allowedOrigins = cmdFiler.Flag.String("allowedOrigins", "*", "comma separated list of allowed origins")
 	f.exposeDirectoryData = cmdFiler.Flag.Bool("exposeDirectoryData", true, "whether to return directory metadata and content in Filer UI")
 	f.tusBasePath = cmdFiler.Flag.String("tusBasePath", "/.tus", "TUS resumable upload endpoint base path (e.g., /.tus)")
+	f.atimeMode = cmdFiler.Flag.String("atime", string(filer.AtimeModeOff), "filer access-time policy: off | relatime | strict (default off; opt in per deployment)")
+	f.atimeRelatimeThreshold = cmdFiler.Flag.Duration("atime.relatime_threshold", filer.DefaultRelatimeThreshold, "minimum age before relatime persists an atime update")
+	f.atimePaths = cmdFiler.Flag.String("atime.paths", "", "comma-separated path prefixes that atime tracking applies to; empty = every path when atime mode is on")
 
 	// start s3 on filer
 	filerStartS3 = cmdFiler.Flag.Bool("s3", false, "whether to start S3 gateway")
@@ -363,6 +388,11 @@ func (fo *FilerOptions) startFiler() {
 		}
 	}
 
+	atimePolicy, atimeErr := fo.buildAtimePolicy()
+	if atimeErr != nil {
+		glog.Fatalf("Filer atime configuration error: %v", atimeErr)
+	}
+
 	fs, nfs_err := weed_server.NewFilerServer(defaultMux, publicVolumeMux, &weed_server.FilerOption{
 		Masters:                   fo.masters,
 		FilerGroup:                *fo.filerGroup,
@@ -386,6 +416,7 @@ func (fo *FilerOptions) startFiler() {
 		AllowedOrigins:            strings.Split(*fo.allowedOrigins, ","),
 		TusBasePath:               *fo.tusBasePath,
 		CredentialManager:         credentialManager,
+		AtimePolicy:               atimePolicy,
 	})
 	if nfs_err != nil {
 		glog.Fatalf("Filer startup error: %v", nfs_err)

--- a/weed/command/filer_atime_test.go
+++ b/weed/command/filer_atime_test.go
@@ -1,0 +1,49 @@
+package command
+
+import (
+	"testing"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/filer"
+)
+
+func TestFilerOptions_BuildAtimePolicy_NilFlagsDefaultToOff(t *testing.T) {
+	fo := &FilerOptions{}
+	policy, err := fo.buildAtimePolicy()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if policy.Mode != filer.AtimeModeOff {
+		t.Fatalf("expected default policy off, got %q", policy.Mode)
+	}
+	if policy.AppliesToPath("/anywhere") {
+		t.Fatal("default policy must never apply")
+	}
+}
+
+func TestFilerOptions_BuildAtimePolicy_HonoursConfiguredFlags(t *testing.T) {
+	mode := string(filer.AtimeModeRelatime)
+	threshold := 30 * time.Minute
+	paths := "/buckets/a,/buckets/b"
+	fo := &FilerOptions{
+		atimeMode:              &mode,
+		atimeRelatimeThreshold: &threshold,
+		atimePaths:             &paths,
+	}
+	policy, err := fo.buildAtimePolicy()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if policy.Mode != filer.AtimeModeRelatime {
+		t.Fatalf("expected relatime, got %q", policy.Mode)
+	}
+	if policy.RelatimeThreshold != threshold {
+		t.Fatalf("expected threshold %v, got %v", threshold, policy.RelatimeThreshold)
+	}
+	if !policy.AppliesToPath("/buckets/a/object") {
+		t.Fatal("expected configured prefix to apply")
+	}
+	if policy.AppliesToPath("/buckets/other/object") {
+		t.Fatal("expected non-matching prefix to be skipped")
+	}
+}

--- a/weed/command/server.go
+++ b/weed/command/server.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb"
 	stats_collect "github.com/seaweedfs/seaweedfs/weed/stats"
@@ -130,6 +131,9 @@ func init() {
 	filerOptions.diskType = cmdServer.Flag.String("filer.disk", "", "[hdd|ssd|<tag>] hard drive or solid state drive or any tag")
 	filerOptions.exposeDirectoryData = cmdServer.Flag.Bool("filer.exposeDirectoryData", true, "expose directory data via filer. If false, filer UI will be innaccessible.")
 	filerOptions.tusBasePath = cmdServer.Flag.String("filer.tusBasePath", "/.tus", "TUS resumable upload endpoint base path (e.g., /.tus)")
+	filerOptions.atimeMode = cmdServer.Flag.String("filer.atime", string(filer.AtimeModeOff), "filer access-time policy: off | relatime | strict (default off; opt in per deployment)")
+	filerOptions.atimeRelatimeThreshold = cmdServer.Flag.Duration("filer.atime.relatime_threshold", filer.DefaultRelatimeThreshold, "minimum age before relatime persists an atime update")
+	filerOptions.atimePaths = cmdServer.Flag.String("filer.atime.paths", "", "comma-separated path prefixes that atime tracking applies to; empty = every path when atime mode is on")
 
 	serverOptions.v.port = cmdServer.Flag.Int("volume.port", 8080, "volume server http listen port")
 	serverOptions.v.portGrpc = cmdServer.Flag.Int("volume.port.grpc", 0, "volume server grpc listen port")

--- a/weed/filer/atime_policy.go
+++ b/weed/filer/atime_policy.go
@@ -1,0 +1,141 @@
+package filer
+
+import (
+	"errors"
+	"strings"
+	"time"
+)
+
+type AtimeMode string
+
+const (
+	AtimeModeOff      AtimeMode = "off"
+	AtimeModeRelatime AtimeMode = "relatime"
+	AtimeModeStrict   AtimeMode = "strict"
+
+	DefaultRelatimeThreshold = 24 * time.Hour
+)
+
+var ErrInvalidAtimeMode = errors.New("invalid atime mode: expected one of off, relatime, strict")
+
+type AtimePolicy struct {
+	Mode              AtimeMode
+	RelatimeThreshold time.Duration
+	// PathPrefixes restricts atime tracking to entries whose full path
+	// begins with one of the listed prefixes. An empty list means atime
+	// applies to every path the chosen mode would otherwise update.
+	PathPrefixes []string
+}
+
+func NewAtimePolicy(mode string, threshold time.Duration, pathPrefixes []string) (*AtimePolicy, error) {
+	parsed, err := ParseAtimeMode(mode)
+	if err != nil {
+		return nil, err
+	}
+	if threshold <= 0 {
+		threshold = DefaultRelatimeThreshold
+	}
+	return &AtimePolicy{
+		Mode:              parsed,
+		RelatimeThreshold: threshold,
+		PathPrefixes:      normalisePathPrefixes(pathPrefixes),
+	}, nil
+}
+
+func ParseAtimeMode(s string) (AtimeMode, error) {
+	switch AtimeMode(strings.ToLower(strings.TrimSpace(s))) {
+	case AtimeModeOff, "":
+		return AtimeModeOff, nil
+	case AtimeModeRelatime:
+		return AtimeModeRelatime, nil
+	case AtimeModeStrict:
+		return AtimeModeStrict, nil
+	}
+	return "", ErrInvalidAtimeMode
+}
+
+// ParsePathPrefixes splits a comma-separated prefix list, trimming whitespace
+// and dropping empty entries. Convenience for command-line plumbing.
+func ParsePathPrefixes(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	return normalisePathPrefixes(strings.Split(raw, ","))
+}
+
+func normalisePathPrefixes(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(in))
+	for _, p := range in {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// AppliesToPath reports whether the policy is active for the given full path,
+// combining mode and prefix restrictions. Prefixes are matched at path
+// component boundaries so that "/buckets/cache" matches "/buckets/cache/x" but
+// not "/buckets/cache_backup/x".
+func (p *AtimePolicy) AppliesToPath(fullpath string) bool {
+	if p == nil || p.Mode == AtimeModeOff {
+		return false
+	}
+	if len(p.PathPrefixes) == 0 {
+		return true
+	}
+	for _, prefix := range p.PathPrefixes {
+		if pathHasPrefix(fullpath, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func pathHasPrefix(fullpath, prefix string) bool {
+	if prefix == "" {
+		return true
+	}
+	if !strings.HasPrefix(fullpath, prefix) {
+		return false
+	}
+	if len(fullpath) == len(prefix) {
+		return true
+	}
+	if prefix[len(prefix)-1] == '/' {
+		return true
+	}
+	return fullpath[len(prefix)] == '/'
+}
+
+func (p *AtimePolicy) ShouldUpdate(existing Attr, candidate time.Time) bool {
+	if p == nil || p.Mode == AtimeModeOff {
+		return false
+	}
+	if candidate.IsZero() {
+		return false
+	}
+	if existing.Atime.IsZero() {
+		return true
+	}
+	if !candidate.After(existing.Atime) {
+		return false
+	}
+	if p.Mode == AtimeModeStrict {
+		return true
+	}
+	if !existing.Mtime.IsZero() && existing.Atime.Before(existing.Mtime) {
+		return true
+	}
+	if !existing.Ctime.IsZero() && existing.Atime.Before(existing.Ctime) {
+		return true
+	}
+	return candidate.Sub(existing.Atime) >= p.RelatimeThreshold
+}

--- a/weed/filer/atime_policy_test.go
+++ b/weed/filer/atime_policy_test.go
@@ -1,0 +1,173 @@
+package filer
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAtimePolicy_Off_NeverUpdates(t *testing.T) {
+	policy := &AtimePolicy{Mode: AtimeModeOff}
+	now := time.Now()
+	existing := Attr{Atime: now.Add(-48 * time.Hour), Mtime: now.Add(-48 * time.Hour), Ctime: now.Add(-48 * time.Hour)}
+	if policy.ShouldUpdate(existing, now) {
+		t.Fatal("off mode must not update")
+	}
+}
+
+func TestAtimePolicy_Strict_UpdatesWhenCandidateAdvances(t *testing.T) {
+	policy := &AtimePolicy{Mode: AtimeModeStrict}
+	existing := Attr{
+		Atime: time.Unix(1_700_000_000, 0),
+		Mtime: time.Unix(1_700_000_000, 0),
+		Ctime: time.Unix(1_700_000_000, 0),
+	}
+	if !policy.ShouldUpdate(existing, time.Unix(1_700_000_001, 0)) {
+		t.Fatal("strict must update when candidate is newer")
+	}
+	if policy.ShouldUpdate(existing, existing.Atime) {
+		t.Fatal("strict must not update when candidate equals existing atime")
+	}
+}
+
+func TestAtimePolicy_Relatime_AtimeOlderThanMtime(t *testing.T) {
+	policy := &AtimePolicy{Mode: AtimeModeRelatime, RelatimeThreshold: 24 * time.Hour}
+	existing := Attr{
+		Atime: time.Unix(1_700_000_000, 0),
+		Mtime: time.Unix(1_700_500_000, 0),
+		Ctime: time.Unix(1_700_500_000, 0),
+	}
+	if !policy.ShouldUpdate(existing, time.Unix(1_700_500_001, 0)) {
+		t.Fatal("relatime must update when atime < mtime")
+	}
+}
+
+func TestAtimePolicy_Relatime_ThresholdExpired(t *testing.T) {
+	policy := &AtimePolicy{Mode: AtimeModeRelatime, RelatimeThreshold: time.Hour}
+	atime := time.Unix(1_700_000_000, 0)
+	existing := Attr{Atime: atime, Mtime: atime, Ctime: atime}
+	candidate := atime.Add(2 * time.Hour)
+	if !policy.ShouldUpdate(existing, candidate) {
+		t.Fatal("relatime must update once threshold elapses")
+	}
+}
+
+func TestAtimePolicy_Relatime_DebouncesFreshReads(t *testing.T) {
+	policy := &AtimePolicy{Mode: AtimeModeRelatime, RelatimeThreshold: 24 * time.Hour}
+	atime := time.Unix(1_700_000_000, 0)
+	existing := Attr{Atime: atime, Mtime: atime, Ctime: atime}
+	candidate := atime.Add(time.Minute)
+	if policy.ShouldUpdate(existing, candidate) {
+		t.Fatal("relatime must not update within threshold when atime >= mtime/ctime")
+	}
+}
+
+func TestParseAtimeMode(t *testing.T) {
+	cases := map[string]AtimeMode{
+		"":          AtimeModeOff,
+		"relatime":  AtimeModeRelatime,
+		"RelAtime":  AtimeModeRelatime,
+		"off":       AtimeModeOff,
+		"  strict ": AtimeModeStrict,
+	}
+	for input, expected := range cases {
+		got, err := ParseAtimeMode(input)
+		if err != nil {
+			t.Fatalf("ParseAtimeMode(%q): unexpected error: %v", input, err)
+		}
+		if got != expected {
+			t.Fatalf("ParseAtimeMode(%q): expected %q, got %q", input, expected, got)
+		}
+	}
+
+	if _, err := ParseAtimeMode("nope"); err == nil {
+		t.Fatal("expected ParseAtimeMode to reject unknown mode")
+	}
+}
+
+func TestNewAtimePolicy_DefaultsToOff(t *testing.T) {
+	policy, err := NewAtimePolicy("", 0, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if policy.Mode != AtimeModeOff {
+		t.Fatalf("expected default policy off, got %q", policy.Mode)
+	}
+	if policy.AppliesToPath("/anything") {
+		t.Fatal("off policy must never apply")
+	}
+}
+
+func TestParsePathPrefixes_TrimsAndDropsEmpty(t *testing.T) {
+	got := ParsePathPrefixes("  /buckets/a , ,/buckets/b ,  ")
+	want := []string{"/buckets/a", "/buckets/b"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	for i, p := range want {
+		if got[i] != p {
+			t.Fatalf("prefix %d: expected %q, got %q", i, p, got[i])
+		}
+	}
+	if ParsePathPrefixes("") != nil {
+		t.Fatal("empty input must yield nil")
+	}
+	if ParsePathPrefixes(" , , ") != nil {
+		t.Fatal("whitespace-only input must yield nil")
+	}
+}
+
+func TestAtimePolicy_AppliesToPath(t *testing.T) {
+	cases := []struct {
+		name     string
+		policy   *AtimePolicy
+		path     string
+		expected bool
+	}{
+		{"nil policy never applies", nil, "/anywhere", false},
+		{"off mode never applies", &AtimePolicy{Mode: AtimeModeOff}, "/anywhere", false},
+		{"no prefixes applies globally", &AtimePolicy{Mode: AtimeModeStrict}, "/anywhere", true},
+		{
+			"matching prefix applies",
+			&AtimePolicy{Mode: AtimeModeRelatime, PathPrefixes: []string{"/buckets/cache"}},
+			"/buckets/cache/object",
+			true,
+		},
+		{
+			"non-matching prefix is skipped",
+			&AtimePolicy{Mode: AtimeModeRelatime, PathPrefixes: []string{"/buckets/cache"}},
+			"/buckets/other/object",
+			false,
+		},
+		{
+			"prefix match respects component boundary",
+			&AtimePolicy{Mode: AtimeModeRelatime, PathPrefixes: []string{"/buckets/cache"}},
+			"/buckets/cache_backup/object",
+			false,
+		},
+		{
+			"exact path equals prefix",
+			&AtimePolicy{Mode: AtimeModeRelatime, PathPrefixes: []string{"/buckets/cache"}},
+			"/buckets/cache",
+			true,
+		},
+		{
+			"trailing slash prefix matches sub-path",
+			&AtimePolicy{Mode: AtimeModeRelatime, PathPrefixes: []string{"/buckets/cache/"}},
+			"/buckets/cache/object",
+			true,
+		},
+		{
+			"empty prefix bypassing constructor matches everything",
+			&AtimePolicy{Mode: AtimeModeRelatime, PathPrefixes: []string{""}},
+			"/anywhere/at/all",
+			true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.policy.AppliesToPath(tc.path); got != tc.expected {
+				t.Fatalf("AppliesToPath(%q): expected %v, got %v", tc.path, tc.expected, got)
+			}
+		})
+	}
+}

--- a/weed/server/filer_grpc_server_atime.go
+++ b/weed/server/filer_grpc_server_atime.go
@@ -1,0 +1,77 @@
+package weed_server
+
+import (
+	"context"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/filer"
+	"github.com/seaweedfs/seaweedfs/weed/glog"
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+)
+
+func (fs *FilerServer) TouchAccessTime(ctx context.Context, req *filer_pb.TouchAccessTimeRequest) (*filer_pb.TouchAccessTimeResponse, error) {
+	now := time.Now()
+	candidate := now
+	if req.ClientAtimeNs > 0 {
+		if t := time.Unix(0, req.ClientAtimeNs); !t.After(now) {
+			candidate = t
+		}
+	}
+	persistedNs, updated, err := fs.touchAccessTime(ctx, util.NewFullPath(req.Directory, req.Name), candidate)
+	if err != nil {
+		return &filer_pb.TouchAccessTimeResponse{}, err
+	}
+	return &filer_pb.TouchAccessTimeResponse{PersistedAtimeNs: persistedNs, Updated: updated}, nil
+}
+
+// touchAccessTime applies the configured atime policy to an entry and persists
+// it through the filer's canonical update path. Returns (persistedNs, updated,
+// err) where persistedNs is 0 when no write was performed.
+//
+// Atime updates are intentionally best-effort: this is a read-modify-write
+// against the underlying filer store and a concurrent write to the same entry
+// can overwrite the bump. That trade-off matches POSIX atime semantics and is
+// made safe in practice by the relatime debouncing and by the fact that bumps
+// only happen on read paths, where concurrent metadata mutations are rare.
+func (fs *FilerServer) touchAccessTime(ctx context.Context, fullpath util.FullPath, candidate time.Time) (int64, bool, error) {
+	policy := fs.atimePolicy()
+	if !policy.AppliesToPath(string(fullpath)) {
+		return 0, false, nil
+	}
+
+	entry, err := fs.filer.FindEntry(ctx, fullpath)
+	if err == filer_pb.ErrNotFound {
+		return 0, false, nil
+	}
+	if err != nil {
+		glog.V(3).InfofCtx(ctx, "touchAccessTime %s: lookup: %v", fullpath, err)
+		return 0, false, err
+	}
+
+	if !policy.ShouldUpdate(entry.Attr, candidate) {
+		return 0, false, nil
+	}
+
+	updated := entry.ShallowClone()
+	updated.Attr.Atime = candidate
+	if err := fs.filer.UpdateEntry(ctx, entry, updated); err != nil {
+		glog.V(3).InfofCtx(ctx, "touchAccessTime %s: update: %v", fullpath, err)
+		return 0, false, err
+	}
+	return candidate.UnixNano(), true, nil
+}
+
+// disabledAtimePolicy is returned when the server has no policy configured so
+// that callers do not allocate on the hot read path.
+var disabledAtimePolicy = &filer.AtimePolicy{
+	Mode:              filer.AtimeModeOff,
+	RelatimeThreshold: filer.DefaultRelatimeThreshold,
+}
+
+func (fs *FilerServer) atimePolicy() *filer.AtimePolicy {
+	if fs.option == nil || fs.option.AtimePolicy == nil {
+		return disabledAtimePolicy
+	}
+	return fs.option.AtimePolicy
+}

--- a/weed/server/filer_server.go
+++ b/weed/server/filer_server.go
@@ -86,6 +86,7 @@ type FilerOption struct {
 	TusBasePath               string
 	S3ConfigFile              string // optional path to static S3 identity config file
 	CredentialManager         *credential.CredentialManager
+	AtimePolicy               *filer.AtimePolicy
 }
 
 type FilerServer struct {


### PR DESCRIPTION
> **Part 2 of 2** of the `AtimePolicy` work. Depends on #9898 (the policy primitive).
> Roadmap & design: #9899.
>
> **Draft until #9898 merges.** This branch is stacked on top of #9898, so the diff
> currently shows both the policy commit and the handler commit. Once #9898 lands on
> master I will rebase this onto master (dropping the policy commit) and mark it ready
> for review.

# What problem are we solving?

Filers fronting remote/cloud storage need to evict their local cache by
*least-recently-accessed* (true LRU) rather than least-recently-synced, but the filer
does not track access time. This PR wires the `AtimePolicy` primitive (#9898) into the
filer, completing the **server-side** half of the work begun in #9556.

No read-path bumpers are wired here — those follow once the client-side Toucher helper
lands (see the roadmap in #9899). The feature stays opt-in and defaults to `off`.

# How are we solving the problem?

- **`TouchAccessTime` gRPC handler**: runs each request through the configured policy,
  clamps a future client-supplied atime to server-now, and persists via the canonical
  `Filer.UpdateEntry` path. Best-effort by design (documented on the handler): relatime
  debouncing keeps the read-modify-write race window small, and only read paths bump atime.
- **`FilerOption.AtimePolicy` field**, defaulting to a disabled policy, so the handler is
  a safe no-op until an operator opts in.
- **Flags**: `-atime` / `-atime.relatime_threshold` / `-atime.paths` on `weed filer`,
  and the `-filer.atime*` equivalents on `weed server`.
- **`buildAtimePolicy()`** tolerates nil flag pointers so embedders that construct
  `FilerOptions` without registering the flags (`weed mini`, integration tests) do not
  panic on startup.

# How is the PR tested?

- Unit tests for the nil-tolerant policy builder in `weed/command/filer_atime_test.go`
  (both the nil-default path and a fully configured one).
- Policy-predicate / path-prefix unit tests land with the primitive in #9898.

`go test ./weed/command/ -run 'FilerOptions_BuildAtimePolicy' -count=1`
`go build ./weed/...`

# Checks

- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed.

# Checks for AI generated PRs

- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Access-time tracking for filer entries with modes: off, relatime, strict (defaults to off)
  * CLI flags to configure atime mode, relatime threshold, and path-prefix filters (applied at startup)
  * gRPC endpoint to report/update access times that respects configured atime policies and path filters

* **Tests**
  * Unit tests covering mode parsing, path-prefix behavior, relatime threshold, update decision logic, and options wiring

<!-- end of auto-generated comment: release notes by coderabbit.ai -->