### PR TITLE
s3: skip 503 when client disconnects during remote cache wait

### DIFF
--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -1011,6 +1011,11 @@ func (s3a *S3ApiServer) streamFromVolumeServers(w http.ResponseWriter, r *http.R
 				}
 				return newStreamErrorWithResponse(cacheErr)
 			} else {
+				// Client disconnected during the cache wait: report cancellation, not 503,
+				// so we don't write to a closed connection.
+				if ctxErr := r.Context().Err(); ctxErr != nil {
+					return ctxErr
+				}
 				// Cache not ready yet; return 503 with Retry-After for client backoff
 				glog.V(1).Infof("streamFromVolumeServers: remote object %s/%s not cached yet, returning 503 for retry", bucket, object)
 				w.Header().Set("Retry-After", "2")


### PR DESCRIPTION
Follow-up to #10010.

In `streamFromVolumeServers`, when the remote-only cache poll returns without chunks (cache not ready yet), the handler writes `503 Service Unavailable` + `Retry-After`. That branch dropped the client-disconnection check: if the client went away during the poll wait, the 503 is written to a closed connection, producing broken-pipe / connection-reset log noise and pointless work.

Restore the `r.Context().Err()` check before writing the 503. A disconnected client surfaces as `context.Canceled`, which the caller in `GetObjectHandler` already treats as a silent client-gone case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of client disconnections during cache operations by detecting request cancellation and avoiding unnecessary error responses on closed connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->