### PR TITLE
fix(filer): propagate proxyChunkId query params to volume server

### DIFF
--- a/weed/server/filer_server_handlers.go
+++ b/weed/server/filer_server_handlers.go
@@ -58,7 +58,7 @@ func (fs *FilerServer) filerHandler(w http.ResponseWriter, r *http.Request) {
 
 	// proxy to volume servers
 	var fileId string
-	if strings.HasPrefix(r.RequestURI, "/?proxyChunkId=") {
+	if r.URL.Path == "/" {
 		fileId = r.URL.Query().Get("proxyChunkId")
 	}
 	if fileId != "" {

--- a/weed/server/filer_server_handlers.go
+++ b/weed/server/filer_server_handlers.go
@@ -59,7 +59,7 @@ func (fs *FilerServer) filerHandler(w http.ResponseWriter, r *http.Request) {
 	// proxy to volume servers
 	var fileId string
 	if strings.HasPrefix(r.RequestURI, "/?proxyChunkId=") {
-		fileId = r.RequestURI[len("/?proxyChunkId="):]
+		fileId = r.URL.Query().Get("proxyChunkId")
 	}
 	if fileId != "" {
 		fs.proxyToVolumeServer(w, r, fileId)

--- a/weed/server/filer_server_handlers_proxy.go
+++ b/weed/server/filer_server_handlers_proxy.go
@@ -2,7 +2,6 @@ package weed_server
 
 import (
 	"context"
-	"strings"
 	"sync"
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
@@ -62,16 +61,14 @@ func (fs *FilerServer) proxyToVolumeServer(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// Build target URL. urlStrings from LookupFileId already contain the fileId
-	// in the path (e.g. http://server:8080/6,08136bdce4). Forward any original
-	// query params (e.g. readDeleted=true from weed mount).
+	// urlStrings from LookupFileId already contain the fileId in the path
+	// (e.g. http://server:8080/6,08136bdce4). Forward the caller's query params
+	// (e.g. readDeleted=true from weed mount) but drop the internal proxyChunkId.
 	targetURL := urlStrings[rand.IntN(len(urlStrings))]
-	if r.URL.RawQuery != "" {
-		if strings.Contains(targetURL, "?") {
-			targetURL += "&" + r.URL.RawQuery
-		} else {
-			targetURL += "?" + r.URL.RawQuery
-		}
+	query := r.URL.Query()
+	query.Del("proxyChunkId")
+	if encoded := query.Encode(); encoded != "" {
+		targetURL += "?" + encoded
 	}
 
 	proxyReq, err := http.NewRequest(r.Method, targetURL, r.Body)

--- a/weed/server/filer_server_handlers_proxy.go
+++ b/weed/server/filer_server_handlers_proxy.go
@@ -2,6 +2,7 @@ package weed_server
 
 import (
 	"context"
+	"strings"
 	"sync"
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
@@ -61,9 +62,21 @@ func (fs *FilerServer) proxyToVolumeServer(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	proxyReq, err := http.NewRequest(r.Method, urlStrings[rand.IntN(len(urlStrings))], r.Body)
+	// Build target URL. urlStrings from LookupFileId already contain the fileId
+	// in the path (e.g. http://server:8080/6,08136bdce4). Forward any original
+	// query params (e.g. readDeleted=true from weed mount).
+	targetURL := urlStrings[rand.IntN(len(urlStrings))]
+	if r.URL.RawQuery != "" {
+		if strings.Contains(targetURL, "?") {
+			targetURL += "&" + r.URL.RawQuery
+		} else {
+			targetURL += "?" + r.URL.RawQuery
+		}
+	}
+
+	proxyReq, err := http.NewRequest(r.Method, targetURL, r.Body)
 	if err != nil {
-		glog.ErrorfCtx(ctx, "NewRequest %s: %v", urlStrings[0], err)
+		glog.ErrorfCtx(ctx, "NewRequest %s: %v", targetURL, err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
Fixes: weed mount failing with 400 Bad Request when using `-volumeServerAccess=filerProxy`

## The Bug

When `weed mount` reads chunks through the filer proxy (enabled with `-volumeServerAccess=filerProxy`), the mount process automatically appends query parameters to chunk read requests (e.g., `readDeleted=true` for handling deleted chunks during volume merges).

Two bugs prevented these requests from succeeding:

1. **File ID Extraction**: `filer_server_handlers.go` extracted the `fileId` from the raw `RequestURI`, which includes query params. This corrupted the file ID (e.g., `6,08136bdce4&readDeleted=true` instead of `6,08136bdce4`), causing lookup failures.

2. **Query Param Propagation**: `filer_server_handlers_proxy.go` proxied requests to the volume server without forwarding the original query parameters. The volume server expected standard paths like `/6,08136bdce4?readDeleted=true` but received the URL without the fileId path or query params.

## The Fix

1. **Clean extraction**: Replace raw string slicing with `r.URL.Query().Get("proxyChunkId")` to isolate the file ID from query parameters.

2. **Propagate query string**: Append the original `r.URL.RawQuery` to the volume server URL before proxying. Note that `LookupFileIdFunction()` already returns full URLs with the fileId in the path (e.g., `http://server:port/6,abc`), so we only need to append the query string.

## Testing

- **CI**: All standard tests pass (`go test ./server/` and `go test ./util/http/`)
- **Manual**: Built Docker image locally and verified with `weed mount` and `curl` requests matching the reported scenario:
  - `GET /?proxyChunkId=6,08136bdce4` → 200 OK ✅
  - `GET /?proxyChunkId=6,08136bdce4&readDeleted=true` → 200 OK ✅ (was 400 before)

## Co-Authors

By submitting this PR, I acknowledge that an AI agent (Athena - Hermes Agent) assisted in identifying the root cause and writing the fix. This PR was created and managed with the help of the [Hermes Agent](https://github.com/nousresearch/hermes-agent).

Co-authored-by: Athena / Qwen 3.6 35B A3B

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request handling when proxying file operations to volume servers.
  * The system now derives the correct `fileId` from the incoming URL and reliably forwards the caller’s query parameters to the proxied target.
  * The internal `proxyChunkId` parameter is no longer passed through, preventing unintended behavior at the destination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->