### PR TITLE
util/http: lazily init the global HTTP client to fix admin metrics nil panic

### DIFF
--- a/weed/util/http/http_global_client_init.go
+++ b/weed/util/http/http_global_client_init.go
@@ -1,27 +1,37 @@
 package http
 
 import (
+	"sync"
+
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	util_http_client "github.com/seaweedfs/seaweedfs/weed/util/http/client"
 )
 
 var (
-	globalHttpClient *util_http_client.HTTPClient
+	globalHttpClient     *util_http_client.HTTPClient
+	globalHttpClientOnce sync.Once
 )
 
 func NewGlobalHttpClient(opt ...util_http_client.HttpClientOpt) (*util_http_client.HTTPClient, error) {
 	return util_http_client.NewHttpClient(util_http_client.Client, opt...)
 }
 
+// GetGlobalHttpClient returns the process-wide HTTP client, initializing it on
+// first use. Lazy init keeps callers that bypass weed.go's main (in-process
+// test harnesses, libraries) from dereferencing a nil client.
 func GetGlobalHttpClient() *util_http_client.HTTPClient {
+	globalHttpClientOnce.Do(initGlobalHttpClient)
 	return globalHttpClient
 }
 
 func InitGlobalHttpClient() {
-	var err error
+	globalHttpClientOnce.Do(initGlobalHttpClient)
+}
 
-	globalHttpClient, err = NewGlobalHttpClient()
+func initGlobalHttpClient() {
+	client, err := NewGlobalHttpClient()
 	if err != nil {
 		glog.Fatalf("error init global http client: %v", err)
 	}
+	globalHttpClient = client
 }


### PR DESCRIPTION
The S3 Policy Shell integration tests intermittently panic during startup:

```
panic: runtime error: invalid memory address or nil pointer dereference
weed/util/http/client.(*HTTPClient).GetHttpScheme(...)
weed/util/http/client.(*HTTPClient).Do
weed/admin/dash.(*AdminServer).fetchPublicUrlMap        cluster_topology.go:61
weed/admin/dash.(*AdminServer).getTopologyViaGRPC       cluster_topology.go:115
weed/admin/dash.(*AdminServer).GetClusterTopology       cluster_topology.go:30
weed/admin/dash.(*AdminServer).recordDashboardSample    dashboard_metrics.go:51
weed/admin/dash.(*AdminServer).publishMaintenanceMetrics admin_server.go:386
created by weed/admin/dash.NewAdminServer
```

`GetGlobalHttpClient()` returns the package-global `globalHttpClient`, which stays nil until `InitGlobalHttpClient()` runs. That call only happens in `weed.go`'s `main`. The policy tests start `weed mini` in-process via `cmd.Run`, bypassing `main`, so the global client is never initialized in the test binary.

The admin server's `publishMaintenanceMetrics` goroutine seeds a dashboard sample as soon as `NewAdminServer` starts, walking `GetClusterTopology` -> `fetchPublicUrlMap` -> `GetGlobalHttpClient().Do(req)`. With a nil receiver, `GetHttpScheme` dereferences a nil pointer.

It's intermittent because `fetchPublicUrlMap` returns early (before `.Do`) when the master isn't known yet, so the panic only lands when the master is already resolved at seed time.

Fix: initialize the global client on first `GetGlobalHttpClient()` via `sync.Once` so it is never nil, regardless of whether a command runs through `main`, an in-process test harness, or a library import. `InitGlobalHttpClient()` keeps its eager-init role through the same `Once`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced HTTP client initialization for improved system reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->