### PR TITLE
fix(worker): fix goroutine deadlock when worker Stop()

### DIFF
--- a/weed/worker/worker.go
+++ b/weed/worker/worker.go
@@ -192,7 +192,7 @@ func NewWorker(config *types.WorkerConfig) (*Worker, error) {
 		config:         config,
 		registry:       registry,
 		taskLogHandler: taskLogHandler,
-		cmds:           make(chan workerCommand),
+		cmds:           make(chan workerCommand, 16),
 	}
 
 	glog.V(1).Infof("Worker created with %d registered task types", len(registry.GetAll()))


### PR DESCRIPTION
## Problem
The w.cmds channel is unbuffered. After Stop() sends ActionStop to managerLoop, managerLoop exits and stops consuming cmds.
Background executeTask goroutine will block forever when sending ActionIncTaskFail / ActionIncTaskComplete, and w.wg.Wait() hangs infinitely, leading to goroutine deadlock.
File location: weed/worker/worker.go line 195, 665, 679

## Solution
Modify line 195, change unbuffered channel to buffered channel with capacity 16:
cmds: make(chan workerCommand, 16)
Buffered channel can hold task finish signals without blocking send operations during Stop().

## Checklist
- Minimal one-line modification, no breaking changes
- Passed local go fmt & go vet static check
- Resolved the infinite blocking deadlock scenario

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved command queue handling by buffering worker commands, allowing more concurrent command scheduling and smoother responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->