### PR TITLE
mini: resolve admin credentials from security.toml and env vars

### DIFF
--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -1487,6 +1487,18 @@ func startS3Service() {
 	miniS3Options.startS3Server()
 }
 
+// applyMiniAdminCredentialFallback fills the admin credential flags from
+// security.toml [admin] / WEED_ADMIN_* env vars when they were not set on the
+// command line, mirroring the standalone `weed admin` command. CLI flags take
+// precedence. Note the read-only viper keys (admin.readonly.*) differ from the
+// mini flag names (admin.readOnly*).
+func applyMiniAdminCredentialFallback(options *AdminOptions) {
+	applyViperFallback(cmdMini, options.adminUser, "admin.user", "admin.user")
+	applyViperFallback(cmdMini, options.adminPassword, "admin.password", "admin.password")
+	applyViperFallback(cmdMini, options.readOnlyUser, "admin.readOnlyUser", "admin.readonly.user")
+	applyViperFallback(cmdMini, options.readOnlyPassword, "admin.readOnlyPassword", "admin.readonly.password")
+}
+
 // startMiniAdminWithWorker starts the admin server with one worker
 func startMiniAdminWithWorker(allServicesReady chan struct{}) {
 	defer close(allServicesReady) // Ensure channel is always closed on all paths
@@ -1502,6 +1514,10 @@ func startMiniAdminWithWorker(allServicesReady chan struct{}) {
 
 	// Set admin options
 	*miniAdminOptions.master = masterAddr
+
+	// Resolve admin credentials from security.toml [admin] / WEED_ADMIN_* env
+	// vars, matching the standalone `weed admin` command.
+	applyMiniAdminCredentialFallback(&miniAdminOptions)
 
 	// Security validation: prevent empty username when password is set
 	if *miniAdminOptions.adminPassword != "" && *miniAdminOptions.adminUser == "" {

--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -548,6 +548,7 @@ func initMiniAdminFlags() {
 	miniAdminOptions.adminPassword = cmdMini.Flag.String("admin.password", "", "admin interface password (if empty, auth is disabled)")
 	miniAdminOptions.readOnlyUser = cmdMini.Flag.String("admin.readOnlyUser", "", "read-only user username (optional, for view-only access)")
 	miniAdminOptions.readOnlyPassword = cmdMini.Flag.String("admin.readOnlyPassword", "", "read-only user password (optional, for view-only access; requires admin.password to be set)")
+	miniAdminOptions.urlPrefix = cmdMini.Flag.String("admin.urlPrefix", "", "URL path prefix when running the admin UI behind a reverse proxy under a subdirectory (e.g. /seaweedfs)")
 }
 
 func init() {
@@ -1549,6 +1550,12 @@ func startMiniAdminWithWorker(allServicesReady chan struct{}) {
 		*miniAdminOptions.dataDir = filepath.Join(*miniDataFolders, "admin")
 	}
 
+	// Normalize URL prefix the same way `weed admin` does.
+	urlPrefix := strings.TrimRight(*miniAdminOptions.urlPrefix, "/")
+	if urlPrefix != "" && !strings.HasPrefix(urlPrefix, "/") {
+		urlPrefix = "/" + urlPrefix
+	}
+
 	// Start admin server in background. trackMiniClient lets the Ctrl+C
 	// handler wait for startAdminServer's graceful shutdown before filer/
 	// volume/master tear down.
@@ -1563,7 +1570,7 @@ func startMiniAdminWithWorker(allServicesReady chan struct{}) {
 		if miniS3Options.portIceberg != nil {
 			icebergPort = *miniS3Options.portIceberg
 		}
-		if err := startAdminServer(ctx, miniAdminOptions, *miniEnableAdminUI, icebergPort, ""); err != nil {
+		if err := startAdminServer(ctx, miniAdminOptions, *miniEnableAdminUI, icebergPort, urlPrefix); err != nil {
 			glog.Errorf("Admin server error: %v", err)
 		}
 	}()

--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -1164,6 +1164,7 @@ func runMini(cmd *Command, args []string) bool {
 	util.LoadSecurityConfiguration()
 	util.LoadConfiguration("master", false)
 	util.LoadConfiguration("volume", false)
+	util.LoadConfiguration("admin", false)
 	miniOptions.v.applyDiskIOProbeConfig()
 
 	ensureMiniVolumeGrowthDefaults()

--- a/weed/command/mini_admin_auth_test.go
+++ b/weed/command/mini_admin_auth_test.go
@@ -1,0 +1,41 @@
+package command
+
+import "testing"
+
+// weed mini must resolve admin credentials from security.toml [admin] /
+// WEED_ADMIN_* env vars the same way the standalone `weed admin` command does.
+// This exercises the production fallback so the flag-name -> viper-key mapping
+// stays correct, in particular the read-only keys where the mini flag
+// (admin.readOnlyUser) and viper key (admin.readonly.user) differ.
+func TestApplyMiniAdminCredentialFallbackFromEnv(t *testing.T) {
+	adminUser, adminPassword, readOnlyUser, readOnlyPassword := "admin", "", "", ""
+	options := &AdminOptions{
+		adminUser:        &adminUser,
+		adminPassword:    &adminPassword,
+		readOnlyUser:     &readOnlyUser,
+		readOnlyPassword: &readOnlyPassword,
+	}
+
+	t.Setenv("WEED_ADMIN_USER", "env-admin")
+	t.Setenv("WEED_ADMIN_PASSWORD", "env-secret")
+	t.Setenv("WEED_ADMIN_READONLY_USER", "env-ro")
+	t.Setenv("WEED_ADMIN_READONLY_PASSWORD", "env-ro-secret")
+
+	applyMiniAdminCredentialFallback(options)
+
+	checks := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"adminUser", *options.adminUser, "env-admin"},
+		{"adminPassword", *options.adminPassword, "env-secret"},
+		{"readOnlyUser", *options.readOnlyUser, "env-ro"},
+		{"readOnlyPassword", *options.readOnlyPassword, "env-ro-secret"},
+	}
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s = %q, want %q", c.name, c.got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
`weed mini` serves the Admin UI with no authentication even when admin credentials are configured via `security.toml [admin]` or `WEED_ADMIN_*` env vars. Only the `-admin.password` CLI flag works.

Cause: the env/toml credential fallback (`applyViperFallback`) lives in `runAdmin`, but `weed mini` has its own admin bootstrap (`startMiniAdminWithWorker`) that calls the shared `startAdminServer` directly and never resolves the credentials. `miniAdminOptions.adminPassword` stays empty, so `authRequired := *options.adminPassword != ""` is false and the UI serves with no login. This is the same class of gap for two other admin settings runMini never wired up.

Three commits, each closing one gap between the mini admin path and `weed admin`:

1. **credentials** — apply the four fallbacks (admin + read-only user/password) in the mini admin path before validation. CLI flags still take precedence. The read-only viper keys (`admin.readonly.*`) differ from the mini flag names (`admin.readOnly*`), so the mapping is explicit and covered by a test.
2. **admin.toml** — load it in `runMini` so file-based maintenance settings (`[maintenance.vacuum]`, `.balance`, `.erasure_coding`) are honored, matching `weed admin`. Env (`WEED_MAINTENANCE_*`) already worked via AutomaticEnv.
3. **-admin.urlPrefix** — expose the reverse-proxy subdirectory prefix so the mini admin UI can run under e.g. `/seaweedfs`.

Reported in discussion #10017.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `weed mini` admin now resolves credentials consistently with `weed admin`, sourcing from environment variables and `security.toml` when not provided via command-line flags, including separate handling for read-only credentials.
  * Added `-admin.urlPrefix` flag; the prefix is normalized for consistent admin URL routing.
* **Tests**
  * Added unit test covering credential fallback behavior from environment variables for both admin and read-only admin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->