### PR TITLE
fix: Resolve inconsistent usage of error variables

### DIFF
--- a/weed/filer/mysql2/mysql2_store.go
+++ b/weed/filer/mysql2/mysql2_store.go
@@ -82,7 +82,7 @@ func (store *MysqlStore2) initialize(createTable, upsertQuery string, enableUpse
 	if dbErr != nil {
 		store.DB.Close()
 		store.DB = nil
-		return fmt.Errorf("can not connect to %s error:%v", adaptedSqlUrl, err)
+		return fmt.Errorf("can not connect to %s error:%v", adaptedSqlUrl, dbErr)
 	}
 
 	store.DB.SetMaxIdleConns(maxIdle)

--- a/weed/filer/mysql2/mysql2_store.go
+++ b/weed/filer/mysql2/mysql2_store.go
@@ -80,9 +80,11 @@ func (store *MysqlStore2) initialize(createTable, upsertQuery string, enableUpse
 	var dbErr error
 	store.DB, dbErr = sql.Open("mysql", sqlUrl)
 	if dbErr != nil {
-		store.DB.Close()
+		if store.DB != nil {
+			store.DB.Close()
+		}
 		store.DB = nil
-		return fmt.Errorf("can not connect to %s error:%v", adaptedSqlUrl, dbErr)
+		return fmt.Errorf("can not connect to %s error:%w", adaptedSqlUrl, dbErr)
 	}
 
 	store.DB.SetMaxIdleConns(maxIdle)


### PR DESCRIPTION
# What problem are we solving?
weed/filer/mysql2/mysql2_store.go
Inconsistent usage of error variables. Line 85 uses the variable err instead of dbErr, which may lead to inaccurate error messages.

# How are we solving the problem?
Replace err with dbErr as the returned error value.
return fmt.Errorf("can not connect to %s error:%v", adaptedSqlUrl, dbErr)
# How is the PR tested?

# Checks
- [ ] I have added unit tests if possible.
- [ y] I will add related wiki document changes and link to this PR after merging.
- [ y] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MySQL connection failure reporting by returning the actual connection error details when initialization fails. This replaces misleading error information so you can more easily diagnose database connectivity issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->