### PR TITLE
fix(volume): serve reads from remote after tier upload (Rust)

### DIFF
--- a/seaweed-volume/src/server/grpc_server.rs
+++ b/seaweed-volume/src/server/grpc_server.rs
@@ -3327,9 +3327,15 @@ impl VolumeServer for VolumeGrpcService {
                             )));
                         }
 
-                        // Close local dat file handle (matches Go's v.LoadRemoteFile
-                        // which closes DataBackend before switching to remote)
-                        vol.close_local_dat_backend();
+                        // Switch the data backend from the local .dat to the remote
+                        // object so reads keep working after upload (matches Go's
+                        // LoadRemoteFile).
+                        if let Err(e) = vol.load_remote_dat_file() {
+                            return Err(Status::internal(format!(
+                                "volume {} failed to load remote file: {}",
+                                vid, e
+                            )));
+                        }
 
                         // Optionally remove local .dat file from disk
                         if !keep_local {

--- a/seaweed-volume/src/storage/volume.rs
+++ b/seaweed-volume/src/storage/volume.rs
@@ -949,7 +949,7 @@ impl Volume {
         Ok(())
     }
 
-    fn load_remote_dat_file(&mut self) -> Result<(), VolumeError> {
+    pub(crate) fn load_remote_dat_file(&mut self) -> Result<(), VolumeError> {
         let (storage_name, storage_key) = self.remote_storage_name_key();
         let backend = crate::remote_storage::s3_tier::global_s3_tier_registry()
             .read()
@@ -2223,12 +2223,6 @@ impl Volume {
         } else {
             self.no_write_can_delete = false;
         }
-    }
-
-    /// Close the local .dat file handle (matches Go's v.DataBackend.Close() in LoadRemoteFile).
-    /// Called after tier-upload when the local file is being replaced by remote storage.
-    pub fn close_local_dat_backend(&mut self) {
-        self.dat_file = None;
     }
 
     /// Close the remote dat file backend (matches Go's v.DataBackend.Close(); v.DataBackend = nil).


### PR DESCRIPTION
After `VolumeTierMoveDatToRemote` uploads the .dat, the Rust volume server closed its local backend but never opened the remote one, so both `dat_file` and `remote_dat_file` were left empty. The needle read path has no lazy reopen, so every read returned `dat file not open` until the volume was reloaded.

Switch to the remote backend right after saving the .vif — the same as the Go volume server's `LoadRemoteFile` — so the volume keeps serving from remote storage immediately after tiering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * After moving volume data to remote storage, the server now switches active reads to the new remote data source immediately.
  * This helps keep volumes available for reads after tier migration and avoids interruptions from closing the previous local data backend too early.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->