### PR TITLE
fix(chunk_cache): close data/index files on initialization error

### DIFF
--- a/weed/util/chunk_cache/chunk_cache_on_disk.go
+++ b/weed/util/chunk_cache/chunk_cache_on_disk.go
@@ -37,6 +37,18 @@ func LoadOrCreateChunkCacheVolume(fileName string, preallocate int64) (*ChunkCac
 	}
 
 	var err error
+	var indexFile *os.File
+
+	defer func() {
+		if err != nil {
+			if v.DataBackend != nil {
+				v.DataBackend.Close()
+			}
+			if indexFile != nil {
+				indexFile.Close()
+			}
+		}
+	}()
 
 	if exists, canRead, canWrite, modTime, fileSize := util.CheckFile(v.fileName + ".dat"); exists {
 		if !canRead {
@@ -59,7 +71,6 @@ func LoadOrCreateChunkCacheVolume(fileName string, preallocate int64) (*ChunkCac
 		v.lastModTime = time.Now()
 	}
 
-	var indexFile *os.File
 	if indexFile, err = os.OpenFile(v.fileName+".idx", os.O_RDWR|os.O_CREATE, 0644); err != nil {
 		return nil, fmt.Errorf("cannot write cache index %s.idx: %v", v.fileName, err)
 	}

--- a/weed/util/chunk_cache/chunk_cache_on_disk.go
+++ b/weed/util/chunk_cache/chunk_cache_on_disk.go
@@ -57,13 +57,13 @@ func LoadOrCreateChunkCacheVolume(fileName string, preallocate int64) (*ChunkCac
 		if !canWrite {
 			return nil, fmt.Errorf("cannot write cache file %s.dat", v.fileName)
 		}
-		if dataFile, err := os.OpenFile(v.fileName+".dat", os.O_RDWR|os.O_CREATE, 0644); err != nil {
+		var dataFile *os.File
+		if dataFile, err = os.OpenFile(v.fileName+".dat", os.O_RDWR|os.O_CREATE, 0644); err != nil {
 			return nil, fmt.Errorf("cannot create cache file %s.dat: %v", v.fileName, err)
-		} else {
-			v.DataBackend = backend.NewDiskFile(dataFile)
-			v.lastModTime = modTime
-			v.fileSize = fileSize
 		}
+		v.DataBackend = backend.NewDiskFile(dataFile)
+		v.lastModTime = modTime
+		v.fileSize = fileSize
 	} else {
 		if v.DataBackend, err = backend.CreateVolumeFile(v.fileName+".dat", preallocate, 0); err != nil {
 			return nil, fmt.Errorf("cannot create cache file %s.dat: %v", v.fileName, err)

--- a/weed/util/chunk_cache/chunk_cache_on_disk_test.go
+++ b/weed/util/chunk_cache/chunk_cache_on_disk_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"math/rand"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/seaweedfs/seaweedfs/weed/util/mem"
@@ -131,3 +133,37 @@ func TestOnDisk(t *testing.T) {
 	cache.Shutdown()
 
 }
+
+func TestLoadOrCreateChunkCacheVolumeClosesFilesOnError(t *testing.T) {
+	tmpDir := t.TempDir()
+	fileName := filepath.Join(tmpDir, "cache")
+
+	// Pre-create .dat so LoadOrCreateChunkCacheVolume opens it.
+	if err := os.WriteFile(fileName+".dat", []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create .ldb as a regular file so NewLevelDbNeedleMap fails.
+	// leveldb.OpenFile expects a directory.
+	if err := os.WriteFile(fileName+".ldb", []byte("not a directory"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadOrCreateChunkCacheVolume(fileName, 1024)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	// On Windows, open files cannot be removed. If the files can be
+	// removed, they were closed by the error path.
+	for _, ext := range []string{".dat", ".idx"} {
+		path := fileName + ext
+		if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
+			continue
+		}
+		if rmErr := os.Remove(path); rmErr != nil {
+			t.Errorf("failed to remove %s: %v", path, rmErr)
+		}
+	}
+}
+

--- a/weed/util/chunk_cache/chunk_cache_on_disk_test.go
+++ b/weed/util/chunk_cache/chunk_cache_on_disk_test.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/seaweedfs/seaweedfs/weed/util/mem"
@@ -149,21 +150,52 @@ func TestLoadOrCreateChunkCacheVolumeClosesFilesOnError(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	before := openFDCount()
+
 	_, err := LoadOrCreateChunkCacheVolume(fileName, 1024)
 	if err == nil {
 		t.Fatal("expected error")
 	}
 
-	// On Windows, open files cannot be removed. If the files can be
-	// removed, they were closed by the error path.
-	for _, ext := range []string{".dat", ".idx"} {
-		path := fileName + ext
-		if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
-			continue
+	// On POSIX a leaked descriptor keeps the count elevated; the error path
+	// should close both files, returning the count to its baseline.
+	if before >= 0 {
+		if after := openFDCount(); after > before {
+			t.Errorf("descriptors leaked on error: before=%d after=%d", before, after)
 		}
-		if rmErr := os.Remove(path); rmErr != nil {
-			t.Errorf("failed to remove %s: %v", path, rmErr)
+	}
+
+	// On Windows open files cannot be removed, so successful removal also
+	// confirms the descriptors were closed.
+	if runtime.GOOS == "windows" {
+		for _, ext := range []string{".dat", ".idx"} {
+			path := fileName + ext
+			if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
+				continue
+			}
+			if rmErr := os.Remove(path); rmErr != nil {
+				t.Errorf("failed to remove %s: %v", path, rmErr)
+			}
 		}
 	}
 }
 
+// openFDCount returns the number of open file descriptors for the current
+// process, or -1 where it cannot be determined (e.g. Windows).
+// Readdirnames is used instead of os.ReadDir because the latter stats every
+// entry, which fails on macOS /dev/fd ("bad file descriptor").
+func openFDCount() int {
+	for _, dir := range []string{"/proc/self/fd", "/dev/fd"} {
+		f, err := os.Open(dir)
+		if err != nil {
+			continue
+		}
+		names, err := f.Readdirnames(-1)
+		f.Close()
+		if err != nil {
+			continue
+		}
+		return len(names)
+	}
+	return -1
+}


### PR DESCRIPTION
# What problem are we solving?

In `weed/util/chunk_cache/chunk_cache_on_disk.go`, the `LoadOrCreateChunkCacheVolume` function opens the `.dat` cache data file and `.idx` index file before creating the LevelDB needle map. If opening the `.idx` file or creating the needle map fails, the function returns `nil, err`. Because the returned `ChunkCacheVolume` is `nil`, the already opened `.dat` backend and `.idx` file are never closed, causing file descriptor leaks.

# How are we solving the problem?

Added a deferred cleanup function in `LoadOrCreateChunkCacheVolume` that closes any already opened resources when the function returns an error:

```diff
+       var indexFile *os.File
+
+       defer func() {
+               if err != nil {
+                       if v.DataBackend != nil {
+                               v.DataBackend.Close()
+                       }
+                       if indexFile != nil {
+                               indexFile.Close()
+                       }
+               }
+       }()
```

This ensures that both the data backend and the index file are closed on every error return path, including:
1. The `.dat` file is closed when the `.idx` file cannot be opened.
2. Both files are closed when `NewLevelDbNeedleMap` fails.

# How is the PR tested?

- Added a new unit test `TestLoadOrCreateChunkCacheVolumeClosesFilesOnError` in `weed/util/chunk_cache/chunk_cache_on_disk_test.go`.
- The test pre-creates a `.dat` file and a `.ldb` file as a regular file (so LevelDB open fails), then calls `LoadOrCreateChunkCacheVolume` and verifies that the `.dat` and `.idx` files can be removed afterward, confirming they were closed.
- All existing tests in the `chunk_cache` package continue to pass.

# Checks
- [X] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [X] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [X] I have reviewed every line of code.
- [X] The PR is kept as minimum as possible. Large PRs would not be accepted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved on-disk cache initialization cleanup so file handles are reliably closed when setup fails, preventing resource leaks.

* **Tests**
  * Added coverage to verify cache setup cleans up file descriptors on error, including platform-specific checks to confirm temporary cache artifacts can be removed after failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->