### PR TITLE
fix(s3api): preserve requested AES256 copy encryption

### DIFF
--- a/test/s3/iam/s3_iam_inline_policy_condition_test.go
+++ b/test/s3/iam/s3_iam_inline_policy_condition_test.go
@@ -37,10 +37,43 @@ func isAccessDenied(err error) bool {
 	return ok && awsErr.Code() == "AccessDenied"
 }
 
+// localSourceAllowCIDRs lists every address a loopback-targeted test client may
+// present as aws:SourceIp. The SDK reaches the server over localhost, but
+// depending on resolver order and host routing the source the server observes
+// can be IPv4 loopback, IPv6 loopback, or one of the host's RFC1918 addresses
+// (CI runners advertise the S3 endpoint on a 10.x interface). An allow policy
+// meant to match "this local client" must cover all of them or the
+// positive-condition assertion flakes.
+var localSourceAllowCIDRs = []string{
+	"127.0.0.0/8",
+	"::1/128",
+	"10.0.0.0/8",
+	"172.16.0.0/12",
+	"192.168.0.0/16",
+}
+
+// sourceIpAllowPolicy builds an Allow policy for s3:* on bucketName gated by an
+// aws:SourceIp IpAddress condition over the given CIDRs.
+func sourceIpAllowPolicy(bucketName string, cidrs ...string) string {
+	quoted := make([]string, len(cidrs))
+	for i, c := range cidrs {
+		quoted[i] = `"` + c + `"`
+	}
+	return `{
+		"Version":"2012-10-17",
+		"Statement":[{
+			"Effect":"Allow",
+			"Action":"s3:*",
+			"Resource":["arn:aws:s3:::` + bucketName + `","arn:aws:s3:::` + bucketName + `/*"],
+			"Condition":{"IpAddress":{"aws:SourceIp":[` + strings.Join(quoted, ",") + `]}}
+		}]
+	}`
+}
+
 // TestIAMUserInlinePolicySourceIpCondition verifies that an aws:SourceIp condition
-// on a user inline policy is honored. Tests run from localhost (127.0.0.1), so a
-// policy that only allows access from a non-loopback CIDR must deny the request,
-// and a policy that allows access from 127.0.0.0/8 must allow it.
+// on a user inline policy is honored. Tests run against a local server, so a
+// policy that only allows a non-local CIDR must deny the request, and a policy
+// that allows the local client's address (see localSourceAllowCIDRs) must allow it.
 func TestIAMUserInlinePolicySourceIpCondition(t *testing.T) {
 	framework := NewS3IAMTestFramework(t)
 	defer framework.Cleanup()
@@ -87,30 +120,13 @@ func TestIAMUserInlinePolicySourceIpCondition(t *testing.T) {
 		}
 	})
 
-	policyDoc := func(cidrs ...string) string {
-		quoted := make([]string, len(cidrs))
-		for i, c := range cidrs {
-			quoted[i] = `"` + c + `"`
-		}
-		return `{
-			"Version":"2012-10-17",
-			"Statement":[{
-				"Effect":"Allow",
-				"Action":"s3:*",
-				"Resource":["arn:aws:s3:::` + bucketName + `","arn:aws:s3:::` + bucketName + `/*"],
-				"Condition":{"IpAddress":{"aws:SourceIp":[` + strings.Join(quoted, ",") + `]}}
-			}]
-		}`
-	}
-
 	t.Run("denies_when_source_ip_does_not_match", func(t *testing.T) {
 		// SourceIp 198.51.100.0/24 is RFC5737 TEST-NET-2; the test client is on
-		// loopback (127.0.0.1 or ::1 depending on resolver), so the condition
-		// must fail and the action must be denied.
+		// the local host, so the condition must fail and the action be denied.
 		_, err = iamClient.PutUserPolicy(&iam.PutUserPolicyInput{
 			UserName:       aws.String(userName),
 			PolicyName:     aws.String(policyName),
-			PolicyDocument: aws.String(policyDoc("198.51.100.0/24")),
+			PolicyDocument: aws.String(sourceIpAllowPolicy(bucketName, "198.51.100.0/24")),
 		})
 		require.NoError(t, err)
 
@@ -127,25 +143,25 @@ func TestIAMUserInlinePolicySourceIpCondition(t *testing.T) {
 	})
 
 	t.Run("allows_when_source_ip_matches", func(t *testing.T) {
-		// Cover both IPv4 and IPv6 loopback: on CI runners `localhost` may
-		// resolve to ::1 first, in which case a 127.0.0.0/8-only allow would
-		// silently never match and the test would hang.
 		_, err = iamClient.PutUserPolicy(&iam.PutUserPolicyInput{
 			UserName:       aws.String(userName),
 			PolicyName:     aws.String(policyName),
-			PolicyDocument: aws.String(policyDoc("127.0.0.0/8", "::1/128")),
+			PolicyDocument: aws.String(sourceIpAllowPolicy(bucketName, localSourceAllowCIDRs...)),
 		})
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
-			_, err := userS3.PutObject(&s3.PutObjectInput{
+			_, putErr := userS3.PutObject(&s3.PutObjectInput{
 				Bucket: aws.String(bucketName),
 				Key:    aws.String("allowed.txt"),
 				Body:   aws.ReadSeekCloser(strings.NewReader("ok")),
 			})
-			return err == nil
+			if putErr != nil {
+				t.Logf("allow attempt denied (source IP not in %v?): %v", localSourceAllowCIDRs, putErr)
+			}
+			return putErr == nil
 		}, 10*time.Second, 500*time.Millisecond,
-			"PutObject must succeed when aws:SourceIp condition matches the loopback range")
+			"PutObject must succeed when aws:SourceIp condition matches the local client address")
 	})
 }
 
@@ -215,27 +231,8 @@ func TestIAMGroupInlinePolicyEnforcement(t *testing.T) {
 		}
 	})
 
-	// Cover both IPv4 and IPv6 loopback in the allow CIDR list: on CI runners
-	// `localhost` may resolve to ::1 first, in which case a 127.0.0.0/8-only
-	// allow would silently never match and the test would hang.
-	allowDoc := `{
-		"Version":"2012-10-17",
-		"Statement":[{
-			"Effect":"Allow",
-			"Action":"s3:*",
-			"Resource":["arn:aws:s3:::` + bucketName + `","arn:aws:s3:::` + bucketName + `/*"],
-			"Condition":{"IpAddress":{"aws:SourceIp":["127.0.0.0/8","::1/128"]}}
-		}]
-	}`
-	denyDoc := `{
-		"Version":"2012-10-17",
-		"Statement":[{
-			"Effect":"Allow",
-			"Action":"s3:*",
-			"Resource":["arn:aws:s3:::` + bucketName + `","arn:aws:s3:::` + bucketName + `/*"],
-			"Condition":{"IpAddress":{"aws:SourceIp":"198.51.100.0/24"}}
-		}]
-	}`
+	allowDoc := sourceIpAllowPolicy(bucketName, localSourceAllowCIDRs...)
+	denyDoc := sourceIpAllowPolicy(bucketName, "198.51.100.0/24")
 
 	t.Run("crud_round_trip", func(t *testing.T) {
 		_, err := iamClient.PutGroupPolicy(&iam.PutGroupPolicyInput{
@@ -277,12 +274,15 @@ func TestIAMGroupInlinePolicyEnforcement(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Eventually(t, func() bool {
-			_, err := userS3.PutObject(&s3.PutObjectInput{
+			_, putErr := userS3.PutObject(&s3.PutObjectInput{
 				Bucket: aws.String(bucketName),
 				Key:    aws.String("group-allowed.txt"),
 				Body:   aws.ReadSeekCloser(strings.NewReader("ok")),
 			})
-			return err == nil
+			if putErr != nil {
+				t.Logf("allow attempt denied (source IP not in %v?): %v", localSourceAllowCIDRs, putErr)
+			}
+			return putErr == nil
 		}, 10*time.Second, 500*time.Millisecond,
 			"group member must be allowed when the group policy condition matches")
 	})

--- a/weed/s3api/s3api_copy_validation.go
+++ b/weed/s3api/s3api_copy_validation.go
@@ -115,9 +115,19 @@ func validateSSEKMSCopyRequirements(srcMetadata map[string][]byte, headers http.
 
 // validateEncryptionCompatibility validates that encryption methods are not conflicting
 func validateEncryptionCompatibility(headers http.Header) error {
+	sseAlgorithm := headers.Get(s3_constants.AmzServerSideEncryption)
 	hasSSEC := hasSSECHeaders(headers)
-	hasSSEKMS := headers.Get(s3_constants.AmzServerSideEncryption) == "aws:kms"
-	hasSSES3 := headers.Get(s3_constants.AmzServerSideEncryption) == "AES256"
+	hasSSEKMS := sseAlgorithm == s3_constants.SSEAlgorithmKMS
+	hasSSES3 := sseAlgorithm == s3_constants.SSEAlgorithmAES256
+
+	// Reject unsupported algorithms so they are never persisted as a bogus
+	// destination header advertising encryption that was never applied.
+	if sseAlgorithm != "" && !hasSSEKMS && !hasSSES3 {
+		return &CopyValidationError{
+			Code:    s3err.ErrInvalidEncryptionAlgorithm,
+			Message: fmt.Sprintf("Unsupported server-side encryption algorithm: %s", sseAlgorithm),
+		}
+	}
 
 	// Count how many encryption methods are specified
 	encryptionCount := 0

--- a/weed/s3api/s3api_object_handlers_copy.go
+++ b/weed/s3api/s3api_object_handlers_copy.go
@@ -1029,26 +1029,28 @@ func processMetadataBytes(reqHeader http.Header, existing map[string][]byte, rep
 		metadata[s3_constants.AmzStorageClass] = []byte(sc)
 	}
 
-	// Handle SSE-KMS headers - these are always processed from request headers if present
-	if sseAlgorithm := reqHeader.Get(s3_constants.AmzServerSideEncryption); sseAlgorithm == "aws:kms" {
+	// Handle destination SSE headers from the request when present.
+	if sseAlgorithm := reqHeader.Get(s3_constants.AmzServerSideEncryption); sseAlgorithm != "" {
 		metadata[s3_constants.AmzServerSideEncryption] = []byte(sseAlgorithm)
 
-		// KMS Key ID (optional - can use default key)
-		if kmsKeyID := reqHeader.Get(s3_constants.AmzServerSideEncryptionAwsKmsKeyId); kmsKeyID != "" {
-			metadata[s3_constants.AmzServerSideEncryptionAwsKmsKeyId] = []byte(kmsKeyID)
-		}
+		if sseAlgorithm == "aws:kms" {
+			// KMS Key ID (optional - can use default key)
+			if kmsKeyID := reqHeader.Get(s3_constants.AmzServerSideEncryptionAwsKmsKeyId); kmsKeyID != "" {
+				metadata[s3_constants.AmzServerSideEncryptionAwsKmsKeyId] = []byte(kmsKeyID)
+			}
 
-		// Encryption Context (optional)
-		if encryptionContext := reqHeader.Get(s3_constants.AmzServerSideEncryptionContext); encryptionContext != "" {
-			metadata[s3_constants.AmzServerSideEncryptionContext] = []byte(encryptionContext)
-		}
+			// Encryption Context (optional)
+			if encryptionContext := reqHeader.Get(s3_constants.AmzServerSideEncryptionContext); encryptionContext != "" {
+				metadata[s3_constants.AmzServerSideEncryptionContext] = []byte(encryptionContext)
+			}
 
-		// Bucket Key Enabled (optional)
-		if bucketKeyEnabled := reqHeader.Get(s3_constants.AmzServerSideEncryptionBucketKeyEnabled); bucketKeyEnabled != "" {
-			metadata[s3_constants.AmzServerSideEncryptionBucketKeyEnabled] = []byte(bucketKeyEnabled)
+			// Bucket Key Enabled (optional)
+			if bucketKeyEnabled := reqHeader.Get(s3_constants.AmzServerSideEncryptionBucketKeyEnabled); bucketKeyEnabled != "" {
+				metadata[s3_constants.AmzServerSideEncryptionBucketKeyEnabled] = []byte(bucketKeyEnabled)
+			}
 		}
 	} else {
-		// If not explicitly setting SSE-KMS, preserve existing SSE headers from source
+		// If not explicitly setting SSE, preserve existing SSE headers from source
 		for _, sseHeader := range []string{
 			s3_constants.AmzServerSideEncryption,
 			s3_constants.AmzServerSideEncryptionAwsKmsKeyId,

--- a/weed/s3api/s3api_object_handlers_copy.go
+++ b/weed/s3api/s3api_object_handlers_copy.go
@@ -1035,7 +1035,7 @@ func processMetadataBytes(reqHeader http.Header, existing map[string][]byte, rep
 	if sseAlgorithm := reqHeader.Get(s3_constants.AmzServerSideEncryption); sseAlgorithm != "" {
 		metadata[s3_constants.AmzServerSideEncryption] = []byte(sseAlgorithm)
 
-		if sseAlgorithm == "aws:kms" {
+		if sseAlgorithm == s3_constants.SSEAlgorithmKMS {
 			// KMS Key ID (optional - can use default key)
 			if kmsKeyID := reqHeader.Get(s3_constants.AmzServerSideEncryptionAwsKmsKeyId); kmsKeyID != "" {
 				metadata[s3_constants.AmzServerSideEncryptionAwsKmsKeyId] = []byte(kmsKeyID)

--- a/weed/s3api/s3api_object_handlers_copy.go
+++ b/weed/s3api/s3api_object_handlers_copy.go
@@ -350,8 +350,10 @@ func (s3a *S3ApiServer) CopyObjectHandler(w http.ResponseWriter, r *http.Request
 	if entry.Attributes.FileSize == 0 || len(entry.GetChunks()) == 0 {
 		dstEntry.Chunks = nil
 
-		// Handle inline encrypted content - fixes GitHub #7562
-		if len(entry.Content) > 0 {
+		// Handle inline encrypted content - fixes GitHub #7562.
+		// Also run when the destination requests encryption with no content so
+		// empty objects get real key metadata, not just a bare algorithm header.
+		if len(entry.Content) > 0 || dstWantsSSEC || dstWantsSSEKMS || dstWantsSSES3 {
 			inlineContent, inlineMetadata, inlineErr := s3a.processInlineContentForCopy(
 				entry, r, dstBucket, dstObject,
 				srcHasSSEC, srcHasSSEKMS, srcHasSSES3,

--- a/weed/s3api/s3api_object_handlers_copy_mime_test.go
+++ b/weed/s3api/s3api_object_handlers_copy_mime_test.go
@@ -294,3 +294,17 @@ func TestProcessMetadataBytes_CopyAppliesRequestedSSES3Header(t *testing.T) {
 		t.Fatalf("%s = %q, want %q", s3_constants.AmzServerSideEncryption, got, s3_constants.SSEAlgorithmAES256)
 	}
 }
+
+func TestProcessMetadataBytes_CopyPreservesSourceSSEWhenRequestOmitsHeader(t *testing.T) {
+	existing := map[string][]byte{
+		s3_constants.AmzServerSideEncryption: []byte(s3_constants.SSEAlgorithmKMS),
+	}
+
+	out, err := processMetadataBytes(http.Header{}, existing, false, false)
+	if err != nil {
+		t.Fatalf("processMetadataBytes returned error: %v", err)
+	}
+	if got := string(out[s3_constants.AmzServerSideEncryption]); got != s3_constants.SSEAlgorithmKMS {
+		t.Fatalf("%s = %q, want %q", s3_constants.AmzServerSideEncryption, got, s3_constants.SSEAlgorithmKMS)
+	}
+}

--- a/weed/s3api/s3api_object_handlers_copy_mime_test.go
+++ b/weed/s3api/s3api_object_handlers_copy_mime_test.go
@@ -3,6 +3,8 @@ package s3api
 import (
 	"net/http"
 	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 )
 
 func TestResolveDestinationMime(t *testing.T) {
@@ -277,5 +279,18 @@ func TestProcessMetadataBytes_CopyInheritsSystemHeaders(t *testing.T) {
 	}
 	if got := string(out["Content-Encoding"]); got != "gzip" {
 		t.Errorf("Content-Encoding = %q, want %q", got, "gzip")
+	}
+}
+
+func TestProcessMetadataBytes_CopyAppliesRequestedSSES3Header(t *testing.T) {
+	req := http.Header{}
+	req.Set(s3_constants.AmzServerSideEncryption, s3_constants.SSEAlgorithmAES256)
+
+	out, err := processMetadataBytes(req, nil, false, false)
+	if err != nil {
+		t.Fatalf("processMetadataBytes returned error: %v", err)
+	}
+	if got := string(out[s3_constants.AmzServerSideEncryption]); got != s3_constants.SSEAlgorithmAES256 {
+		t.Fatalf("%s = %q, want %q", s3_constants.AmzServerSideEncryption, got, s3_constants.SSEAlgorithmAES256)
 	}
 }


### PR DESCRIPTION
# What problem are we solving?

CopyObject ignored an explicit `x-amz-server-side-encryption: AES256` request header while processing destination metadata. As a result, a copied object could lose the requested SSE-S3 metadata even though SSE-KMS requests were preserved correctly.

# How are we solving the problem?

When `x-amz-server-side-encryption` is present on the copy request, preserve that requested algorithm in the destination metadata. Keep the KMS-specific metadata handling limited to `aws:kms`, and keep the existing behavior of inheriting source SSE metadata when the request does not explicitly set destination SSE.

# How is the PR tested?

```bash
env GOCACHE=/private/tmp/seaweedfs-go-cache go test ./weed/s3api -run TestProcessMetadataBytes_CopyAppliesRequestedSSES3Header -count=1
```

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-side encryption (SSE) handling during S3 COPY operations, including zero-size copies, so destination encryption metadata reflects the request and metadata replacement behavior is corrected.
  * Updated COPY encryption compatibility validation to explicitly reject unsupported SSE algorithms with a clear error.
* **Tests**
  * Added COPY-mode SSE header coverage to ensure requested SSE headers are applied and source SSE metadata is preserved when the request omits SSE headers.
  * Refactored IAM inline policy condition tests to make `aws:SourceIp` matching deterministic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->