### PR TITLE
iceberg: return 400 for invalid namespace/table names

### DIFF
--- a/weed/s3api/iceberg/handlers_commit.go
+++ b/weed/s3api/iceberg/handlers_commit.go
@@ -189,7 +189,7 @@ func (s *Server) handleUpdateTable(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			glog.V(1).Infof("Iceberg: CommitTable GetTable error: %v", err)
-			writeError(w, http.StatusInternalServerError, "InternalServerError", err.Error())
+			writeManagerError(w, err)
 			return
 		}
 

--- a/weed/s3api/iceberg/handlers_namespace.go
+++ b/weed/s3api/iceberg/handlers_namespace.go
@@ -82,7 +82,7 @@ func (s *Server) handleListNamespaces(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		glog.Infof("Iceberg: ListNamespaces error: %v", err)
-		writeError(w, http.StatusInternalServerError, "InternalServerError", err.Error())
+		writeManagerError(w, err)
 		return
 	}
 
@@ -138,7 +138,7 @@ func (s *Server) handleCreateNamespace(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		glog.Errorf("Iceberg: CreateNamespace error: %v", err)
-		writeError(w, http.StatusInternalServerError, "InternalServerError", err.Error())
+		writeManagerError(w, err)
 		return
 	}
 
@@ -182,7 +182,7 @@ func (s *Server) handleGetNamespace(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		glog.V(1).Infof("Iceberg: GetNamespace error: %v", err)
-		writeError(w, http.StatusInternalServerError, "InternalServerError", err.Error())
+		writeManagerError(w, err)
 		return
 	}
 
@@ -222,6 +222,10 @@ func (s *Server) handleNamespaceExists(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
 			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if nameValidationError(err) {
+			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
 		glog.V(1).Infof("Iceberg: NamespaceExists error: %v", err)
@@ -267,7 +271,7 @@ func (s *Server) handleDropNamespace(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		glog.V(1).Infof("Iceberg: DropNamespace error: %v", err)
-		writeError(w, http.StatusInternalServerError, "InternalServerError", err.Error())
+		writeManagerError(w, err)
 		return
 	}
 

--- a/weed/s3api/iceberg/handlers_table.go
+++ b/weed/s3api/iceberg/handlers_table.go
@@ -69,7 +69,7 @@ func (s *Server) handleListTables(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		glog.V(1).Infof("Iceberg: ListTables error: %v", err)
-		writeError(w, http.StatusInternalServerError, "InternalServerError", err.Error())
+		writeManagerError(w, err)
 		return
 	}
 
@@ -212,7 +212,7 @@ func (s *Server) handleCreateTable(w http.ResponseWriter, r *http.Request) {
 	}
 	if !isNoSuchTableError(existsErr) {
 		glog.V(1).Infof("Iceberg: CreateTable existence check failed for %s.%s: %v", flattenNamespacePath(namespace), tableName, existsErr)
-		writeError(w, http.StatusInternalServerError, "InternalServerError", existsErr.Error())
+		writeManagerError(w, existsErr)
 		return
 	}
 
@@ -302,7 +302,7 @@ func (s *Server) handleCreateTable(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		glog.V(1).Infof("Iceberg: CreateTable error: %v", err)
-		writeError(w, http.StatusInternalServerError, "InternalServerError", err.Error())
+		writeManagerError(w, err)
 		return
 	}
 
@@ -359,7 +359,7 @@ func (s *Server) handleLoadTable(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		glog.V(1).Infof("Iceberg: LoadTable error: %v", err)
-		writeError(w, http.StatusInternalServerError, "InternalServerError", err.Error())
+		writeManagerError(w, err)
 		return
 	}
 
@@ -509,7 +509,7 @@ func (s *Server) handleDropTable(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		glog.V(1).Infof("Iceberg: DropTable error: %v", err)
-		writeError(w, http.StatusInternalServerError, "InternalServerError", err.Error())
+		writeManagerError(w, err)
 		return
 	}
 

--- a/weed/s3api/iceberg/iceberg_invalid_name_test.go
+++ b/weed/s3api/iceberg/iceberg_invalid_name_test.go
@@ -18,9 +18,13 @@ func TestNameValidationError(t *testing.T) {
 		{fmt.Errorf("all filers failed, last error: invalid namespace name: only 'a-z', '0-9', and '_' are allowed"), true},
 		{fmt.Errorf("invalid table name: only 'a-z', '0-9', and '_' are allowed"), true},
 		{fmt.Errorf("namespace name must start with a letter or digit"), true},
+		{fmt.Errorf("namespace name cannot start with reserved prefix 'aws'"), true},
 		{fmt.Errorf("table name must be between 1 and 255 characters"), true},
 		{fmt.Errorf("namespace not found"), false},
 		{fmt.Errorf("all filers failed, last error: rpc timeout"), false},
+		// Unrelated faults that merely mention a name must stay 500.
+		{fmt.Errorf("failed to resolve table name from index"), false},
+		{fmt.Errorf("error fetching namespace name mapping"), false},
 	}
 	for _, c := range cases {
 		if got := nameValidationError(c.err); got != c.want {

--- a/weed/s3api/iceberg/iceberg_invalid_name_test.go
+++ b/weed/s3api/iceberg/iceberg_invalid_name_test.go
@@ -1,0 +1,61 @@
+package iceberg
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNameValidationError(t *testing.T) {
+	cases := []struct {
+		err  error
+		want bool
+	}{
+		{nil, false},
+		// Wrapped exactly as the s3tables manager surfaces it.
+		{fmt.Errorf("all filers failed, last error: invalid namespace name: only 'a-z', '0-9', and '_' are allowed"), true},
+		{fmt.Errorf("invalid table name: only 'a-z', '0-9', and '_' are allowed"), true},
+		{fmt.Errorf("namespace name must start with a letter or digit"), true},
+		{fmt.Errorf("table name must be between 1 and 255 characters"), true},
+		{fmt.Errorf("namespace not found"), false},
+		{fmt.Errorf("all filers failed, last error: rpc timeout"), false},
+	}
+	for _, c := range cases {
+		if got := nameValidationError(c.err); got != c.want {
+			t.Errorf("nameValidationError(%v) = %v, want %v", c.err, got, c.want)
+		}
+	}
+}
+
+func TestWriteManagerError(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      error
+		wantCode int
+		wantType string
+	}{
+		{"invalid name is a client error", fmt.Errorf("invalid namespace name: only 'a-z', '0-9', and '_' are allowed"), http.StatusBadRequest, "BadRequestException"},
+		{"everything else is a server fault", fmt.Errorf("all filers failed, last error: connection refused"), http.StatusInternalServerError, "InternalServerError"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			writeManagerError(rec, c.err)
+			if rec.Code != c.wantCode {
+				t.Fatalf("status = %d, want %d", rec.Code, c.wantCode)
+			}
+			var resp ErrorResponse
+			if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if resp.Error.Type != c.wantType {
+				t.Fatalf("error type = %q, want %q", resp.Error.Type, c.wantType)
+			}
+			if resp.Error.Code != c.wantCode {
+				t.Fatalf("error code = %d, want %d", resp.Error.Code, c.wantCode)
+			}
+		})
+	}
+}

--- a/weed/s3api/iceberg/utils.go
+++ b/weed/s3api/iceberg/utils.go
@@ -107,8 +107,20 @@ func nameValidationError(err error) bool {
 	if err == nil {
 		return false
 	}
-	msg := err.Error()
-	return strings.Contains(msg, "namespace name") || strings.Contains(msg, "table name")
+	// Match the validator's own phrasings rather than a bare "namespace name"/
+	// "table name" so unrelated faults (e.g. "failed to resolve table name")
+	// aren't misreported as client errors. Lowercased for resilience to
+	// capitalization changes.
+	msg := strings.ToLower(err.Error())
+	for _, marker := range []string{
+		"invalid namespace name", "namespace name must", "namespace name cannot",
+		"invalid table name", "table name must", "table name cannot",
+	} {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 // writeManagerError maps a residual s3tables manager error to a response:

--- a/weed/s3api/iceberg/utils.go
+++ b/weed/s3api/iceberg/utils.go
@@ -99,6 +99,29 @@ func writeError(w http.ResponseWriter, status int, errType, message string) {
 	writeJSON(w, status, resp)
 }
 
+// nameValidationError reports whether err is an S3 Tables namespace or table
+// name validation failure. Such names are client input (the S3 Tables charset
+// is stricter than the Iceberg REST spec), so the catalog answers 400 rather
+// than treating it as a server fault.
+func nameValidationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "namespace name") || strings.Contains(msg, "table name")
+}
+
+// writeManagerError maps a residual s3tables manager error to a response:
+// name validation failures are client errors (400); anything else is a server
+// fault (500).
+func writeManagerError(w http.ResponseWriter, err error) {
+	if nameValidationError(err) {
+		writeError(w, http.StatusBadRequest, "BadRequestException", err.Error())
+		return
+	}
+	writeError(w, http.StatusInternalServerError, "InternalServerError", err.Error())
+}
+
 // getBucketFromPrefix extracts table bucket name from prefix parameter.
 // For now, we use the prefix as the table bucket name.
 //


### PR DESCRIPTION
The Iceberg REST Catalog rejects namespace/table names that violate the S3 Tables charset (`a-z`, `0-9`, `_`) with a 500. Generic Iceberg REST clients routinely use hyphens and uppercase, so they get a server error for what is plainly bad input.

Map the manager's name-validation error to `400 BadRequestException` across the namespace and table handlers (and the HEAD namespace-exists path), keeping genuine server faults as 500. `writeManagerError` centralizes the classification so the handlers stay uniform.

Found while running the apache/iceberg-go client's REST integration suite against SeaweedFS: every test errored at the first call because the suite's namespace name contains hyphens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Iceberg S3 API error responses by mapping name-validation failures to `400 BadRequestException` instead of generic `500` errors.
  * Unified manager-related failure handling across namespace and table operations to provide consistent HTTP status codes and JSON error details.
* **Tests**
  * Added coverage for name-validation error classification and for verifying correct HTTP status and error fields in the JSON responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->