### PR TITLE
mount: tolerance-window write pattern detection for concurrent writeback

### DIFF
--- a/weed/mount/page_writer_pattern.go
+++ b/weed/mount/page_writer_pattern.go
@@ -4,27 +4,54 @@ import "sync/atomic"
 
 type WriterPattern struct {
 	isSequentialCounter int64
-	lastWriteStopOffset int64
+	writeFrontier       int64 // highest (offset+size) observed across writes
 	chunkSize           int64
 }
 
 const ModeChangeLimit = 3
 
-// For streaming write: only cache the first chunk
-// For random write: fall back to temp file approach
+// SeqTolerance: a write whose start is within this many bytes of the current
+// write frontier still counts as sequential. Using a tolerance window rather
+// than strict contiguity absorbs reordered/concurrent FUSE writeback — multiple
+// Write upcalls for one handle interleave (MonitorWriteAt runs before the
+// per-handle write lock) and writeback flushes dirty pages slightly out of
+// offset order — while still rejecting far random seeks.
+const SeqTolerance = 8 << 20 // 8 MiB
+
+// For streaming write: keep dirty chunks in memory (NewMemChunk).
+// For random write: fall back to the on-disk swap file (NewSwapFileChunk).
 
 func NewWriterPattern(chunkSize int64) *WriterPattern {
 	return &WriterPattern{
 		isSequentialCounter: 0,
-		lastWriteStopOffset: 0,
+		writeFrontier:       0,
 		chunkSize:           chunkSize,
 	}
 }
 
 func (rp *WriterPattern) MonitorWriteAt(offset int64, size int) {
-	lastOffset := atomic.SwapInt64(&rp.lastWriteStopOffset, offset+int64(size))
+	// Snapshot the frontier this write is judged against, then advance it to
+	// max(frontier, offset+size). The CAS loop keeps this lock-free under the
+	// concurrent writeback upcalls described above, consistent with the atomic
+	// counter below.
+	frontier := atomic.LoadInt64(&rp.writeFrontier)
+	end := offset + int64(size)
+	for {
+		cur := atomic.LoadInt64(&rp.writeFrontier)
+		if end <= cur || atomic.CompareAndSwapInt64(&rp.writeFrontier, cur, end) {
+			break
+		}
+	}
+
+	// near = this write starts within SeqTolerance of where writes had reached.
+	// Hysteresis (the ±ModeChangeLimit counter) keeps a single outlier write
+	// from flipping the mode and spilling a sequential stream to the swap file.
+	diff := offset - frontier
+	if diff < 0 {
+		diff = -diff
+	}
 	counter := atomic.LoadInt64(&rp.isSequentialCounter)
-	if lastOffset == offset {
+	if diff <= SeqTolerance {
 		if counter < ModeChangeLimit {
 			atomic.AddInt64(&rp.isSequentialCounter, 1)
 		}

--- a/weed/mount/page_writer_pattern.go
+++ b/weed/mount/page_writer_pattern.go
@@ -30,15 +30,16 @@ func NewWriterPattern(chunkSize int64) *WriterPattern {
 }
 
 func (rp *WriterPattern) MonitorWriteAt(offset int64, size int) {
-	// Snapshot the frontier this write is judged against, then advance it to
-	// max(frontier, offset+size). The CAS loop keeps this lock-free under the
-	// concurrent writeback upcalls described above, consistent with the atomic
-	// counter below.
-	frontier := atomic.LoadInt64(&rp.writeFrontier)
+	// Advance the frontier to max(frontier, offset+size) and capture, in the same
+	// CAS loop, the pre-image this write is judged against. Reading the frontier
+	// inside the loop (rather than once up front) keeps `diff` below comparing
+	// against the freshest value even if a concurrent writeback upcall advances
+	// the frontier while we loop. Lock-free, consistent with the atomic counter.
 	end := offset + int64(size)
+	var frontier int64
 	for {
-		cur := atomic.LoadInt64(&rp.writeFrontier)
-		if end <= cur || atomic.CompareAndSwapInt64(&rp.writeFrontier, cur, end) {
+		frontier = atomic.LoadInt64(&rp.writeFrontier)
+		if end <= frontier || atomic.CompareAndSwapInt64(&rp.writeFrontier, frontier, end) {
 			break
 		}
 	}

--- a/weed/mount/page_writer_pattern_test.go
+++ b/weed/mount/page_writer_pattern_test.go
@@ -1,0 +1,104 @@
+package mount
+
+import (
+	"sync/atomic"
+	"testing"
+)
+
+const mb = 1 << 20
+
+func TestWriterPatternSequentialAndHysteresis(t *testing.T) {
+	wp := NewWriterPattern(2 * mb)
+	wp.MonitorWriteAt(0, mb)    // near(0 vs frontier 0) -> +1
+	wp.MonitorWriteAt(mb, mb)   // +2
+	wp.MonitorWriteAt(2*mb, mb) // +3 (capped)
+	if !wp.IsSequentialMode() {
+		t.Fatal("a stream from offset 0 must be sequential")
+	}
+	// a single far outlier does not flip to random (hysteresis): +3 -> +2
+	wp.MonitorWriteAt(900*mb, mb)
+	if !wp.IsSequentialMode() {
+		t.Fatal("a single outlier write must not flip out of sequential mode")
+	}
+}
+
+func TestWriterPatternFarFirstWriteIsRandom(t *testing.T) {
+	wp := NewWriterPattern(2 * mb)
+	wp.MonitorWriteAt(500*mb, mb) // far from frontier 0 -> -1
+	if wp.IsSequentialMode() {
+		t.Fatal("a far first write should be random")
+	}
+}
+
+func TestWriterPatternToleranceAbsorbsReorder(t *testing.T) {
+	wp := NewWriterPattern(2 * mb)
+	wp.MonitorWriteAt(0, mb)    // +1, frontier 1MB
+	wp.MonitorWriteAt(6*mb, mb) // |6-1|=5MB <= 8MB tolerance -> near, +2, frontier 7MB
+	wp.MonitorWriteAt(3*mb, mb) // |3-7|=4MB <= 8MB -> near, +3
+	if !wp.IsSequentialMode() {
+		t.Fatal("reordered writes within tolerance must stay sequential")
+	}
+}
+
+func TestWriterPatternRandomRecoveryNeedsHysteresis(t *testing.T) {
+	wp := NewWriterPattern(2 * mb)
+	wp.MonitorWriteAt(100*mb, mb) // far -> -1
+	wp.MonitorWriteAt(300*mb, mb) // far -> -2
+	wp.MonitorWriteAt(500*mb, mb) // far -> -3 (capped), frontier 501MB
+	// a single near write must not immediately flip back to sequential: -3 -> -2
+	wp.MonitorWriteAt(501*mb, mb)
+	if wp.IsSequentialMode() {
+		t.Fatal("one near write must not flip back from deep random mode")
+	}
+}
+
+// The max-frontier (vs the old atomic.Swap of the last write's stop offset) is the
+// load-bearing difference of this detector: the frontier must never move backward,
+// or a backward write would lower the baseline and make later far writes look near.
+func TestWriterPatternFrontierNeverRegresses(t *testing.T) {
+	wp := NewWriterPattern(2 * mb)
+	wp.MonitorWriteAt(500*mb, mb) // far first write -> -1, frontier 501MB
+	wp.MonitorWriteAt(0, mb)      // a backward write must not pull the frontier back
+	if got := atomic.LoadInt64(&wp.writeFrontier); got != 501*mb {
+		t.Fatalf("frontier regressed to %d; the max-frontier must never move backward", got)
+	}
+	// Behavioral consequence: writes far below the preserved frontier stay random.
+	// Had the frontier regressed to ~1MB, this would wrongly read as sequential.
+	if wp.IsSequentialMode() {
+		t.Fatal("writes far below the preserved frontier must remain random")
+	}
+}
+
+// SeqTolerance is the central new tuning knob; pin both sides of the inclusive
+// boundary so an off-by-one or a '<' vs '<=' change can't slip through silently.
+func TestWriterPatternToleranceBoundary(t *testing.T) {
+	atBoundary := NewWriterPattern(2 * mb)
+	atBoundary.MonitorWriteAt(SeqTolerance, 0) // diff == SeqTolerance -> near (inclusive), +1
+	if !atBoundary.IsSequentialMode() {
+		t.Fatal("a write exactly at frontier+SeqTolerance must count as sequential")
+	}
+	pastBoundary := NewWriterPattern(2 * mb)
+	pastBoundary.MonitorWriteAt(SeqTolerance+1, 0) // diff == SeqTolerance+1 -> far, -1
+	if pastBoundary.IsSequentialMode() {
+		t.Fatal("a write one byte past frontier+SeqTolerance must count as random")
+	}
+}
+
+// The perf-relevant escape from random (swap-file) mode: sustained near writes must
+// climb the counter back out of the negative floor and re-enter sequential (RAM) mode.
+func TestWriterPatternRecoversToSequential(t *testing.T) {
+	wp := NewWriterPattern(2 * mb)
+	wp.MonitorWriteAt(100*mb, mb) // far -> -1
+	wp.MonitorWriteAt(300*mb, mb) // far -> -2
+	wp.MonitorWriteAt(500*mb, mb) // far -> -3 (capped), frontier 501MB
+	if wp.IsSequentialMode() {
+		t.Fatal("three far writes must be random")
+	}
+	// contiguous near writes: -3 -> -2 -> -1 -> 0 -> +1, back into sequential mode
+	for i := int64(0); i < 4; i++ {
+		wp.MonitorWriteAt(501*mb+i*mb, mb)
+	}
+	if !wp.IsSequentialMode() {
+		t.Fatal("sustained near writes must recover sequential mode (escape the swap-file cliff)")
+	}
+}


### PR DESCRIPTION
## Problem

`WriterPattern` (`weed/mount/page_writer_pattern.go`) decides, per dirty chunk, whether it stays buffered in RAM (`NewMemChunk`) or spills to an on-disk swap file (`NewSwapFileChunk`) — see `weed/mount/page_writer/upload_pipeline.go` `SaveDataAt`. So a **sequential stream misclassified as random gets pushed through disk-backed swap**, a real throughput cliff.

The old detector compared each write's start to the *previous write's exact stop offset*:

```go
lastOffset := atomic.SwapInt64(&rp.lastWriteStopOffset, offset+int64(size))
if lastOffset == offset { counter++ } else { counter-- }
```

That is brittle under concurrent FUSE writeback:

- `MonitorWriteAt` runs **before** the per-handle write lock (`weedfs_file_write.go`), so parallel `Write` upcalls interleave the `Swap`.
- Writeback flushes dirty pages slightly out of offset order.
- The `Swap` tracks the *last* write's stop (not a max), so any reorder corrupts the baseline.

A genuinely sequential stream then repeatedly reads as random and spills to swap.

## Change

Apply the same **frontier + tolerance** approach already merged on the read side (#9983):

- Track a **never-regressing max frontier** (`offset+size`) via a CAS loop.
- Treat a write whose start is within `SeqTolerance` (8 MiB) of that frontier as sequential.
- Keep the existing `±ModeChangeLimit` **hysteresis** so a single outlier write can't flip the mode.

The write-side polarity is unchanged (optimistic: `IsSequentialMode() == counter >= 0`). No call-site changes — `MonitorWriteAt` / `IsSequentialMode` signatures are stable.

## Tests

Adds `weed/mount/page_writer_pattern_test.go`: sequentiality + hysteresis, reorder tolerance, the inclusive `SeqTolerance` boundary, frontier non-regression (guards the CAS invariant), and recovery back to sequential mode. Each guard was mutation-checked — reverting the CAS to a plain store, breaking the recovery clamp, and flipping `<=` to `<` each make the matching test fail.

This is the write-side companion to #9983 (read-pattern tolerance).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved write-order tracking to more accurately detect sequential writes using a frontier-based approach.
  * Added configurable sequential tolerance to smooth out minor reordering and reduce unnecessary mode switching.
  * Updated write monitoring logic to use atomic frontier advancement and hysteresis for stable sequential/random behavior.
* **Tests**
  * Added comprehensive unit tests covering sequential/hysteresis transitions, tolerance boundaries, tolerance-based absorption, frontier non-regression, and recovery back to sequential mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->