### PR TITLE
storage: register tier backends at the binary composition root

### DIFF
--- a/weed/command/backends.go
+++ b/weed/command/backends.go
@@ -1,0 +1,5 @@
+package command
+
+// Register the tiered-storage backends here, at the binary's composition root,
+// so library consumers of weed/storage don't pull the backend SDKs.
+import _ "github.com/seaweedfs/seaweedfs/weed/storage/backend/all"

--- a/weed/storage/backend/all/all.go
+++ b/weed/storage/backend/all/all.go
@@ -1,0 +1,10 @@
+// Package all registers every tiered-storage backend factory. Binaries that
+// serve or manage tiered volumes blank-import it from their composition root;
+// keeping the registrations out of weed/storage lets library consumers avoid
+// pulling the backend SDKs into their dependency graph.
+package all
+
+import (
+	_ "github.com/seaweedfs/seaweedfs/weed/storage/backend/rclone_backend"
+	_ "github.com/seaweedfs/seaweedfs/weed/storage/backend/s3_backend"
+)

--- a/weed/storage/volume_info/volume_info.go
+++ b/weed/storage/volume_info/volume_info.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb/volume_server_pb"
-	_ "github.com/seaweedfs/seaweedfs/weed/storage/backend/rclone_backend"
-	_ "github.com/seaweedfs/seaweedfs/weed/storage/backend/s3_backend"
 	"github.com/seaweedfs/seaweedfs/weed/util"
 	jsonpb "google.golang.org/protobuf/encoding/protojson"
 )

--- a/weed/storage/volume_tier.go
+++ b/weed/storage/volume_tier.go
@@ -7,8 +7,6 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb/volume_server_pb"
 	"github.com/seaweedfs/seaweedfs/weed/storage/backend"
-	_ "github.com/seaweedfs/seaweedfs/weed/storage/backend/rclone_backend"
-	_ "github.com/seaweedfs/seaweedfs/weed/storage/backend/s3_backend"
 	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
 	"github.com/seaweedfs/seaweedfs/weed/storage/types"
 	"github.com/seaweedfs/seaweedfs/weed/storage/volume_info"


### PR DESCRIPTION
## Problem

The `s3` and `rclone` tiered-storage backends are registered through blank imports in the `weed/storage` library itself — `weed/storage/volume_tier.go` and `weed/storage/volume_info/volume_info.go`:

```go
_ "github.com/seaweedfs/seaweedfs/weed/storage/backend/rclone_backend"
_ "github.com/seaweedfs/seaweedfs/weed/storage/backend/s3_backend"
```

Because `weed/storage` is imported by `weed/shell` (and transitively by external tools that embed it, e.g. the seaweedfs-operator), every such consumer is forced to link `aws-sdk-go` and — under `-tags rclone` — the full `rclone/backend/all` set and its cloud-storage SDKs (Azure, Oracle, ProtonMail, Storj, Dropbox, …). These consumers never tier volumes, yet they inherit the entire backend dependency graph.

Concretely, in the operator this manifested as ~200 indirect modules in `go.mod`/`go.sum` and `aws-sdk-go` v1 linked into the binary.

## Fix

Register the backends at the binary's composition root instead of in the library, the standard Go pattern (cf. `database/sql` drivers, `rclone/backend/all`):

- New `weed/storage/backend/all` aggregator that blank-imports `s3_backend` + `rclone_backend`.
- Blank-import it once from `weed/command` (`backends.go`) so the `weed` binary still registers both backends.
- Drop the four blank imports from `weed/storage`.

No behavior change for the `weed` binary; library consumers of `weed/storage` stop pulling the backend SDKs.

## Verification

- `go build ./...` (default and `-tags rclone`) passes; `gofmt`/`go vet` clean.
- Tier/backend tests pass (`weed/storage`, `weed/storage/backend/...`, `weed/server`).
- `weed` binary still links `weed/storage/backend/all` (both factories registered); `weed/shell` and `weed/storage` no longer reference `s3_backend`/`rclone_backend`.
- Confirmed downstream effect via a local `replace`: a `weed/shell` consumer's `go.mod` drops rclone, aws-sdk-go-v2, Azure storage, ProtonMail and the rest. (`aws-sdk-go` v1 legitimately stays — used by `weed/iam` and `s3_constants` types.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized internal backend registration system for improved code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->