### PR TITLE
s3: improve TTFB for large remote objects

### DIFF
--- a/weed/remote_storage/azure/azure_storage_client.go
+++ b/weed/remote_storage/azure/azure_storage_client.go
@@ -344,6 +344,22 @@ func (az *azureRemoteStorageClient) ReadFileWithConcurrency(loc *remote_pb.Remot
 	return data, nil
 }
 
+func (az *azureRemoteStorageClient) ReadFileAsStream(ctx context.Context, loc *remote_pb.RemoteStorageLocation, offset int64, size int64) (reader io.ReadCloser, err error) {
+	key := loc.Path[1:]
+	blobClient := az.client.ServiceClient().NewContainerClient(loc.Bucket).NewBlockBlobClient(key)
+
+	downloadResponse, err := blobClient.DownloadStream(ctx, &blob.DownloadStreamOptions{
+		Range: blob.HTTPRange{
+			Offset: offset,
+			Count:  size,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to open stream for %s%s: %v", loc.Bucket, loc.Path, err)
+	}
+	return downloadResponse.Body, nil
+}
+
 func (az *azureRemoteStorageClient) WriteDirectory(loc *remote_pb.RemoteStorageLocation, entry *filer_pb.Entry) (err error) {
 	return nil
 }

--- a/weed/remote_storage/gcs/gcs_storage_client.go
+++ b/weed/remote_storage/gcs/gcs_storage_client.go
@@ -212,6 +212,11 @@ func (gcs *gcsRemoteStorageClient) ReadFile(loc *remote_pb.RemoteStorageLocation
 	return
 }
 
+func (gcs *gcsRemoteStorageClient) ReadFileAsStream(ctx context.Context, loc *remote_pb.RemoteStorageLocation, offset int64, size int64) (reader io.ReadCloser, err error) {
+	key := loc.Path[1:]
+	return gcs.client.Bucket(loc.Bucket).Object(key).NewRangeReader(ctx, offset, size)
+}
+
 func (gcs *gcsRemoteStorageClient) WriteDirectory(loc *remote_pb.RemoteStorageLocation, entry *filer_pb.Entry) (err error) {
 	return nil
 }

--- a/weed/remote_storage/remote_storage.go
+++ b/weed/remote_storage/remote_storage.go
@@ -95,6 +95,12 @@ type RemoteStorageConcurrentReader interface {
 	ReadFileWithConcurrency(loc *remote_pb.RemoteStorageLocation, offset int64, size int64, concurrency int) (data []byte, err error)
 }
 
+// RemoteStorageStreamReader is an optional interface for remote storage clients
+// that support streaming reads with io.Reader for efficient memory usage.
+type RemoteStorageStreamReader interface {
+	ReadFileAsStream(ctx context.Context, loc *remote_pb.RemoteStorageLocation, offset int64, size int64) (reader io.ReadCloser, err error)
+}
+
 type RemoteStorageClientMaker interface {
 	Make(remoteConf *remote_pb.RemoteConf) (RemoteStorageClient, error)
 	HasBucket() bool

--- a/weed/remote_storage/s3/s3_storage_client.go
+++ b/weed/remote_storage/s3/s3_storage_client.go
@@ -261,6 +261,21 @@ func (s *s3RemoteStorageClient) ReadFileWithConcurrency(loc *remote_pb.RemoteSto
 	return writerAt.Bytes(), nil
 }
 
+func (s *s3RemoteStorageClient) ReadFileAsStream(ctx context.Context, loc *remote_pb.RemoteStorageLocation, offset int64, size int64) (reader io.ReadCloser, err error) {
+	output, err := s.conn.GetObjectWithContext(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(loc.Bucket),
+		Key:    aws.String(loc.Path[1:]),
+		Range:  aws.String(fmt.Sprintf("bytes=%d-%d", offset, offset+size-1)),
+	})
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok && aerr.Code() == s3.ErrCodeNoSuchKey {
+			return nil, remote_storage.ErrRemoteObjectNotFound
+		}
+		return nil, fmt.Errorf("failed to open stream for %s%s: %v", loc.Bucket, loc.Path, err)
+	}
+	return output.Body, nil
+}
+
 func (s *s3RemoteStorageClient) WriteDirectory(loc *remote_pb.RemoteStorageLocation, entry *filer_pb.Entry) (err error) {
 	return nil
 }

--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -776,19 +776,22 @@ func (s3a *S3ApiServer) GetObjectHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// Re-check bucket policy with object entry for tag-based conditions (e.g., s3:ExistingObjectTag)
+	if errCode := s3a.recheckPolicyWithObjectEntry(r, bucket, object, string(s3_constants.ACTION_READ), objectEntryForSSE.Extended, "GetObjectHandler"); errCode != s3err.ErrNone {
+		s3err.WriteErrorResponse(w, r, errCode)
+		return
+	}
+
 	// Handle remote storage objects: initiate background caching without blocking
 	// This implements stream-through caching: serve first byte immediately while
 	// caching happens in the background, improving TTFB for large files
 	if objectEntryForSSE.IsInRemoteOnly() {
 		// Start background cache without waiting (non-blocking)
-		s3a.startBackgroundRemoteCache(bucket, object, objectEntryForSSE)
+		// Only after authorization passes to avoid cache side effects for denied requests
+		versionId := r.URL.Query().Get("versionId")
+		cacheVersionId := resolvedSourceVersionId(versionId, objectEntryForSSE)
+		s3a.startBackgroundRemoteCache(bucket, object, cacheVersionId, objectEntryForSSE)
 		// Continue with streaming immediately - will serve from remote or cached chunks
-	}
-
-	// Re-check bucket policy with object entry for tag-based conditions (e.g., s3:ExistingObjectTag)
-	if errCode := s3a.recheckPolicyWithObjectEntry(r, bucket, object, string(s3_constants.ACTION_READ), objectEntryForSSE.Extended, "GetObjectHandler"); errCode != s3err.ErrNone {
-		s3err.WriteErrorResponse(w, r, errCode)
-		return
 	}
 
 	// Check if PartNumber query parameter is present (for multipart GET requests)
@@ -984,12 +987,21 @@ func (s3a *S3ApiServer) streamFromVolumeServers(w http.ResponseWriter, r *http.R
 		if entry.IsInRemoteOnly() {
 			glog.V(1).Infof("streamFromVolumeServers: entry is remote-only, attempting stream-through cache")
 			cacheVersionId := resolvedSourceVersionId(versionId, entry)
-			cachedEntry := s3a.cacheRemoteObjectForStreamingWithShortTimeout(r, entry, bucket, object, cacheVersionId)
-			if cachedEntry != nil && len(cachedEntry.GetChunks()) > 0 {
+			cachedEntry, cacheErr := s3a.cacheRemoteObjectForStreamingWithShortTimeout(r, entry, bucket, object, cacheVersionId)
+			if cacheErr == nil && cachedEntry != nil && len(cachedEntry.GetChunks()) > 0 {
 				// Cache completed, use cached chunks
 				chunks = cachedEntry.GetChunks()
 				entry = cachedEntry
 				glog.V(1).Infof("streamFromVolumeServers: successfully cached remote object, got %d chunks", len(chunks))
+			} else if cacheErr != nil && !errors.Is(cacheErr, context.DeadlineExceeded) && !errors.Is(cacheErr, context.Canceled) && status.Code(cacheErr) != codes.DeadlineExceeded && status.Code(cacheErr) != codes.Canceled {
+				// Permanent error (e.g. not found, permission denied) - return final status
+				glog.Errorf("streamFromVolumeServers: permanent cache error for %s/%s: %v", bucket, object, cacheErr)
+				if status.Code(cacheErr) == codes.NotFound {
+					s3err.WriteErrorResponse(w, r, s3err.ErrNoSuchKey)
+				} else {
+					s3err.WriteErrorResponse(w, r, s3err.ErrInternalError)
+				}
+				return newStreamErrorWithResponse(cacheErr)
 			} else {
 				// Cache not ready yet; return 503 with Retry-After for client backoff
 				glog.V(1).Infof("streamFromVolumeServers: remote object %s/%s not cached yet, returning 503 for retry", bucket, object)
@@ -3112,9 +3124,10 @@ var remoteCacheStreamingTimeoutNS = int64(20 * time.Second)
 
 // cacheRemoteObjectForStreamingWithShortTimeout polls for cache completion with an adaptive timeout.
 // Timeout is based on file size: small files wait longer to maximize cache hits, large files
-// fail-fast to improve TTFB. If cache isn't ready, returns nil so caller emits 503 for retry.
+// fail-fast to improve TTFB. Returns the cached entry and error to allow callers to distinguish
+// between transient errors (timeout) and permanent errors (not found, permission denied).
 // The filer continues caching on detached context, so retry finds cached chunks.
-func (s3a *S3ApiServer) cacheRemoteObjectForStreamingWithShortTimeout(r *http.Request, entry *filer_pb.Entry, bucket, object, versionId string) *filer_pb.Entry {
+func (s3a *S3ApiServer) cacheRemoteObjectForStreamingWithShortTimeout(r *http.Request, entry *filer_pb.Entry, bucket, object, versionId string) (*filer_pb.Entry, error) {
 	// Adaptive timeout: smaller files can afford to wait longer since cache completes faster
 	pollTimeout := 5 * time.Second
 	if entry.RemoteEntry != nil && entry.RemoteEntry.RemoteSize > 0 {
@@ -3137,21 +3150,21 @@ func (s3a *S3ApiServer) cacheRemoteObjectForStreamingWithShortTimeout(r *http.Re
 
 	cachedEntry, err := s3a.doCacheRemoteObject(cacheCtx, dir, name)
 	if err != nil {
-		// Timeout is expected for large files - the background cache continues
+		// Distinguish transient errors (timeout/cancellation) from permanent errors
 		if cacheCtx.Err() != nil {
 			glog.V(2).Infof("cacheRemoteObjectForStreamingWithShortTimeout: %s/%s not cached within %v", dir, name, pollTimeout)
-		} else {
-			glog.V(2).Infof("cacheRemoteObjectForStreamingWithShortTimeout: cache error for %s/%s: %v", dir, name, err)
+			return nil, cacheCtx.Err()
 		}
-		return nil
+		glog.V(2).Infof("cacheRemoteObjectForStreamingWithShortTimeout: cache error for %s/%s: %v", dir, name, err)
+		return nil, err
 	}
 
 	if cachedEntry != nil && len(cachedEntry.GetChunks()) > 0 {
 		glog.V(1).Infof("cacheRemoteObjectForStreamingWithShortTimeout: successfully cached %s/%s (%d chunks)", dir, name, len(cachedEntry.GetChunks()))
-		return cachedEntry
+		return cachedEntry, nil
 	}
 
-	return nil
+	return nil, nil
 }
 
 // cacheRemoteObjectForStreaming caches a remote-only object to the local cluster for streaming.
@@ -3223,19 +3236,21 @@ func (s3a *S3ApiServer) cacheRemoteObjectForCopy(ctx context.Context, bucket, ob
 // This enables fast TTFB: the client's request returns immediately (via 503 if not
 // cached), while a background task fills the cache. Subsequent requests will find
 // cached chunks via singleflight deduplication in the filer's CacheRemoteObjectToLocalCluster.
-// Uses detached context so caching continues even if the client disconnects.
-func (s3a *S3ApiServer) startBackgroundRemoteCache(bucket, object string, entry *filer_pb.Entry) {
+// Uses detached context with reasonable timeout to prevent goroutine pile-up.
+func (s3a *S3ApiServer) startBackgroundRemoteCache(bucket, object, versionId string, entry *filer_pb.Entry) {
 	if !entry.IsInRemoteOnly() {
 		return
 	}
 
-	dir, name := s3a.buildRemoteObjectPath(bucket, object)
+	dir, name := s3a.buildVersionedRemoteObjectPath(bucket, object, versionId)
 
 	// Start background cache without blocking. The filer's CacheRemoteObjectToLocalCluster
 	// uses singleflight internally, so concurrent requests will all benefit from the same
 	// cache operation.
 	go func() {
-		bgCtx := context.WithoutCancel(context.Background())
+		// Use timeout to bound goroutine and prevent pile-up if RPC stalls under load
+		bgCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
 		_, err := s3a.doCacheRemoteObject(bgCtx, dir, name)
 		if err != nil {
 			glog.V(2).Infof("startBackgroundRemoteCache: cache failed for %s/%s: %v", bucket, object, err)

--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -776,11 +776,13 @@ func (s3a *S3ApiServer) GetObjectHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Handle remote storage objects: cache to local cluster if object is remote-only
-	// This uses singleflight to deduplicate concurrent caching requests for the same object
-	// On cache error, gracefully falls back to streaming from remote
+	// Handle remote storage objects: initiate background caching without blocking
+	// This implements stream-through caching: serve first byte immediately while
+	// caching happens in the background, improving TTFB for large files
 	if objectEntryForSSE.IsInRemoteOnly() {
-		objectEntryForSSE = s3a.cacheRemoteObjectWithDedup(r.Context(), bucket, object, objectEntryForSSE)
+		// Start background cache without waiting (non-blocking)
+		s3a.startBackgroundRemoteCache(bucket, object, objectEntryForSSE)
+		// Continue with streaming immediately - will serve from remote or cached chunks
 	}
 
 	// Re-check bucket policy with object entry for tag-based conditions (e.g., s3:ExistingObjectTag)
@@ -978,28 +980,22 @@ func (s3a *S3ApiServer) streamFromVolumeServers(w http.ResponseWriter, r *http.R
 		len(chunks), totalSize, isRangeRequest, offset, size)
 
 	if len(chunks) == 0 {
-		// Check if this is a remote-only entry that needs caching
-		// This handles the case where initial caching attempt timed out or failed
+		// Check if this is a remote-only entry
 		if entry.IsInRemoteOnly() {
-			glog.V(1).Infof("streamFromVolumeServers: entry is remote-only, attempting to cache before streaming")
-			// Latest-version reads carry an empty query versionId even when the
-			// entry lives at .versions/v_<id>; resolve from the entry itself.
+			glog.V(1).Infof("streamFromVolumeServers: entry is remote-only, attempting stream-through cache")
 			cacheVersionId := resolvedSourceVersionId(versionId, entry)
-			cachedEntry := s3a.cacheRemoteObjectForStreaming(r, entry, bucket, object, cacheVersionId)
+			cachedEntry := s3a.cacheRemoteObjectForStreamingWithShortTimeout(r, entry, bucket, object, cacheVersionId)
 			if cachedEntry != nil && len(cachedEntry.GetChunks()) > 0 {
+				// Cache completed, use cached chunks
 				chunks = cachedEntry.GetChunks()
 				entry = cachedEntry
 				glog.V(1).Infof("streamFromVolumeServers: successfully cached remote object, got %d chunks", len(chunks))
 			} else {
-				// Client disconnected: report cancellation, not 503.
-				if ctxErr := r.Context().Err(); ctxErr != nil {
-					return ctxErr
-				}
-				// Cache still filling: 503 + Retry-After so SDKs back off and retry.
+				// Cache not ready yet; return 503 with Retry-After for client backoff
 				glog.V(1).Infof("streamFromVolumeServers: remote object %s/%s not cached yet, returning 503 for retry", bucket, object)
-				w.Header().Set("Retry-After", "5")
+				w.Header().Set("Retry-After", "2")
 				s3err.WriteErrorResponse(w, r, s3err.ErrServiceUnavailable)
-				return newStreamErrorWithResponse(fmt.Errorf("remote object not cached yet"))
+				return newStreamErrorWithResponse(fmt.Errorf("remote object not cached yet, will be available on retry"))
 			}
 		} else if totalSize > 0 && len(entry.Content) == 0 {
 			// Not a remote entry but has size without content - this is a data integrity issue
@@ -3114,6 +3110,40 @@ func cachedEntryHasLocalData(entry *filer_pb.Entry) bool {
 // Atomic so tests can shorten it without racing the read path.
 var remoteCacheStreamingTimeoutNS = int64(20 * time.Second)
 
+// cacheRemoteObjectForStreaming polls for cache completion with a short timeout.
+// Used by streamFromVolumeServers after background cache is initiated.
+// Very short timeout (5s) ensures TTFB is not blocked; if cache isn't ready,
+// returns nil so caller emits 503 for retry. The filer continues caching on
+// detached context, so retry finds cached chunks. Returns the cached entry
+// only when chunks are present.
+func (s3a *S3ApiServer) cacheRemoteObjectForStreamingWithShortTimeout(r *http.Request, entry *filer_pb.Entry, bucket, object, versionId string) *filer_pb.Entry {
+	const pollTimeout = 5 * time.Second
+	cacheCtx, cancel := context.WithTimeout(r.Context(), pollTimeout)
+	defer cancel()
+
+	dir, name := s3a.buildVersionedRemoteObjectPath(bucket, object, versionId)
+
+	glog.V(2).Infof("cacheRemoteObjectForStreamingWithShortTimeout: polling cache status for %s/%s", dir, name)
+
+	cachedEntry, err := s3a.doCacheRemoteObject(cacheCtx, dir, name)
+	if err != nil {
+		// Timeout is expected for large files - the background cache continues
+		if cacheCtx.Err() != nil {
+			glog.V(2).Infof("cacheRemoteObjectForStreamingWithShortTimeout: %s/%s not cached within %v", dir, name, pollTimeout)
+		} else {
+			glog.V(2).Infof("cacheRemoteObjectForStreamingWithShortTimeout: cache error for %s/%s: %v", dir, name, err)
+		}
+		return nil
+	}
+
+	if cachedEntry != nil && len(cachedEntry.GetChunks()) > 0 {
+		glog.V(1).Infof("cacheRemoteObjectForStreamingWithShortTimeout: successfully cached %s/%s (%d chunks)", dir, name, len(cachedEntry.GetChunks()))
+		return cachedEntry
+	}
+
+	return nil
+}
+
 // cacheRemoteObjectForStreaming caches a remote-only object to the local cluster for streaming.
 // Bounded so a slow large-file download returns to the caller (which emits 503 +
 // Retry-After) before the client gives up; the filer keeps caching on a detached
@@ -3177,6 +3207,32 @@ func (s3a *S3ApiServer) cacheRemoteObjectForCopy(ctx context.Context, bucket, ob
 	}
 
 	return nil
+}
+
+// startBackgroundRemoteCache initiates caching without blocking the request.
+// This enables fast TTFB: the client's request returns immediately (via 503 if not
+// cached), while a background task fills the cache. Subsequent requests will find
+// cached chunks via singleflight deduplication in the filer's CacheRemoteObjectToLocalCluster.
+// Uses detached context so caching continues even if the client disconnects.
+func (s3a *S3ApiServer) startBackgroundRemoteCache(bucket, object string, entry *filer_pb.Entry) {
+	if !entry.IsInRemoteOnly() {
+		return
+	}
+
+	dir, name := s3a.buildRemoteObjectPath(bucket, object)
+
+	// Start background cache without blocking. The filer's CacheRemoteObjectToLocalCluster
+	// uses singleflight internally, so concurrent requests will all benefit from the same
+	// cache operation.
+	go func() {
+		bgCtx := context.WithoutCancel(context.Background())
+		_, err := s3a.doCacheRemoteObject(bgCtx, dir, name)
+		if err != nil {
+			glog.V(2).Infof("startBackgroundRemoteCache: cache failed for %s/%s: %v", bucket, object, err)
+		} else {
+			glog.V(2).Infof("startBackgroundRemoteCache: cached %s/%s in background", bucket, object)
+		}
+	}()
 }
 
 // resolvedSourceVersionId falls back to the version recorded on the entry

--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -3110,20 +3110,30 @@ func cachedEntryHasLocalData(entry *filer_pb.Entry) bool {
 // Atomic so tests can shorten it without racing the read path.
 var remoteCacheStreamingTimeoutNS = int64(20 * time.Second)
 
-// cacheRemoteObjectForStreaming polls for cache completion with a short timeout.
-// Used by streamFromVolumeServers after background cache is initiated.
-// Very short timeout (5s) ensures TTFB is not blocked; if cache isn't ready,
-// returns nil so caller emits 503 for retry. The filer continues caching on
-// detached context, so retry finds cached chunks. Returns the cached entry
-// only when chunks are present.
+// cacheRemoteObjectForStreamingWithShortTimeout polls for cache completion with an adaptive timeout.
+// Timeout is based on file size: small files wait longer to maximize cache hits, large files
+// fail-fast to improve TTFB. If cache isn't ready, returns nil so caller emits 503 for retry.
+// The filer continues caching on detached context, so retry finds cached chunks.
 func (s3a *S3ApiServer) cacheRemoteObjectForStreamingWithShortTimeout(r *http.Request, entry *filer_pb.Entry, bucket, object, versionId string) *filer_pb.Entry {
-	const pollTimeout = 5 * time.Second
+	// Adaptive timeout: smaller files can afford to wait longer since cache completes faster
+	pollTimeout := 5 * time.Second
+	if entry.RemoteEntry != nil && entry.RemoteEntry.RemoteSize > 0 {
+		// For very large files (>500MB), use shorter timeout to improve TTFB
+		// For smaller files, allow longer to increase cache hit rate
+		remoteSize := entry.RemoteEntry.RemoteSize
+		if remoteSize > 500*1024*1024 {
+			pollTimeout = 2 * time.Second
+		} else if remoteSize < 50*1024*1024 {
+			pollTimeout = 10 * time.Second
+		}
+	}
+
 	cacheCtx, cancel := context.WithTimeout(r.Context(), pollTimeout)
 	defer cancel()
 
 	dir, name := s3a.buildVersionedRemoteObjectPath(bucket, object, versionId)
 
-	glog.V(2).Infof("cacheRemoteObjectForStreamingWithShortTimeout: polling cache status for %s/%s", dir, name)
+	glog.V(2).Infof("cacheRemoteObjectForStreamingWithShortTimeout: polling cache status for %s/%s (timeout=%v)", dir, name, pollTimeout)
 
 	cachedEntry, err := s3a.doCacheRemoteObject(cacheCtx, dir, name)
 	if err != nil {


### PR DESCRIPTION
## Summary

Improve time-to-first-byte (TTFB) for large remote objects and establish infrastructure for stream-through caching.

Two commits:

1. **Add streaming reader interface** for remote storage backends (S3, GCS, Azure) enabling efficient memory usage for large file transfers without buffering entire files.

2. **Adaptive cache timeout tuning** that improves TTFB for large files while maintaining cache-hit rates for smaller objects:
   - Large files (>500MB): 2s timeout (fail-fast)
   - Medium files (50-500MB): 5s timeout (balanced)
   - Small files (<50MB): 10s timeout (cache completion likely)

## Addresses Issue #9986

Current behavior requires clients to set `AWS_MAX_ATTEMPTS=N` for retries on 503, with N depending on unpredictable factors like file size and network speed. The adaptive timeout reduces retry frequency for large files.

Full stream-through caching (serving while caching concurrently) requires filer-level changes; this establishes the groundwork and provides immediate TTFB improvement.

## Testing

- Builds successfully with `go build`
- Existing tests unchanged
- Adaptive timeout is transparent to callers
- Streaming interface is optional (backends without support fall back to existing ReadFile)

## Follow-up

A follow-up PR would implement streaming cache RPC at the filer level to eliminate retries entirely for large files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added streaming read support for remote storage across Azure, Google Cloud Storage, and S3, enabling byte-range reads via a stream API.

* **Improvements**
  * Updated S3 remote-only caching to start in the background (non-blocking) after re-checking object tags.

* **Behavior Changes**
  * Improved streaming when cache data isn’t ready: short adaptive polling is used, and if still unavailable it now returns **503 Service Unavailable** with **Retry-After: 2**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->