### PR TITLE
Volume balancing by step

### DIFF
--- a/weed/shell/command_volume_balance.go
+++ b/weed/shell/command_volume_balance.go
@@ -56,18 +56,20 @@ func (c *commandVolumeBalance) Help() string {
 	    * Use exact match: volume.balance -collection="^mybucket$"
 	    * Match multiple buckets: volume.balance -collection="bucket.*"
 	    * Match all user collections: volume.balance -collection="user-.*"
-	
-	The -volumesPerStep parameter limits the maximum number of volume moves in one run.
-	
+
+	The -volumesPerStep parameter limits the maximum number of volume moves in one command execution.
+	If unset - the command will try to balance all volumes at once.
+	It might be beneficial to set it if your cluster has lots of blocks growing and topology changes faster than balancing can occur.
+
 	Algorithm:
-	
+
 	For each type of volume server (different max volume count limit){
 		for each collection {
 			balanceWritableVolumes()
 			balanceReadOnlyVolumes()
 		}
 	}
-	
+
 	func balanceWritableVolumes(){
 		idealWritableVolumeRatio = totalWritableVolumes / totalNumberOfMaxVolumes
 		for hasMovedOneVolume {
@@ -110,7 +112,7 @@ func (c *commandVolumeBalance) Do(args []string, commandEnv *CommandEnv, writer 
 	applyBalancing := balanceCommand.Bool("apply", false, "apply the balancing plan.")
 	// TODO: remove this alias
 	applyBalancingAlias := balanceCommand.Bool("force", false, "apply the balancing plan (alias for -apply)")
-	volumesPerStep := balanceCommand.Int("volumesPerStep", 0, "how many volumes to move in one run")
+	volumesPerStep := balanceCommand.Int("volumesPerStep", 0, "how many volumes to move in one run (default is 0 for unlimited)")
 
 	balanceCommand.Func("volumeBy", "only apply the balancing for ALL volumes and ACTIVE or FULL", func(flagValue string) error {
 		if flagValue == "" {
@@ -485,7 +487,7 @@ func (c *commandVolumeBalance) balanceSelectedVolume(diskType types.DiskType, vo
 				fmt.Fprintf(os.Stdout, "%s %.1f %.1f:%.1f\t", diskType.ReadableString(), idealVolumeRatio*100,
 					fullNode.localVolumeDensityRatio(capacityFunc)*100, emptyNode.localVolumeDensityNextRatio(capacityFunc)*100)
 			}
-			hasMoved, err = c.attemptToMoveOneVolume(volumeReplicas, fullNode, candidateVolumes, emptyNode)
+			hasMoved, err = attemptToMoveOneVolume(c.commandEnv, volumeReplicas, fullNode, candidateVolumes, emptyNode, c.applyBalancing)
 			if err != nil {
 				if c.commandEnv != nil && c.commandEnv.verbose {
 					fmt.Fprintf(os.Stdout, "attempt to move one volume error %+v\n", err)
@@ -496,7 +498,7 @@ func (c *commandVolumeBalance) balanceSelectedVolume(diskType types.DiskType, vo
 				return
 			}
 			if hasMoved {
-				// moved one volume
+				c.movedCount++
 				break
 			}
 		}
@@ -504,13 +506,10 @@ func (c *commandVolumeBalance) balanceSelectedVolume(diskType types.DiskType, vo
 	return nil
 }
 
-func (c *commandVolumeBalance) attemptToMoveOneVolume(volumeReplicas map[uint32][]*VolumeReplica, fullNode *Node, candidateVolumes []*master_pb.VolumeInformationMessage, emptyNode *Node) (hasMoved bool, err error) {
+func attemptToMoveOneVolume(commandEnv *CommandEnv, volumeReplicas map[uint32][]*VolumeReplica, fullNode *Node, candidateVolumes []*master_pb.VolumeInformationMessage, emptyNode *Node, applyBalancing bool) (hasMoved bool, err error) {
 
 	for _, v := range candidateVolumes {
-		if c.volumesPerStep > 0 && c.movedCount >= c.volumesPerStep {
-			return false, nil
-		}
-		hasMoved, err = c.maybeMoveOneVolume(volumeReplicas, fullNode, v, emptyNode)
+		hasMoved, err = maybeMoveOneVolume(commandEnv, volumeReplicas, fullNode, v, emptyNode, applyBalancing)
 		if err != nil {
 			return
 		}
@@ -521,17 +520,13 @@ func (c *commandVolumeBalance) attemptToMoveOneVolume(volumeReplicas map[uint32]
 	return
 }
 
-func (c *commandVolumeBalance) maybeMoveOneVolume(volumeReplicas map[uint32][]*VolumeReplica, fullNode *Node, candidateVolume *master_pb.VolumeInformationMessage, emptyNode *Node) (hasMoved bool, err error) {
-	if !c.commandEnv.isLocked() {
+func maybeMoveOneVolume(commandEnv *CommandEnv, volumeReplicas map[uint32][]*VolumeReplica, fullNode *Node, candidateVolume *master_pb.VolumeInformationMessage, emptyNode *Node, applyChange bool) (hasMoved bool, err error) {
+	if !commandEnv.isLocked() {
 		return false, fmt.Errorf("lock is lost")
 	}
 
 	if candidateVolume.RemoteStorageName != "" {
 		return false, fmt.Errorf("does not move volume in remote storage")
-	}
-
-	if c.volumesPerStep > 0 && c.movedCount >= c.volumesPerStep {
-		return false, nil
 	}
 
 	if candidateVolume.ReplicaPlacement > 0 {
@@ -541,9 +536,8 @@ func (c *commandVolumeBalance) maybeMoveOneVolume(volumeReplicas map[uint32][]*V
 		}
 	}
 	if _, found := emptyNode.selectedVolumes[candidateVolume.Id]; !found {
-		if err = moveVolume(c.commandEnv, candidateVolume, fullNode, emptyNode, c.applyBalancing); err == nil {
+		if err = moveVolume(commandEnv, candidateVolume, fullNode, emptyNode, applyChange); err == nil {
 			adjustAfterMove(candidateVolume, volumeReplicas, fullNode, emptyNode)
-			c.movedCount++
 			return true, nil
 		} else {
 			return

--- a/weed/shell/command_volume_balance.go
+++ b/weed/shell/command_volume_balance.go
@@ -475,9 +475,6 @@ func (c *commandVolumeBalance) balanceSelectedVolume(diskType types.DiskType, vo
 		}
 		sortCandidatesFn(candidateVolumes)
 		for _, emptyNode := range nodesWithCapacity[:fullNodeIndex] {
-			if c.volumesPerExec > 0 && c.movedCount >= c.volumesPerExec {
-				break
-			}
 			if !(fullNode.localVolumeDensityNextRatio(capacityFunc) > idealVolumeRatio && emptyNode.localVolumeDensityNextRatio(capacityFunc) <= idealVolumeRatio) {
 				if c.commandEnv != nil && c.commandEnv.verbose {
 					fmt.Printf("no more volume servers with empty slots %s, idealVolumeRatio %f\n", emptyNode.info.Id, idealVolumeRatio)

--- a/weed/shell/command_volume_balance.go
+++ b/weed/shell/command_volume_balance.go
@@ -59,7 +59,7 @@ func (c *commandVolumeBalance) Help() string {
 
 	The -volumesPerStep parameter limits the maximum number of volume moves in one command execution.
 	If unset - the command will try to balance all volumes at once.
-	It might be beneficial to set it if your cluster has lots of blocks growing and topology changes faster than balancing can occur.
+	It might be beneficial to set, if your cluster has lots of blocks growing and topology changes faster than balancing can occur.
 
 	Algorithm:
 

--- a/weed/shell/command_volume_balance.go
+++ b/weed/shell/command_volume_balance.go
@@ -36,7 +36,7 @@ type commandVolumeBalance struct {
 	commandEnv        *CommandEnv
 	volumeByActive    *bool
 	applyBalancing    bool
-	volumesPerStep    int
+	volumesPerExec    int
 	movedCount        int
 }
 
@@ -47,7 +47,7 @@ func (c *commandVolumeBalance) Name() string {
 func (c *commandVolumeBalance) Help() string {
 	return `balance all volumes among volume servers
 
-	volume.balance [-collection ALL_COLLECTIONS|EACH_COLLECTION|<collection_name>] [-apply] [-dataCenter=<data_center_name>] [-racks=rack_name_one,rack_name_two] [-nodes=192.168.0.1:8080,192.168.0.2:8080] [-volumesPerStep=5]
+	volume.balance [-collection ALL_COLLECTIONS|EACH_COLLECTION|<collection_name>] [-apply] [-dataCenter=<data_center_name>] [-racks=rack_name_one,rack_name_two] [-nodes=192.168.0.1:8080,192.168.0.2:8080] [-volumesPerExec=5]
 
 	The -collection parameter supports:
 	  - ALL_COLLECTIONS: balance across all collections
@@ -57,7 +57,7 @@ func (c *commandVolumeBalance) Help() string {
 	    * Match multiple buckets: volume.balance -collection="bucket.*"
 	    * Match all user collections: volume.balance -collection="user-.*"
 
-	The -volumesPerStep parameter limits the maximum number of volume moves in one command execution.
+	The -volumesPerExec parameter limits the maximum number of volume moves in one command execution.
 	If unset - the command will try to balance all volumes at once.
 	It might be beneficial to set, if your cluster has lots of volumes growing and topology changes faster than balancing can occur.
 
@@ -112,7 +112,7 @@ func (c *commandVolumeBalance) Do(args []string, commandEnv *CommandEnv, writer 
 	applyBalancing := balanceCommand.Bool("apply", false, "apply the balancing plan.")
 	// TODO: remove this alias
 	applyBalancingAlias := balanceCommand.Bool("force", false, "apply the balancing plan (alias for -apply)")
-	volumesPerStep := balanceCommand.Int("volumesPerStep", 0, "how many volumes to move in one run (default is 0 for unlimited)")
+	volumesPerExec := balanceCommand.Int("volumesPerExec", 0, "how many volumes to move in one run (default is 0 for unlimited)")
 
 	balanceCommand.Func("volumeBy", "only apply the balancing for ALL volumes and ACTIVE or FULL", func(flagValue string) error {
 		if flagValue == "" {
@@ -131,10 +131,10 @@ func (c *commandVolumeBalance) Do(args []string, commandEnv *CommandEnv, writer 
 	}
 	handleDeprecatedForceFlag(writer, balanceCommand, applyBalancingAlias, applyBalancing)
 	c.applyBalancing = *applyBalancing
-	if *volumesPerStep < 0 {
-		return fmt.Errorf("volumesPerStep must be >= 0")
+	if *volumesPerExec < 0 {
+		return fmt.Errorf("volumesPerExec must be >= 0")
 	}
-	c.volumesPerStep = *volumesPerStep
+	c.volumesPerExec = *volumesPerExec
 	c.movedCount = 0
 
 	infoAboutSimulationMode(writer, c.applyBalancing, "-apply")
@@ -166,7 +166,7 @@ func (c *commandVolumeBalance) Do(args []string, commandEnv *CommandEnv, writer 
 			return err
 		}
 		for _, col := range collections {
-			if c.volumesPerStep > 0 && c.movedCount >= c.volumesPerStep {
+			if c.volumesPerExec > 0 && c.movedCount >= c.volumesPerExec {
 				break
 			}
 			// Use direct string comparison for exact match (more efficient than regex)
@@ -195,7 +195,7 @@ func (c *commandVolumeBalance) Do(args []string, commandEnv *CommandEnv, writer 
 
 func (c *commandVolumeBalance) balanceVolumeServers(diskTypes []types.DiskType, volumeReplicas map[uint32][]*VolumeReplica, nodes []*Node, collectionPattern *regexp.Regexp, collectionName string) error {
 	for _, diskType := range diskTypes {
-		if c.volumesPerStep > 0 && c.movedCount >= c.volumesPerStep {
+		if c.volumesPerExec > 0 && c.movedCount >= c.volumesPerExec {
 			break
 		}
 		if err := c.balanceVolumeServersByDiskType(diskType, volumeReplicas, nodes, collectionPattern, collectionName); err != nil {
@@ -439,7 +439,7 @@ func (c *commandVolumeBalance) balanceSelectedVolume(diskType types.DiskType, vo
 	}
 	for hasMoved {
 		hasMoved = false
-		if c.volumesPerStep > 0 && c.movedCount >= c.volumesPerStep {
+		if c.volumesPerExec > 0 && c.movedCount >= c.volumesPerExec {
 			break
 		}
 		slices.SortFunc(nodesWithCapacity, func(a, b *Node) int {
@@ -475,7 +475,7 @@ func (c *commandVolumeBalance) balanceSelectedVolume(diskType types.DiskType, vo
 		}
 		sortCandidatesFn(candidateVolumes)
 		for _, emptyNode := range nodesWithCapacity[:fullNodeIndex] {
-			if c.volumesPerStep > 0 && c.movedCount >= c.volumesPerStep {
+			if c.volumesPerExec > 0 && c.movedCount >= c.volumesPerExec {
 				break
 			}
 			if !(fullNode.localVolumeDensityNextRatio(capacityFunc) > idealVolumeRatio && emptyNode.localVolumeDensityNextRatio(capacityFunc) <= idealVolumeRatio) {

--- a/weed/shell/command_volume_balance.go
+++ b/weed/shell/command_volume_balance.go
@@ -47,44 +47,44 @@ func (c *commandVolumeBalance) Name() string {
 func (c *commandVolumeBalance) Help() string {
 	return `balance all volumes among volume servers
 
-        volume.balance [-collection ALL_COLLECTIONS|EACH_COLLECTION|<collection_name>] [-apply] [-dataCenter=<data_center_name>] [-racks=rack_name_one,rack_name_two] [-nodes=192.168.0.1:8080,192.168.0.2:8080] [-volumesPerStep=5]
+	volume.balance [-collection ALL_COLLECTIONS|EACH_COLLECTION|<collection_name>] [-apply] [-dataCenter=<data_center_name>] [-racks=rack_name_one,rack_name_two] [-nodes=192.168.0.1:8080,192.168.0.2:8080] [-volumesPerStep=5]
 
-        The -collection parameter supports:
-          - ALL_COLLECTIONS: balance across all collections
-          - EACH_COLLECTION: balance each collection separately
-          - Regular expressions for pattern matching:
-            * Use exact match: volume.balance -collection="^mybucket$"
-            * Match multiple buckets: volume.balance -collection="bucket.*"
-            * Match all user collections: volume.balance -collection="user-.*"
-
-        The -volumesPerStep parameter limits the maximum number of volume moves in one run.
-
-        Algorithm:
-
-        For each type of volume server (different max volume count limit){
-                for each collection {
-                        balanceWritableVolumes()
-                        balanceReadOnlyVolumes()
-                }
-        }
-
-        func balanceWritableVolumes(){
-                idealWritableVolumeRatio = totalWritableVolumes / totalNumberOfMaxVolumes
-                for hasMovedOneVolume {
-                        sort all volume servers ordered by the localWritableVolumeRatio = localWritableVolumes to localVolumeMax
-                        pick the volume server B with the highest localWritableVolumeRatio y
-                        for any the volume server A with the number of writable volumes x + 1 <= idealWritableVolumeRatio * localVolumeMax {
-                                if y > localWritableVolumeRatio {
-                                        if B has a writable volume id v that A does not have, and satisfy v replication requirements {
-                                                move writable volume v from A to B
-                                        }
-                                }
-                        }
-                }
-        }
-        func balanceReadOnlyVolumes(){
-                //similar to balanceWritableVolumes
-        }
+	The -collection parameter supports:
+	  - ALL_COLLECTIONS: balance across all collections
+	  - EACH_COLLECTION: balance each collection separately
+	  - Regular expressions for pattern matching:
+	    * Use exact match: volume.balance -collection="^mybucket$"
+	    * Match multiple buckets: volume.balance -collection="bucket.*"
+	    * Match all user collections: volume.balance -collection="user-.*"
+	
+	The -volumesPerStep parameter limits the maximum number of volume moves in one run.
+	
+	Algorithm:
+	
+	For each type of volume server (different max volume count limit){
+		for each collection {
+			balanceWritableVolumes()
+			balanceReadOnlyVolumes()
+		}
+	}
+	
+	func balanceWritableVolumes(){
+		idealWritableVolumeRatio = totalWritableVolumes / totalNumberOfMaxVolumes
+		for hasMovedOneVolume {
+			sort all volume servers ordered by the localWritableVolumeRatio = localWritableVolumes to localVolumeMax
+			pick the volume server B with the highest localWritableVolumeRatio y
+			for any the volume server A with the number of writable volumes x + 1 <= idealWritableVolumeRatio * localVolumeMax {
+				if y > localWritableVolumeRatio {
+					if B has a writable volume id v that A does not have, and satisfy v replication requirements {
+						move writable volume v from A to B
+					}
+				}
+			}
+		}
+	}
+	func balanceReadOnlyVolumes(){
+		//similar to balanceWritableVolumes
+	}
 
 `
 }

--- a/weed/shell/command_volume_balance.go
+++ b/weed/shell/command_volume_balance.go
@@ -36,6 +36,8 @@ type commandVolumeBalance struct {
 	commandEnv        *CommandEnv
 	volumeByActive    *bool
 	applyBalancing    bool
+	volumesPerStep    int
+	movedCount        int
 }
 
 func (c *commandVolumeBalance) Name() string {
@@ -45,42 +47,44 @@ func (c *commandVolumeBalance) Name() string {
 func (c *commandVolumeBalance) Help() string {
 	return `balance all volumes among volume servers
 
-	volume.balance [-collection ALL_COLLECTIONS|EACH_COLLECTION|<collection_name>] [-apply] [-dataCenter=<data_center_name>] [-racks=rack_name_one,rack_name_two] [-nodes=192.168.0.1:8080,192.168.0.2:8080]
+        volume.balance [-collection ALL_COLLECTIONS|EACH_COLLECTION|<collection_name>] [-apply] [-dataCenter=<data_center_name>] [-racks=rack_name_one,rack_name_two] [-nodes=192.168.0.1:8080,192.168.0.2:8080] [-volumesPerStep=5]
 
-	The -collection parameter supports:
-	  - ALL_COLLECTIONS: balance across all collections
-	  - EACH_COLLECTION: balance each collection separately
-	  - Regular expressions for pattern matching:
-	    * Use exact match: volume.balance -collection="^mybucket$"
-	    * Match multiple buckets: volume.balance -collection="bucket.*"
-	    * Match all user collections: volume.balance -collection="user-.*"
+        The -collection parameter supports:
+          - ALL_COLLECTIONS: balance across all collections
+          - EACH_COLLECTION: balance each collection separately
+          - Regular expressions for pattern matching:
+            * Use exact match: volume.balance -collection="^mybucket$"
+            * Match multiple buckets: volume.balance -collection="bucket.*"
+            * Match all user collections: volume.balance -collection="user-.*"
 
-	Algorithm:
+        The -volumesPerStep parameter limits the maximum number of volume moves in one run.
 
-	For each type of volume server (different max volume count limit){
-		for each collection {
-			balanceWritableVolumes()
-			balanceReadOnlyVolumes()
-		}
-	}
+        Algorithm:
 
-	func balanceWritableVolumes(){
-		idealWritableVolumeRatio = totalWritableVolumes / totalNumberOfMaxVolumes
-		for hasMovedOneVolume {
-			sort all volume servers ordered by the localWritableVolumeRatio = localWritableVolumes to localVolumeMax
-			pick the volume server B with the highest localWritableVolumeRatio y
-			for any the volume server A with the number of writable volumes x + 1 <= idealWritableVolumeRatio * localVolumeMax {
-				if y > localWritableVolumeRatio {
-					if B has a writable volume id v that A does not have, and satisfy v replication requirements {
-						move writable volume v from A to B
-					}
-				}
-			}
-		}
-	}
-	func balanceReadOnlyVolumes(){
-		//similar to balanceWritableVolumes
-	}
+        For each type of volume server (different max volume count limit){
+                for each collection {
+                        balanceWritableVolumes()
+                        balanceReadOnlyVolumes()
+                }
+        }
+
+        func balanceWritableVolumes(){
+                idealWritableVolumeRatio = totalWritableVolumes / totalNumberOfMaxVolumes
+                for hasMovedOneVolume {
+                        sort all volume servers ordered by the localWritableVolumeRatio = localWritableVolumes to localVolumeMax
+                        pick the volume server B with the highest localWritableVolumeRatio y
+                        for any the volume server A with the number of writable volumes x + 1 <= idealWritableVolumeRatio * localVolumeMax {
+                                if y > localWritableVolumeRatio {
+                                        if B has a writable volume id v that A does not have, and satisfy v replication requirements {
+                                                move writable volume v from A to B
+                                        }
+                                }
+                        }
+                }
+        }
+        func balanceReadOnlyVolumes(){
+                //similar to balanceWritableVolumes
+        }
 
 `
 }
@@ -106,6 +110,8 @@ func (c *commandVolumeBalance) Do(args []string, commandEnv *CommandEnv, writer 
 	applyBalancing := balanceCommand.Bool("apply", false, "apply the balancing plan.")
 	// TODO: remove this alias
 	applyBalancingAlias := balanceCommand.Bool("force", false, "apply the balancing plan (alias for -apply)")
+	volumesPerStep := balanceCommand.Int("volumesPerStep", 0, "how many volumes to move in one run")
+
 	balanceCommand.Func("volumeBy", "only apply the balancing for ALL volumes and ACTIVE or FULL", func(flagValue string) error {
 		if flagValue == "" {
 			return nil
@@ -123,6 +129,8 @@ func (c *commandVolumeBalance) Do(args []string, commandEnv *CommandEnv, writer 
 	}
 	handleDeprecatedForceFlag(writer, balanceCommand, applyBalancingAlias, applyBalancing)
 	c.applyBalancing = *applyBalancing
+	c.volumesPerStep = *volumesPerStep
+	c.movedCount = 0
 
 	infoAboutSimulationMode(writer, c.applyBalancing, "-apply")
 
@@ -153,6 +161,9 @@ func (c *commandVolumeBalance) Do(args []string, commandEnv *CommandEnv, writer 
 			return err
 		}
 		for _, col := range collections {
+			if c.volumesPerStep > 0 && c.movedCount >= c.volumesPerStep {
+				break
+			}
 			// Use direct string comparison for exact match (more efficient than regex)
 			if err = c.balanceVolumeServers(diskTypes, volumeReplicas, volumeServers, nil, col); err != nil {
 				return err
@@ -179,6 +190,9 @@ func (c *commandVolumeBalance) Do(args []string, commandEnv *CommandEnv, writer 
 
 func (c *commandVolumeBalance) balanceVolumeServers(diskTypes []types.DiskType, volumeReplicas map[uint32][]*VolumeReplica, nodes []*Node, collectionPattern *regexp.Regexp, collectionName string) error {
 	for _, diskType := range diskTypes {
+		if c.volumesPerStep > 0 && c.movedCount >= c.volumesPerStep {
+			break
+		}
 		if err := c.balanceVolumeServersByDiskType(diskType, volumeReplicas, nodes, collectionPattern, collectionName); err != nil {
 			return err
 		}
@@ -208,7 +222,7 @@ func (c *commandVolumeBalance) balanceVolumeServersByDiskType(diskType types.Dis
 			return selectVolumesByActive(v.Size, c.volumeByActive, c.volumeSizeLimitMb)
 		})
 	}
-	if err := balanceSelectedVolume(c.commandEnv, diskType, volumeReplicas, nodes, sortWritableVolumes, c.volumeSizeLimitMb, c.applyBalancing); err != nil {
+	if err := c.balanceSelectedVolume(diskType, volumeReplicas, nodes, sortWritableVolumes); err != nil {
 		return err
 	}
 
@@ -392,9 +406,10 @@ func selectVolumesByActive(volumeSize uint64, volumeByActive *bool, volumeSizeLi
 	}
 }
 
-func balanceSelectedVolume(commandEnv *CommandEnv, diskType types.DiskType, volumeReplicas map[uint32][]*VolumeReplica, nodes []*Node, sortCandidatesFn func(volumes []*master_pb.VolumeInformationMessage), volumeSizeLimitMb uint64, applyBalancing bool) (err error) {
+func (c *commandVolumeBalance) balanceSelectedVolume(diskType types.DiskType, volumeReplicas map[uint32][]*VolumeReplica, nodes []*Node, sortCandidatesFn func(volumes []*master_pb.VolumeInformationMessage)) (err error) {
 	selectedVolumeCount, volumeCapacities := uint64(0), float64(0)
 	var nodesWithCapacity []*Node
+	volumeSizeLimitMb := c.volumeSizeLimitMb
 	if volumeSizeLimitMb == 0 {
 		volumeSizeLimitMb = util.VolumeSizeLimitGB * util.KiByte
 	}
@@ -414,16 +429,19 @@ func balanceSelectedVolume(commandEnv *CommandEnv, diskType types.DiskType, volu
 
 	hasMoved := true
 
-	if commandEnv != nil && commandEnv.verbose {
+	if c.commandEnv != nil && c.commandEnv.verbose {
 		fmt.Fprintf(os.Stdout, "selected nodes %d, volumes:%d, cap:%d, idealVolumeRatio %f\n", len(nodesWithCapacity), selectedVolumeCount, int64(volumeCapacities), idealVolumeRatio*100)
 	}
 	for hasMoved {
 		hasMoved = false
+		if c.volumesPerStep > 0 && c.movedCount >= c.volumesPerStep {
+			break
+		}
 		slices.SortFunc(nodesWithCapacity, func(a, b *Node) int {
 			return cmp.Compare(a.localVolumeDensityRatio(capacityFunc), b.localVolumeDensityRatio(capacityFunc))
 		})
 		if len(nodesWithCapacity) == 0 {
-			if commandEnv != nil && commandEnv.verbose {
+			if c.commandEnv != nil && c.commandEnv.verbose {
 				fmt.Fprintf(os.Stdout, "no volume server found with capacity for %s", diskType.ReadableString())
 			}
 			return nil
@@ -445,28 +463,31 @@ func balanceSelectedVolume(commandEnv *CommandEnv, diskType types.DiskType, volu
 			candidateVolumes = append(candidateVolumes, v)
 		}
 		if fullNodeIndex == -1 {
-			if commandEnv != nil && commandEnv.verbose {
+			if c.commandEnv != nil && c.commandEnv.verbose {
 				fmt.Fprintf(os.Stdout, "no nodes with capacity found for %s, nodes %d", diskType.ReadableString(), len(nodesWithCapacity))
 			}
 			return nil
 		}
 		sortCandidatesFn(candidateVolumes)
 		for _, emptyNode := range nodesWithCapacity[:fullNodeIndex] {
+			if c.volumesPerStep > 0 && c.movedCount >= c.volumesPerStep {
+				break
+			}
 			if !(fullNode.localVolumeDensityNextRatio(capacityFunc) > idealVolumeRatio && emptyNode.localVolumeDensityNextRatio(capacityFunc) <= idealVolumeRatio) {
-				if commandEnv != nil && commandEnv.verbose {
+				if c.commandEnv != nil && c.commandEnv.verbose {
 					fmt.Printf("no more volume servers with empty slots %s, idealVolumeRatio %f\n", emptyNode.info.Id, idealVolumeRatio)
 				}
 				break
 			}
 			fmt.Fprintf(os.Stdout, "%s %.2f %.2f:%.2f\t", diskType.ReadableString(), idealVolumeRatio,
 				fullNode.localVolumeDensityRatio(capacityFunc), emptyNode.localVolumeDensityNextRatio(capacityFunc))
-			if commandEnv != nil && commandEnv.verbose {
+			if c.commandEnv != nil && c.commandEnv.verbose {
 				fmt.Fprintf(os.Stdout, "%s %.1f %.1f:%.1f\t", diskType.ReadableString(), idealVolumeRatio*100,
 					fullNode.localVolumeDensityRatio(capacityFunc)*100, emptyNode.localVolumeDensityNextRatio(capacityFunc)*100)
 			}
-			hasMoved, err = attemptToMoveOneVolume(commandEnv, volumeReplicas, fullNode, candidateVolumes, emptyNode, applyBalancing)
+			hasMoved, err = c.attemptToMoveOneVolume(volumeReplicas, fullNode, candidateVolumes, emptyNode)
 			if err != nil {
-				if commandEnv != nil && commandEnv.verbose {
+				if c.commandEnv != nil && c.commandEnv.verbose {
 					fmt.Fprintf(os.Stdout, "attempt to move one volume error %+v\n", err)
 				}
 				if strings.Contains(err.Error(), util.ErrVolumeNoSpaceLeft) {
@@ -483,10 +504,13 @@ func balanceSelectedVolume(commandEnv *CommandEnv, diskType types.DiskType, volu
 	return nil
 }
 
-func attemptToMoveOneVolume(commandEnv *CommandEnv, volumeReplicas map[uint32][]*VolumeReplica, fullNode *Node, candidateVolumes []*master_pb.VolumeInformationMessage, emptyNode *Node, applyBalancing bool) (hasMoved bool, err error) {
+func (c *commandVolumeBalance) attemptToMoveOneVolume(volumeReplicas map[uint32][]*VolumeReplica, fullNode *Node, candidateVolumes []*master_pb.VolumeInformationMessage, emptyNode *Node) (hasMoved bool, err error) {
 
 	for _, v := range candidateVolumes {
-		hasMoved, err = maybeMoveOneVolume(commandEnv, volumeReplicas, fullNode, v, emptyNode, applyBalancing)
+		if c.volumesPerStep > 0 && c.movedCount >= c.volumesPerStep {
+			return false, nil
+		}
+		hasMoved, err = c.maybeMoveOneVolume(volumeReplicas, fullNode, v, emptyNode)
 		if err != nil {
 			return
 		}
@@ -497,13 +521,17 @@ func attemptToMoveOneVolume(commandEnv *CommandEnv, volumeReplicas map[uint32][]
 	return
 }
 
-func maybeMoveOneVolume(commandEnv *CommandEnv, volumeReplicas map[uint32][]*VolumeReplica, fullNode *Node, candidateVolume *master_pb.VolumeInformationMessage, emptyNode *Node, applyChange bool) (hasMoved bool, err error) {
-	if !commandEnv.isLocked() {
+func (c *commandVolumeBalance) maybeMoveOneVolume(volumeReplicas map[uint32][]*VolumeReplica, fullNode *Node, candidateVolume *master_pb.VolumeInformationMessage, emptyNode *Node) (hasMoved bool, err error) {
+	if !c.commandEnv.isLocked() {
 		return false, fmt.Errorf("lock is lost")
 	}
 
 	if candidateVolume.RemoteStorageName != "" {
 		return false, fmt.Errorf("does not move volume in remote storage")
+	}
+
+	if c.volumesPerStep > 0 && c.movedCount >= c.volumesPerStep {
+		return false, nil
 	}
 
 	if candidateVolume.ReplicaPlacement > 0 {
@@ -513,8 +541,9 @@ func maybeMoveOneVolume(commandEnv *CommandEnv, volumeReplicas map[uint32][]*Vol
 		}
 	}
 	if _, found := emptyNode.selectedVolumes[candidateVolume.Id]; !found {
-		if err = moveVolume(commandEnv, candidateVolume, fullNode, emptyNode, applyChange); err == nil {
+		if err = moveVolume(c.commandEnv, candidateVolume, fullNode, emptyNode, c.applyBalancing); err == nil {
 			adjustAfterMove(candidateVolume, volumeReplicas, fullNode, emptyNode)
+			c.movedCount++
 			return true, nil
 		} else {
 			return

--- a/weed/shell/command_volume_balance.go
+++ b/weed/shell/command_volume_balance.go
@@ -59,7 +59,7 @@ func (c *commandVolumeBalance) Help() string {
 
 	The -volumesPerStep parameter limits the maximum number of volume moves in one command execution.
 	If unset - the command will try to balance all volumes at once.
-	It might be beneficial to set, if your cluster has lots of blocks growing and topology changes faster than balancing can occur.
+	It might be beneficial to set, if your cluster has lots of volumes growing and topology changes faster than balancing can occur.
 
 	Algorithm:
 
@@ -131,6 +131,9 @@ func (c *commandVolumeBalance) Do(args []string, commandEnv *CommandEnv, writer 
 	}
 	handleDeprecatedForceFlag(writer, balanceCommand, applyBalancingAlias, applyBalancing)
 	c.applyBalancing = *applyBalancing
+	if *volumesPerStep < 0 {
+		return fmt.Errorf("volumesPerStep must be >= 0")
+	}
 	c.volumesPerStep = *volumesPerStep
 	c.movedCount = 0
 

--- a/weed/shell/command_volume_balance_test.go
+++ b/weed/shell/command_volume_balance_test.go
@@ -341,7 +341,8 @@ func TestBalanceDoesNotDrainOntoOneNode(t *testing.T) {
 		n.selectVolumes(func(v *master_pb.VolumeInformationMessage) bool { return true })
 	}
 
-	if err := balanceSelectedVolume(nil, types.HardDriveType, volumeReplicas, nodes, sortWritableVolumes, volumeSizeLimitMb, false); err != nil {
+	c := &commandVolumeBalance{volumeSizeLimitMb: volumeSizeLimitMb}
+	if err := c.balanceSelectedVolume(types.HardDriveType, volumeReplicas, nodes, sortWritableVolumes); err != nil {
 		t.Fatalf("balanceSelectedVolume: %v", err)
 	}
 
@@ -352,6 +353,59 @@ func TestBalanceDoesNotDrainOntoOneNode(t *testing.T) {
 	}
 	if diff := fullCount - emptyCount; diff > 1 || diff < -1 {
 		t.Fatalf("expected balanced distribution within one volume, got full=%d empty=%d", fullCount, emptyCount)
+	}
+}
+
+// volumesPerStep caps the number of moves performed in a single execution.
+func TestBalanceVolumesPerStep(t *testing.T) {
+	const mb = 1024 * 1024
+	volumeSizeLimitMb := uint64(100)
+
+	makeNode := func(id string, volumes []*master_pb.VolumeInformationMessage) *Node {
+		return &Node{
+			info: &master_pb.DataNodeInfo{
+				Id: id,
+				DiskInfos: map[string]*master_pb.DiskInfo{
+					"": {
+						MaxVolumeCount: 10,
+						VolumeCount:    int64(len(volumes)),
+						VolumeInfos:    volumes,
+					},
+				},
+			},
+			dc:   "dc1",
+			rack: "rack1",
+		}
+	}
+
+	var fullVolumes []*master_pb.VolumeInformationMessage
+	for id := uint32(1); id <= 6; id++ {
+		fullVolumes = append(fullVolumes, &master_pb.VolumeInformationMessage{Id: id, Size: 95 * mb})
+	}
+	fullNode := makeNode("full", fullVolumes)
+	emptyNode := makeNode("empty", nil)
+	nodes := []*Node{fullNode, emptyNode}
+
+	volumeReplicas := map[uint32][]*VolumeReplica{}
+	for _, v := range fullVolumes {
+		loc := newLocation("dc1", "rack1", fullNode.info)
+		volumeReplicas[v.Id] = []*VolumeReplica{{location: &loc, info: v}}
+	}
+
+	for _, n := range nodes {
+		n.selectVolumes(func(v *master_pb.VolumeInformationMessage) bool { return true })
+	}
+
+	c := &commandVolumeBalance{volumeSizeLimitMb: volumeSizeLimitMb, volumesPerStep: 1}
+	if err := c.balanceSelectedVolume(types.HardDriveType, volumeReplicas, nodes, sortWritableVolumes); err != nil {
+		t.Fatalf("balanceSelectedVolume: %v", err)
+	}
+
+	if c.movedCount != 1 {
+		t.Fatalf("expected exactly 1 move with volumesPerStep=1, got %d", c.movedCount)
+	}
+	if got := len(emptyNode.info.DiskInfos[""].VolumeInfos); got != 1 {
+		t.Fatalf("expected empty node to receive exactly 1 volume, got %d", got)
 	}
 }
 

--- a/weed/shell/command_volume_balance_test.go
+++ b/weed/shell/command_volume_balance_test.go
@@ -356,8 +356,8 @@ func TestBalanceDoesNotDrainOntoOneNode(t *testing.T) {
 	}
 }
 
-// volumesPerStep caps the number of moves performed in a single execution.
-func TestBalanceVolumesPerStep(t *testing.T) {
+// volumesPerExec caps the number of moves performed in a single execution.
+func TestBalanceVolumesPerExec(t *testing.T) {
 	const mb = 1024 * 1024
 	volumeSizeLimitMb := uint64(100)
 
@@ -396,13 +396,13 @@ func TestBalanceVolumesPerStep(t *testing.T) {
 		n.selectVolumes(func(v *master_pb.VolumeInformationMessage) bool { return true })
 	}
 
-	c := &commandVolumeBalance{volumeSizeLimitMb: volumeSizeLimitMb, volumesPerStep: 1}
+	c := &commandVolumeBalance{volumeSizeLimitMb: volumeSizeLimitMb, volumesPerExec: 1}
 	if err := c.balanceSelectedVolume(types.HardDriveType, volumeReplicas, nodes, sortWritableVolumes); err != nil {
 		t.Fatalf("balanceSelectedVolume: %v", err)
 	}
 
 	if c.movedCount != 1 {
-		t.Fatalf("expected exactly 1 move with volumesPerStep=1, got %d", c.movedCount)
+		t.Fatalf("expected exactly 1 move with volumesPerExec=1, got %d", c.movedCount)
 	}
 	if got := len(emptyNode.info.DiskInfos[""].VolumeInfos); got != 1 {
 		t.Fatalf("expected empty node to receive exactly 1 volume, got %d", got)


### PR DESCRIPTION
# What problem are we solving?

In case of large disbalance between nodes - balancing may take a long time.
During this time the topology may change due to volume.growth
It might be beneficial to have -volumesPerStep flag for volume.balance to make the command only execute 5-10 volume movements.

# How are we solving the problem?

Add a volumesPerStep flag.

**There is a catch that volume.fix.replication volumesPerStep-flag keeps the command running, but my implementation stops/breaks the execution entirely.
It might be more reasonable to name the flag "volumesPerExec"
Or rework it, to keep working while rescanning topo after each step**

# How is the PR tested?

I've deployed my version of code and it works. The command executes 2 balances and finishes.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated `volume.balance` with a `-volumesPerExec` flag to cap how many volume moves can succeed per command execution.
* **Bug Fixes**
  * Added validation to reject negative `-volumesPerExec` values and enforce the move limit consistently across balancing loops.
* **Tests**
  * Added a regression test ensuring balancing stops after the configured move count and that the involved node ends with the expected volume state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->