### PR TITLE
s3: keep a file promoted to a directory retrievable as an object

### DIFF
--- a/weed/filer/filer.go
+++ b/weed/filer/filer.go
@@ -616,5 +616,6 @@ func (f *Filer) IsDirectoryKeyObject(ctx context.Context, p util.FullPath) (bool
 	if entry == nil {
 		return false, nil
 	}
-	return entry.IsDirectory() && entry.Mime != "", nil
+	// Mirror filer_pb.Entry.IsDirectoryKeyObject so the cleaner keeps a promoted file's data.
+	return entry.IsDirectory() && (entry.Mime != "" || len(entry.GetChunks()) > 0 || len(entry.Content) > 0 || entry.IsInRemoteOnly()), nil
 }

--- a/weed/pb/filer_pb/filer_pb_helper.go
+++ b/weed/pb/filer_pb/filer_pb_helper.go
@@ -23,7 +23,10 @@ func (entry *Entry) IsInRemoteOnly() bool {
 }
 
 func (entry *Entry) IsDirectoryKeyObject() bool {
-	return entry.IsDirectory && entry.Attributes != nil && entry.Attributes.Mime != ""
+	// Also true for a file promoted to a directory by a child write, which keeps its
+	// chunks/content, or its remote entry when the file was tiered to remote storage.
+	return entry.IsDirectory &&
+		((entry.Attributes != nil && entry.Attributes.Mime != "") || len(entry.GetChunks()) > 0 || len(entry.GetContent()) > 0 || entry.IsInRemoteOnly())
 }
 
 func (entry *Entry) GetExpiryTime() (expiryTime int64) {

--- a/weed/pb/filer_pb/filer_pb_helper_test.go
+++ b/weed/pb/filer_pb/filer_pb_helper_test.go
@@ -1,0 +1,32 @@
+package filer_pb
+
+import (
+	"testing"
+)
+
+func TestIsDirectoryKeyObject(t *testing.T) {
+	chunk := []*FileChunk{{FileId: "1,01", Size: 75}}
+
+	cases := []struct {
+		name string
+		e    *Entry
+		want bool
+	}{
+		{"plain directory", &Entry{IsDirectory: true, Attributes: &FuseAttributes{}}, false},
+		{"directory marker with mime", &Entry{IsDirectory: true, Attributes: &FuseAttributes{Mime: "application/octet-stream"}}, true},
+		{"directory promoted from file keeps chunks", &Entry{IsDirectory: true, Attributes: &FuseAttributes{}, Chunks: chunk}, true},
+		{"directory promoted from small file keeps content", &Entry{IsDirectory: true, Attributes: &FuseAttributes{}, Content: []byte("abc")}, true},
+		{"directory promoted from remote-tiered file", &Entry{IsDirectory: true, Attributes: &FuseAttributes{}, RemoteEntry: &RemoteEntry{RemoteSize: 100}}, true},
+		{"directory with chunks and nil attributes", &Entry{IsDirectory: true, Chunks: chunk}, true},
+		{"regular file with chunks", &Entry{IsDirectory: false, Attributes: &FuseAttributes{}, Chunks: chunk}, false},
+		{"remote mount directory has no remote size", &Entry{IsDirectory: true, Attributes: &FuseAttributes{}, RemoteEntry: &RemoteEntry{StorageName: "s3"}}, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.e.IsDirectoryKeyObject(); got != c.want {
+				t.Errorf("IsDirectoryKeyObject() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -158,8 +158,8 @@ func (s3a *S3ApiServer) parseAndValidateRange(w http.ResponseWriter, r *http.Req
 		return 0, totalSize, false, nil
 	}
 
-	// S3 semantics: directories (without trailing "/") should return 404
-	if entry.IsDirectory {
+	// Empty directory: 404. A file promoted to a directory keeps its data and stays retrievable.
+	if entry.IsDirectory && totalSize == 0 {
 		s3err.WriteErrorResponse(w, r, s3err.ErrNoSuchKey)
 		return 0, 0, false, newStreamErrorWithResponse(fmt.Errorf("directory object %s/%s cannot be retrieved", bucket, object))
 	}

--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -2341,7 +2341,8 @@ func (s3a *S3ApiServer) HeadObjectHandler(w http.ResponseWriter, r *http.Request
 		// PyArrow may create 0-byte files when writing datasets, or the filer may have actual directories
 		if objectEntryForSSE.Attributes != nil {
 			isZeroByteFile := objectEntryForSSE.Attributes.FileSize == 0 && !objectEntryForSSE.IsDirectory
-			if objectEntryForSSE.IsDirectory {
+			// A directory with data (a promoted file) is retrievable; empty directories 404 for LIST fallback.
+			if objectEntryForSSE.IsDirectory && filer.FileSize(objectEntryForSSE) == 0 {
 				s3err.WriteErrorResponse(w, r, s3err.ErrNoSuchKey)
 				return
 			}


### PR DESCRIPTION
## Problem

Writing a child key under an existing object (`PUT foldernew/test` then `PUT foldernew/test/abc1`) promotes the file to a directory. The promoted entry keeps its chunks/content, but the S3 gateway handled it inconsistently:

- full `GET` served the object, but ranged `GET` and `HEAD` returned 404
- `LIST` hid it whenever its `Mime` was empty
- the empty-folder cleaner could later delete it once its children were gone, permanently losing the data

The root cause is that "a directory that is also an S3 object" was recognized only by a non-empty `Mime`. The filer strips the default `application/octet-stream` content-type to empty, so a promoted file (especially one created via the filer API) often has no `Mime` and was not recognized as the object it still is.

## Changes

- `filer`: `IsDirectoryKeyObject` (both the `filer_pb.Entry` and the filer-level helper) now also treats a directory carrying chunks/content as a key object, not only one with a `Mime`. This restores LIST visibility, delete-demotion, and lifecycle handling, and stops the empty-folder cleaner from reclaiming the object.
- `s3`: ranged `GET` rejects only zero-size directories, so a promoted object streams range requests.
- `s3`: `HEAD` 404s a directory only when it has no data, so the object is retrievable while empty/implicit directories still fall back to LIST (preserves the s3fs/PyArrow behavior).

## Behavior after

A path that is both an object and a prefix now coexists like S3's flat keyspace: the object lists, HEADs, and GETs (full and ranged), and `DELETE` of the object reclaims only its chunks while keeping the children. The object's data is no longer destroyed by background cleanup. Chunks stay in the canonical `Chunks` field, so fsck/replication continue to see them.

## Notes

- The filer HTTP API still presents the path as a directory listing — that is the hierarchical filesystem surface and is left as-is.
- `LIST` with a delimiter rolls the key into its common prefix rather than also emitting it as a key; this is pre-existing directory-object behavior, not changed here.

Fixes #10063


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data loss issue for directories with content during cleanup operations.
  * Improved S3 API to properly retrieve directories containing data, enabling access to promoted file directories.

* **Tests**
  * Added test coverage for directory content detection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->