### PR TITLE
fix(s3api): sort repeated SigV4 query values

### DIFF
--- a/weed/s3api/auth_signature_v4.go
+++ b/weed/s3api/auth_signature_v4.go
@@ -599,15 +599,14 @@ func extractV4AuthInfoFromQuery(r *http.Request) (*v4AuthInfo, s3err.ErrorCode) 
 }
 
 func getCanonicalQueryString(r *http.Request, isPresigned bool) string {
-	var queryToEncode string
-	if !isPresigned {
-		queryToEncode = r.URL.Query().Encode()
-	} else {
-		queryForCanonical := r.URL.Query()
+	queryForCanonical := r.URL.Query()
+	if isPresigned {
 		queryForCanonical.Del("X-Amz-Signature")
-		queryToEncode = queryForCanonical.Encode()
 	}
-	return queryToEncode
+	for key := range queryForCanonical {
+		sort.Strings(queryForCanonical[key])
+	}
+	return queryForCanonical.Encode()
 }
 
 func checkPresignedRequestExpiry(r *http.Request, t time.Time) s3err.ErrorCode {

--- a/weed/s3api/auth_signature_v4_test.go
+++ b/weed/s3api/auth_signature_v4_test.go
@@ -111,16 +111,53 @@ func TestExtractV4AuthInfoFromQueryRejectsEmptySignedHeaderNames(t *testing.T) {
 	}
 }
 
-func TestGetCanonicalQueryStringSortsRepeatedValues(t *testing.T) {
-	req, err := http.NewRequest(http.MethodGet, "http://localhost/bucket/key?partNumber=2&partNumber=10&uploadId=z", nil)
-	if err != nil {
-		t.Fatalf("NewRequest: %v", err)
+func TestGetCanonicalQueryString(t *testing.T) {
+	tests := []struct {
+		name        string
+		target      string
+		isPresigned bool
+		want        string
+	}{
+		{
+			name:   "sorts repeated values",
+			target: "http://localhost/bucket/key?partNumber=2&partNumber=10&uploadId=z",
+			want:   "partNumber=10&partNumber=2&uploadId=z",
+		},
+		{
+			name:        "removes presigned signature",
+			target:      "http://localhost/bucket/key?X-Amz-Date=20260618T000000Z&X-Amz-Signature=dummy&X-Amz-SignedHeaders=host",
+			isPresigned: true,
+			want:        "X-Amz-Date=20260618T000000Z&X-Amz-SignedHeaders=host",
+		},
+		{
+			name:   "sorts mixed single and repeated parameters",
+			target: "http://localhost/bucket/key?z=last&a=2&bucket=b&a=1",
+			want:   "a=1&a=2&bucket=b&z=last",
+		},
+		{
+			name:   "encodes query parameter values",
+			target: "http://localhost/bucket/key?prefix=photos/2026&marker=a%2Bb",
+			want:   "marker=a%2Bb&prefix=photos%2F2026",
+		},
+		{
+			name:   "empty query string",
+			target: "http://localhost/bucket/key",
+			want:   "",
+		},
 	}
 
-	got := getCanonicalQueryString(req, false)
-	want := "partNumber=10&partNumber=2&uploadId=z"
-	if got != want {
-		t.Fatalf("canonical query = %q, want %q", got, want)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, tt.target, nil)
+			if err != nil {
+				t.Fatalf("NewRequest: %v", err)
+			}
+
+			got := getCanonicalQueryString(req, tt.isPresigned)
+			if got != tt.want {
+				t.Fatalf("canonical query = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/weed/s3api/auth_signature_v4_test.go
+++ b/weed/s3api/auth_signature_v4_test.go
@@ -111,6 +111,19 @@ func TestExtractV4AuthInfoFromQueryRejectsEmptySignedHeaderNames(t *testing.T) {
 	}
 }
 
+func TestGetCanonicalQueryStringSortsRepeatedValues(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "http://localhost/bucket/key?partNumber=2&partNumber=10&uploadId=z", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	got := getCanonicalQueryString(req, false)
+	want := "partNumber=10&partNumber=2&uploadId=z"
+	if got != want {
+		t.Fatalf("canonical query = %q, want %q", got, want)
+	}
+}
+
 func TestBuildPathWithForwardedPrefix(t *testing.T) {
 	tests := []struct {
 		name            string


### PR DESCRIPTION
# What problem are we solving?

SigV4 canonical query generation did not sort repeated query parameter values.

AWS SigV4 canonical requests require query parameters to be sorted by name and value. SeaweedFS already relied on `url.Values.Encode()` for key sorting, but repeated values for the same key kept their original request order. This can make valid SigV4 requests fail authentication when clients sign the same repeated query parameters in AWS-compatible sorted order.

# How are we solving the problem?

Before encoding the canonical query string, sort the value slice for each query key.

For presigned URLs, the existing behavior is preserved: `X-Amz-Signature` is removed before canonicalization, and then the remaining query values are sorted and encoded.

# How is the PR tested?

Added a unit test covering repeated query parameters:

- `TestGetCanonicalQueryStringSortsRepeatedValues`

The test verifies that:

```text
partNumber=2&partNumber=10&uploadId=z
```
is canonicalized as:

```text
partNumber=10&partNumber=2&uploadId=z
```

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Fixed S3 API authentication signature verification for presigned requests with repeated query parameters. Multi-value query parameters are now deterministically sorted during canonicalization, and signature-related metadata is excluded from the canonical query string. This improves consistency and reliability of authentication for S3 API operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->