### PR TITLE
util: support IPv6 host port parsing

### DIFF
--- a/weed/util/parse.go
+++ b/weed/util/parse.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"net"
 	"net/url"
 	"strconv"
 	"strings"
@@ -60,15 +61,15 @@ func ParseFilerUrl(entryPath string) (filerServer string, filerPort int64, path 
 }
 
 func ParseHostPort(hostPort string) (filerServer string, filerPort int64, err error) {
-	parts := strings.Split(hostPort, ":")
-	if len(parts) != 2 {
+	host, port, err := net.SplitHostPort(hostPort)
+	if err != nil {
 		err = fmt.Errorf("failed to parse %s\n", hostPort)
 		return
 	}
 
-	filerPort, err = strconv.ParseInt(parts[1], 10, 64)
+	filerPort, err = strconv.ParseInt(port, 10, 64)
 	if err == nil {
-		filerServer = parts[0]
+		filerServer = host
 	}
 
 	return

--- a/weed/util/parse.go
+++ b/weed/util/parse.go
@@ -63,7 +63,7 @@ func ParseFilerUrl(entryPath string) (filerServer string, filerPort int64, path 
 func ParseHostPort(hostPort string) (filerServer string, filerPort int64, err error) {
 	host, port, err := net.SplitHostPort(hostPort)
 	if err != nil {
-		err = fmt.Errorf("failed to parse %s\n", hostPort)
+		err = fmt.Errorf("failed to parse %s", hostPort)
 		return
 	}
 

--- a/weed/util/parse_test.go
+++ b/weed/util/parse_test.go
@@ -1,0 +1,57 @@
+package util
+
+import "testing"
+
+func TestParseHostPort(t *testing.T) {
+	tests := []struct {
+		name       string
+		hostPort   string
+		wantHost   string
+		wantPort   int64
+		wantErr    bool
+	}{
+		{
+			name:     "hostname",
+			hostPort: "localhost:8888",
+			wantHost: "localhost",
+			wantPort: 8888,
+		},
+		{
+			name:     "ipv4",
+			hostPort: "127.0.0.1:8888",
+			wantHost: "127.0.0.1",
+			wantPort: 8888,
+		},
+		{
+			name:     "bracketed ipv6",
+			hostPort: "[::1]:8888",
+			wantHost: "::1",
+			wantPort: 8888,
+		},
+		{
+			name:     "missing port",
+			hostPort: "localhost",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid port",
+			hostPort: "localhost:bad",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotHost, gotPort, err := ParseHostPort(tt.hostPort)
+			if gotErr := err != nil; gotErr != tt.wantErr {
+				t.Fatalf("ParseHostPort(%q) error = %v, wantErr %v", tt.hostPort, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if gotHost != tt.wantHost || gotPort != tt.wantPort {
+				t.Fatalf("ParseHostPort(%q) = (%q, %d), want (%q, %d)", tt.hostPort, gotHost, gotPort, tt.wantHost, tt.wantPort)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changed

Use `net.SplitHostPort` in `ParseHostPort` so bracketed IPv6 addresses such as `[::1]:8888` are parsed correctly.

The existing hostname and IPv4 host:port behavior is preserved.

## Testing

Please run:

- `go test ./weed/util -run TestParseHostPort -count=1`
- `go test ./weed/util`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved address parsing to correctly handle hostnames, IPv4, and bracketed IPv6 using standard host/port splitting.
  * Enhanced validation so malformed inputs (missing or invalid ports) fail reliably with clearer parsing errors.

* **Tests**
  * Added table-driven test coverage for `ParseHostPort`, including success cases for hostname, IPv4, and IPv6, plus error cases for missing and non-numeric ports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->