### PR TITLE
Weed shell `ec.rebuild`: Allow targeting rebuild to specific volume IDs.

### DIFF
--- a/weed/shell/command_ec_rebuild.go
+++ b/weed/shell/command_ec_rebuild.go
@@ -5,6 +5,9 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"slices"
+	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/seaweedfs/seaweedfs/weed/operation"
@@ -25,6 +28,7 @@ type ecRebuilder struct {
 	writer       io.Writer
 	applyChanges bool
 	collections  []string
+	volumeIds    []needle.VolumeId
 	diskType     types.DiskType
 
 	ewg       *ErrorWaitGroup
@@ -84,6 +88,7 @@ func (c *commandEcRebuild) Do(args []string, commandEnv *CommandEnv, writer io.W
 
 	fixCommand := flag.NewFlagSet(c.Name(), flag.ContinueOnError)
 	collection := fixCommand.String("collection", "EACH_COLLECTION", "collection name, or \"EACH_COLLECTION\" for each collection")
+	volumeIdsStr := fixCommand.String("volumeIds", "", "optional comma-separated list of volume ID to process; defaults to all volumes in the collection")
 	maxParallelization := fixCommand.Int("maxParallelization", DefaultMaxParallelization, "run up to X tasks in parallel, whenever possible")
 	applyChanges := fixCommand.Bool("apply", false, "apply the changes")
 	diskTypeStr := fixCommand.String("diskType", "", "disk type for EC shards (hdd, ssd, or empty for default hdd)")
@@ -117,12 +122,28 @@ func (c *commandEcRebuild) Do(args []string, commandEnv *CommandEnv, writer io.W
 		collections = []string{*collection}
 	}
 
+	var volumeIds []needle.VolumeId
+	if *volumeIdsStr != "" {
+		for _, vidStr := range strings.Split(*volumeIdsStr, ",") {
+			vidStr = strings.TrimSpace(vidStr)
+			if len(vidStr) == 0 {
+				continue
+			}
+			if vid, err := strconv.ParseUint(vidStr, 10, 32); err == nil {
+				volumeIds = append(volumeIds, needle.VolumeId(vid))
+			} else {
+				return fmt.Errorf("invalid volume ID %q", vidStr)
+			}
+		}
+	}
+
 	erb := &ecRebuilder{
 		commandEnv:   commandEnv,
 		ecNodes:      allEcNodes,
 		writer:       writer,
 		applyChanges: *applyChanges,
 		collections:  collections,
+		volumeIds:    volumeIds,
 		diskType:     diskType,
 
 		ewg: NewErrorWaitGroup(*maxParallelization),
@@ -142,6 +163,15 @@ func (erb *ecRebuilder) write(format string, a ...any) {
 
 func (erb *ecRebuilder) isLocked() bool {
 	return erb.commandEnv.isLocked()
+}
+
+// matchesVolumeId verifies whether the rebuilder is targeted at a given volume ID.
+func (erb *ecRebuilder) matchesVolumeId(vid needle.VolumeId) bool {
+	if len(erb.volumeIds) == 0 {
+		return true
+	}
+
+	return slices.Contains(erb.volumeIds, vid)
 }
 
 // countLocalShards returns the number of shards already present locally on the node for the given volume.
@@ -229,6 +259,9 @@ func (erb *ecRebuilder) rebuildEcVolumes(collection string) {
 	erb.ecNodesMu.Unlock()
 
 	for vid, locations := range ecShardMap {
+		if !erb.matchesVolumeId(vid) {
+			continue
+		}
 		shardCount := locations.shardCount()
 		if shardCount == erasure_coding.TotalShardsCount {
 			continue

--- a/weed/shell/command_ec_rebuild_test.go
+++ b/weed/shell/command_ec_rebuild_test.go
@@ -307,3 +307,29 @@ func TestPrepareDataToRecoverTargetShardCount(t *testing.T) {
 		}
 	}
 }
+
+func TestRebuilderVolumeIdMatches(t *testing.T) {
+	testCases := []struct {
+		name               string
+		rebuilderVolumeIds []needle.VolumeId
+		volumeId           needle.VolumeId
+		want               bool
+	}{
+		{"no target volume IDs (nil)", nil, needle.VolumeId(1234), true},
+		{"no target volume IDs", []needle.VolumeId{}, needle.VolumeId(5678), true},
+		{"volume ID matches", []needle.VolumeId{needle.VolumeId(123), needle.VolumeId(456), needle.VolumeId(789)}, needle.VolumeId(456), true},
+		{"volume ID mismatch", []needle.VolumeId{needle.VolumeId(123), needle.VolumeId(456), needle.VolumeId(789)}, needle.VolumeId(321), false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ecb := &ecRebuilder{
+				volumeIds: tc.rebuilderVolumeIds,
+			}
+
+			if got, want := ecb.matchesVolumeId(tc.volumeId), tc.want; got != want {
+				t.Errorf("Expected %v, got %v", want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# What problem are we solving?

Allows targeting EC reconstruction to specific volumes; this is very useful when dealing with
individual EC failures that'd otherwise require rebuilding entire collections.

# How are we solving the problem?

Adds a `--volumeIds` parameter to `ec.rebuild`, which optionally limits EC reconstruction to specific volume IDs.

# How is the PR tested?

Added unit tests.

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `-volumeIds` option to `ec.rebuild` so you can limit rebuilding to specific volume IDs.
  * The command now accepts a comma-separated list, ignores extra spaces, and skips empty entries.

* **Bug Fixes**
  * Invalid volume IDs are now rejected with clear validation.
  * When no volume filter is provided, rebuild behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->