### PR TITLE
shell: show remote storage name/key in volume.list output

### DIFF
--- a/weed/storage/volume_info.go
+++ b/weed/storage/volume_info.go
@@ -75,8 +75,12 @@ func (vi VolumeInfo) IsRemote() bool {
 }
 
 func (vi VolumeInfo) String() string {
-	return fmt.Sprintf("Id:%d, Size:%d, ReplicaPlacement:%s, Collection:%s, Version:%v, Ttl:%s, FileCount:%d, DeleteCount:%d, DeletedByteCount:%d, ReadOnly:%v, ModifiedAtSecond:%d",
+	s := fmt.Sprintf("Id:%d, Size:%d, ReplicaPlacement:%s, Collection:%s, Version:%v, Ttl:%s, FileCount:%d, DeleteCount:%d, DeletedByteCount:%d, ReadOnly:%v, ModifiedAtSecond:%d",
 		vi.Id, vi.Size, vi.ReplicaPlacement, vi.Collection, vi.Version, vi.Ttl.String(), vi.FileCount, vi.DeleteCount, vi.DeletedByteCount, vi.ReadOnly, vi.ModifiedAtSecond)
+	if vi.IsRemote() {
+		s += fmt.Sprintf(", RemoteStorageName:%s, RemoteStorageKey:%s", vi.RemoteStorageName, vi.RemoteStorageKey)
+	}
+	return s
 }
 
 func (vi VolumeInfo) ToVolumeInformationMessage() *master_pb.VolumeInformationMessage {


### PR DESCRIPTION
Fixes #9985

`VolumeInfo.String()` dropped `RemoteStorageName`/`RemoteStorageKey`, which are useful when debugging volume tiering. Append them to the output when the volume is remote, so `volume.list` in `weed shell` surfaces them again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced volume information display to include remote storage details when applicable for remote volumes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->