### PR TITLE
install.sh: fix stale --version example (v3.93 -> 4.34)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/seaweedfs/seaweedfs/master/install.sh | bash
 #   curl -fsSL ... | bash -s -- --component volume-rust --large-disk
-#   curl -fsSL ... | bash -s -- --version v3.93 --dir /usr/local/bin
+#   curl -fsSL ... | bash -s -- --version 4.34 --dir /usr/local/bin
 #
 # Options:
 #   --component COMP   Which binary to install: weed, volume-rust, all (default: weed)


### PR DESCRIPTION
The header usage example used `--version v3.93`, but release tags are `MAJOR.MINOR` with **no `v` prefix** (e.g. `4.34`) — copying it builds `.../releases/download/v3.93/...` and 404s. Updated to a real tag. Default behavior (omit `--version` to get the latest via the GitHub API) is unchanged.

https://claude.ai/code/session_011sdkuCoRghMokGdHJAGLZL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated version examples in installation documentation to reflect current version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->