### PR TITLE
iceberg: detect table-exists through the wrapped manager error

### DIFF
--- a/weed/s3api/iceberg/handlers_table.go
+++ b/weed/s3api/iceberg/handlers_table.go
@@ -263,7 +263,8 @@ func (s *Server) handleCreateTable(w http.ResponseWriter, r *http.Request) {
 	})
 
 	if err != nil {
-		if tableErr, ok := err.(*s3tables.S3TablesError); ok && tableErr.Type == s3tables.ErrCodeTableAlreadyExists {
+		var tableErr *s3tables.S3TablesError
+		if errors.As(err, &tableErr) && tableErr.Type == s3tables.ErrCodeTableAlreadyExists {
 			getReq := &s3tables.GetTableRequest{
 				TableBucketARN: bucketARN,
 				Namespace:      namespace,


### PR DESCRIPTION
handleCreateTable classified the CreateTable error with a type assertion (`err.(*s3tables.S3TablesError)`), which can't see through WithFilerClient's "all filers failed, last error: %w" wrap. So when a concurrent create slips past the pre-check and the manager returns TableAlreadyExists, the assertion fails and the request falls through instead of returning the existing table. Switch to errors.As, matching every other handler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table creation handling so “table already exists” errors are recognized even when wrapped, reducing false failures.
  * Existing table lookup behavior remains unchanged, preserving the current response when a table is already present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->