### PR TITLE
fix(replication): add JWT auth header for chunk reads via filer proxy

### DIFF
--- a/weed/command/filer_backup.go
+++ b/weed/command/filer_backup.go
@@ -167,6 +167,14 @@ func doFilerBackup(grpcDialOption grpc.DialOption, backupOption *FilerBackupOpti
 		*backupOption.proxyByFiler); err != nil {
 		return fmt.Errorf("filersource initialization failed: %v", err)
 	}
+	// Configure JWT signing key for authenticated chunk reads via filer proxy.
+	// Falls back to jwt.filer_signing.key if read.key is not set.
+	util.GetViper().SetDefault("jwt.filer_signing.read.expires_after_seconds", 60)
+	filerSource.SetJwtSigningKeys(
+		util.GetViper().GetString("jwt.filer_signing.read.key"),
+		util.GetViper().GetString("jwt.filer_signing.key"),
+		util.GetViper().GetInt("jwt.filer_signing.read.expires_after_seconds"),
+	)
 
 	if err := repl_util.InitializeSSEForReplication(filerSource); err != nil {
 		return fmt.Errorf("SSE initialization failed: %v", err)

--- a/weed/command/filer_sync.go
+++ b/weed/command/filer_sync.go
@@ -353,6 +353,16 @@ func doSubscribeFilerMetaChanges(clientId int32, clientEpoch int32, sourceGrpcDi
 	if sourceHttpClient != nil {
 		filerSource.SetHttpClient(sourceHttpClient)
 	}
+	// Configure JWT signing key for authenticated chunk reads via filer proxy.
+	// When the source filer has jwt.filer_signing.read.key configured, the sync
+	// process must include a valid Bearer token in its HTTP GET requests.
+	// Falls back to jwt.filer_signing.key if read.key is not set.
+	util.GetViper().SetDefault("jwt.filer_signing.read.expires_after_seconds", 60)
+	filerSource.SetJwtSigningKeys(
+		util.GetViper().GetString("jwt.filer_signing.read.key"),
+		util.GetViper().GetString("jwt.filer_signing.key"),
+		util.GetViper().GetInt("jwt.filer_signing.read.expires_after_seconds"),
+	)
 	filerSink := &filersink.FilerSink{}
 	filerSink.DoInitialize(targetFiler.ToHttpAddress(), targetFiler.ToGrpcAddress(), targetPath, replicationStr, collection, ttlSec, diskType, targetGrpcDialOption, sinkWriteChunkByFiler)
 	filerSink.SetChunkConcurrency(chunkConcurrency)

--- a/weed/replication/source/filer_source.go
+++ b/weed/replication/source/filer_source.go
@@ -19,14 +19,16 @@ import (
 )
 
 type FilerSource struct {
-	grpcAddress    string
-	grpcDialOption grpc.DialOption
-	Dir            string
-	address        string
-	proxyByFiler   bool
-	dataCenter     string
-	signature      int32
-	httpClient     *util_http_client.HTTPClient
+	grpcAddress       string
+	grpcDialOption    grpc.DialOption
+	Dir               string
+	address           string
+	proxyByFiler      bool
+	dataCenter        string
+	signature         int32
+	httpClient        *util_http_client.HTTPClient
+	signingKey        string
+	signingExpiresSec int
 }
 
 func (fs *FilerSource) Initialize(configuration util.Configuration, prefix string) error {
@@ -58,6 +60,20 @@ func (fs *FilerSource) SetGrpcDialOption(option grpc.DialOption) {
 
 func (fs *FilerSource) SetHttpClient(client *util_http_client.HTTPClient) {
 	fs.httpClient = client
+}
+
+// SetJwtSigningKeys configures the JWT signing key and token lifetime used
+// when reading chunk data through the filer proxy. It tries readKey first,
+// then falls back to fallbackKey if readKey is empty. This ensures compatibility
+// with deployments that only configure jwt.filer_signing.key (the generic key)
+// rather than the dedicated jwt.filer_signing.read.key.
+func (fs *FilerSource) SetJwtSigningKeys(readKey, fallbackKey string, expiresSec int) {
+	if readKey != "" {
+		fs.signingKey = readKey
+	} else if fallbackKey != "" {
+		fs.signingKey = fallbackKey
+	}
+	fs.signingExpiresSec = expiresSec
 }
 
 func (fs *FilerSource) LookupFileId(ctx context.Context, part string) (fileUrls []string, err error) {
@@ -118,7 +134,12 @@ func (fs *FilerSource) ReadPart(fileId string, offset int64) (filename string, h
 	}
 
 	if fs.proxyByFiler {
-		filename, header, resp, err = downloadFn("http://"+fs.address+"/?proxyChunkId="+fileId, "", offset)
+		var jwtToken string
+		if fs.signingKey != "" {
+			jwtToken = string(security.GenJwtForFilerServer(
+				security.SigningKey(fs.signingKey), fs.signingExpiresSec))
+		}
+		filename, header, resp, err = downloadFn("http://"+fs.address+"/?proxyChunkId="+fileId, jwtToken, offset)
 		if err != nil {
 			glog.V(0).Infof("read part %s via filer proxy %s offset %d: %v", fileId, fs.address, offset, err)
 		} else {


### PR DESCRIPTION
## What

When the source filer has `jwt.filer_signing.key` configured, `filer.sync` and `filer.backup` now include a valid Bearer JWT token in HTTP GET requests made through the filer proxy (`-a.filerProxy` / `-filerProxy`).

## Why

Before this change, `FilerSource.ReadPart()` passed an empty JWT string (`""`) when proxying chunk data:

```go
filename, header, resp, err = downloadFn("http://"+fs.address+"/?proxyChunkId="+fileId, "", offset)
```

This caused **401 Unauthorized** errors when the destination filer had JWT authentication enabled, because the HTTP GET had no `Authorization: Bearer <JWT>` header. The S3 API already generates JWT tokens for filer reads, but replication didn't — making filer.sync unusable behind JWT-authenticated filers with `-a.filerProxy`.

This matches issue [#3352](https://github.com/seaweedfs/seaweedfs/issues/3352).

## Changes

### `weed/replication/source/filer_source.go`
- Add `signingKey` and `signingExpiresSec` fields to `FilerSource` struct
- Add `SetJwtSigningKey(key, expiresSec)` setter method
- Modify `ReadPart()` to generate JWT via `GenJwtForFilerServer()` and pass it to `downloadFn()` when `proxyByFiler` is true

### `weed/command/filer_sync.go`
- After creating `FilerSource`, configure JWT signing key from `jwt.filer_signing.read.key` and `jwt.filer_signing.read.expires_after_seconds` (default 60s)

### `weed/command/filer_backup.go`
- Same JWT configuration for `filer.backup`

## Testing
- Build passes clean: `go build ./weed/replication/source/ ./weed/command/`
- All existing replication tests pass: `go test ./weed/replication/`
- Backward compatible: when `signingKey` is empty, the code behaves exactly as before (empty JWT, no auth header)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backup and sync now use authenticated filer-proxy chunk reads by generating and attaching JWTs when signing keys are configured.

* **Bug Fixes**
  * Improved reliability for backup/replication when accessing chunk data via the filer proxy.
  * Added a default JWT read token expiry (60 seconds) and fallback key behavior to keep proxy read access working smoothly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->