### PR TITLE
fix: enforce XATTR_REPLACE semantics in setxattr

### DIFF
--- a/weed/mount/weedfs_xattr.go
+++ b/weed/mount/weedfs_xattr.go
@@ -129,6 +129,9 @@ func (wfs *WFS) SetXAttr(cancel <-chan struct{}, input *fuse.SetXAttrIn, attr st
 		}
 		fallthrough
 	case sys.XATTR_REPLACE:
+		if len(oldData) == 0 {
+    		return fuse.ENODATA
+    	}
 		fallthrough
 	default:
 		// data aliases the FUSE request's pooled input buffer, which is

--- a/weed/mount/weedfs_xattr.go
+++ b/weed/mount/weedfs_xattr.go
@@ -121,24 +121,22 @@ func (wfs *WFS) SetXAttr(cancel <-chan struct{}, input *fuse.SetXAttrIn, attr st
 	if entry.Extended == nil {
 		entry.Extended = make(map[string][]byte)
 	}
-	oldData, _ := entry.Extended[XATTR_PREFIX+attr]
+	_, exists := entry.Extended[XATTR_PREFIX+attr]
 	switch input.Flags {
 	case sys.XATTR_CREATE:
-		if len(oldData) > 0 {
-			break
+		if exists {
+			return fuse.Status(syscall.EEXIST)
 		}
-		fallthrough
 	case sys.XATTR_REPLACE:
-		if len(oldData) == 0 {
-    		return fuse.ENODATA
-    	}
-		fallthrough
-	default:
-		// data aliases the FUSE request's pooled input buffer, which is
-		// recycled once this handler returns. Copy before storing so a
-		// later request reusing the buffer cannot corrupt the value.
-		entry.Extended[XATTR_PREFIX+attr] = append([]byte(nil), data...)
+		if !exists {
+			return fuse.ENODATA
+		}
 	}
+
+	// data aliases the FUSE request's pooled input buffer, which is
+	// recycled once this handler returns. Copy before storing so a
+	// later request reusing the buffer cannot corrupt the value.
+	entry.Extended[XATTR_PREFIX+attr] = append([]byte(nil), data...)
 
 	if fh != nil {
 		fh.dirtyMetadata = true


### PR DESCRIPTION
In `weed/mount/weedfs_xattr.go`, the `XATTR_REPLACE` case unconditionally fell through to the default behavior. This caused the attribute to be created even if it did not exist, which violates the Linux `setxattr(2)` semantics where `XATTR_REPLACE` requires the attribute to already exist and should return `ENODATA` if it is missing.

This patch adds a check to return `fuse.ENODATA` when the existing attribute data is empty before falling through to the default set logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extended attribute replacement validation. The system now checks that an attribute exists before allowing replacement operations, and returns appropriate error codes when attempting to replace attributes that aren’t present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->