### PR TITLE
refactor: 将fmt.Errorf中的%v替换为%w以保留错误链

### DIFF
--- a/weed/wdclient/vidmap_client.go
+++ b/weed/wdclient/vidmap_client.go
@@ -199,7 +199,7 @@ func (vc *vidMapClient) LookupVolumeIdsWithFallback(ctx context.Context, volumeI
 
 		providerResults, err := vc.provider.LookupVolumeIds(ctx, stillNeedLookup)
 		if err != nil {
-			return batchResult, fmt.Errorf("provider lookup failed: %v", err)
+			return batchResult, fmt.Errorf("provider lookup failed: %w", err)
 		}
 
 		// Update cache with results

--- a/weed/worker/tasks/balance/balance_task.go
+++ b/weed/worker/tasks/balance/balance_task.go
@@ -83,7 +83,7 @@ func (t *BalanceTask) Execute(ctx context.Context, params *worker_pb.TaskParams)
 	t.ReportProgress(10.0)
 	t.GetLogger().Info("Marking volume readonly for move")
 	if err := t.markVolumeReadonly(ctx, sourceServer, volumeId); err != nil {
-		return fmt.Errorf("failed to mark volume readonly: %v", err)
+		return fmt.Errorf("failed to mark volume readonly: %w", err)
 	}
 	// Restore source writability if any subsequent step fails, so the
 	// source volume is not left permanently readonly on abort.
@@ -102,7 +102,7 @@ func (t *BalanceTask) Execute(ctx context.Context, params *worker_pb.TaskParams)
 	t.ReportProgress(15.0)
 	sourceStatus, err := t.readVolumeFileStatus(ctx, sourceServer, volumeId)
 	if err != nil {
-		return fmt.Errorf("failed to read source volume status: %v", err)
+		return fmt.Errorf("failed to read source volume status: %w", err)
 	}
 
 	// Step 3: Copy volume to destination (VolumeCopy also mounts the volume)
@@ -110,7 +110,7 @@ func (t *BalanceTask) Execute(ctx context.Context, params *worker_pb.TaskParams)
 	t.GetLogger().Info("Copying volume to destination")
 	lastAppendAtNs, err := t.copyVolume(ctx, sourceServer, targetServer, volumeId)
 	if err != nil {
-		return fmt.Errorf("failed to copy volume: %v", err)
+		return fmt.Errorf("failed to copy volume: %w", err)
 	}
 
 	// Step 4: Tail for updates
@@ -147,7 +147,7 @@ func (t *BalanceTask) Execute(ctx context.Context, params *worker_pb.TaskParams)
 	t.ReportProgress(90.0)
 	t.GetLogger().Info("Deleting volume from source server")
 	if err := t.deleteVolume(ctx, sourceServer, volumeId); err != nil {
-		return fmt.Errorf("failed to delete volume from source: %v", err)
+		return fmt.Errorf("failed to delete volume from source: %w", err)
 	}
 	sourceMarkedReadonly = false
 

--- a/weed/worker/tasks/ec_balance/ec_balance_task.go
+++ b/weed/worker/tasks/ec_balance/ec_balance_task.go
@@ -96,7 +96,7 @@ func (t *ECBalanceTask) Execute(ctx context.Context, params *worker_pb.TaskParam
 	// Step 1: Copy shard to destination and mount
 	t.reportProgress(10.0, "Copying EC shard to destination")
 	if err := t.copyAndMountShard(ctx, params.VolumeId, sourceAddr, targetAddr, source.ShardIds, target.DiskId); err != nil {
-		return fmt.Errorf("copy and mount shard: %v", err)
+		return fmt.Errorf("copy and mount shard: %w", err)
 	}
 
 	// Step 1.5: confirm the destination actually registered the shard(s)
@@ -112,13 +112,13 @@ func (t *ECBalanceTask) Execute(ctx context.Context, params *worker_pb.TaskParam
 	// Step 2: Unmount shard on source
 	t.reportProgress(50.0, "Unmounting EC shard from source")
 	if err := t.unmountShard(ctx, params.VolumeId, sourceAddr, source.ShardIds); err != nil {
-		return fmt.Errorf("unmount shard on source: %v", err)
+		return fmt.Errorf("unmount shard on source: %w", err)
 	}
 
 	// Step 3: Delete shard from source
 	t.reportProgress(75.0, "Deleting EC shard from source")
 	if err := t.deleteShard(ctx, params.VolumeId, params.Collection, sourceAddr, source.ShardIds); err != nil {
-		return fmt.Errorf("delete shard on source: %v", err)
+		return fmt.Errorf("delete shard on source: %w", err)
 	}
 
 	t.reportProgress(100.0, "EC shard move complete")
@@ -131,12 +131,12 @@ func (t *ECBalanceTask) Execute(ctx context.Context, params *worker_pb.TaskParam
 func (t *ECBalanceTask) executeDedupDelete(ctx context.Context, volumeID uint32, sourceAddr pb.ServerAddress, shardIDs []uint32) error {
 	t.reportProgress(25.0, "Unmounting duplicate EC shard")
 	if err := t.unmountShard(ctx, volumeID, sourceAddr, shardIDs); err != nil {
-		return fmt.Errorf("unmount duplicate shard: %v", err)
+		return fmt.Errorf("unmount duplicate shard: %w", err)
 	}
 
 	t.reportProgress(75.0, "Deleting duplicate EC shard")
 	if err := t.deleteShard(ctx, volumeID, t.collection, sourceAddr, shardIDs); err != nil {
-		return fmt.Errorf("delete duplicate shard: %v", err)
+		return fmt.Errorf("delete duplicate shard: %w", err)
 	}
 
 	t.reportProgress(100.0, "Duplicate shard removed")

--- a/weed/worker/tasks/erasure_coding/ec_task.go
+++ b/weed/worker/tasks/erasure_coding/ec_task.go
@@ -521,7 +521,7 @@ func (t *ErasureCodingTask) copyFileFromSource(ctx context.Context, ext, localPa
 				if len(resp.FileContent) > 0 {
 					written, writeErr := localFile.Write(resp.FileContent)
 					if writeErr != nil {
-						return fmt.Errorf("failed to write to local file: %v", writeErr)
+						return fmt.Errorf("failed to write to local file: %w", writeErr)
 					}
 					totalBytes += int64(written)
 				}

--- a/weed/worker/tasks/vacuum/vacuum_task.go
+++ b/weed/worker/tasks/vacuum/vacuum_task.go
@@ -82,7 +82,7 @@ func (t *VacuumTask) Execute(ctx context.Context, params *worker_pb.TaskParams) 
 	t.GetLogger().Info("Checking volume status")
 	targets, currentGarbageRatios, err := t.checkVacuumEligibility(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to check vacuum eligibility: %v", err)
+		return fmt.Errorf("failed to check vacuum eligibility: %w", err)
 	}
 
 	if len(targets) == 0 {
@@ -105,7 +105,7 @@ func (t *VacuumTask) Execute(ctx context.Context, params *worker_pb.TaskParams) 
 	}).Info("Performing vacuum operation")
 
 	if err := t.performVacuum(ctx); err != nil {
-		return fmt.Errorf("failed to perform vacuum: %v", err)
+		return fmt.Errorf("failed to perform vacuum: %w", err)
 	}
 
 	// Step 3: Verify vacuum results on each target replica.


### PR DESCRIPTION
替换了多个文件中的错误格式化方式，使用%w包裹原始错误，
保留完整的错误调用链以提升调试时的错误追踪能力。

# What problem are we solving?
在 Go 中， fmt.Errorf 使用 %v 格式化 error 会丢失原始错误的类型信息，导致调用方无法使用 errors.Is() 和 errors.As() 进行错误追溯。这是 Go 项目中最常见的反模式之一。

本次修复涉及以下文件中的错误处理问题：

文件 问题数量 weed/worker/tasks/erasure_coding/ec_task.go 1处 weed/worker/tasks/vacuum/vacuum_task.go 2处 weed/worker/tasks/balance/balance_task.go 4处 weed/worker/tasks/ec_balance/ec_balance_task.go 5处 weed/wdclient/vidmap_client.go 1处

这些文件内部已存在正确使用 %w 的写法（如 ec_task.go 第129行、第170行等），说明只是代码风格不统一，修复无争议。


# How are we solving the problem?

将所有 fmt.Errorf("...: %v", err) 替换为 fmt.Errorf("...: %w", err) ，使错误链得以保留。
- ec_task.go : 第524行 failed to write to local file
- vacuum_task.go : 第85行 failed to check vacuum eligibility 、第108行 failed to perform vacuum
- balance_task.go : 第86行 failed to mark volume readonly 、第105行 failed to read source volume status 、第113行 failed to copy volume 、第150行 failed to delete volume from source
- ec_balance_task.go : 第99行 copy and mount shard 、第115行 unmount shard on source 、第121行 delete shard on source 、第134行 unmount duplicate shard 、第139行 delete duplicate shard
- vidmap_client.go : 第202行 provider lookup failed
- 
# How is the PR tested?
- 代码审查：确认所有修改点仅涉及 %v → %w 的格式化动词替换，不影响业务逻辑
- 风格一致性：确认同一文件内其他位置已正确使用 %w ，修改后风格统一
- 单元测试：建议运行相关模块的现有测试确保无回归（如 go test ./weed/worker/tasks/... ）
- 错误链验证：可通过 errors.Is() / errors.As() 测试确认错误追溯功能正常


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal error handling and diagnostics across volume management, balance operations, erasure coding, and vacuum tasks to enable better error chain preservation and debugging support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->