### PR TITLE
helm: reject emptyDir for volume idx, and rebuild a missing idx on restart

### DIFF
--- a/k8s/charts/seaweedfs/templates/volume/volume-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/volume/volume-statefulset.yaml
@@ -83,7 +83,23 @@ spec:
           image: {{ template "seaweedfs.volume.image" $ }}
           imagePullPolicy: {{ $.Values.global.seaweedfs.imagePullPolicy | default "IfNotPresent" }}
           command: [ '/bin/sh', '-c' ]
-          args: [ '{{range $dir :=  $volume.dataDirs }}if ls /{{$dir.name}}/*.idx  >/dev/null 2>&1; then mv /{{$dir.name}}/*.idx /idx/ ; fi; {{end}}' ]
+          args:
+            - |
+              for dir in {{ range $index, $dir := $volume.dataDirs }}{{ if ne $index 0 }} {{ end }}/{{ $dir.name }}{{ end }}; do
+                # Rebuild a .idx missing from both dirs (e.g. an index volume that lost files) from the .dat, else the server fatally exits on its idx check.
+                for dat in "$dir"/*.dat; do
+                  [ -e "$dat" ] || continue
+                  base=${dat##*/}; base=${base%.dat}
+                  if [ ! -e "$dir/$base.idx" ] && [ ! -e "/idx/$base.idx" ]; then
+                    echo "rebuilding missing idx in $dir (trigger: volume $base)"
+                    weed fix "$dir"
+                    break
+                  fi
+                done
+                if ls "$dir"/*.idx >/dev/null 2>&1; then
+                  mv "$dir"/*.idx /idx/
+                fi
+              done
           volumeMounts:
             - name: idx
               mountPath: /idx

--- a/k8s/charts/seaweedfs/templates/volume/volume-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/volume/volume-statefulset.yaml
@@ -4,6 +4,10 @@
 {{- $volumeName := trimSuffix "-" (printf "volume-%s" $vname) }}
 {{- $volume := mergeOverwrite (deepCopy $.Values.volume) (dict "enabled" true) $volume }}
 
+{{- if and $volume.idx (eq ($volume.idx.type | toString) "emptyDir") }}
+{{- fail (printf "%s: idx.type \"emptyDir\" is not supported. An ephemeral index is wiped on every pod restart while the data persists, forcing a full index rebuild from the .dat on each start (a fatal crash on older versions). Use the default (idx: {}, kept next to the data) or a persistentVolumeClaim/hostPath/existingClaim for a separate persistent index." $volumeName) }}
+{{- end }}
+
 {{- if $volume.enabled }}
 ---
 apiVersion: apps/v1

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -385,7 +385,7 @@ volume:
     enabled: true
     image: alpine/k8s:1.28.4
 
-  # idx can be defined by:
+  # idx (the volume index) may use a separate PERSISTENT volume:
   #
   # idx:
   #  type: "hostPath"
@@ -404,13 +404,14 @@ volume:
   #   type: "existingClaim"
   #   claimName: "myClaim"
   #
-  # or
+  # "emptyDir" is rejected for idx (the chart fails to render): an ephemeral
+  # index is wiped on every restart while the data persists, forcing a full
+  # rebuild each start (a fatal crash on older versions). "logs" may still use
+  # any of the above or emptyDir.
   #
-  # idx:
-  #  type: "emptyDir"
-
-  # same applies to "logs"
-
+  # Default {} keeps the index next to the data, so it persists with the data and
+  # needs no separate volume. Recommended unless you must split the index onto
+  # its own persistent storage.
   idx: {}
 
   # Resource requests, limits, etc. for the vol-move-idx initContainer. This


### PR DESCRIPTION
Addresses #10003 (and the recovery side of #10004).

Two atomic commits.

## 1. Reject `emptyDir` for volume `idx`

An ephemeral index on a separate volume is wiped on every pod restart while `.dat`/`.vif` persist on the data PVCs. The volume server then finds data with no matching `.idx`, hits its startup idx check, and exits via `glog.Fatalf` (exit 255) -> `CrashLoopBackOff`, with no automatic recovery (`weed/storage/volume_loading.go`).

`emptyDir` is never the right choice for `idx`:
- If the data is persistent, an ephemeral index is a durability mismatch.
- If the data is also ephemeral, the default (`idx: {}`, index co-located with the data) already covers it.

So the chart now fails to render with a clear message pointing at the default or a persistent volume, and `emptyDir` is dropped from the documented `idx` options. (`logs` may still use `emptyDir` -- only `idx` is restricted.)

Note: the chart's `idx` default has never actually been `emptyDir` -- it is `idx: {}` (co-located with data, safe). `emptyDir` was only ever listed as one of the selectable examples, which is how it gets chosen.

## 2. Rebuild a missing idx on restart

With `emptyDir` rejected, a separate `idx` volume is always persistent -- but it can still lose its `.idx` out of band: a node-local PVC reprovisioned on reschedule, or a pre-#9944 compaction crash that left a `.dat` without its matching `.idx` (the situation in #10004). The `seaweedfs-vol-move-idx` init container already moves idx files next to the data into the index dir; it now first regenerates, via `weed fix`, any `.idx` absent from both the data dir and the index dir, then moves it into place. The rebuild runs only when an idx is genuinely missing, so a healthy index adds no startup cost. `weed` ships in the same image even on the Rust volume path, and the init container runs before the volume server, satisfying `weed fix`'s "stop the volume server first" requirement.

## Testing

`helm lint` + `helm template` (rendered manifests parsed as YAML, init script checked with `sh -n`):

- `idx.type: emptyDir` (one and two data dirs, and per-volume override via `.Values.volumes`): render and `lint` both fail with the rejection message, naming the offending volume.
- `idx.type: persistentVolumeClaim`: renders; init container present with the rebuild loop; valid YAML.
- Default (`idx: {}`): renders; no init container; unchanged behavior.
- Functional run of the rendered init script against a stub `weed fix`: rebuild-on-loss (rebuilds + moves), no-op when the index persists, move-only for the legacy idx-beside-data layout, no-op on fresh start, and mixed `collection_volid` names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved index file recovery during volume initialization; when index files are missing, they are automatically rebuilt from persisted data as needed.

* **Documentation**
  * Expanded guidance for configuring a separate persistent index volume, including the behavior on pod restarts and clarification that index storage cannot use ephemeral `emptyDir` (while logs can).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->