### PR TITLE
s3api: add optional request interceptor to circuit breaker

### DIFF
--- a/weed/s3api/s3api_circuit_breaker.go
+++ b/weed/s3api/s3api_circuit_breaker.go
@@ -25,6 +25,14 @@ type CircuitBreaker struct {
 	counters    map[string]*int64
 	limitations map[string]int64
 	s3a         *S3ApiServer
+
+	// Interceptor, if set, wraps the per-route handler ahead of ALL
+	// circuit-breaker logic (upload limiting and the breaker checks) and runs
+	// even when the breaker is disabled. It is a general per-request
+	// interceptor seam: an implementation may reject the request (write its own
+	// response and not call next) or wrap next to observe/shape it. Nil by
+	// default, so it is a no-op unless explicitly set.
+	Interceptor func(next http.HandlerFunc, action string) http.HandlerFunc
 }
 
 func NewCircuitBreaker(option *S3ApiServerOption) *CircuitBreaker {
@@ -92,7 +100,7 @@ func (cb *CircuitBreaker) loadCircuitBreakerConfig(cfg *s3_pb.S3CircuitBreakerCo
 }
 
 func (cb *CircuitBreaker) Limit(f func(w http.ResponseWriter, r *http.Request), action string) (http.HandlerFunc, Action) {
-	return func(w http.ResponseWriter, r *http.Request) {
+	inner := func(w http.ResponseWriter, r *http.Request) {
 		// Apply upload limiting for write actions if configured
 		if cb.s3a != nil && (action == s3_constants.ACTION_WRITE) &&
 			(cb.s3a.option.ConcurrentUploadLimit != 0 || cb.s3a.option.ConcurrentFileUploadLimit != 0) {
@@ -161,7 +169,14 @@ func (cb *CircuitBreaker) Limit(f func(w http.ResponseWriter, r *http.Request), 
 			return
 		}
 		s3err.WriteErrorResponse(w, r, errCode)
-	}, Action(action)
+	}
+
+	// Run the optional interceptor outermost, so it executes before upload
+	// limiting and the breaker checks and regardless of cb.Enabled.
+	if cb.Interceptor != nil {
+		return cb.Interceptor(inner, action), Action(action)
+	}
+	return inner, Action(action)
 }
 
 func (cb *CircuitBreaker) limit(r *http.Request, bucket string, action string) (rollback []func(), errCode s3err.ErrorCode) {

--- a/weed/s3api/s3api_circuit_breaker.go
+++ b/weed/s3api/s3api_circuit_breaker.go
@@ -171,12 +171,19 @@ func (cb *CircuitBreaker) Limit(f func(w http.ResponseWriter, r *http.Request), 
 		s3err.WriteErrorResponse(w, r, errCode)
 	}
 
-	// Run the optional interceptor outermost, so it executes before upload
-	// limiting and the breaker checks and regardless of cb.Enabled.
-	if cb.Interceptor != nil {
-		return cb.Interceptor(inner, action), Action(action)
-	}
-	return inner, Action(action)
+	// The interceptor is consulted per request rather than captured here, so it
+	// can be installed after the routes are registered (e.g. once the server and
+	// its dependencies are constructed) and so a nil CircuitBreaker is never
+	// dereferenced at registration time. When unset this is just a nil check.
+	// It runs outermost: before upload limiting and the breaker checks, and
+	// regardless of cb.Enabled.
+	return func(w http.ResponseWriter, r *http.Request) {
+		if cb.Interceptor != nil {
+			cb.Interceptor(inner, action)(w, r)
+			return
+		}
+		inner(w, r)
+	}, Action(action)
 }
 
 func (cb *CircuitBreaker) limit(r *http.Request, bucket string, action string) (rollback []func(), errCode s3err.ErrorCode) {

--- a/weed/s3api/s3api_circuit_breaker_test.go
+++ b/weed/s3api/s3api_circuit_breaker_test.go
@@ -182,4 +182,24 @@ func TestLimitInterceptor(t *testing.T) {
 			t.Fatalf("interceptor must run before the handler, got %v", order)
 		}
 	})
+
+	// 4. installed AFTER Limit() returns: still takes effect, because the
+	//    interceptor is consulted per request rather than captured at
+	//    registration time (the handlers are built during router registration,
+	//    before dependencies that need the running server exist).
+	t.Run("interceptor installed after registration takes effect", func(t *testing.T) {
+		cb := newCB()
+		h, _ := cb.Limit(func(w http.ResponseWriter, r *http.Request) {}, readAction) // built while nil
+		ran := false
+		cb.Interceptor = func(next http.HandlerFunc, action string) http.HandlerFunc {
+			return func(w http.ResponseWriter, r *http.Request) {
+				ran = true
+				next(w, r)
+			}
+		}
+		h(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/bucket/object", nil))
+		if !ran {
+			t.Fatal("interceptor set after Limit() must still run (request-time evaluation)")
+		}
+	})
 }

--- a/weed/s3api/s3api_circuit_breaker_test.go
+++ b/weed/s3api/s3api_circuit_breaker_test.go
@@ -2,6 +2,7 @@ package s3api
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -105,4 +106,80 @@ func doLimit(circuitBreaker *CircuitBreaker, routineCount int, r *http.Request, 
 		}
 	}
 	return successCounter
+}
+
+// TestLimitInterceptor verifies the optional request interceptor: it is a no-op
+// when nil, runs ahead of the (disabled) breaker logic, and can either reject a
+// request or pass it through to the wrapped handler.
+func TestLimitInterceptor(t *testing.T) {
+	readAction := s3_constants.ACTION_READ
+	newCB := func() *CircuitBreaker {
+		// Enabled defaults to false and s3a is nil, so without an interceptor
+		// Limit's handler falls straight through to the wrapped handler.
+		return &CircuitBreaker{counters: make(map[string]*int64), limitations: make(map[string]int64)}
+	}
+
+	// 1. nil interceptor must not change behavior: the handler still runs.
+	t.Run("nil interceptor is a no-op", func(t *testing.T) {
+		cb := newCB()
+		called := false
+		h, _ := cb.Limit(func(w http.ResponseWriter, r *http.Request) { called = true }, readAction)
+		h(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/bucket/object", nil))
+		if !called {
+			t.Fatal("handler should run when no interceptor is set")
+		}
+	})
+
+	// 2. a rejecting interceptor runs first and prevents the handler, even
+	//    though the breaker itself is disabled.
+	t.Run("interceptor can reject", func(t *testing.T) {
+		cb := newCB()
+		var order []string
+		cb.Interceptor = func(next http.HandlerFunc, action string) http.HandlerFunc {
+			return func(w http.ResponseWriter, r *http.Request) {
+				order = append(order, "interceptor")
+				s3err.WriteErrorResponse(w, r, s3err.ErrTooManyRequest) // reject; do not call next
+			}
+		}
+		handlerRan := false
+		h, _ := cb.Limit(func(w http.ResponseWriter, r *http.Request) {
+			handlerRan = true
+			order = append(order, "handler")
+		}, readAction)
+		rec := httptest.NewRecorder()
+		h(rec, httptest.NewRequest(http.MethodGet, "/bucket/object", nil))
+		if handlerRan {
+			t.Fatal("a rejecting interceptor must prevent the handler from running")
+		}
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Fatalf("expected 503 from ErrTooManyRequest, got %d", rec.Code)
+		}
+		if len(order) != 1 || order[0] != "interceptor" {
+			t.Fatalf("interceptor should run alone, got %v", order)
+		}
+	})
+
+	// 3. a pass-through interceptor runs before the handler and sees the action.
+	t.Run("interceptor can pass through", func(t *testing.T) {
+		cb := newCB()
+		var order []string
+		var seenAction string
+		cb.Interceptor = func(next http.HandlerFunc, action string) http.HandlerFunc {
+			return func(w http.ResponseWriter, r *http.Request) {
+				seenAction = action
+				order = append(order, "interceptor")
+				next(w, r)
+			}
+		}
+		h, _ := cb.Limit(func(w http.ResponseWriter, r *http.Request) {
+			order = append(order, "handler")
+		}, readAction)
+		h(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/bucket/object", nil))
+		if seenAction != readAction {
+			t.Fatalf("interceptor should receive the route action, got %q", seenAction)
+		}
+		if len(order) != 2 || order[0] != "interceptor" || order[1] != "handler" {
+			t.Fatalf("interceptor must run before the handler, got %v", order)
+		}
+	})
 }


### PR DESCRIPTION
## What

Adds an optional request-interceptor extension point to the S3 `CircuitBreaker`:

```go
type CircuitBreaker struct {
    // ...
    Interceptor func(next http.HandlerFunc, action string) http.HandlerFunc
}
```

It is applied at the **very top** of `CircuitBreaker.Limit()` — before the upload-concurrency wait and before the `if !cb.Enabled` early return — so it runs for every route regardless of whether the breaker is enabled:

```go
inner := func(w, r) { /* existing upload limiting + breaker logic + handler */ }
if cb.Interceptor != nil {
    return cb.Interceptor(inner, action), Action(action)
}
return inner, Action(action)
```

## Why

`cb.Limit(...)` already wraps nearly every S3 route in `registerRouter`, so it is the natural single chokepoint for cross-cutting per-request behavior. Exposing one interceptor seam there lets such behavior — request tracing, auditing, or rate limiting / QoS — be added without editing the large route table.

Because the interceptor wraps the handler (rather than returning a bool), an implementation can either **reject** a request (write its own response and not call `next`) or **wrap** `next` to observe/shape it (e.g. metering a response writer).

## Behavior change

None. The field is `nil` by default, so `Limit()` returns exactly the handler it does today for every existing build.

## Tests

`TestLimitInterceptor` covers three cases: nil interceptor is a no-op; a rejecting interceptor runs first and prevents the handler (even with the breaker disabled); a pass-through interceptor runs before the handler and receives the route action. `go test ./weed/s3api/ -run TestLimit` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an optional request interceptor hook to the S3 API circuit breaker, allowing custom per-request preprocessing/validation.
  * The interceptor runs for every request (including when the circuit breaker is disabled), and can short-circuit requests (e.g., returning `503` when rejected).

* **Tests**
  * Added coverage for interceptor behavior in multiple scenarios, including nil interceptor handling, rejection/short-circuiting, pass-through, and interceptor assignment timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->