### PR TITLE
admin: surface user inline policies in object store user details

### DIFF
--- a/weed/admin/dash/user_inline_policy_test.go
+++ b/weed/admin/dash/user_inline_policy_test.go
@@ -1,0 +1,62 @@
+package dash
+
+import (
+	"context"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/credential"
+	_ "github.com/seaweedfs/seaweedfs/weed/credential/memory" // register the memory credential store
+	"github.com/seaweedfs/seaweedfs/weed/pb/iam_pb"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/policy_engine"
+)
+
+// TestGetObjectStoreUserDetailsIncludesInlinePolicies verifies that inline user
+// policies — which are stored separately from the identity record and are
+// authoritative at S3 enforcement time (they take precedence over the legacy
+// Actions list) — are surfaced in the admin user details. They were previously
+// invisible in the admin API/UI, so an operator could not tell what actually
+// governed a user's access.
+func TestGetObjectStoreUserDetailsIncludesInlinePolicies(t *testing.T) {
+	cm, err := credential.NewCredentialManagerWithDefaults(credential.StoreTypeMemory)
+	if err != nil {
+		t.Fatalf("failed to init credential manager: %v", err)
+	}
+	ctx := context.Background()
+
+	const username = "svc-app"
+	if err := cm.CreateUser(ctx, &iam_pb.Identity{Name: username}); err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+
+	const inlinePolicyName = "svc-app-policy"
+	doc := policy_engine.PolicyDocument{
+		Version: "2012-10-17",
+		Statement: []policy_engine.PolicyStatement{
+			{
+				Effect:   "Allow",
+				Action:   policy_engine.NewStringOrStringSlice("s3:GetObject"),
+				Resource: policy_engine.NewStringOrStringSlicePtr("arn:aws:s3:::ml-artifacts/*"),
+			},
+		},
+	}
+	if err := cm.PutUserInlinePolicy(ctx, username, inlinePolicyName, doc); err != nil {
+		t.Fatalf("failed to put inline policy: %v", err)
+	}
+
+	s := &AdminServer{credentialManager: cm}
+	details, err := s.GetObjectStoreUserDetails(username)
+	if err != nil {
+		t.Fatalf("GetObjectStoreUserDetails failed: %v", err)
+	}
+
+	found := false
+	for _, p := range details.PolicyNames {
+		if p == inlinePolicyName {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected inline policy %q in details.PolicyNames, got %v", inlinePolicyName, details.PolicyNames)
+	}
+}

--- a/weed/admin/dash/user_management.go
+++ b/weed/admin/dash/user_management.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/credential"
+	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/iam"
 	"github.com/seaweedfs/seaweedfs/weed/pb/iam_pb"
 )
@@ -188,6 +189,17 @@ func (s *AdminServer) GetObjectStoreUserDetails(username string) (*UserDetails, 
 		Username:    username,
 		Actions:     identity.Actions,
 		PolicyNames: identity.PolicyNames,
+	}
+
+	// Inline user policies are stored separately from the identity record and
+	// are authoritative at enforcement time (they take precedence over the
+	// legacy Actions list). Surface their names alongside attached policies so
+	// the admin reflects the user's actual permissions rather than only the
+	// (potentially overridden) Actions.
+	if inlinePolicyNames, err := s.credentialManager.ListUserInlinePolicies(ctx, username); err != nil {
+		glog.Warningf("failed to list inline policies for user %s: %v", username, err)
+	} else if len(inlinePolicyNames) > 0 {
+		details.PolicyNames = append(details.PolicyNames, inlinePolicyNames...)
 	}
 
 	// Set email from account if available


### PR DESCRIPTION
### What problem are we solving?
Per-user inline policies created via the S3 IAM API (`PutUserPolicy`) are not surfaced anywhere in the admin object-store user details — only `Actions` and attached managed policy names are shown.

Inline policies are authoritative at S3 enforcement time: in `VerifyActionPermission`, when a user has attached/inline policies the legacy `Actions` list is ignored. So the admin can show `Actions` that are silently overridden by an inline policy the operator cannot see, making a user's effective permissions impossible to audit from the admin UI.

This does not affect admin-UI-only management (the admin has no path that creates inline policies); it surfaces when inline policies are created via the IAM API and then inspected in the admin UI — two official surfaces disagreeing.

Fixes #10012

### How are we solving the problem?
`GetObjectStoreUserDetails` now also includes the user's inline policy names (via the existing `credentialManager.ListUserInlinePolicies`) in the returned `PolicyNames`, so the admin reflects the user's actual permissions instead of only the (potentially overridden) `Actions`.

The change is limited to the admin read path (`weed/admin/dash/user_management.go`); it does not change S3 enforcement, the credential store, or policy semantics.

### How is the PR tested?
Ran:
```
go test ./weed/admin/dash/
go vet ./weed/admin/dash/
```
Added a focused unit test (`TestGetObjectStoreUserDetailsIncludesInlinePolicies`, memory credential store) asserting an inline policy name appears in the user details. Full browser/manual regression testing was not performed.

### Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed.

### Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Inline user policies are now displayed in admin user details, providing complete visibility into all user access controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->