### PR TITLE
s3tables: allow hyphens in namespace and table names

### DIFF
--- a/weed/s3api/s3api_tables_rest_validation_test.go
+++ b/weed/s3api/s3api_tables_rest_validation_test.go
@@ -21,7 +21,7 @@ func TestBuildListTablesRequestRejectsInvalidNamespaceQuery(t *testing.T) {
 		namespace string
 	}{
 		{name: "uppercase", namespace: "InvalidNamespace"},
-		{name: "hyphen", namespace: "invalid-ns"},
+		{name: "leading hyphen", namespace: "-invalid"},
 		{name: "slash", namespace: "a/b"},
 	}
 
@@ -47,7 +47,7 @@ func TestBuildGetTableRequestRejectsInvalidNamespaceQuery(t *testing.T) {
 		namespace string
 	}{
 		{name: "uppercase", namespace: "InvalidNamespace"},
-		{name: "hyphen", namespace: "invalid-ns"},
+		{name: "leading hyphen", namespace: "-invalid"},
 		{name: "slash", namespace: "a/b"},
 	}
 
@@ -72,7 +72,7 @@ func TestHandleRestOperationReturnsBadRequestForInvalidNamespaceQuery(t *testing
 		namespace string
 	}{
 		{name: "uppercase", namespace: "InvalidNamespace"},
-		{name: "hyphen", namespace: "invalid-ns"},
+		{name: "leading hyphen", namespace: "-invalid"},
 		{name: "slash", namespace: "a/b"},
 	}
 

--- a/weed/s3api/s3tables/handler_name_charset_test.go
+++ b/weed/s3api/s3tables/handler_name_charset_test.go
@@ -1,0 +1,29 @@
+package s3tables
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNameValidationAllowsHyphens(t *testing.T) {
+	// Hyphen interior is accepted (Iceberg REST clients use names like these).
+	require.NoError(t, validateNamespacePart("rest-integration-test"))
+	if _, err := validateTableName("test-create-table"); err != nil {
+		t.Fatalf("hyphenated table name rejected: %v", err)
+	}
+
+	// A leading or trailing hyphen on a namespace is still rejected (must start
+	// and end with a letter or digit), as are characters outside the charset.
+	require.Error(t, validateNamespacePart("-leading"))
+	require.Error(t, validateNamespacePart("trailing-"))
+	require.Error(t, validateNamespacePart("Upper"))
+
+	// Table names must still start with a letter or digit and stay in charset.
+	if _, err := validateTableName("-leading"); err == nil {
+		t.Fatal("table name with leading hyphen should be rejected")
+	}
+	if _, err := validateTableName("Upper"); err == nil {
+		t.Fatal("uppercase table name should be rejected")
+	}
+}

--- a/weed/s3api/s3tables/handler_name_charset_test.go
+++ b/weed/s3api/s3tables/handler_name_charset_test.go
@@ -27,3 +27,11 @@ func TestNameValidationAllowsHyphens(t *testing.T) {
 		t.Fatal("uppercase table name should be rejected")
 	}
 }
+
+func TestParseTableFromARNAllowsHyphens(t *testing.T) {
+	bucket, ns, table, err := parseTableFromARN("arn:aws:s3tables:us-east-1:123456789012:bucket/my-bucket/table/rest-integration-test/test-create-table")
+	require.NoError(t, err)
+	require.Equal(t, "my-bucket", bucket)
+	require.Equal(t, "rest-integration-test", ns)
+	require.Equal(t, "test-create-table", table)
+}

--- a/weed/s3api/s3tables/utils.go
+++ b/weed/s3api/s3tables/utils.go
@@ -15,8 +15,8 @@ import (
 
 const (
 	bucketNamePatternStr     = `[a-z0-9-]+`
-	tableNamespacePatternStr = `[a-z0-9_.]+`
-	tableNamePatternStr      = `[a-z0-9_]+`
+	tableNamespacePatternStr = `[a-z0-9_.-]+`
+	tableNamePatternStr      = `[a-z0-9_-]+`
 )
 
 const (

--- a/weed/s3api/s3tables/utils.go
+++ b/weed/s3api/s3tables/utils.go
@@ -344,12 +344,12 @@ func validateNamespacePart(name string) error {
 		return fmt.Errorf("namespace name must end with a letter or digit")
 	}
 
-	// Allowed characters: a-z, 0-9, _
+	// Allowed characters: a-z, 0-9, _, - (hyphen interior; start/end checked above)
 	for _, ch := range name {
-		if (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '_' {
+		if (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '_' || ch == '-' {
 			continue
 		}
-		return fmt.Errorf("invalid namespace name: only 'a-z', '0-9', and '_' are allowed")
+		return fmt.Errorf("invalid namespace name: only 'a-z', '0-9', '_', and '-' are allowed")
 	}
 
 	// Reserved prefix
@@ -411,12 +411,12 @@ func validateTableName(name string) (string, error) {
 		return "", fmt.Errorf("table name must start with a letter or digit")
 	}
 
-	// Allowed characters: a-z, 0-9, _
+	// Allowed characters: a-z, 0-9, _, - (start checked above)
 	for _, ch := range name {
-		if (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '_' {
+		if (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '_' || ch == '-' {
 			continue
 		}
-		return "", fmt.Errorf("invalid table name: only 'a-z', '0-9', and '_' are allowed")
+		return "", fmt.Errorf("invalid table name: only 'a-z', '0-9', '_', and '-' are allowed")
 	}
 	return name, nil
 }


### PR DESCRIPTION
Iceberg REST clients routinely use hyphenated namespace and table names (`my-table`, `daily-events`, `rest-integration-test`). The S3 Tables charset only allowed `a-z`, `0-9`, `_`, so the Iceberg REST catalog rejected those names with a 400 — not conformant for those clients.

Accept `-` as an interior character in `validateNamespacePart` / `validateTableName`. Names must still start (and namespaces still end) with a letter or digit, and the `.`/`..`/`/`/`aws`-prefix guards are unchanged, so this is a permissive superset of the AWS S3 Tables charset — it never breaks an AWS-valid name.

With this, the full apache/iceberg-go REST integration suite passes against SeaweedFS using its original (hyphenated) names, unpatched: CreateNamespace, CreateTable, CreateView, LoadNamespaceProps, MultiTableCommit, UpdateNamespaceProps, UpdateView, WriteCommitTable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded S3 Tables namespace and table-name validation to allow hyphens (`-`) in valid positions.
* **Tests**
  * Added coverage for hyphenated identifiers, including ARN parsing and REST request validation, and ensured invalid hyphen placements (such as leading hyphens) are rejected with clear errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->