### PR TITLE
fix(s3api): listMultipartUploads key-marker not compliant with S3 spec

### DIFF
--- a/weed/s3api/filer_multipart.go
+++ b/weed/s3api/filer_multipart.go
@@ -936,20 +936,31 @@ func (s3a *S3ApiServer) listMultipartUploads(input *s3.ListMultipartUploadsInput
 
 	uploadsCount := int64(0)
 	for _, entry := range entries {
-		if entry.Extended != nil {
-			key := string(entry.Extended[s3_constants.ExtMultipartObjectKey])
-			if *input.KeyMarker != "" && *input.KeyMarker != key {
-				continue
-			}
-			if *input.Prefix != "" && !strings.HasPrefix(key, *input.Prefix) {
-				continue
-			}
-			output.Upload = append(output.Upload, &s3.MultipartUpload{
-				Key:      objectKey(aws.String(key)),
-				UploadId: aws.String(entry.Name),
-			})
-			uploadsCount += 1
+		if entry.Extended == nil {
+			continue
 		}
+		keyBytes, ok := entry.Extended[s3_constants.ExtMultipartObjectKey]
+		if !ok {
+			glog.Warningf("listMultipartUploads %s: missing object key metadata for upload entry %s", *input.Bucket, entry.Name)
+			continue
+		}
+		key := string(keyBytes)
+		if *input.KeyMarker != "" {
+			if key < *input.KeyMarker {
+					continue
+			}
+			if key == *input.KeyMarker && (*input.UploadIdMarker == "" || entry.Name <= *input.UploadIdMarker) {
+					continue
+			}
+		}
+		if *input.Prefix != "" && !strings.HasPrefix(key, *input.Prefix) {
+			continue
+		}
+		output.Upload = append(output.Upload, &s3.MultipartUpload{
+			Key:      objectKey(aws.String(key)),
+			UploadId: aws.String(entry.Name),
+		})
+		uploadsCount += 1
 		if uploadsCount >= *input.MaxUploads {
 			output.IsTruncated = aws.Bool(true)
 			output.NextUploadIdMarker = aws.String(entry.Name)

--- a/weed/s3api/filer_multipart.go
+++ b/weed/s3api/filer_multipart.go
@@ -928,7 +928,7 @@ func (s3a *S3ApiServer) listMultipartUploads(input *s3.ListMultipartUploadsInput
 		IsTruncated:  aws.Bool(false),
 	}
 
-	entries, _, err := s3a.list(s3a.genUploadsFolder(*input.Bucket), "", *input.UploadIdMarker, false, math.MaxInt32)
+	entries, _, err := s3a.list(s3a.genUploadsFolder(*input.Bucket), "", "", false, math.MaxInt32)
 	if err != nil {
 		glog.Errorf("listMultipartUploads %s error: %v", *input.Bucket, err)
 		return

--- a/weed/s3api/filer_multipart_list_multipart_upload_test.go
+++ b/weed/s3api/filer_multipart_list_multipart_upload_test.go
@@ -1,6 +1,7 @@
 package s3api
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -28,6 +29,11 @@ func isMultipartUploadSkipped(entry *filer_pb.Entry, input *s3.ListMultipartUplo
 			return true, key
 		}
 	}
+	
+	if *input.Prefix != "" && !strings.HasPrefix(key, *input.Prefix) {
+		return true, key
+	}
+	
 	return false, key
 }
 
@@ -89,6 +95,28 @@ func TestListMultipartUploadsResultKeyMarkers(t *testing.T) {
 					MaxUploads:     aws.Int64(10),
 			},
 			expectedUploadIDs: []string{"UID-4"},
+		},
+		{
+			name: "with prefix matching some uploads",
+			input: &s3.ListMultipartUploadsInput{
+				Bucket:         aws.String("test-bucket"),
+				KeyMarker:      aws.String(""),
+				UploadIdMarker: aws.String(""),
+				Prefix:         aws.String("fileB"),
+				MaxUploads:     aws.Int64(10),
+			},
+			expectedUploadIDs: []string{"UID-2", "UID-3"},
+		},
+		{
+			name: "with prefix matching no uploads",
+			input: &s3.ListMultipartUploadsInput{
+				Bucket:         aws.String("test-bucket"),
+				KeyMarker:      aws.String(""),
+				UploadIdMarker: aws.String(""),
+				Prefix:         aws.String("fileX"),
+				MaxUploads:     aws.Int64(10),
+			},
+			expectedUploadIDs: nil,
 		},
 	}
 

--- a/weed/s3api/filer_multipart_list_multipart_upload_test.go
+++ b/weed/s3api/filer_multipart_list_multipart_upload_test.go
@@ -1,0 +1,98 @@
+package s3api
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
+	"github.com/stretchr/testify/assert"
+)
+
+func isMultipartUploadSkipped(entry *filer_pb.Entry, input *s3.ListMultipartUploadsInput) (bool, string) {
+	if entry.Extended == nil {
+		return true, ""
+	}
+	keyBytes, ok := entry.Extended[s3_constants.ExtMultipartObjectKey]
+	if !ok {
+		return true, ""
+	}
+	key := string(keyBytes)
+	
+	if *input.KeyMarker != "" {
+		if key < *input.KeyMarker {
+			return true, key
+		}
+		if key == *input.KeyMarker && (*input.UploadIdMarker == "" || entry.Name <= *input.UploadIdMarker) {
+			return true, key
+		}
+	}
+	return false, key
+}
+
+func TestListMultipartUploadsResultKeyMarkers(t *testing.T) {
+	entries := []*filer_pb.Entry{
+		{Name: "UID-nil-extended", Extended: nil},          
+    {Name: "UID-error", Extended: map[string][]byte{}}, 
+    {Name: "UID-1", Extended: map[string][]byte{s3_constants.ExtMultipartObjectKey: []byte("fileA")}},
+    {Name: "UID-2", Extended: map[string][]byte{s3_constants.ExtMultipartObjectKey: []byte("fileB")}},
+    {Name: "UID-3", Extended: map[string][]byte{s3_constants.ExtMultipartObjectKey: []byte("fileB")}},
+    {Name: "UID-4", Extended: map[string][]byte{s3_constants.ExtMultipartObjectKey: []byte("fileC")}},
+}
+
+	tests := []struct {
+		name              string
+		input             *s3.ListMultipartUploadsInput
+		expectedUploadIDs []string
+	}{
+		{
+			name: "skips entries missing multipart object key metadata",
+			input: &s3.ListMultipartUploadsInput{
+				Bucket:         aws.String("test-bucket"),
+				KeyMarker:      aws.String(""),
+				UploadIdMarker: aws.String(""),
+				Prefix:         aws.String(""),
+				MaxUploads:     aws.Int64(10),
+			},
+			expectedUploadIDs: []string{"UID-1", "UID-2", "UID-3", "UID-4"},
+		},
+		{
+			name: "without upload id marker returns only keys greater than key marker",
+			input: &s3.ListMultipartUploadsInput{
+				Bucket:         aws.String("test-bucket"),
+				KeyMarker:      aws.String("fileA"),
+				UploadIdMarker: aws.String(""),
+				Prefix:         aws.String(""),
+				MaxUploads:     aws.Int64(10),
+			},
+			expectedUploadIDs: []string{"UID-2", "UID-3", "UID-4"},
+		},
+		{
+			name: "with upload id marker includes same key with greater upload ids",
+			input: &s3.ListMultipartUploadsInput{
+				Bucket:         aws.String("test-bucket"),
+				KeyMarker:      aws.String("fileB"),
+				UploadIdMarker: aws.String("UID-2"),
+				Prefix:         aws.String(""),
+				MaxUploads:     aws.Int64(10),
+			},
+			expectedUploadIDs: []string{"UID-3", "UID-4"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var actualUploadIDs []string
+			
+			for _, entry := range entries {
+				skipped, _ := isMultipartUploadSkipped(entry, tt.input)
+				if !skipped {
+					actualUploadIDs = append(actualUploadIDs, entry.Name)
+				}
+			}
+
+			assert.Equal(t, tt.expectedUploadIDs, actualUploadIDs)
+		})
+	}
+}

--- a/weed/s3api/filer_multipart_list_multipart_upload_test.go
+++ b/weed/s3api/filer_multipart_list_multipart_upload_test.go
@@ -79,6 +79,17 @@ func TestListMultipartUploadsResultKeyMarkers(t *testing.T) {
 			},
 			expectedUploadIDs: []string{"UID-3", "UID-4"},
 		},
+		{
+			name: "cross-key regression: ensures key > KeyMarker is included even if uploadId <= UploadIdMarker",
+			input: &s3.ListMultipartUploadsInput{
+					Bucket:         aws.String("test-bucket"),
+					KeyMarker:      aws.String("fileB"),
+					UploadIdMarker: aws.String("UID-3"),
+					Prefix:         aws.String(""),
+					MaxUploads:     aws.Int64(10),
+			},
+			expectedUploadIDs: []string{"UID-4"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# What problem are we solving?
`listMultipartUploads` did not comply with the S3 API spec for `KeyMarker`. 
Reference: [https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListMultipartUploads.html](url)

# How are we solving the problem?
If `UploadIdMarker` is not specified, only the keys lexicographically greater than the specified `KeyMarker` will be included in the list.
If `UploadIdMarker` is specified, any multipart uploads for a key equal to the `KeyMarker` might also be included, provided those multipart uploads have upload IDs lexicographically greater than the specified `UploadIdMarker`.

# How is the PR tested?
Unit tests added in `weed/s3api/filer_multipart_list_multipart_upload_test.go`:
- Skips entries with `nil` extended or missing `ExtMultipartObjectKey` metadata.
- Without `UploadIdMarker`: only returns keys lexicographically greater than `KeyMarker`.
- With `UploadIdMarker`: includes uploads for `key` that is equal to `KeyMarker` only if upload IDs is greater than `UploadIdMarker`.
- Regression case: keys greater than `KeyMarker` are always included regardless of `UploadIdMarker`.

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed multipart upload listing to correctly apply `KeyMarker`, `UploadIdMarker`, and `Prefix` across pages, and to ignore entries missing required multipart upload metadata. This improves accuracy when paginating through multipart uploads.

* **Tests**
  * Added unit coverage for marker and prefix filtering behavior, including cases with missing/empty metadata and repeated multipart object keys with different upload IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->