### PR TITLE
fix(benchmark): close CPU profile file handle after profiling

### DIFF
--- a/weed/command/benchmark.go
+++ b/weed/command/benchmark.go
@@ -131,7 +131,10 @@ func runBenchmark(cmd *Command, args []string) bool {
 			glog.Fatal(err)
 		}
 		pprof.StartCPUProfile(f)
-		defer pprof.StopCPUProfile()
+		defer func() {
+			pprof.StopCPUProfile()
+			f.Close()
+		}()
 	}
 
 	// Determine what operations to perform


### PR DESCRIPTION
# What problem are we solving?

In `weed/command/benchmark.go`, the `runBenchmark` function opens a file via `os.Create` when the `-cpuprofile` flag is used. The file is passed to `pprof.StartCPUProfile(f)` to record CPU profiling data. However, the current code only defers `pprof.StopCPUProfile()`, which stops profiling and flushes data but **does not close the underlying file**. This leaves the file descriptor open until the process exits, causing a resource leak.

# How are we solving the problem?

Changed `defer pprof.StopCPUProfile()` to a deferred function that first stops the CPU profile and then closes the file handle:

```diff
-               defer pprof.StopCPUProfile()
+               defer func() {
+                       pprof.StopCPUProfile()
+                       f.Close()
+               }()
```

This ensures:
1. `pprof.StopCPUProfile()` is called first to flush all profiling data to the file.
2. `f.Close()` is then called to release the file descriptor.

# How is the PR tested?

- The change is minimal and localized to a single block in `weed/command/benchmark.go`.
- No behavioral changes to the benchmark logic.
- Verified that the file closure order is correct: stop profiling first, then close file.
- This PR does not include new unit tests because the issue is a straightforward resource-release fix; the existing benchmark command already exercises this code path.

# Checks
- [X] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [X] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [X] I have reviewed every line of code.
- [X] The PR is kept as minimum as possible. Large PRs would not be accepted.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource cleanup in CPU profiling during benchmark operations to prevent file descriptor leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->