### PR TITLE
feat(filer): add AtimePolicy (off/relatime/strict) primitive

### DIFF
--- a/weed/filer/atime_policy.go
+++ b/weed/filer/atime_policy.go
@@ -27,6 +27,9 @@ type AtimePolicy struct {
 	PathPrefixes []string
 }
 
+// NewAtimePolicy builds a policy from a mode string, relatime threshold and
+// optional path-prefix list. A non-positive threshold falls back to
+// DefaultRelatimeThreshold.
 func NewAtimePolicy(mode string, threshold time.Duration, pathPrefixes []string) (*AtimePolicy, error) {
 	parsed, err := ParseAtimeMode(mode)
 	if err != nil {
@@ -42,6 +45,8 @@ func NewAtimePolicy(mode string, threshold time.Duration, pathPrefixes []string)
 	}, nil
 }
 
+// ParseAtimeMode normalises a mode string (case- and whitespace-insensitive),
+// treating the empty string as AtimeModeOff and rejecting anything unknown.
 func ParseAtimeMode(s string) (AtimeMode, error) {
 	switch AtimeMode(strings.ToLower(strings.TrimSpace(s))) {
 	case AtimeModeOff, "":
@@ -70,6 +75,10 @@ func normalisePathPrefixes(in []string) []string {
 	out := make([]string, 0, len(in))
 	for _, p := range in {
 		p = strings.TrimSpace(p)
+		// Treat "/a/b" and "/a/b/" as the same subtree so a prefix also
+		// matches the directory itself. A bare "/" collapses to "" and is
+		// dropped, which correctly means "no restriction".
+		p = strings.TrimRight(p, "/")
 		if p != "" {
 			out = append(out, p)
 		}
@@ -115,6 +124,10 @@ func pathHasPrefix(fullpath, prefix string) bool {
 	return fullpath[len(prefix)] == '/'
 }
 
+// ShouldUpdate reports whether a candidate access time should be persisted for
+// an entry under this policy. The relatime threshold is normalised here too, so
+// a policy built via a struct literal with a non-positive threshold still
+// debounces using DefaultRelatimeThreshold rather than degrading to strict.
 func (p *AtimePolicy) ShouldUpdate(existing Attr, candidate time.Time) bool {
 	if p == nil || p.Mode == AtimeModeOff {
 		return false
@@ -137,5 +150,9 @@ func (p *AtimePolicy) ShouldUpdate(existing Attr, candidate time.Time) bool {
 	if !existing.Ctime.IsZero() && existing.Atime.Before(existing.Ctime) {
 		return true
 	}
-	return candidate.Sub(existing.Atime) >= p.RelatimeThreshold
+	threshold := p.RelatimeThreshold
+	if threshold <= 0 {
+		threshold = DefaultRelatimeThreshold
+	}
+	return candidate.Sub(existing.Atime) >= threshold
 }

--- a/weed/filer/atime_policy.go
+++ b/weed/filer/atime_policy.go
@@ -1,0 +1,141 @@
+package filer
+
+import (
+	"errors"
+	"strings"
+	"time"
+)
+
+type AtimeMode string
+
+const (
+	AtimeModeOff      AtimeMode = "off"
+	AtimeModeRelatime AtimeMode = "relatime"
+	AtimeModeStrict   AtimeMode = "strict"
+
+	DefaultRelatimeThreshold = 24 * time.Hour
+)
+
+var ErrInvalidAtimeMode = errors.New("invalid atime mode: expected one of off, relatime, strict")
+
+type AtimePolicy struct {
+	Mode              AtimeMode
+	RelatimeThreshold time.Duration
+	// PathPrefixes restricts atime tracking to entries whose full path
+	// begins with one of the listed prefixes. An empty list means atime
+	// applies to every path the chosen mode would otherwise update.
+	PathPrefixes []string
+}
+
+func NewAtimePolicy(mode string, threshold time.Duration, pathPrefixes []string) (*AtimePolicy, error) {
+	parsed, err := ParseAtimeMode(mode)
+	if err != nil {
+		return nil, err
+	}
+	if threshold <= 0 {
+		threshold = DefaultRelatimeThreshold
+	}
+	return &AtimePolicy{
+		Mode:              parsed,
+		RelatimeThreshold: threshold,
+		PathPrefixes:      normalisePathPrefixes(pathPrefixes),
+	}, nil
+}
+
+func ParseAtimeMode(s string) (AtimeMode, error) {
+	switch AtimeMode(strings.ToLower(strings.TrimSpace(s))) {
+	case AtimeModeOff, "":
+		return AtimeModeOff, nil
+	case AtimeModeRelatime:
+		return AtimeModeRelatime, nil
+	case AtimeModeStrict:
+		return AtimeModeStrict, nil
+	}
+	return "", ErrInvalidAtimeMode
+}
+
+// ParsePathPrefixes splits a comma-separated prefix list, trimming whitespace
+// and dropping empty entries. Convenience for command-line plumbing.
+func ParsePathPrefixes(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	return normalisePathPrefixes(strings.Split(raw, ","))
+}
+
+func normalisePathPrefixes(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(in))
+	for _, p := range in {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// AppliesToPath reports whether the policy is active for the given full path,
+// combining mode and prefix restrictions. Prefixes are matched at path
+// component boundaries so that "/buckets/cache" matches "/buckets/cache/x" but
+// not "/buckets/cache_backup/x".
+func (p *AtimePolicy) AppliesToPath(fullpath string) bool {
+	if p == nil || p.Mode == AtimeModeOff {
+		return false
+	}
+	if len(p.PathPrefixes) == 0 {
+		return true
+	}
+	for _, prefix := range p.PathPrefixes {
+		if pathHasPrefix(fullpath, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func pathHasPrefix(fullpath, prefix string) bool {
+	if prefix == "" {
+		return true
+	}
+	if !strings.HasPrefix(fullpath, prefix) {
+		return false
+	}
+	if len(fullpath) == len(prefix) {
+		return true
+	}
+	if prefix[len(prefix)-1] == '/' {
+		return true
+	}
+	return fullpath[len(prefix)] == '/'
+}
+
+func (p *AtimePolicy) ShouldUpdate(existing Attr, candidate time.Time) bool {
+	if p == nil || p.Mode == AtimeModeOff {
+		return false
+	}
+	if candidate.IsZero() {
+		return false
+	}
+	if existing.Atime.IsZero() {
+		return true
+	}
+	if !candidate.After(existing.Atime) {
+		return false
+	}
+	if p.Mode == AtimeModeStrict {
+		return true
+	}
+	if !existing.Mtime.IsZero() && existing.Atime.Before(existing.Mtime) {
+		return true
+	}
+	if !existing.Ctime.IsZero() && existing.Atime.Before(existing.Ctime) {
+		return true
+	}
+	return candidate.Sub(existing.Atime) >= p.RelatimeThreshold
+}

--- a/weed/filer/atime_policy_test.go
+++ b/weed/filer/atime_policy_test.go
@@ -61,6 +61,20 @@ func TestAtimePolicy_Relatime_DebouncesFreshReads(t *testing.T) {
 	}
 }
 
+func TestAtimePolicy_Relatime_ZeroThresholdUsesDefault(t *testing.T) {
+	// A struct literal with no threshold must still debounce using the
+	// default rather than degrading to strict (every advance updating).
+	policy := &AtimePolicy{Mode: AtimeModeRelatime}
+	atime := time.Unix(1_700_000_000, 0)
+	existing := Attr{Atime: atime, Mtime: atime, Ctime: atime}
+	if policy.ShouldUpdate(existing, atime.Add(time.Minute)) {
+		t.Fatal("zero threshold must fall back to default and debounce fresh reads")
+	}
+	if !policy.ShouldUpdate(existing, atime.Add(DefaultRelatimeThreshold)) {
+		t.Fatal("zero threshold must update once the default threshold elapses")
+	}
+}
+
 func TestParseAtimeMode(t *testing.T) {
 	cases := map[string]AtimeMode{
 		"":          AtimeModeOff,
@@ -97,6 +111,18 @@ func TestNewAtimePolicy_DefaultsToOff(t *testing.T) {
 	}
 }
 
+func TestNewAtimePolicy_NonPositiveThresholdUsesDefault(t *testing.T) {
+	for _, threshold := range []time.Duration{0, -time.Hour} {
+		policy, err := NewAtimePolicy("relatime", threshold, nil)
+		if err != nil {
+			t.Fatalf("threshold %v: unexpected error: %v", threshold, err)
+		}
+		if policy.RelatimeThreshold != DefaultRelatimeThreshold {
+			t.Fatalf("threshold %v: expected default %v, got %v", threshold, DefaultRelatimeThreshold, policy.RelatimeThreshold)
+		}
+	}
+}
+
 func TestParsePathPrefixes_TrimsAndDropsEmpty(t *testing.T) {
 	got := ParsePathPrefixes("  /buckets/a , ,/buckets/b ,  ")
 	want := []string{"/buckets/a", "/buckets/b"}
@@ -113,6 +139,9 @@ func TestParsePathPrefixes_TrimsAndDropsEmpty(t *testing.T) {
 	}
 	if ParsePathPrefixes(" , , ") != nil {
 		t.Fatal("whitespace-only input must yield nil")
+	}
+	if got := ParsePathPrefixes("/buckets/cache/, /"); len(got) != 1 || got[0] != "/buckets/cache" {
+		t.Fatalf("trailing slashes must be trimmed and bare / dropped, got %v", got)
 	}
 }
 
@@ -152,8 +181,14 @@ func TestAtimePolicy_AppliesToPath(t *testing.T) {
 		},
 		{
 			"trailing slash prefix matches sub-path",
-			&AtimePolicy{Mode: AtimeModeRelatime, PathPrefixes: []string{"/buckets/cache/"}},
+			&AtimePolicy{Mode: AtimeModeRelatime, PathPrefixes: ParsePathPrefixes("/buckets/cache/")},
 			"/buckets/cache/object",
+			true,
+		},
+		{
+			"trailing slash prefix matches directory itself",
+			&AtimePolicy{Mode: AtimeModeRelatime, PathPrefixes: ParsePathPrefixes("/buckets/cache/")},
+			"/buckets/cache",
 			true,
 		},
 		{

--- a/weed/filer/atime_policy_test.go
+++ b/weed/filer/atime_policy_test.go
@@ -1,0 +1,173 @@
+package filer
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAtimePolicy_Off_NeverUpdates(t *testing.T) {
+	policy := &AtimePolicy{Mode: AtimeModeOff}
+	now := time.Now()
+	existing := Attr{Atime: now.Add(-48 * time.Hour), Mtime: now.Add(-48 * time.Hour), Ctime: now.Add(-48 * time.Hour)}
+	if policy.ShouldUpdate(existing, now) {
+		t.Fatal("off mode must not update")
+	}
+}
+
+func TestAtimePolicy_Strict_UpdatesWhenCandidateAdvances(t *testing.T) {
+	policy := &AtimePolicy{Mode: AtimeModeStrict}
+	existing := Attr{
+		Atime: time.Unix(1_700_000_000, 0),
+		Mtime: time.Unix(1_700_000_000, 0),
+		Ctime: time.Unix(1_700_000_000, 0),
+	}
+	if !policy.ShouldUpdate(existing, time.Unix(1_700_000_001, 0)) {
+		t.Fatal("strict must update when candidate is newer")
+	}
+	if policy.ShouldUpdate(existing, existing.Atime) {
+		t.Fatal("strict must not update when candidate equals existing atime")
+	}
+}
+
+func TestAtimePolicy_Relatime_AtimeOlderThanMtime(t *testing.T) {
+	policy := &AtimePolicy{Mode: AtimeModeRelatime, RelatimeThreshold: 24 * time.Hour}
+	existing := Attr{
+		Atime: time.Unix(1_700_000_000, 0),
+		Mtime: time.Unix(1_700_500_000, 0),
+		Ctime: time.Unix(1_700_500_000, 0),
+	}
+	if !policy.ShouldUpdate(existing, time.Unix(1_700_500_001, 0)) {
+		t.Fatal("relatime must update when atime < mtime")
+	}
+}
+
+func TestAtimePolicy_Relatime_ThresholdExpired(t *testing.T) {
+	policy := &AtimePolicy{Mode: AtimeModeRelatime, RelatimeThreshold: time.Hour}
+	atime := time.Unix(1_700_000_000, 0)
+	existing := Attr{Atime: atime, Mtime: atime, Ctime: atime}
+	candidate := atime.Add(2 * time.Hour)
+	if !policy.ShouldUpdate(existing, candidate) {
+		t.Fatal("relatime must update once threshold elapses")
+	}
+}
+
+func TestAtimePolicy_Relatime_DebouncesFreshReads(t *testing.T) {
+	policy := &AtimePolicy{Mode: AtimeModeRelatime, RelatimeThreshold: 24 * time.Hour}
+	atime := time.Unix(1_700_000_000, 0)
+	existing := Attr{Atime: atime, Mtime: atime, Ctime: atime}
+	candidate := atime.Add(time.Minute)
+	if policy.ShouldUpdate(existing, candidate) {
+		t.Fatal("relatime must not update within threshold when atime >= mtime/ctime")
+	}
+}
+
+func TestParseAtimeMode(t *testing.T) {
+	cases := map[string]AtimeMode{
+		"":          AtimeModeOff,
+		"relatime":  AtimeModeRelatime,
+		"RelAtime":  AtimeModeRelatime,
+		"off":       AtimeModeOff,
+		"  strict ": AtimeModeStrict,
+	}
+	for input, expected := range cases {
+		got, err := ParseAtimeMode(input)
+		if err != nil {
+			t.Fatalf("ParseAtimeMode(%q): unexpected error: %v", input, err)
+		}
+		if got != expected {
+			t.Fatalf("ParseAtimeMode(%q): expected %q, got %q", input, expected, got)
+		}
+	}
+
+	if _, err := ParseAtimeMode("nope"); err == nil {
+		t.Fatal("expected ParseAtimeMode to reject unknown mode")
+	}
+}
+
+func TestNewAtimePolicy_DefaultsToOff(t *testing.T) {
+	policy, err := NewAtimePolicy("", 0, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if policy.Mode != AtimeModeOff {
+		t.Fatalf("expected default policy off, got %q", policy.Mode)
+	}
+	if policy.AppliesToPath("/anything") {
+		t.Fatal("off policy must never apply")
+	}
+}
+
+func TestParsePathPrefixes_TrimsAndDropsEmpty(t *testing.T) {
+	got := ParsePathPrefixes("  /buckets/a , ,/buckets/b ,  ")
+	want := []string{"/buckets/a", "/buckets/b"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+	for i, p := range want {
+		if got[i] != p {
+			t.Fatalf("prefix %d: expected %q, got %q", i, p, got[i])
+		}
+	}
+	if ParsePathPrefixes("") != nil {
+		t.Fatal("empty input must yield nil")
+	}
+	if ParsePathPrefixes(" , , ") != nil {
+		t.Fatal("whitespace-only input must yield nil")
+	}
+}
+
+func TestAtimePolicy_AppliesToPath(t *testing.T) {
+	cases := []struct {
+		name     string
+		policy   *AtimePolicy
+		path     string
+		expected bool
+	}{
+		{"nil policy never applies", nil, "/anywhere", false},
+		{"off mode never applies", &AtimePolicy{Mode: AtimeModeOff}, "/anywhere", false},
+		{"no prefixes applies globally", &AtimePolicy{Mode: AtimeModeStrict}, "/anywhere", true},
+		{
+			"matching prefix applies",
+			&AtimePolicy{Mode: AtimeModeRelatime, PathPrefixes: []string{"/buckets/cache"}},
+			"/buckets/cache/object",
+			true,
+		},
+		{
+			"non-matching prefix is skipped",
+			&AtimePolicy{Mode: AtimeModeRelatime, PathPrefixes: []string{"/buckets/cache"}},
+			"/buckets/other/object",
+			false,
+		},
+		{
+			"prefix match respects component boundary",
+			&AtimePolicy{Mode: AtimeModeRelatime, PathPrefixes: []string{"/buckets/cache"}},
+			"/buckets/cache_backup/object",
+			false,
+		},
+		{
+			"exact path equals prefix",
+			&AtimePolicy{Mode: AtimeModeRelatime, PathPrefixes: []string{"/buckets/cache"}},
+			"/buckets/cache",
+			true,
+		},
+		{
+			"trailing slash prefix matches sub-path",
+			&AtimePolicy{Mode: AtimeModeRelatime, PathPrefixes: []string{"/buckets/cache/"}},
+			"/buckets/cache/object",
+			true,
+		},
+		{
+			"empty prefix bypassing constructor matches everything",
+			&AtimePolicy{Mode: AtimeModeRelatime, PathPrefixes: []string{""}},
+			"/anywhere/at/all",
+			true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.policy.AppliesToPath(tc.path); got != tc.expected {
+				t.Fatalf("AppliesToPath(%q): expected %v, got %v", tc.path, tc.expected, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# What problem are we solving?

Filers fronting remote/cloud storage need to evict their local cache by
*least-recently-accessed* (true LRU) rather than least-recently-synced, but the filer
does not track access time. This is the second slice of that work, following the merged
proto/codec foundation in #9556.

This PR adds **only** the policy primitive that decides *whether and when* an entry's
access time should be persisted. There is **no read-path wiring yet** — kept deliberately
small and self-contained so it can be reviewed in isolation. The server handler and CLI
flags that consume it follow in a stacked PR.

# How are we solving the problem?

A new `filer.AtimePolicy` type modeled on POSIX mount options:

- `off` (default) — never track; no behaviour changes unless an operator opts in.
- `relatime` — persist only when the candidate atime is older than a threshold
  (default 24h) or older than the entry's mtime/ctime, debouncing frequent reads.
- `strict` — persist every forward-moving access.

An optional path-prefix allow-list (`AppliesToPath`) scopes tracking to specific
subtrees, matched at path-component boundaries so `/buckets/cache` matches
`/buckets/cache/x` but not `/buckets/cache_backup/x`. Helper parsers (`ParseAtimeMode`,
`ParsePathPrefixes`) support command-line plumbing in the follow-up PR.

Pure logic; no other package depends on it yet.

# How is the PR tested?

Unit tests in `weed/filer/atime_policy_test.go` cover the relatime predicate, strict
mode, default-off behaviour, path-prefix matching (including component-boundary and
trailing-slash cases), and the parse helpers.

`go test ./weed/filer/ -run 'AtimePolicy|ParseAtimeMode|PathPrefixes' -count=1`

# Checks

- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed.

# Checks for AI generated PRs

- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable atime update policy with modes: **off**, **relatime**, and **strict**.
  * Policies can be optionally scoped to specific path prefixes and include a configurable relatime threshold (with a sensible default when unset/invalid).
  * Added validation for atime mode and normalized parsing for path-prefix lists.
* **Tests**
  * Added unit tests for mode-specific update decisions, threshold debouncing behavior, parsing/validation, and path-prefix matching edge cases (including boundary-aware prefix checks).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->