### PR TITLE
Logs typos

### DIFF
--- a/weed/shell/command_fs_verify.go
+++ b/weed/shell/command_fs_verify.go
@@ -194,7 +194,7 @@ func (c *commandFsVerify) verifyProcessMetadata(path string, wg *sync.WaitGroup)
 			return nil
 		}
 		if *c.verbose {
-			fmt.Fprintf(c.writer, "file: %s needles:%d verifed\n", entryPath, chunkCount)
+			fmt.Fprintf(c.writer, "file: %s needles:%d verified\n", entryPath, chunkCount)
 		}
 		fileCount++
 		return nil
@@ -312,7 +312,7 @@ func (c *commandFsVerify) verifyTraverseBfs(path string) (fileCount uint64, errC
 				itemPath := string(i.path)
 				if c.verifyEntry(itemPath, i.chunks, itemErrCount, &wg) {
 					if *c.verbose {
-						fmt.Fprintf(c.writer, "file: %s needles:%d verifed\n", itemPath, len(i.chunks))
+						fmt.Fprintf(c.writer, "file: %s needles:%d verified\n", itemPath, len(i.chunks))
 					}
 					fileCount++
 				}

--- a/weed/shell/command_volume_fsck.go
+++ b/weed/shell/command_volume_fsck.go
@@ -225,7 +225,7 @@ func (c *commandVolumeFsck) Do(args []string, commandEnv *CommandEnv, writer io.
 				}
 			}
 			if *c.verbose {
-				fmt.Fprintf(c.writer, "dn %+v filtred %d volumes and locations.\n", dataNodeId, len(dataNodeVolumeIdToVInfo[dataNodeId]))
+				fmt.Fprintf(c.writer, "dn %+v filtered %d volumes and locations.\n", dataNodeId, len(dataNodeVolumeIdToVInfo[dataNodeId]))
 			}
 			return nil
 		})


### PR DESCRIPTION
# What problem are we solving?

Some typos in logs have been bugging me for a long time
I've also seen that there're functions in fs.verify with a bad name (verifed), but I don't want to go mess with the code

# How are we solving the problem?

Fix these typos in messages

# How is the PR tested?

English dictionary :)
This is strictly cosmetic within printf and should not break anything

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed spelling errors in `fs.verify` command output messages.
  * Fixed spelling in `volume.fsck` command progress logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->