### PR TITLE
s3api: preserve equals signs in tag values

### DIFF
--- a/weed/s3api/tags.go
+++ b/weed/s3api/tags.go
@@ -54,25 +54,19 @@ func parseTagsHeader(tags string) (map[string]string, error) {
 	parsedTags := make(map[string]string)
 	for _, v := range util.StringSplit(tags, "&") {
 		key, value, hasValue := strings.Cut(v, "=")
-		if hasValue {
-			// URL decode both key and value
-			decodedKey, err := url.QueryUnescape(key)
-			if err != nil {
-				return nil, fmt.Errorf("failed to decode tag key '%s': %w", key, err)
-			}
-			decodedValue, err := url.QueryUnescape(value)
-			if err != nil {
-				return nil, fmt.Errorf("failed to decode tag value '%s': %w", value, err)
-			}
-			parsedTags[decodedKey] = decodedValue
-		} else {
-			// URL decode key for empty value tags
-			decodedKey, err := url.QueryUnescape(key)
-			if err != nil {
-				return nil, fmt.Errorf("failed to decode tag key '%s': %w", key, err)
-			}
-			parsedTags[decodedKey] = ""
+		decodedKey, err := url.QueryUnescape(key)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode tag key '%s': %w", key, err)
 		}
+		if !hasValue {
+			parsedTags[decodedKey] = ""
+			continue
+		}
+		decodedValue, err := url.QueryUnescape(value)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode tag value '%s': %w", value, err)
+		}
+		parsedTags[decodedKey] = decodedValue
 	}
 	return parsedTags, nil
 }

--- a/weed/s3api/tags.go
+++ b/weed/s3api/tags.go
@@ -53,23 +53,23 @@ func FromTags(tags map[string]string) (t *Tagging) {
 func parseTagsHeader(tags string) (map[string]string, error) {
 	parsedTags := make(map[string]string)
 	for _, v := range util.StringSplit(tags, "&") {
-		tag := strings.Split(v, "=")
-		if len(tag) == 2 {
+		key, value, hasValue := strings.Cut(v, "=")
+		if hasValue {
 			// URL decode both key and value
-			decodedKey, err := url.QueryUnescape(tag[0])
+			decodedKey, err := url.QueryUnescape(key)
 			if err != nil {
-				return nil, fmt.Errorf("failed to decode tag key '%s': %w", tag[0], err)
+				return nil, fmt.Errorf("failed to decode tag key '%s': %w", key, err)
 			}
-			decodedValue, err := url.QueryUnescape(tag[1])
+			decodedValue, err := url.QueryUnescape(value)
 			if err != nil {
-				return nil, fmt.Errorf("failed to decode tag value '%s': %w", tag[1], err)
+				return nil, fmt.Errorf("failed to decode tag value '%s': %w", value, err)
 			}
 			parsedTags[decodedKey] = decodedValue
-		} else if len(tag) == 1 {
+		} else {
 			// URL decode key for empty value tags
-			decodedKey, err := url.QueryUnescape(tag[0])
+			decodedKey, err := url.QueryUnescape(key)
 			if err != nil {
-				return nil, fmt.Errorf("failed to decode tag key '%s': %w", tag[0], err)
+				return nil, fmt.Errorf("failed to decode tag key '%s': %w", key, err)
 			}
 			parsedTags[decodedKey] = ""
 		}

--- a/weed/s3api/tags_test.go
+++ b/weed/s3api/tags_test.go
@@ -71,6 +71,15 @@ func TestParseTagsHeader(t *testing.T) {
 			},
 			expectError: false,
 		},
+		{
+			name:  "unescaped equals in value",
+			input: "token=part1=part2&normal=test",
+			expected: map[string]string{
+				"token":  "part1=part2",
+				"normal": "test",
+			},
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What changed

Update `parseTagsHeader` to split tag pairs on the first `=` only.

Previously, a tag header segment like `token=part1=part2` was split into more than two fields and silently ignored. This keeps the key as `token` and preserves `part1=part2` as the value.

## Testing

Please run:

- `go test ./weed/s3api -run TestParseTagsHeader -count=1`
- `go test ./weed/s3api`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed S3 API tag parsing to correctly handle tag values that include equals signs (e.g., preserving everything after the first `=` in a tag value).
  * Improved decoding behavior for parsed tag keys and values, with clearer error reporting when decoding fails.
* **Tests**
  * Added coverage for unescaped equals inside tag values to ensure correct parsing with no error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->