### PR TITLE
util: trim minFreeSpace values before parsing

### DIFF
--- a/weed/util/minfreespace.go
+++ b/weed/util/minfreespace.go
@@ -87,6 +87,7 @@ var ErrMinFreeSpaceBadValue = errors.New("minFreeSpace is invalid")
 
 // ParseMinFreeSpace parses min free space expression s as percentage like 1,10 or human readable size like 10G
 func ParseMinFreeSpace(s string) (*MinFreeSpace, error) {
+	s = strings.TrimSpace(s)
 	if percent, e := strconv.ParseFloat(s, 32); e == nil {
 		if percent < 0 || percent > 100 {
 			return nil, ErrMinFreeSpaceBadValue

--- a/weed/util/minfreespace_test.go
+++ b/weed/util/minfreespace_test.go
@@ -15,6 +15,8 @@ func TestParseMinFreeSpace(t *testing.T) {
 		{in: "100Ki", ok: true, value: &MinFreeSpace{Type: AsBytes, Bytes: 100 * 1024, Raw: "100Ki"}},
 		{in: "100GiB", ok: true, value: &MinFreeSpace{Type: AsBytes, Bytes: 100 * 1024 * 1024 * 1024, Raw: "100GiB"}},
 		{in: "42M", ok: true, value: &MinFreeSpace{Type: AsBytes, Bytes: 42 * 1000 * 1000, Raw: "42M"}},
+		{in: " 42 ", ok: true, value: &MinFreeSpace{Type: AsPercent, Percent: 42, Raw: "42"}},
+		{in: " 42M ", ok: true, value: &MinFreeSpace{Type: AsBytes, Bytes: 42 * 1000 * 1000, Raw: "42M"}},
 	}
 
 	for _, p := range tests {


### PR DESCRIPTION
## What changed

Trim leading and trailing whitespace before parsing `minFreeSpace` values.

This allows comma-separated settings with spaces, such as `10, 20GiB`, to parse each value consistently.

## Testing

Please run:

- `go test ./weed/util -run TestParseMinFreeSpace -count=1`
- `go test ./weed/util`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Parsing of minimum free space values now ignores surrounding whitespace, so inputs like `" 42 "` and `" 42M "` are accepted.
  * Invalid values still return the same error as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->