### PR TITLE
s3: propagate IAM changes from standalone weed s3 to peer pods

### DIFF
--- a/weed/s3api/s3api_server.go
+++ b/weed/s3api/s3api_server.go
@@ -216,6 +216,12 @@ func NewS3ApiServerWithStore(router *mux.Router, option *S3ApiServerOption, expl
 	// Update credential store to use FilerClient's current filer for HA
 	iam.SetFilerClient(filerClient)
 
+	// Fan IAM mutations out to peer S3 servers, mirroring the filer-embedded path.
+	iamPropagationEnabled := masterClient != nil && iam.credentialManager != nil
+	if iamPropagationEnabled {
+		iam.credentialManager.SetMasterClient(masterClient, option.GrpcDialOption)
+	}
+
 	// Keep attempting to load configuration from filer now that we have a client
 	// The initial load in NewIdentityAccessManagementWithStore might have failed if client was nil
 	go func() {
@@ -381,8 +387,10 @@ func NewS3ApiServerWithStore(router *mux.Router, option *S3ApiServerOption, expl
 		s3ApiServer.embeddedIam = NewEmbeddedIamApi(s3ApiServer.credentialManager, iam, option.IamReadOnly)
 		if option.IamReadOnly {
 			glog.V(1).Infof("Embedded IAM API initialized in read-only mode (use -s3.iam.readOnly=false to enable write operations)")
+		} else if iamPropagationEnabled {
+			glog.V(1).Infof("Embedded IAM API initialized in writable mode (updates propagate to other S3 servers)")
 		} else {
-			glog.V(1).Infof("Embedded IAM API initialized in writable mode (WARNING: updates will not be propagated to other S3 servers)")
+			glog.Warningf("Embedded IAM API initialized in writable mode but no master is configured; updates will not be propagated to other S3 servers")
 		}
 	}
 


### PR DESCRIPTION
## Problem

Running multiple standalone `weed s3` pods (not `weed filer -s3`), IAM credentials created via the IAM API on one pod are invisible to the others. Peers return `InvalidAccessKeyId` until restarted.

## Root cause

`PropagatingCredentialStore` fans IAM mutations out to peer S3 servers over the `SeaweedS3IamCache` gRPC service, but only after the credential store has been wrapped via `SetMasterClient`. That call lived only in the filer-embedded path (`weed/server/filer_server.go`). Standalone `weed s3` already:

- creates a master client (when masters are discoverable from the filer config), and
- registers the receiving `SeaweedS3IamCache` gRPC server,

but never wrapped its credential store. So mutations only persisted to the filer/db, and every other S3 pod kept serving a stale in-memory identity cache until it restarted.

## Fix

In `NewS3ApiServerWithStore`, wrap the credential store with the master client when one is available, mirroring the filer path. Mutations now fan out over the existing gRPC cache service.

The receiving handlers (`PutIdentity`/`RemoveIdentity`/`PutPolicy`...) update the in-memory cache directly via `UpsertIdentity`, independent of the metadata-subscription path — so this works regardless of whether `-config` is set.

Also corrected the embedded-IAM startup log, which unconditionally warned that updates would not propagate; it now reflects whether a master is configured.

## Notes

- Scope is the reported `weed s3` path. Standalone `weed iam` has the same un-wired credential manager but hardcodes an empty filer group for peer discovery, so a complete fix there needs separate filer-group plumbing; left out of this change.

## Testing

- `go build ./weed/...` clean
- `weed/s3api` and `weed/credential` test suites pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IAM update propagation in high-availability setups, so credential changes can now be shared across connected S3 servers when available.
  * Added clearer startup messaging to show whether embedded IAM changes will sync to other servers or remain local.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->