### PR TITLE
filer: mint volume read JWT when proxying chunk reads

### DIFF
--- a/weed/server/filer_server_handlers_proxy.go
+++ b/weed/server/filer_server_handlers_proxy.go
@@ -97,6 +97,11 @@ func (fs *FilerServer) proxyToVolumeServer(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
+	// volume server may require a read JWT even though the proxy endpoint doesn't
+	if jwt := fs.maybeGetVolumeReadJwtAuthorizationToken(fileId); jwt != "" {
+		proxyReq.Header.Set("Authorization", "BEARER "+jwt)
+	}
+
 	proxyResponse, postErr := util_http.GetGlobalHttpClient().Do(proxyReq)
 
 	if postErr != nil {


### PR DESCRIPTION
The `/?proxyChunkId=` endpoint forwards the caller's headers straight to the volume server but never mints a read token. Once `jwt.signing.read.key` is set, the volume server's read check rejects the proxied request — it wants a `SeaweedFileIdClaims` token scoped to the fileId — so every proxied chunk read 401s.

Fix it where the filer already knows the fileId and holds the volume read key: mint a fileId-scoped volume token in `proxyToVolumeServer`, exactly as the direct filer read path does via `maybeGetVolumeReadJwtAuthorizationToken`. One change covers all proxy callers — `filer.sync`, `filer.backup`, `filerProxy` mounts, the MQ broker, and the upload gateway.

The token is only attached when read signing is configured (the helper returns empty otherwise), so the no-auth path is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Proxied file requests now include an access token when available, improving access to downstream file volumes.
  * Existing request forwarding behavior remains intact while adding more reliable authorization handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->