### PR TITLE
fix(s3api): reject duplicate trailer checksums

### DIFF
--- a/weed/s3api/chunked_reader_v4.go
+++ b/weed/s3api/chunked_reader_v4.go
@@ -534,7 +534,7 @@ func parseChunkChecksum(b *bufio.Reader) (ChecksumAlgorithm, []byte, error) {
 			value := bytes.TrimSpace(parts[1])
 			if alg, err := extractChecksumAlgorithm(key); err == nil {
 				if checksumAlgorithm != ChecksumAlgorithmNone {
-					glog.V(3).Infof("multiple checksum headers found in trailer, using last: %s", key)
+					return ChecksumAlgorithmNone, nil, errors.New("multiple checksum headers found in trailer")
 				}
 				checksumAlgorithm = alg
 				checksum = value

--- a/weed/s3api/chunked_reader_v4_test.go
+++ b/weed/s3api/chunked_reader_v4_test.go
@@ -1,6 +1,7 @@
 package s3api
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/base64"
 	"fmt"
@@ -37,6 +38,14 @@ func TestExtractChecksumAlgorithmIsCaseInsensitive(t *testing.T) {
 	}
 	if got != ChecksumAlgorithmCRC32 {
 		t.Fatalf("extractChecksumAlgorithm() = %v, want %v", got, ChecksumAlgorithmCRC32)
+	}
+}
+
+func TestParseChunkChecksumRejectsDuplicateChecksumHeaders(t *testing.T) {
+	trailer := "x-amz-checksum-crc32:first\r\nx-amz-checksum-crc32:second\r\n\r\n"
+	_, _, err := parseChunkChecksum(bufio.NewReader(strings.NewReader(trailer)))
+	if err == nil {
+		t.Fatal("parseChunkChecksum accepted duplicate checksum trailer headers")
 	}
 }
 


### PR DESCRIPTION
# What problem are we solving?

SigV4 streaming trailer parsing accepted multiple `x-amz-checksum-*` trailer headers and silently used the last value.

That makes checksum validation ambiguous when a request provides duplicate checksum trailers.

# How are we solving the problem?

Return an error as soon as a second checksum trailer header is found in `parseChunkChecksum`.

Unrelated trailer headers, such as `x-amz-trailer-signature`, are still ignored as before.

# How is the PR tested?

```sh
go test ./weed/s3api -run TestParseChunkChecksumRejectsDuplicateChecksumHeaders -count=1
go test ./weed/s3api -count=1
git diff --check
```

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation of checksum headers in chunked uploads. The system now properly rejects requests containing multiple checksum headers instead of silently accepting them, ensuring stricter compliance with protocol requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->