### PR TITLE
filer: skip COLLATE "C" list fallback on CockroachDB

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -114,6 +114,7 @@ require (
 require (
 	cloud.google.com/go/kms v1.31.0
 	github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys v0.10.0
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/Jille/raft-grpc-transport v1.6.1
 	github.com/ThreeDotsLabs/watermill v1.5.1
 	github.com/a-h/templ v0.3.1020

--- a/go.sum
+++ b/go.sum
@@ -1468,6 +1468,7 @@ github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRt
 github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/asmfmt v1.3.2 h1:4Ri7ox3EwapiOjCki+hw14RyKk201CN4rzyCJRFLpK4=
 github.com/klauspost/asmfmt v1.3.2/go.mod h1:AG8TuvYojzulgDAMCnYn50l/5QV3Bs/tp6j0HLHbNSE=
 github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=

--- a/weed/filer/postgres/postgres_collation.go
+++ b/weed/filer/postgres/postgres_collation.go
@@ -12,6 +12,11 @@ import (
 // filemeta.name collation is locale-aware, so S3 ListObjectsV2 stays
 // lexicographic. The fallback costs a sort, so warn the operator to fix it.
 func ConfigureListOrdering(db *sql.DB, gen *SqlGenPostgres) {
+	if isCockroachDB(db) {
+		// CockroachDB string comparison is already byte-ordered, so the
+		// fallback is redundant; older versions also reject COLLATE "C".
+		return
+	}
 	collation, isBinary, err := nameColumnCollation(db)
 	if err != nil {
 		glog.V(1).Infof("postgres: skip filemeta.name collation check: %v", err)
@@ -22,6 +27,17 @@ func ConfigureListOrdering(db *sql.DB, gen *SqlGenPostgres) {
 	}
 	gen.ForceBinaryCollation = true
 	glog.Warningf(`postgres: filemeta.name collation %q is not byte-ordered, so S3 list order is not byte-lexicographic and clients that merge sorted listings may report spurious diffs. Falling back to a slower COLLATE "C" sort; declare the name column COLLATE "C" (or use a C/C.UTF-8 database collation) for correct, indexed ordering.`, collation)
+}
+
+// isCockroachDB reports whether db is a CockroachDB backend, whose version()
+// string carries "CockroachDB". On any error we assume real Postgres.
+func isCockroachDB(db *sql.DB) bool {
+	var version string
+	if err := db.QueryRow("SELECT version()").Scan(&version); err != nil {
+		glog.V(1).Infof("postgres: skip CockroachDB detection: %v", err)
+		return false
+	}
+	return strings.Contains(version, "CockroachDB")
 }
 
 func nameColumnCollation(db *sql.DB) (collation string, isBinary bool, err error) {

--- a/weed/filer/postgres/postgres_collation_test.go
+++ b/weed/filer/postgres/postgres_collation_test.go
@@ -1,0 +1,49 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestConfigureListOrderingSkipsCockroachDB(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT version\\(\\)").WillReturnRows(
+		sqlmock.NewRows([]string{"version"}).AddRow("CockroachDB CCL v22.1.22 (x86_64-pc-linux-gnu)"))
+
+	gen := &SqlGenPostgres{}
+	ConfigureListOrdering(db, gen)
+	if gen.ForceBinaryCollation {
+		t.Fatal("CockroachDB default ordering is byte-ordered; COLLATE \"C\" must not be forced")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+func TestConfigureListOrderingForcesBinaryOnLocalePostgres(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT version\\(\\)").WillReturnRows(
+		sqlmock.NewRows([]string{"version"}).AddRow("PostgreSQL 16.2 on x86_64-pc-linux-gnu"))
+	mock.ExpectQuery("datcollate").WillReturnRows(
+		sqlmock.NewRows([]string{"collation_name", "datcollate"}).AddRow(nil, "en_US.UTF-8"))
+
+	gen := &SqlGenPostgres{}
+	ConfigureListOrdering(db, gen)
+	if !gen.ForceBinaryCollation {
+		t.Fatal("locale-aware Postgres collation must force byte ordering")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

The collation-detection step appends `COLLATE "C"` to filer list queries when the live `filemeta.name` collation is not detected as byte-ordered, so S3 `ListObjectsV2` stays byte-lexicographic.

CockroachDB reports `datcollate = en_US.utf8` regardless of how the database was created (the field is informational only; CockroachDB's actual string comparison is always binary/byte-ordered). That value isn't in the byte-ordered set, so the fallback always triggers and every list query is emitted with `ORDER BY name COLLATE "C"`.

The suffix is redundant on every CockroachDB version, but worse than redundant on 22.1 and older: those versions reject `COLLATE "C"` as an invalid ICU locale, so every filer list query becomes a hard failure and the meta-subscription loop fails at startup:

```
list /topics/.system/log : ERROR: invalid locale C: language: tag is not well-formed (SQLSTATE 22023)
```

## Fix

Detect the backend via `SELECT version()` (its string carries `CockroachDB`) and keep the default ordering, which is already byte-ordered. On any error we assume real Postgres and fall through to the existing collation check.

Covers both the `postgres` and `postgres2` stores, which share `ConfigureListOrdering`.

## Verified

Reproduced against `cockroachdb/cockroach:v22.1.22` in Docker:

- `version()` -> `CockroachDB CCL v22.1.22 ...`
- `ORDER BY name COLLATE "C"` -> `ERROR: invalid locale C (SQLSTATE 22023)`
- default ordering returns byte order (`! B Z a z`), byte-identical to `COLLATE "C"`
- `datcollate = en_US.utf8`, which is why the old detection misfired

Unit tests use go-sqlmock to cover the CockroachDB skip path and the locale-aware Postgres force path.