### PR TITLE
filer: optional client-side replication fan-out

### DIFF
--- a/weed/server/filer_server_handlers_write.go
+++ b/weed/server/filer_server_handlers_write.go
@@ -77,6 +77,53 @@ func (fs *FilerServer) assignNewFileInfo(ctx context.Context, so *operation.Stor
 	return
 }
 
+// assignNewFileInfoReplicas assigns a file id and returns one upload URL per
+// replica holder (the assigned volume plus assignResult.Replicas). Each URL
+// carries type=replicate so the receiving volume writes locally and does not
+// fan out again — the filer performs the replication itself by uploading to
+// every holder. Used by the client-side replication write path.
+func (fs *FilerServer) assignNewFileInfoReplicas(ctx context.Context, so *operation.StorageOption, expectedDataSize uint64) (fileId string, urls []string, auth security.EncodedJwt, err error) {
+
+	stats.FilerHandlerCounter.WithLabelValues(stats.ChunkAssign).Inc()
+	start := time.Now()
+	defer func() {
+		stats.FilerRequestHistogram.WithLabelValues(stats.ChunkAssign).Observe(time.Since(start).Seconds())
+	}()
+
+	ar, altRequest := so.ToAssignRequests(1)
+	ar.ExpectedDataSize = expectedDataSize
+	if altRequest != nil {
+		altRequest.ExpectedDataSize = expectedDataSize
+	}
+
+	assignResult, ae := operation.Assign(context.WithoutCancel(ctx), fs.filer.GetMaster, fs.grpcDialOption, ar, altRequest)
+	if ae != nil {
+		glog.ErrorfCtx(ctx, "failing to assign a file id: %v", ae)
+		err = ae
+		return
+	}
+	fileId = assignResult.Fid
+	auth = assignResult.Auth
+
+	seen := make(map[string]bool)
+	addHost := func(host string) {
+		if host == "" || seen[host] {
+			return
+		}
+		seen[host] = true
+		u := "http://" + host + "/" + assignResult.Fid + "?type=replicate"
+		if so.Fsync {
+			u += "&fsync=true"
+		}
+		urls = append(urls, u)
+	}
+	addHost(assignResult.Url)
+	for _, repl := range assignResult.Replicas {
+		addHost(repl.Url)
+	}
+	return
+}
+
 func (fs *FilerServer) PostHandler(w http.ResponseWriter, r *http.Request, contentLength int64) {
 	ctx := r.Context()
 

--- a/weed/server/filer_server_handlers_write_upload.go
+++ b/weed/server/filer_server_handlers_write_upload.go
@@ -9,6 +9,7 @@ import (
 	"hash"
 	"io"
 	"net/http"
+	"os"
 	"strconv"
 	"sync"
 	"time"
@@ -27,6 +28,49 @@ var bufPool = sync.Pool{
 	New: func() interface{} {
 		return new(bytes.Buffer)
 	},
+}
+
+// clientSideReplication reports whether the filer should replicate a chunk by
+// uploading it to every replica holder in parallel (type=replicate), instead of
+// uploading to one volume and letting that volume relay to the others. Opt-in
+// via WEED_FILER_CLIENT_SIDE_REPLICATION=true.
+func clientSideReplication() bool {
+	return os.Getenv("WEED_FILER_CLIENT_SIDE_REPLICATION") == "true"
+}
+
+// doUploadToReplicas uploads the same chunk bytes to every replica holder
+// concurrently. It returns the first successful result; the chunk is acked only
+// if every holder succeeds (matching the all-or-nothing semantics of the
+// server-driven replication path).
+func (fs *FilerServer) doUploadToReplicas(ctx context.Context, urls []string, data []byte, fileName, contentType string, auth security.EncodedJwt, contentMd5 string) (*operation.UploadResult, error) {
+	type uploadOutcome struct {
+		result *operation.UploadResult
+		err    error
+	}
+	outcomes := make(chan uploadOutcome, len(urls))
+	for _, u := range urls {
+		go func(uploadUrl string) {
+			result, err, _ := fs.doUpload(ctx, uploadUrl, util.NewBytesReader(data), fileName, contentType, nil, auth, contentMd5)
+			outcomes <- uploadOutcome{result, err}
+		}(u)
+	}
+
+	var firstResult *operation.UploadResult
+	var firstErr error
+	for range urls {
+		o := <-outcomes
+		if o.err != nil {
+			if firstErr == nil {
+				firstErr = o.err
+			}
+		} else if firstResult == nil {
+			firstResult = o.result
+		}
+	}
+	if firstErr != nil {
+		return nil, firstErr
+	}
+	return firstResult, nil
 }
 
 func (fs *FilerServer) uploadRequestToChunks(ctx context.Context, w http.ResponseWriter, r *http.Request, reader io.Reader, chunkSize int32, fileName, contentType string, contentLength int64, so *operation.StorageOption) (fileChunks []*filer_pb.FileChunk, md5Hash hash.Hash, chunkOffset int64, uploadErr error, smallContent []byte) {
@@ -206,9 +250,16 @@ func (fs *FilerServer) dataToChunkWithSSE(ctx context.Context, r *http.Request, 
 	var uploadResult *operation.UploadResult
 	var failedFileChunks []*filer_pb.FileChunk
 
+	useClientReplication := clientSideReplication()
+
 	err := util.Retry("filerDataToChunk", func() error {
 		// assign one file id for one chunk
-		fileId, urlLocation, auth, uploadErr = fs.assignNewFileInfo(ctx, so, uint64(len(data)))
+		var replicaUrls []string
+		if useClientReplication {
+			fileId, replicaUrls, auth, uploadErr = fs.assignNewFileInfoReplicas(ctx, so, uint64(len(data)))
+		} else {
+			fileId, urlLocation, auth, uploadErr = fs.assignNewFileInfo(ctx, so, uint64(len(data)))
+		}
 		if uploadErr != nil {
 			glog.V(4).InfofCtx(ctx, "retry later due to assign error: %v", uploadErr)
 			stats.FilerHandlerCounter.WithLabelValues(stats.ChunkAssignRetry).Inc()
@@ -217,7 +268,15 @@ func (fs *FilerServer) dataToChunkWithSSE(ctx context.Context, r *http.Request, 
 		chunkMd5 := md5.Sum(data)
 		chunkMd5B64 := base64.StdEncoding.EncodeToString(chunkMd5[:])
 		// upload the chunk to the volume server
-		uploadResult, uploadErr, _ = fs.doUpload(ctx, urlLocation, dataReader, fileName, contentType, nil, auth, chunkMd5B64)
+		if useClientReplication && len(replicaUrls) > 1 {
+			// filer replicates by uploading to every holder in parallel
+			uploadResult, uploadErr = fs.doUploadToReplicas(ctx, replicaUrls, data, fileName, contentType, auth, chunkMd5B64)
+		} else if useClientReplication {
+			// single holder (no replication): upload directly
+			uploadResult, uploadErr, _ = fs.doUpload(ctx, replicaUrls[0], util.NewBytesReader(data), fileName, contentType, nil, auth, chunkMd5B64)
+		} else {
+			uploadResult, uploadErr, _ = fs.doUpload(ctx, urlLocation, dataReader, fileName, contentType, nil, auth, chunkMd5B64)
+		}
 		if uploadErr != nil {
 			glog.V(4).InfofCtx(ctx, "retry later due to upload error: %v", uploadErr)
 			stats.FilerHandlerCounter.WithLabelValues(stats.ChunkDoUploadRetry).Inc()


### PR DESCRIPTION
**Draft / RFC — opt-in (`WEED_FILER_CLIENT_SIDE_REPLICATION=true`), default off. Performance needs validation on a real multi-host cluster.**

## What

Today the filer uploads a chunk to **one** volume server, and that volume server relays the copies to the other replica holders (server-driven replication). This adds a `type=replicate` fan-out path on the filer: it uploads the chunk to **every** holder in parallel and writes each with `type=replicate`, so no volume relays.

The assign result already lists every holder (`AssignResult.Replicas`), so the filer addresses them directly. Gated behind `WEED_FILER_CLIENT_SIDE_REPLICATION`; unset keeps the existing server-driven path byte-for-byte.

- `assignNewFileInfoReplicas` — assign + one `?type=replicate` URL per holder.
- `doUploadToReplicas` — upload the chunk to all holders concurrently; ack only if all succeed (all-or-nothing, matching server-driven).
- `dataToChunkWithSSE` branches on the flag.

## Why it might help

It removes the primary volume server's **receive-then-resend relay** and writes all copies from the source at once. Under concurrent load that relay is a per-primary bottleneck, so spreading writes evenly across holders should help most there.

## Correctness — validated

On a 3-volume `replication=001` cluster (writes via the S3 gateway):
- Each chunk lands on 2 of 3 volumes (file counts confirm the fan-out), reads return correct data.
- **Killed one of three volumes → all objects still readable** (every chunk survived on another holder). Replication is real and durable.

## Performance — inconclusive on a single machine

A/B (flag off vs on), 3 volumes + filer + s3 + load generator all co-located on one RAM disk, ran twice:

| 32 MB ×16 | run 1 | run 2 |
|---|---|---|
| server-driven | 387 MB/s | 404 |
| client-fanout | 427 (**+10%**) | 250 (**−38%**) |

The two runs **disagree by ~50 points** — the result is noise-dominated, because every volume shares one box's storage/CPU and the A/B halves run sequentially (load drifts between them). I can't get a reliable read here.

The intended win (relay elimination, even load spread, parallel-from-source) only shows cleanly when holders are on **separate hosts/disks** — and it comes with a real tradeoff: the filer now sends the data N× from its own NIC, so a filer-uplink-constrained deployment could regress. Holding as a draft until measured on a distributed cluster.


