### PR TITLE
use Leader() instead of MaybeLeader() in SendHeartbeat

### DIFF
--- a/weed/server/master_grpc_server.go
+++ b/weed/server/master_grpc_server.go
@@ -120,9 +120,9 @@ func (ms *MasterServer) SendHeartbeat(stream master_pb.Seaweed_SendHeartbeatServ
 
 		if !ms.Topo.IsLeader() {
 			// tell the volume servers about the leader
-			newLeader, err := ms.Topo.MaybeLeader()
-			if err != nil || newLeader == "" {
-				glog.Warningf("SendHeartbeat find leader: %v, %v", newLeader, err)
+			newLeader, err := ms.Topo.Leader()
+			if err != nil {
+				glog.Warningf("SendHeartbeat find leader: %v", err)
 				return raft.NotLeaderError
 			}
 			if err := stream.Send(&master_pb.HeartbeatResponse{


### PR DESCRIPTION

# What problem are we solving?
https://github.com/seaweedfs/seaweedfs/issues/10028


# How are we solving the problem?
use topo.Leader() instead of MaybeLeader()


# How is the PR tested?
3 node seaweed, shutdown node where master leader is at, then see master leader can changer successfully.


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Improved leader detection reliability in master-to-server heartbeat responses. The system now uses more robust leader resolution logic with better error handling, ensuring volume servers consistently receive accurate, timely leader information even when the master node is not currently serving as the distributed system's leader, enhancing overall cluster stability and failover coordination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->