### PR TITLE
volume: overlap the local needle write with the replica fan-out

### DIFF
--- a/weed/topology/store_replicate.go
+++ b/weed/topology/store_replicate.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
@@ -60,106 +61,142 @@ func ReplicatedWrite(ctx context.Context, masterFn operation.GetMasterFn, grpcDi
 		}(time.Now())
 	}
 
-	if s.GetVolume(volumeId) != nil {
-		start := time.Now()
+	vol := s.GetVolume(volumeId)
 
-		inFlightGauge := stats.VolumeServerInFlightRequestsGauge.WithLabelValues(stats.WriteToLocalDisk)
-		inFlightGauge.Inc()
-		defer inFlightGauge.Dec()
-
-		isUnchanged, err = s.WriteVolumeNeedle(volumeId, n, true, fsync)
-		stats.VolumeServerRequestHistogram.WithLabelValues(stats.WriteToLocalDisk).Observe(time.Since(start).Seconds())
-		if err != nil {
-			stats.VolumeServerHandlerCounter.WithLabelValues(stats.ErrorWriteToLocalDisk).Inc()
-			err = fmt.Errorf("failed to write to local disk: %w", err)
-			glog.V(0).Infoln(err)
-			return
+	// Capture every needle field the replica fan-out reads before the concurrent
+	// local write can mutate the shared needle: WriteVolumeNeedle stamps the
+	// volume TTL and updates needle flags. After this point the fan-out touches
+	// only these locals plus n.Data (read-only on both sides), so the two writes
+	// can run concurrently without racing.
+	replicaTtl := n.Ttl
+	if vol != nil && replicaTtl == needle.EMPTY_TTL && vol.Ttl != needle.EMPTY_TTL {
+		replicaTtl = vol.Ttl
+	}
+	replicaLastModified := n.LastModified
+	replicaIsChunked := n.IsChunkedManifest()
+	replicaIsCompressed := n.IsCompressed()
+	replicaName := string(n.Name)
+	replicaMime := string(n.Mime)
+	replicaData := n.Data
+	replicaPairMap := make(map[string]string)
+	if n.HasPairs() {
+		tmpMap := make(map[string]string)
+		if pe := json.Unmarshal(n.Pairs, &tmpMap); pe != nil {
+			stats.VolumeServerHandlerCounter.WithLabelValues(stats.ErrorUnmarshalPairs).Inc()
+			glog.V(0).Infoln("Unmarshal pairs error:", pe)
+		}
+		for k, v := range tmpMap {
+			replicaPairMap[needle.PairNamePrefix+k] = v
 		}
 	}
 
 	// Observe replication targets histogram for all operations (including zero)
 	stats.VolumeServerReplicationTargets.Observe(float64(replicaCount))
 
-	if replicaCount > 0 { //send to other replica locations
-		start := time.Now()
+	// "buffered streaming": the local disk write and the replica fan-out run
+	// concurrently against the already-buffered needle, so write latency is
+	// max(local, replicas) instead of their sum. The client ack waits for both.
+	var wg sync.WaitGroup
+	var localErr, remoteErr error
 
-		inFlightGauge := stats.VolumeServerInFlightRequestsGauge.WithLabelValues(stats.WriteToReplicas)
-		inFlightGauge.Inc()
-		defer inFlightGauge.Dec()
+	if vol != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			start := time.Now()
+			inFlightGauge := stats.VolumeServerInFlightRequestsGauge.WithLabelValues(stats.WriteToLocalDisk)
+			inFlightGauge.Inc()
+			defer inFlightGauge.Dec()
 
-		err = DistributedOperation(ctx, remoteLocations, func(ctx context.Context, location operation.Location) error {
-			u := url.URL{
-				Scheme: "http",
-				Host:   location.Url,
-				Path:   r.URL.Path,
+			isUnchanged, localErr = s.WriteVolumeNeedle(volumeId, n, true, fsync)
+			stats.VolumeServerRequestHistogram.WithLabelValues(stats.WriteToLocalDisk).Observe(time.Since(start).Seconds())
+			if localErr != nil {
+				stats.VolumeServerHandlerCounter.WithLabelValues(stats.ErrorWriteToLocalDisk).Inc()
+				localErr = fmt.Errorf("failed to write to local disk: %w", localErr)
+				glog.V(0).Infoln(localErr)
 			}
-			q := url.Values{
-				"type": {"replicate"},
-				"ttl":  {n.Ttl.String()},
-			}
-			if n.LastModified > 0 {
-				q.Set("ts", strconv.FormatUint(n.LastModified, 10))
-			}
-			if n.IsChunkedManifest() {
-				q.Set("cm", "true")
-			}
-			u.RawQuery = q.Encode()
-
-			pairMap := make(map[string]string)
-			if n.HasPairs() {
-				tmpMap := make(map[string]string)
-				err := json.Unmarshal(n.Pairs, &tmpMap)
-				if err != nil {
-					stats.VolumeServerHandlerCounter.WithLabelValues(stats.ErrorUnmarshalPairs).Inc()
-					glog.V(0).Infoln("Unmarshal pairs error:", err)
-				}
-				for k, v := range tmpMap {
-					pairMap[needle.PairNamePrefix+k] = v
-				}
-			}
-			bytesBuffer := buffer_pool.SyncPoolGetBuffer()
-			defer buffer_pool.SyncPoolPutBuffer(bytesBuffer)
-
-			// volume server do not know about encryption
-			// TODO optimize here to compress data only once
-			uploadOption := &operation.UploadOption{
-				UploadUrl:         u.String(),
-				Filename:          string(n.Name),
-				Cipher:            false,
-				IsInputCompressed: n.IsCompressed(),
-				IsReplication:     true,
-				MimeType:          string(n.Mime),
-				PairMap:           pairMap,
-				Jwt:               jwt,
-				Md5:               contentMd5,
-				BytesBuffer:       bytesBuffer,
-				MaxAttempts:       1, // fail fast on a dead replica; the client write retries
-			}
-
-			uploader, err := operation.NewUploader()
-			if err != nil {
-				glog.Errorf("replication-UploadData, err:%v, url:%s", err, u.String())
-				return err
-			}
-			_, err = uploader.UploadData(ctx, n.Data, uploadOption)
-			if err != nil {
-				glog.Errorf("replication-UploadData, err:%v, url:%s", err, u.String())
-			}
-			return err
-		})
-		stats.VolumeServerRequestHistogram.WithLabelValues(stats.WriteToReplicas).Observe(time.Since(start).Seconds())
-		if err != nil {
-			stats.VolumeServerHandlerCounter.WithLabelValues(stats.ErrorWriteToReplicas).Inc()
-			stats.VolumeServerReplicationCounter.WithLabelValues(stats.ReplicationOpWrite, stats.ReplicationFailure).Inc()
-			reason := classifyReplicationError(err)
-			stats.VolumeServerReplicationFailures.WithLabelValues(stats.ReplicationOpWrite, reason).Inc()
-			err = fmt.Errorf("failed to write to replicas for volume %d: %v", volumeId, err)
-			glog.V(0).Infoln(err)
-			return false, err
-		}
-		stats.VolumeServerReplicationCounter.WithLabelValues(stats.ReplicationOpWrite, stats.ReplicationSuccess).Inc()
+		}()
 	}
-	return
+
+	if replicaCount > 0 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			start := time.Now()
+			inFlightGauge := stats.VolumeServerInFlightRequestsGauge.WithLabelValues(stats.WriteToReplicas)
+			inFlightGauge.Inc()
+			defer inFlightGauge.Dec()
+
+			remoteErr = DistributedOperation(ctx, remoteLocations, func(ctx context.Context, location operation.Location) error {
+				u := url.URL{
+					Scheme: "http",
+					Host:   location.Url,
+					Path:   r.URL.Path,
+				}
+				q := url.Values{
+					"type": {"replicate"},
+					"ttl":  {replicaTtl.String()},
+				}
+				if replicaLastModified > 0 {
+					q.Set("ts", strconv.FormatUint(replicaLastModified, 10))
+				}
+				if replicaIsChunked {
+					q.Set("cm", "true")
+				}
+				u.RawQuery = q.Encode()
+
+				bytesBuffer := buffer_pool.SyncPoolGetBuffer()
+				defer buffer_pool.SyncPoolPutBuffer(bytesBuffer)
+
+				// volume server do not know about encryption
+				uploadOption := &operation.UploadOption{
+					UploadUrl:         u.String(),
+					Filename:          replicaName,
+					Cipher:            false,
+					IsInputCompressed: replicaIsCompressed,
+					IsReplication:     true,
+					MimeType:          replicaMime,
+					PairMap:           replicaPairMap,
+					Jwt:               jwt,
+					Md5:               contentMd5,
+					BytesBuffer:       bytesBuffer,
+					MaxAttempts:       1, // fail fast on a dead replica; the client write retries
+				}
+
+				uploader, uploaderErr := operation.NewUploader()
+				if uploaderErr != nil {
+					glog.Errorf("replication-UploadData, err:%v, url:%s", uploaderErr, u.String())
+					return uploaderErr
+				}
+				_, uploadErr := uploader.UploadData(ctx, replicaData, uploadOption)
+				if uploadErr != nil {
+					glog.Errorf("replication-UploadData, err:%v, url:%s", uploadErr, u.String())
+				}
+				return uploadErr
+			})
+			stats.VolumeServerRequestHistogram.WithLabelValues(stats.WriteToReplicas).Observe(time.Since(start).Seconds())
+			if remoteErr != nil {
+				stats.VolumeServerHandlerCounter.WithLabelValues(stats.ErrorWriteToReplicas).Inc()
+				stats.VolumeServerReplicationCounter.WithLabelValues(stats.ReplicationOpWrite, stats.ReplicationFailure).Inc()
+				reason := classifyReplicationError(remoteErr)
+				stats.VolumeServerReplicationFailures.WithLabelValues(stats.ReplicationOpWrite, reason).Inc()
+				remoteErr = fmt.Errorf("failed to write to replicas for volume %d: %v", volumeId, remoteErr)
+				glog.V(0).Infoln(remoteErr)
+			} else {
+				stats.VolumeServerReplicationCounter.WithLabelValues(stats.ReplicationOpWrite, stats.ReplicationSuccess).Inc()
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	if localErr != nil {
+		return false, localErr
+	}
+	if remoteErr != nil {
+		return false, remoteErr
+	}
+	return isUnchanged, nil
 }
 
 // ReplicatedDelete deletes a needle from the local volume and sends delete

--- a/weed/topology/store_replicate.go
+++ b/weed/topology/store_replicate.go
@@ -98,6 +98,7 @@ func ReplicatedWrite(ctx context.Context, masterFn operation.GetMasterFn, grpcDi
 	// max(local, replicas) instead of their sum. The client ack waits for both.
 	var wg sync.WaitGroup
 	var localErr, remoteErr error
+	var localIsUnchanged bool
 
 	if vol != nil {
 		wg.Add(1)
@@ -108,7 +109,7 @@ func ReplicatedWrite(ctx context.Context, masterFn operation.GetMasterFn, grpcDi
 			inFlightGauge.Inc()
 			defer inFlightGauge.Dec()
 
-			isUnchanged, localErr = s.WriteVolumeNeedle(volumeId, n, true, fsync)
+			localIsUnchanged, localErr = s.WriteVolumeNeedle(volumeId, n, true, fsync)
 			stats.VolumeServerRequestHistogram.WithLabelValues(stats.WriteToLocalDisk).Observe(time.Since(start).Seconds())
 			if localErr != nil {
 				stats.VolumeServerHandlerCounter.WithLabelValues(stats.ErrorWriteToLocalDisk).Inc()
@@ -196,7 +197,7 @@ func ReplicatedWrite(ctx context.Context, masterFn operation.GetMasterFn, grpcDi
 	if remoteErr != nil {
 		return false, remoteErr
 	}
-	return isUnchanged, nil
+	return localIsUnchanged, nil
 }
 
 // ReplicatedDelete deletes a needle from the local volume and sends delete

--- a/weed/topology/store_replicate.go
+++ b/weed/topology/store_replicate.go
@@ -63,11 +63,9 @@ func ReplicatedWrite(ctx context.Context, masterFn operation.GetMasterFn, grpcDi
 
 	vol := s.GetVolume(volumeId)
 
-	// Capture every needle field the replica fan-out reads before the concurrent
-	// local write can mutate the shared needle: WriteVolumeNeedle stamps the
-	// volume TTL and updates needle flags. After this point the fan-out touches
-	// only these locals plus n.Data (read-only on both sides), so the two writes
-	// can run concurrently without racing.
+	// Snapshot the fields the fan-out reads before the concurrent local write
+	// mutates the needle (it stamps the volume TTL and flags), so the two cannot
+	// race; the fan-out then touches only these locals plus read-only n.Data.
 	replicaTtl := n.Ttl
 	if vol != nil && replicaTtl == needle.EMPTY_TTL && vol.Ttl != needle.EMPTY_TTL {
 		replicaTtl = vol.Ttl
@@ -93,9 +91,8 @@ func ReplicatedWrite(ctx context.Context, masterFn operation.GetMasterFn, grpcDi
 	// Observe replication targets histogram for all operations (including zero)
 	stats.VolumeServerReplicationTargets.Observe(float64(replicaCount))
 
-	// "buffered streaming": the local disk write and the replica fan-out run
-	// concurrently against the already-buffered needle, so write latency is
-	// max(local, replicas) instead of their sum. The client ack waits for both.
+	// Run the local disk write and the replica fan-out concurrently against the
+	// buffered needle (latency max(local, replicas), not the sum); ack after both.
 	var wg sync.WaitGroup
 	var localErr, remoteErr error
 	var localIsUnchanged bool


### PR DESCRIPTION
**Draft / RFC — needs validation on a real multi-host cluster before merge.**

## What

`ReplicatedWrite` did the local disk write and then the replica fan-out
serially, so a replicated write cost `local + replicas`. The needle is already
fully buffered in memory, so this runs the local write and the replica fan-out
concurrently and acks the client only after both complete.

To keep it race-free, the fields the fan-out reads (TTL, last-modified, flags,
name, mime, pairs, data) are snapshotted up front, because the local
`WriteVolumeNeedle` stamps the volume TTL and mutates needle flags. After that
the fan-out touches only locals plus `n.Data` (read-only on both sides).

## Why

Where the local disk and the replica network are separate resources, write
latency drops from `local + replicas` to `max(local, replicas)`.

## Correctness

- Validated under `-race`: replicas byte-identical for 1 KB–20 MB writes, no
  data races in the volume write path.
- Replica-down still fails the write (unchanged semantics).
- `go vet` clean; topology/operation/needle unit tests pass.

## The honest caveat (why this is a draft)

On a single machine where all volume servers share one disk, overlapping the
two writes **doubles the simultaneous disk I/O and regresses** — a loopback A/B
(replication=001) showed:

| workload | serial | overlap |
|---|---|---|
| 4 MB × 1 | 232 MB/s | 249 |
| 4 MB × 16 | 700 | 340 |
| 32 MB × 1 | 323 | 152 |
| 32 MB × 16 | 422 | 65 (p50 5.8 s) |

That contention is a single-disk artifact. The intended win (`max` vs `sum`)
only appears when replicas sit on separate disks/hosts with real network
latency, which a loopback benchmark structurally can't show. Holding as a draft
until someone measures it on a distributed cluster; if it doesn't pay off there
either, this should be dropped.

One behavior change worth a look: the local write no longer strictly precedes
replication, so a local failure can leave a (valid, retry-superseded) needle on
a replica. The client ack still waits for both, so read-after-write is
preserved.


