### PR TITLE
`volume.scrub` and `ec.scrub` shell commands: make the display of scrub details optional.

### DIFF
--- a/weed/shell/command_ec_scrub.go
+++ b/weed/shell/command_ec_scrub.go
@@ -51,6 +51,7 @@ func (c *commandEcVolumeScrub) Do(args []string, commandEnv *CommandEnv, writer 
 	volumeIDsStr := volScrubCommand.String("volumeId", "", "comma-separated EC volume IDs to process (optional)")
 	mode := volScrubCommand.String("mode", "local", "scrubbing mode (index/local/full/checksum)")
 	maxParallelization := volScrubCommand.Int("maxParallelization", DefaultMaxParallelization, "run up to X tasks in parallel, whenever possible")
+	showDetails := volScrubCommand.Bool("details", false, "display scrub result details, if available")
 
 	if err = volScrubCommand.Parse(args); err != nil {
 		return err
@@ -104,10 +105,10 @@ func (c *commandEcVolumeScrub) Do(args []string, commandEnv *CommandEnv, writer 
 	fmt.Fprintf(writer, "using %s mode\n", c.mode.String())
 	c.env = commandEnv
 
-	return c.scrubEcVolumes(writer, *maxParallelization)
+	return c.scrubEcVolumes(writer, *maxParallelization, *showDetails)
 }
 
-func (c *commandEcVolumeScrub) scrubEcVolumes(writer io.Writer, maxParallelization int) error {
+func (c *commandEcVolumeScrub) scrubEcVolumes(writer io.Writer, maxParallelization int, showDetails bool) error {
 	var brokenVolumesStr, brokenShardsStr []string
 	var details []string
 	var totalVolumes, brokenVolumes, brokenShards, totalFiles uint64
@@ -164,7 +165,7 @@ func (c *commandEcVolumeScrub) scrubEcVolumes(writer io.Writer, maxParallelizati
 		if len(brokenShardsStr) != 0 {
 			fmt.Fprintf(writer, "Affected shards:  %s\n", strings.Join(brokenShardsStr, ", "))
 		}
-		if len(details) != 0 {
+		if showDetails && len(details) != 0 {
 			fmt.Fprintf(writer, "Details:\n\t%s\n", strings.Join(details, "\n\t"))
 		}
 	}

--- a/weed/shell/command_volume_scrub.go
+++ b/weed/shell/command_volume_scrub.go
@@ -53,6 +53,7 @@ func (c *commandVolumeScrub) Do(args []string, commandEnv *CommandEnv, writer io
 	mode := volScrubCommand.String("mode", "full", "scrubbing mode (index/local/full)")
 	markBrokenReadonly := volScrubCommand.Bool("markBrokenReadonly", false, "whether to flag volumes with scrub failures as read-only")
 	maxParallelization := volScrubCommand.Int("maxParallelization", DefaultMaxParallelization, "run up to X tasks in parallel, whenever possible")
+	showDetails := volScrubCommand.Bool("details", false, "display scrub result details, if available")
 
 	if err = volScrubCommand.Parse(args); err != nil {
 		return err
@@ -104,10 +105,10 @@ func (c *commandVolumeScrub) Do(args []string, commandEnv *CommandEnv, writer io
 	fmt.Fprintf(writer, "using %s mode\n", c.mode.String())
 	c.env = commandEnv
 
-	return c.scrubVolumes(writer, *maxParallelization, *markBrokenReadonly)
+	return c.scrubVolumes(writer, *maxParallelization, *markBrokenReadonly, *showDetails)
 }
 
-func (c *commandVolumeScrub) scrubVolumes(writer io.Writer, maxParallelization int, markBrokenReadonly bool) error {
+func (c *commandVolumeScrub) scrubVolumes(writer io.Writer, maxParallelization int, markBrokenReadonly bool, showDetails bool) error {
 	var brokenVolumesStr []string
 	var details []string
 	var totalVolumes, brokenVolumes, totalFiles uint64
@@ -158,7 +159,7 @@ func (c *commandVolumeScrub) scrubVolumes(writer io.Writer, maxParallelization i
 	if brokenVolumes != 0 {
 		fmt.Fprintf(writer, "\nGot scrub failures on %d volumes :(\n", brokenVolumes)
 		fmt.Fprintf(writer, "Affected volumes: %s\n", strings.Join(brokenVolumesStr, ", "))
-		if len(details) != 0 {
+		if showDetails && len(details) != 0 {
 			fmt.Fprintf(writer, "Details:\n\t%s\n", strings.Join(details, "\n\t"))
 		}
 	}


### PR DESCRIPTION
# What problem are we solving?

On volumes failing scrubs, the detail output can get very verbose, which makes reading results difficult.

Most users won't care about this information to begin with - just whether or not volumes pass scrub tests.

# How are we solving the problem?

This MR gates the display of scrub result details behind a `--details` flag.

# How is the PR tested?

Shell command display flag, no tests affected.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `--details` flag to the `ec.scrub` command to display detailed scrub results from erasure-coded volumes
  * Added optional `-details` flag to the `volume.scrub` command to display detailed scrub results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->