### PR TITLE
fix(filer): apply -filer.disk default to metadata log assigns

### DIFF
--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -1305,6 +1305,12 @@ func runMini(cmd *Command, args []string) bool {
 	// on the default 10s waiting for background subscription streams.
 	miniFilerOptions.gracefulStopTimeout = 1 * time.Second
 
+	// Mirror weed server: fall back to -volume.disk so the filer's default
+	// disk type still tags metadata-log assigns when only -volume.disk is set.
+	if *miniFilerOptions.diskType == "" && *miniOptions.v.diskType != "" {
+		miniFilerOptions.diskType = miniOptions.v.diskType
+	}
+
 	// Start all services with proper dependency coordination
 	// This channel will be closed when all services are fully ready
 	fmt.Println("\n  Starting SeaweedFS Mini ...")

--- a/weed/filer/filer.go
+++ b/weed/filer/filer.go
@@ -52,6 +52,7 @@ type Filer struct {
 	LocalMetaLogBuffer      *log_buffer.LogBuffer
 	metaLogCollection       string
 	metaLogReplication      string
+	DefaultDiskType         string
 	MetaAggregator          *MetaAggregator
 	Signature               int32
 	FilerConf               *FilerConf

--- a/weed/filer/filer_notify_append.go
+++ b/weed/filer/filer_notify_append.go
@@ -48,14 +48,25 @@ func (f *Filer) appendToFile(targetFile string, data []byte) error {
 	return err
 }
 
+// resolveMetadataLogAssignDiskType returns the disk type and matched path rule for
+// metadata log volume assigns. Disk type uses the rule when set, otherwise
+// Filer.DefaultDiskType (from -filer.disk), mirroring resolveAssignStorageOption.
+func (f *Filer) resolveMetadataLogAssignDiskType(targetFile string) (string, *filer_pb.FilerConf_PathConf) {
+	if f.FilerConf == nil {
+		return f.DefaultDiskType, &filer_pb.FilerConf_PathConf{}
+	}
+	rule := f.FilerConf.MatchStorageRule(targetFile)
+	return util.Nvl(rule.DiskType, f.DefaultDiskType), rule
+}
+
 func (f *Filer) assignAndUpload(targetFile string, data []byte) (*operation.AssignResult, *operation.UploadResult, error) {
 	// assign a volume location
-	rule := f.FilerConf.MatchStorageRule(targetFile)
+	diskType, rule := f.resolveMetadataLogAssignDiskType(targetFile)
 	assignRequest := &operation.VolumeAssignRequest{
 		Count:               1,
 		Collection:          util.Nvl(f.metaLogCollection, rule.Collection),
 		Replication:         util.Nvl(f.metaLogReplication, rule.Replication),
-		DiskType:            rule.DiskType,
+		DiskType:            diskType,
 		WritableVolumeCount: rule.VolumeGrowthCount,
 		ExpectedDataSize:    uint64(len(data)),
 	}

--- a/weed/filer/filer_notify_append_test.go
+++ b/weed/filer/filer_notify_append_test.go
@@ -1,0 +1,56 @@
+package filer
+
+import (
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+)
+
+func TestResolveMetadataLogAssignDiskTypeUsesPathRule(t *testing.T) {
+	fc := NewFilerConf()
+	if err := fc.SetLocationConf(&filer_pb.FilerConf_PathConf{
+		LocationPrefix: "/topics/.system/log",
+		DiskType:       "hot",
+	}); err != nil {
+		t.Fatalf("set location conf: %v", err)
+	}
+
+	f := &Filer{
+		FilerConf:       fc,
+		DefaultDiskType: "hdd",
+	}
+
+	got, rule := f.resolveMetadataLogAssignDiskType("/topics/.system/log/2026-06-23/12-00.1")
+	if got != "hot" {
+		t.Fatalf("disk type = %q, want %q", got, "hot")
+	}
+	if rule.DiskType != "hot" {
+		t.Fatalf("rule disk type = %q, want %q", rule.DiskType, "hot")
+	}
+}
+
+func TestResolveMetadataLogAssignDiskTypeFallsBackToFilerDefault(t *testing.T) {
+	f := &Filer{
+		FilerConf:       NewFilerConf(),
+		DefaultDiskType: "hot",
+	}
+
+	got, _ := f.resolveMetadataLogAssignDiskType("/topics/.system/log/2026-06-23/12-00.1")
+	if got != "hot" {
+		t.Fatalf("disk type = %q, want %q", got, "hot")
+	}
+}
+
+func TestResolveMetadataLogAssignDiskTypeNilFilerConf(t *testing.T) {
+	f := &Filer{
+		DefaultDiskType: "hot",
+	}
+
+	got, rule := f.resolveMetadataLogAssignDiskType("/topics/.system/log/2026-06-23/12-00.1")
+	if got != "hot" {
+		t.Fatalf("disk type = %q, want %q", got, "hot")
+	}
+	if rule == nil {
+		t.Fatal("expected non-nil empty rule")
+	}
+}

--- a/weed/server/filer_server.go
+++ b/weed/server/filer_server.go
@@ -225,6 +225,7 @@ func NewFilerServer(defaultMux, readonlyMux *http.ServeMux, option *FilerOption)
 		}
 	})
 	fs.filer.Cipher = option.Cipher
+	fs.filer.DefaultDiskType = option.DiskType
 	// we do not support IP whitelist right now https://github.com/seaweedfs/seaweedfs/issues/7094
 	if v.GetString("guard.white_list") != "" {
 		glog.Warningf("filer: guard.white_list is configured but the IP whitelist feature is currently disabled. See https://github.com/seaweedfs/seaweedfs/issues/7094")


### PR DESCRIPTION
Fixes #10085

## What problem are we solving?

When writing metadata logs to `/topics/.system/log`, the filer calls `operation.Assign` directly via `assignAndUpload`. That path used only `rule.DiskType` from `FilerConf.MatchStorageRule` and did **not** apply the filer process default from `-filer.disk`.

When path rules are missing or unmatched (e.g. filer.conf not yet loaded from etcd after restart), `DiskType` is sent empty to the master. The master maps empty disk type to the built-in `hdd` layout and may enqueue `volume grow` with `Reason: grpc assign` on a layout with no volume servers (clusters that only register custom disk tags such as `hot`/`warm`).

PR #7918 added `rule.DiskType` to the assign request but did not add the `-filer.disk` fallback that `resolveAssignStorageOption` already applies for the `AssignVolume` gRPC path (see PR #8836).

## How are we solving the problem?

- Store `FilerOption.DiskType` on `filer.Filer` as `DefaultDiskType` when creating `FilerServer`.
- In metadata log assigns, use `util.Nvl(rule.DiskType, f.DefaultDiskType)` (via `resolveMetadataLogAssignDiskType`).
- Add unit tests mirroring `filer_grpc_server_test.go` from #8836.

## Test plan

- [x] `go test ./weed/filer -run ResolveMetadataLogAssignDiskType -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a configurable default disk type used by filer-managed storage assignments.
  * The filer server now propagates the configured default disk type into the underlying filer.

* **Bug Fixes**
  * Improved metadata-log upload disk type selection by resolving the disk type via the filer helper, with consistent fallback to the default when not explicitly set.

* **Tests**
  * Added unit tests covering rule-based disk type resolution and fallback behavior when no configuration (or nil configuration) is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->