### PR TITLE
s3: bound streaming remote-cache wait so large cold GetObject returns 503, not a hang

### DIFF
--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -16,6 +16,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/filer"
@@ -3105,13 +3106,13 @@ func cachedEntryHasLocalData(entry *filer_pb.Entry) bool {
 	return entry != nil && (len(entry.GetChunks()) > 0 || len(entry.Content) > 0)
 }
 
-// remoteCacheStreamingTimeout bounds how long the streaming read path waits for
-// the filer to finish caching a remote-only object. Without a bound a multi-GB
-// download outlasts the client's read timeout, so the request is canceled before
-// the caller can emit 503 + Retry-After. Kept under common S3 client read
-// timeouts (~60s) given the 30s dedup attempt that precedes it. A var so tests
-// can shorten it.
-var remoteCacheStreamingTimeout = 20 * time.Second
+// remoteCacheStreamingTimeoutNS bounds (nanoseconds) how long the streaming read
+// path waits for the filer to finish caching a remote-only object. Without a
+// bound a multi-GB download outlasts the client's read timeout, so the request
+// is canceled before the caller can emit 503 + Retry-After. Kept under common S3
+// client read timeouts (~60s) given the 30s dedup attempt that precedes it.
+// Atomic so tests can shorten it without racing the read path.
+var remoteCacheStreamingTimeoutNS = int64(20 * time.Second)
 
 // cacheRemoteObjectForStreaming caches a remote-only object to the local cluster for streaming.
 // Bounded so a slow large-file download returns to the caller (which emits 503 +
@@ -3119,7 +3120,8 @@ var remoteCacheStreamingTimeout = 20 * time.Second
 // context, so a retry streams from the cached chunks. Returns the cached entry
 // only when chunks are present; the caller cannot read inline Content here.
 func (s3a *S3ApiServer) cacheRemoteObjectForStreaming(r *http.Request, entry *filer_pb.Entry, bucket, object, versionId string) *filer_pb.Entry {
-	cacheCtx, cancel := context.WithTimeout(r.Context(), remoteCacheStreamingTimeout)
+	timeout := time.Duration(atomic.LoadInt64(&remoteCacheStreamingTimeoutNS))
+	cacheCtx, cancel := context.WithTimeout(r.Context(), timeout)
 	defer cancel()
 
 	dir, name := s3a.buildVersionedRemoteObjectPath(bucket, object, versionId)
@@ -3131,7 +3133,7 @@ func (s3a *S3ApiServer) cacheRemoteObjectForStreaming(r *http.Request, entry *fi
 		// A bounded-wait timeout (or client disconnect) is not a cache failure:
 		// the filer keeps downloading and the caller maps a nil return to 503.
 		if cacheCtx.Err() != nil {
-			glog.V(1).Infof("cacheRemoteObjectForStreaming: %s/%s not ready within %v (will retry)", dir, name, remoteCacheStreamingTimeout)
+			glog.V(1).Infof("cacheRemoteObjectForStreaming: %s/%s not ready within %v (will retry)", dir, name, timeout)
 		} else {
 			glog.Errorf("cacheRemoteObjectForStreaming: failed to cache %s/%s: %v", dir, name, err)
 		}

--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -3105,18 +3105,36 @@ func cachedEntryHasLocalData(entry *filer_pb.Entry) bool {
 	return entry != nil && (len(entry.GetChunks()) > 0 || len(entry.Content) > 0)
 }
 
+// remoteCacheStreamingTimeout bounds how long the streaming read path waits for
+// the filer to finish caching a remote-only object. Without a bound a multi-GB
+// download outlasts the client's read timeout, so the request is canceled before
+// the caller can emit 503 + Retry-After. Kept under common S3 client read
+// timeouts (~60s) given the 30s dedup attempt that precedes it. A var so tests
+// can shorten it.
+var remoteCacheStreamingTimeout = 20 * time.Second
+
 // cacheRemoteObjectForStreaming caches a remote-only object to the local cluster for streaming.
-// Uses the request context (no artificial timeout) so the caching can complete.
-// Returns the cached entry only when chunks are present; the streaming caller
-// is not wired to read inline Content from a cache result here.
+// Bounded so a slow large-file download returns to the caller (which emits 503 +
+// Retry-After) before the client gives up; the filer keeps caching on a detached
+// context, so a retry streams from the cached chunks. Returns the cached entry
+// only when chunks are present; the caller cannot read inline Content here.
 func (s3a *S3ApiServer) cacheRemoteObjectForStreaming(r *http.Request, entry *filer_pb.Entry, bucket, object, versionId string) *filer_pb.Entry {
+	cacheCtx, cancel := context.WithTimeout(r.Context(), remoteCacheStreamingTimeout)
+	defer cancel()
+
 	dir, name := s3a.buildVersionedRemoteObjectPath(bucket, object, versionId)
 
 	glog.V(1).Infof("cacheRemoteObjectForStreaming: caching %s/%s (remote size: %d, versionId: %s)", dir, name, entry.RemoteEntry.RemoteSize, versionId)
 
-	cachedEntry, err := s3a.doCacheRemoteObject(r.Context(), dir, name)
+	cachedEntry, err := s3a.doCacheRemoteObject(cacheCtx, dir, name)
 	if err != nil {
-		glog.Errorf("cacheRemoteObjectForStreaming: failed to cache %s/%s: %v", dir, name, err)
+		// A bounded-wait timeout (or client disconnect) is not a cache failure:
+		// the filer keeps downloading and the caller maps a nil return to 503.
+		if cacheCtx.Err() != nil {
+			glog.V(1).Infof("cacheRemoteObjectForStreaming: %s/%s not ready within %v (will retry)", dir, name, remoteCacheStreamingTimeout)
+		} else {
+			glog.Errorf("cacheRemoteObjectForStreaming: failed to cache %s/%s: %v", dir, name, err)
+		}
 		return nil
 	}
 

--- a/weed/s3api/s3api_remote_storage_test.go
+++ b/weed/s3api/s3api_remote_storage_test.go
@@ -1,13 +1,23 @@
 package s3api
 
 import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/filer"
+	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 // TestIsInRemoteOnly tests the IsInRemoteOnly method on filer_pb.Entry
@@ -483,4 +493,92 @@ func TestCopyObjectRemoteOnlySourceDetection(t *testing.T) {
 			assert.Equal(t, tt.expectBrokenWithoutFix, brokenWithoutFix)
 		})
 	}
+}
+
+// fakeCacheFiler is a minimal SeaweedFiler gRPC server whose
+// CacheRemoteObjectToLocalCluster behavior is driven by a callback, so tests can
+// model a slow (still-caching) filer or one that returns cached chunks.
+type fakeCacheFiler struct {
+	filer_pb.UnimplementedSeaweedFilerServer
+	cache func(context.Context, *filer_pb.CacheRemoteObjectToLocalClusterRequest) (*filer_pb.CacheRemoteObjectToLocalClusterResponse, error)
+}
+
+func (f *fakeCacheFiler) CacheRemoteObjectToLocalCluster(ctx context.Context, req *filer_pb.CacheRemoteObjectToLocalClusterRequest) (*filer_pb.CacheRemoteObjectToLocalClusterResponse, error) {
+	return f.cache(ctx, req)
+}
+
+// startFakeCacheFiler serves impl on a random localhost port and returns the
+// S3-style filer address whose ToGrpcAddress resolves back to that port.
+func startFakeCacheFiler(t *testing.T, impl *fakeCacheFiler) pb.ServerAddress {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	srv := grpc.NewServer()
+	filer_pb.RegisterSeaweedFilerServer(srv, impl)
+	go srv.Serve(lis)
+	t.Cleanup(srv.Stop)
+	port := lis.Addr().(*net.TCPAddr).Port
+	return pb.ServerAddress(fmt.Sprintf("127.0.0.1:1.%d", port))
+}
+
+func newRemoteCacheTestServer(filerAddr pb.ServerAddress) *S3ApiServer {
+	return &S3ApiServer{
+		option: &S3ApiServerOption{
+			Filers:         []pb.ServerAddress{filerAddr},
+			BucketsPath:    "/buckets",
+			GrpcDialOption: grpc.WithTransportCredentials(insecure.NewCredentials()),
+		},
+	}
+}
+
+func remoteOnlyEntry(name string, size int64) *filer_pb.Entry {
+	return &filer_pb.Entry{Name: name, RemoteEntry: &filer_pb.RemoteEntry{RemoteSize: size}}
+}
+
+// TestCacheRemoteObjectForStreamingTimeout pins the fix for large-file cold
+// GetObject: when the filer is still caching, the streaming path returns nil
+// within its bound (so the handler emits 503 + Retry-After) instead of blocking
+// on the raw request context until the client gives up.
+func TestCacheRemoteObjectForStreamingTimeout(t *testing.T) {
+	filerAddr := startFakeCacheFiler(t, &fakeCacheFiler{
+		cache: func(ctx context.Context, req *filer_pb.CacheRemoteObjectToLocalClusterRequest) (*filer_pb.CacheRemoteObjectToLocalClusterResponse, error) {
+			<-ctx.Done() // never finishes within the bound
+			return nil, ctx.Err()
+		},
+	})
+	s3a := newRemoteCacheTestServer(filerAddr)
+
+	defer func(prev time.Duration) { remoteCacheStreamingTimeout = prev }(remoteCacheStreamingTimeout)
+	remoteCacheStreamingTimeout = 200 * time.Millisecond
+
+	r := httptest.NewRequest(http.MethodGet, "/mybucket/large.bin", nil)
+	start := time.Now()
+	got := s3a.cacheRemoteObjectForStreaming(r, remoteOnlyEntry("large.bin", 1<<30), "mybucket", "large.bin", "")
+	elapsed := time.Since(start)
+
+	assert.Nil(t, got, "uncached object must return nil so the caller maps to 503")
+	assert.Less(t, elapsed, 5*time.Second, "must not block on the full download")
+	assert.NoError(t, r.Context().Err(), "request context stays alive so the caller chooses 503, not cancellation")
+}
+
+// TestCacheRemoteObjectForStreamingCached confirms that once the filer reports
+// local chunks, the streaming path returns the cached entry to stream from.
+func TestCacheRemoteObjectForStreamingCached(t *testing.T) {
+	filerAddr := startFakeCacheFiler(t, &fakeCacheFiler{
+		cache: func(ctx context.Context, req *filer_pb.CacheRemoteObjectToLocalClusterRequest) (*filer_pb.CacheRemoteObjectToLocalClusterResponse, error) {
+			return &filer_pb.CacheRemoteObjectToLocalClusterResponse{
+				Entry: &filer_pb.Entry{
+					Name:   req.Name,
+					Chunks: []*filer_pb.FileChunk{{FileId: "1,abc", Size: 100, Offset: 0}},
+				},
+			}, nil
+		},
+	})
+	s3a := newRemoteCacheTestServer(filerAddr)
+
+	r := httptest.NewRequest(http.MethodGet, "/mybucket/obj.bin", nil)
+	got := s3a.cacheRemoteObjectForStreaming(r, remoteOnlyEntry("obj.bin", 100), "mybucket", "obj.bin", "")
+
+	require.NotNil(t, got)
+	assert.Len(t, got.GetChunks(), 1)
 }

--- a/weed/s3api/s3api_remote_storage_test.go
+++ b/weed/s3api/s3api_remote_storage_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -548,8 +549,8 @@ func TestCacheRemoteObjectForStreamingTimeout(t *testing.T) {
 	})
 	s3a := newRemoteCacheTestServer(filerAddr)
 
-	defer func(prev time.Duration) { remoteCacheStreamingTimeout = prev }(remoteCacheStreamingTimeout)
-	remoteCacheStreamingTimeout = 200 * time.Millisecond
+	defer func(prev int64) { atomic.StoreInt64(&remoteCacheStreamingTimeoutNS, prev) }(atomic.LoadInt64(&remoteCacheStreamingTimeoutNS))
+	atomic.StoreInt64(&remoteCacheStreamingTimeoutNS, int64(200*time.Millisecond))
 
 	r := httptest.NewRequest(http.MethodGet, "/mybucket/large.bin", nil)
 	start := time.Now()

--- a/weed/s3api/s3api_remote_storage_test.go
+++ b/weed/s3api/s3api_remote_storage_test.go
@@ -549,8 +549,9 @@ func TestCacheRemoteObjectForStreamingTimeout(t *testing.T) {
 	})
 	s3a := newRemoteCacheTestServer(filerAddr)
 
+	const shortTimeout = 200 * time.Millisecond
 	defer func(prev int64) { atomic.StoreInt64(&remoteCacheStreamingTimeoutNS, prev) }(atomic.LoadInt64(&remoteCacheStreamingTimeoutNS))
-	atomic.StoreInt64(&remoteCacheStreamingTimeoutNS, int64(200*time.Millisecond))
+	atomic.StoreInt64(&remoteCacheStreamingTimeoutNS, int64(shortTimeout))
 
 	r := httptest.NewRequest(http.MethodGet, "/mybucket/large.bin", nil)
 	start := time.Now()
@@ -558,6 +559,7 @@ func TestCacheRemoteObjectForStreamingTimeout(t *testing.T) {
 	elapsed := time.Since(start)
 
 	assert.Nil(t, got, "uncached object must return nil so the caller maps to 503")
+	assert.GreaterOrEqual(t, elapsed, shortTimeout/2, "must wait on the bounded timeout, not return early on a setup error")
 	assert.Less(t, elapsed, 5*time.Second, "must not block on the full download")
 	assert.NoError(t, r.Context().Err(), "request context stays alive so the caller chooses 503, not cancellation")
 }


### PR DESCRIPTION
## Problem

Cold GetObject of a large remote-only object (remote-mounted S3 bucket) fails with `500 InternalError`, while small objects through the same path succeed.

The S3 handler caches a remote-only object in two stages:

1. `cacheRemoteObjectWithDedup` — bounded to 30s. For a multi-GB blob the download outlasts this, so it returns the still-uncached entry.
2. `streamFromVolumeServers` then calls `cacheRemoteObjectForStreaming`, which waited on the **raw request context with no bound**, blocking until the whole download finished or the client gave up.

For large files the client's read timeout fires first. The cache call returns a canceled context, and the handler surfaces that as a dropped request / InternalError — even though it already wires up a graceful `503 + Retry-After` for the "cache still filling" case, and the filer keeps caching on a detached context so a retry would stream from the finished chunks. The unbounded wait simply made the 503 path unreachable for large files.

## Fix

Bound the streaming-path cache wait under common S3 client read timeouts. When the wait elapses while the client is still connected, `cacheRemoteObjectForStreaming` returns nil and the existing handler logic emits `503 + Retry-After`; the detached filer cache completes and the client's retry streams from the cached chunks. A genuine client disconnect is still reported as a cancellation (no spurious 503).

## Test

Added gRPC-backed tests for `cacheRemoteObjectForStreaming`:
- a still-caching filer returns nil within the bound (so the caller maps to 503) instead of blocking on the full download, with the request context left alive;
- a filer that reports local chunks returns the cached entry to stream from.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated remote-only streaming object caching to complete within a new default 20s timeout, preventing indefinite waiting.
  * Adjusted cache-failure handling so timeouts and client disconnects are treated as retryable (lower severity) rather than logged as errors.
  * Streaming cache results now return cached entries only when chunked data is present.

* **Tests**
  * Added/updated streaming cache tests to verify timeout behavior and the successful cached-streaming path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->