### PR TITLE
fix(storage): add nil check in MountVolume and remove dead code in vo…

### DIFF
--- a/weed/storage/store.go
+++ b/weed/storage/store.go
@@ -734,6 +734,9 @@ func (s *Store) MountVolume(i needle.VolumeId) error {
 		if found := location.LoadVolume(uint32(diskId), i, s.NeedleMapKind); found == true {
 			glog.V(0).Infof("mount volume %d", i)
 			v := s.findVolume(i)
+			if v == nil {
+				return fmt.Errorf("volume %d not found after LoadVolume", i)
+			}
 			v.diskId = uint32(diskId) // Set disk ID when mounting
 			s.NewVolumesChan <- &master_pb.VolumeShortInformationMessage{
 				Id:               uint32(v.Id),

--- a/weed/storage/volume_write.go
+++ b/weed/storage/volume_write.go
@@ -173,16 +173,15 @@ func (v *Volume) writeNeedle2(n *needle.Needle, checkCookie bool, fsync bool) (o
 
 	if !fsync {
 		return v.syncWrite(n, checkCookie)
-	} else {
-		asyncRequest := needle.NewAsyncRequest(n, true)
-		// using len(n.Data) here instead of n.Size before n.Size is populated in n.Append()
-		asyncRequest.ActualSize = needle.GetActualSize(Size(len(n.Data)), v.Version())
-
-		v.asyncRequestAppend(asyncRequest)
-		offset, _, isUnchanged, err = asyncRequest.WaitComplete()
-
-		return
 	}
+	asyncRequest := needle.NewAsyncRequest(n, true)
+	// using len(n.Data) here instead of n.Size before n.Size is populated in n.Append()
+	asyncRequest.ActualSize = needle.GetActualSize(Size(len(n.Data)), v.Version())
+
+	v.asyncRequestAppend(asyncRequest)
+	offset, _, isUnchanged, err = asyncRequest.WaitComplete()
+
+	return
 }
 
 func (v *Volume) doWriteRequest(n *needle.Needle, checkCookie bool) (offset uint64, size Size, isUnchanged bool, err error) {
@@ -251,19 +250,7 @@ func (v *Volume) syncDelete(n *needle.Needle) (Size, error) {
 
 func (v *Volume) deleteNeedle2(n *needle.Needle) (Size, error) {
 	// todo: delete info is always appended no fsync, it may need fsync in future
-	fsync := false
-
-	if !fsync {
-		return v.syncDelete(n)
-	} else {
-		asyncRequest := needle.NewAsyncRequest(n, false)
-		asyncRequest.ActualSize = needle.GetActualSize(0, v.Version())
-
-		v.asyncRequestAppend(asyncRequest)
-		_, size, _, err := asyncRequest.WaitComplete()
-
-		return Size(size), err
-	}
+	return v.syncDelete(n)
 }
 
 func (v *Volume) doDeleteRequest(n *needle.Needle) (Size, error) {


### PR DESCRIPTION
The user is showing me the SeaweedFS PR template and wants me to fill it out. Let me fill it in based on the changes we've made.

fix(storage): add nil check in MountVolume and remove dead code in volume_write

# What problem are we solving?

1. `MountVolume` in store.go calls `findVolume()` without a nil check,
   then dereferences `v.diskId`. If `findVolume` returns nil (e.g. the
   volume was destroyed between `LoadVolume` and `findVolume`), this panics.

2. `deleteNeedle2` in volume_write.go has a hardcoded `fsync = false`,
   making the async-append else branch permanently dead code.

3. `writeNeedle2` in volume_write.go has a redundant `else { ... }` block
   — the `if` branch already returns unconditionally.

# How are we solving the problem?

- store.go: Add a nil check after `findVolume()`, returning a descriptive
  error instead of panicking.

- volume_write.go: Simplify `deleteNeedle2` to directly call `syncDelete`,
  removing the dead `fsync` variable and unreachable else branch.

- volume_write.go: Flatten `writeNeedle2` by removing the unnecessary
  `else` wrapper, reducing indentation (Go idiom: avoid else when if
  returns).

All function signatures unchanged. Zero caller impact.

# How is the PR tested?

- Lint passes with zero errors on both files.
- Existing unit tests (`volume_vacuum_test`, `volume_vacuum_crash_safe_test`,
  `volume_read_test`) continue to call `deleteNeedle2` with the same
  signature — all test call sites are unaffected.
- The nil-check path in `MountVolume` is defensive; no known reproducer
  for the race condition, but the check cannot regress normal behaviour.

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a potential crash in volume mounting by adding validation to ensure volumes are properly accessible after loading.

* **Refactor**
  * Streamlined internal storage write and delete operations for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->