### PR TITLE
Fix pr zhangax

### DIFF
--- a/.trae/rules/git-commit-message.md
+++ b/.trae/rules/git-commit-message.md
@@ -1,0 +1,6 @@
+---
+alwaysApply: true
+scene: git_message
+---
+
+用英语，在此处编写规则，自定义 AI 生成提交信息的风格。

--- a/weed/mount/weedfs_xattr.go
+++ b/weed/mount/weedfs_xattr.go
@@ -125,10 +125,13 @@ func (wfs *WFS) SetXAttr(cancel <-chan struct{}, input *fuse.SetXAttrIn, attr st
 	switch input.Flags {
 	case sys.XATTR_CREATE:
 		if len(oldData) > 0 {
-			break
+			return fuse.Status(syscall.EEXIST)
 		}
 		fallthrough
 	case sys.XATTR_REPLACE:
+		if len(oldData) == 0 {
+			return fuse.ENODATA
+		}
 		fallthrough
 	default:
 		// data aliases the FUSE request's pooled input buffer, which is

--- a/weed/server/postgres/server.go
+++ b/weed/server/postgres/server.go
@@ -388,6 +388,11 @@ func (s *PostgreSQLServer) handleStartup(session *PostgreSQLSession) error {
 			return fmt.Errorf("failed to read message length during startup: %v", err)
 		}
 
+		// Validate minimum message length to prevent integer underflow
+		if binary.BigEndian.Uint32(length) < 4 {
+			return fmt.Errorf("startup message too short: %d bytes", binary.BigEndian.Uint32(length))
+		}
+
 		msgLength := binary.BigEndian.Uint32(length) - 4
 		if msgLength > 10000 { // Reasonable limit for startup messages
 			return fmt.Errorf("startup message too large: %d bytes", msgLength)

--- a/weed/wdclient/vidmap_client.go
+++ b/weed/wdclient/vidmap_client.go
@@ -199,7 +199,7 @@ func (vc *vidMapClient) LookupVolumeIdsWithFallback(ctx context.Context, volumeI
 
 		providerResults, err := vc.provider.LookupVolumeIds(ctx, stillNeedLookup)
 		if err != nil {
-			return batchResult, fmt.Errorf("provider lookup failed: %v", err)
+			return batchResult, fmt.Errorf("provider lookup failed: %w", err)
 		}
 
 		// Update cache with results

--- a/weed/worker/tasks/balance/balance_task.go
+++ b/weed/worker/tasks/balance/balance_task.go
@@ -83,7 +83,7 @@ func (t *BalanceTask) Execute(ctx context.Context, params *worker_pb.TaskParams)
 	t.ReportProgress(10.0)
 	t.GetLogger().Info("Marking volume readonly for move")
 	if err := t.markVolumeReadonly(ctx, sourceServer, volumeId); err != nil {
-		return fmt.Errorf("failed to mark volume readonly: %v", err)
+		return fmt.Errorf("failed to mark volume readonly: %w", err)
 	}
 	// Restore source writability if any subsequent step fails, so the
 	// source volume is not left permanently readonly on abort.
@@ -102,7 +102,7 @@ func (t *BalanceTask) Execute(ctx context.Context, params *worker_pb.TaskParams)
 	t.ReportProgress(15.0)
 	sourceStatus, err := t.readVolumeFileStatus(ctx, sourceServer, volumeId)
 	if err != nil {
-		return fmt.Errorf("failed to read source volume status: %v", err)
+		return fmt.Errorf("failed to read source volume status: %w", err)
 	}
 
 	// Step 3: Copy volume to destination (VolumeCopy also mounts the volume)
@@ -110,7 +110,7 @@ func (t *BalanceTask) Execute(ctx context.Context, params *worker_pb.TaskParams)
 	t.GetLogger().Info("Copying volume to destination")
 	lastAppendAtNs, err := t.copyVolume(ctx, sourceServer, targetServer, volumeId)
 	if err != nil {
-		return fmt.Errorf("failed to copy volume: %v", err)
+		return fmt.Errorf("failed to copy volume: %w", err)
 	}
 
 	// Step 4: Tail for updates
@@ -147,7 +147,7 @@ func (t *BalanceTask) Execute(ctx context.Context, params *worker_pb.TaskParams)
 	t.ReportProgress(90.0)
 	t.GetLogger().Info("Deleting volume from source server")
 	if err := t.deleteVolume(ctx, sourceServer, volumeId); err != nil {
-		return fmt.Errorf("failed to delete volume from source: %v", err)
+		return fmt.Errorf("failed to delete volume from source: %w", err)
 	}
 	sourceMarkedReadonly = false
 

--- a/weed/worker/tasks/ec_balance/ec_balance_task.go
+++ b/weed/worker/tasks/ec_balance/ec_balance_task.go
@@ -96,7 +96,7 @@ func (t *ECBalanceTask) Execute(ctx context.Context, params *worker_pb.TaskParam
 	// Step 1: Copy shard to destination and mount
 	t.reportProgress(10.0, "Copying EC shard to destination")
 	if err := t.copyAndMountShard(ctx, params.VolumeId, sourceAddr, targetAddr, source.ShardIds, target.DiskId); err != nil {
-		return fmt.Errorf("copy and mount shard: %v", err)
+		return fmt.Errorf("copy and mount shard: %w", err)
 	}
 
 	// Step 1.5: confirm the destination actually registered the shard(s)
@@ -112,13 +112,13 @@ func (t *ECBalanceTask) Execute(ctx context.Context, params *worker_pb.TaskParam
 	// Step 2: Unmount shard on source
 	t.reportProgress(50.0, "Unmounting EC shard from source")
 	if err := t.unmountShard(ctx, params.VolumeId, sourceAddr, source.ShardIds); err != nil {
-		return fmt.Errorf("unmount shard on source: %v", err)
+		return fmt.Errorf("unmount shard on source: %w", err)
 	}
 
 	// Step 3: Delete shard from source
 	t.reportProgress(75.0, "Deleting EC shard from source")
 	if err := t.deleteShard(ctx, params.VolumeId, params.Collection, sourceAddr, source.ShardIds); err != nil {
-		return fmt.Errorf("delete shard on source: %v", err)
+		return fmt.Errorf("delete shard on source: %w", err)
 	}
 
 	t.reportProgress(100.0, "EC shard move complete")
@@ -131,12 +131,12 @@ func (t *ECBalanceTask) Execute(ctx context.Context, params *worker_pb.TaskParam
 func (t *ECBalanceTask) executeDedupDelete(ctx context.Context, volumeID uint32, sourceAddr pb.ServerAddress, shardIDs []uint32) error {
 	t.reportProgress(25.0, "Unmounting duplicate EC shard")
 	if err := t.unmountShard(ctx, volumeID, sourceAddr, shardIDs); err != nil {
-		return fmt.Errorf("unmount duplicate shard: %v", err)
+		return fmt.Errorf("unmount duplicate shard: %w", err)
 	}
 
 	t.reportProgress(75.0, "Deleting duplicate EC shard")
 	if err := t.deleteShard(ctx, volumeID, t.collection, sourceAddr, shardIDs); err != nil {
-		return fmt.Errorf("delete duplicate shard: %v", err)
+		return fmt.Errorf("delete duplicate shard: %w", err)
 	}
 
 	t.reportProgress(100.0, "Duplicate shard removed")

--- a/weed/worker/tasks/erasure_coding/ec_task.go
+++ b/weed/worker/tasks/erasure_coding/ec_task.go
@@ -521,7 +521,7 @@ func (t *ErasureCodingTask) copyFileFromSource(ctx context.Context, ext, localPa
 				if len(resp.FileContent) > 0 {
 					written, writeErr := localFile.Write(resp.FileContent)
 					if writeErr != nil {
-						return fmt.Errorf("failed to write to local file: %v", writeErr)
+						return fmt.Errorf("failed to write to local file: %w", writeErr)
 					}
 					totalBytes += int64(written)
 				}

--- a/weed/worker/tasks/vacuum/vacuum_task.go
+++ b/weed/worker/tasks/vacuum/vacuum_task.go
@@ -82,7 +82,7 @@ func (t *VacuumTask) Execute(ctx context.Context, params *worker_pb.TaskParams) 
 	t.GetLogger().Info("Checking volume status")
 	targets, currentGarbageRatios, err := t.checkVacuumEligibility(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to check vacuum eligibility: %v", err)
+		return fmt.Errorf("failed to check vacuum eligibility: %w", err)
 	}
 
 	if len(targets) == 0 {
@@ -105,7 +105,7 @@ func (t *VacuumTask) Execute(ctx context.Context, params *worker_pb.TaskParams) 
 	}).Info("Performing vacuum operation")
 
 	if err := t.performVacuum(ctx); err != nil {
-		return fmt.Errorf("failed to perform vacuum: %v", err)
+		return fmt.Errorf("failed to perform vacuum: %w", err)
 	}
 
 	// Step 3: Verify vacuum results on each target replica.


### PR DESCRIPTION
# What problem are we solving?
The SetXAttr implementation in weed/mount/weedfs_xattr.go did not correctly follow Linux setxattr(2) semantics for the XATTR_CREATE and XATTR_REPLACE flags:

1. XATTR_CREATE : When the attribute already exists, the code only performed a break without returning an error. According to the man page, this should return EEXIST .
2. XATTR_REPLACE : The code unconditionally fell through to the default case, creating the attribute even when it didn't exist. According to the man page, this should return ENODATA when the attribute is missing.

This violates the documented behavior:
XATTR_CREATE: Perform a pure create, which fails if the named attribute exists already.
XATTR_REPLACE: Perform a pure replace operation, which fails if the named attribute does not already exist.

# How are we solving the problem?
Fixed the switch statement in SetXAttr to properly handle both flags:
case sys.XATTR_CREATE:
    if len(oldData) > 0 {
        return fuse.Status(syscall.EEXIST)  // Was: break (no error)
    }
    fallthrough
case sys.XATTR_REPLACE:
    if len(oldData) == 0 {
        return fuse.ENODATA  // Was: fallthrough (creates anyway)
    }
    fallthrough
default:
    entry.Extended[XATTR_PREFIX+attr] = append([]byte(nil), data...)

# How is the PR tested?
- Code review: Verified the fix matches Linux setxattr(2) semantics
- Logic verification: Both flag cases now properly check existence before proceeding
- Unit tests: Consider adding tests for:
- XATTR_CREATE on existing attribute → EEXIST
- XATTR_CREATE on non-existing attribute → success
- XATTR_REPLACE on existing attribute → success
- XATTR_REPLACE on non-existing attribute → ENODATA


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added validation to prevent integer underflow in startup message processing
  * Corrected error handling for extended attribute operations (create/replace scenarios)
  * Improved error propagation in volume balancing, erasure coding, and vacuum operations

* **Chores**
  * Added AI rule configuration for commit message formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->