### PR TITLE
fix(filer.sync.verify): byte-order re-sort listings for pre-4.32 filers

### DIFF
--- a/weed/command/filer_sync_verify.go
+++ b/weed/command/filer_sync_verify.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -191,6 +192,44 @@ func (c *simpleFilerClient) GetDataCenter() string {
 	return ""
 }
 
+// byteOrderForced{Major,Minor}: first version forcing byte-lexicographic
+// listing regardless of SQL collation (PR #9824, tag 4.32). Older filers may
+// list in locale order and need client-side re-sorting.
+const (
+	byteOrderForcedMajor = 4
+	byteOrderForcedMinor = 32
+)
+
+// versionListsByteOrdered reports whether (major, minor) guarantees byte-ordered
+// listings. Zero major (field absent) is treated as old.
+func versionListsByteOrdered(major, minor int32) bool {
+	if major == 0 {
+		return false
+	}
+	if major != byteOrderForcedMajor {
+		return major > byteOrderForcedMajor
+	}
+	return minor >= byteOrderForcedMinor
+}
+
+// filerNeedsByteOrderSort returns whether a filer's listings must be re-sorted
+// client-side, plus its detected version (for logging). On query error it
+// returns true — sort defensively so version skew can't cause a spurious diff.
+func filerNeedsByteOrderSort(client *simpleFilerClient) (needSort bool, major, minor int32, err error) {
+	err = client.WithFilerClient(false, func(c filer_pb.SeaweedFilerClient) error {
+		resp, e := c.GetFilerConfiguration(context.Background(), &filer_pb.GetFilerConfigurationRequest{})
+		if e != nil {
+			return e
+		}
+		major, minor = resp.MajorVersion, resp.MinorVersion
+		return nil
+	})
+	if err != nil {
+		return true, 0, 0, err
+	}
+	return !versionListsByteOrdered(major, minor), major, minor, nil
+}
+
 func runVerifySync(filerA, filerB pb.ServerAddress, aPath, bPath string,
 	isActivePassive bool, modifiedTimeAgo time.Duration,
 	jsonOutput bool,
@@ -198,6 +237,17 @@ func runVerifySync(filerA, filerB pb.ServerAddress, aPath, bPath string,
 
 	clientA := &simpleFilerClient{grpcAddress: filerA, grpcDialOption: grpcDialOptionA}
 	clientB := &simpleFilerClient{grpcAddress: filerB, grpcDialOption: grpcDialOptionB}
+
+	// Re-sort only the side(s) older than 4.32; a mixed pair buffers just the
+	// older one, the newer side keeps streaming.
+	sortA, majA, minA, errA := filerNeedsByteOrderSort(clientA)
+	if errA != nil {
+		glog.Warningf("detect filer A version (%s): %v; re-sorting its listings defensively", filerA, errA)
+	}
+	sortB, majB, minB, errB := filerNeedsByteOrderSort(clientB)
+	if errB != nil {
+		glog.Warningf("detect filer B version (%s): %v; re-sorting its listings defensively", filerB, errB)
+	}
 
 	var cutoffTime time.Time
 	if modifiedTimeAgo > 0 {
@@ -209,15 +259,17 @@ func runVerifySync(filerA, filerB pb.ServerAddress, aPath, bPath string,
 			fmt.Fprintf(os.Stdout, "Verifying files modified before %v (modifiedTimeAgo=%v)\n",
 				cutoffTime.Format(time.RFC3339), modifiedTimeAgo)
 		}
-		fmt.Fprintf(os.Stdout, "Comparing %s%s => %s%s (isActivePassive=%v)\n\n",
+		fmt.Fprintf(os.Stdout, "Comparing %s%s => %s%s (isActivePassive=%v)\n",
 			filerA, aPath, filerB, bPath, isActivePassive)
+		fmt.Fprintf(os.Stdout, "Client-side byte-order re-sort: A=%v (filer %d.%02d) B=%v (filer %d.%02d) (pre-%d.%d filers re-sorted)\n\n",
+			sortA, majA, minA, sortB, majB, minB, byteOrderForcedMajor, byteOrderForcedMinor)
 	}
 
 	result := &VerifyResult{jsonOutput: jsonOutput}
 	ctx := context.Background()
 	sem := make(chan struct{}, verifySyncConcurrency)
 
-	if err := compareDirectory(ctx, clientA, clientB, aPath, bPath, isActivePassive, cutoffTime, sem, result); err != nil {
+	if err := compareDirectory(ctx, clientA, clientB, aPath, bPath, isActivePassive, cutoffTime, sortA, sortB, sem, result); err != nil {
 		return err
 	}
 
@@ -261,33 +313,50 @@ func runVerifySync(filerA, filerB pb.ServerAddress, aPath, bPath string,
 	return nil
 }
 
+// entrySource is a forward cursor over one directory's entries in Go byte
+// order, which the merge in compareDirectory requires. entryStream trusts the
+// filer's order (4.32+); sortedEntrySource re-sorts client-side for older ones.
+// Both load in a background goroutine; close() cancels that goroutine and waits
+// for it, so callers can clean up deterministically (e.g. on early return).
+type entrySource interface {
+	peek() *filer_pb.Entry
+	advance() *filer_pb.Entry
+	err() error
+	close()
+}
+
 // entryStream is a sorted, streaming view of a single directory's entries.
 // A background goroutine pages through the directory via ReadDirAllEntries
 // and forwards each entry to a buffered channel; the caller consumes entries
 // one at a time through peek/advance. Memory usage is O(channel buffer) —
 // independent of directory size — rather than O(total entries).
 type entryStream struct {
-	ch   <-chan *filer_pb.Entry
-	head *filer_pb.Entry
-	done bool
-	err  error // written before ch is closed; safe to read once done==true
+	ch      <-chan *filer_pb.Entry
+	head    *filer_pb.Entry
+	done    bool
+	readErr error // written before ch is closed; safe to read once done==true
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
 }
 
 // newEntryStream starts the background goroutine. It exits when listing
-// completes, an error occurs, or ctx is cancelled; the channel is always
+// completes, an error occurs, or the context is cancelled; the channel is always
 // closed before exit so consumers do not block indefinitely.
 func newEntryStream(ctx context.Context, client filer_pb.FilerClient, dir string) *entryStream {
+	childCtx, cancel := context.WithCancel(ctx)
 	ch := make(chan *filer_pb.Entry, 64)
-	s := &entryStream{ch: ch}
+	s := &entryStream{ch: ch, cancel: cancel}
+	s.wg.Add(1)
 	go func() {
+		defer s.wg.Done()
 		defer close(ch)
-		s.err = filer_pb.ReadDirAllEntries(ctx, client, util.FullPath(dir), "",
+		s.readErr = filer_pb.ReadDirAllEntries(childCtx, client, util.FullPath(dir), "",
 			func(entry *filer_pb.Entry, isLast bool) error {
 				select {
 				case ch <- entry:
 					return nil
-				case <-ctx.Done():
-					return ctx.Err()
+				case <-childCtx.Done():
+					return childCtx.Err()
 				}
 			})
 	}()
@@ -317,11 +386,96 @@ func (s *entryStream) advance() *filer_pb.Entry {
 	return e
 }
 
+// err returns the listing error, if any. Valid once the stream is drained.
+func (s *entryStream) err() error { return s.readErr }
+
+// close cancels the listing goroutine and waits for it to exit. Draining the
+// channel unblocks the producer if it is parked on a send. Idempotent.
+func (s *entryStream) close() {
+	s.cancel()
+	for range s.ch {
+	}
+	s.wg.Wait()
+}
+
+// sortedEntrySource buffers a whole directory and re-sorts it in Go byte order,
+// for pre-4.32 filers that may list in locale collation. The load runs in a
+// goroutine (like entryStream) so both sides of a compareDirectory list
+// concurrently; peek/advance/err block on `ready` until it finishes. Trade-off
+// vs entryStream: O(directory size) memory; used only on the side(s) that need it.
+type sortedEntrySource struct {
+	ready   chan struct{} // closed once entries and readErr are set
+	entries []*filer_pb.Entry
+	idx     int
+	readErr error
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+}
+
+// newSortedEntrySource starts loading the whole directory and sorting it by Name
+// (the exact same `<` comparator the merge uses, so both sides agree on order),
+// then returns immediately. Consumers block via `ready`.
+func newSortedEntrySource(ctx context.Context, client filer_pb.FilerClient, dir string) *sortedEntrySource {
+	childCtx, cancel := context.WithCancel(ctx)
+	s := &sortedEntrySource{ready: make(chan struct{}), cancel: cancel}
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		defer close(s.ready)
+		s.readErr = filer_pb.ReadDirAllEntries(childCtx, client, util.FullPath(dir), "",
+			func(entry *filer_pb.Entry, isLast bool) error {
+				select {
+				case <-childCtx.Done():
+					return childCtx.Err()
+				default:
+				}
+				s.entries = append(s.entries, entry)
+				return nil
+			})
+		if s.readErr == nil {
+			sort.Slice(s.entries, func(i, j int) bool {
+				return s.entries[i].Name < s.entries[j].Name
+			})
+		}
+	}()
+	return s
+}
+
+func (s *sortedEntrySource) peek() *filer_pb.Entry {
+	<-s.ready
+	if s.idx >= len(s.entries) {
+		return nil
+	}
+	return s.entries[s.idx]
+}
+
+func (s *sortedEntrySource) advance() *filer_pb.Entry {
+	e := s.peek()
+	if e != nil {
+		s.idx++
+	}
+	return e
+}
+
+// err returns the listing error. The close of `ready` happens-before this read,
+// so entries/readErr are visible without extra synchronisation.
+func (s *sortedEntrySource) err() error {
+	<-s.ready
+	return s.readErr
+}
+
+// close cancels the load goroutine and waits for it to exit. Idempotent.
+func (s *sortedEntrySource) close() {
+	s.cancel()
+	s.wg.Wait()
+}
+
 func compareDirectory(ctx context.Context,
 	clientA, clientB filer_pb.FilerClient,
 	dirA, dirB string,
 	isActivePassive bool,
 	cutoffTime time.Time,
+	sortA, sortB bool,
 	sem chan struct{},
 	result *VerifyResult) error {
 
@@ -340,13 +494,19 @@ func compareDirectory(ctx context.Context,
 
 	result.dirCount.Add(1)
 
-	// A child context ensures that stream goroutines are cancelled and their
-	// channels are closed if compareDirectory returns early (e.g. on error).
-	mergeCtx, cancelMerge := context.WithCancel(ctx)
-	defer cancelMerge()
-
-	streamA := newEntryStream(mergeCtx, clientA, dirA)
-	streamB := newEntryStream(mergeCtx, clientB, dirB)
+	// Both sources load in their own goroutine and list concurrently. close()
+	// cancels and waits for that goroutine, so on early return (e.g. an error)
+	// no listing goroutine is left running.
+	newSource := func(client filer_pb.FilerClient, dir string, doSort bool) entrySource {
+		if doSort {
+			return newSortedEntrySource(ctx, client, dir)
+		}
+		return newEntryStream(ctx, client, dir)
+	}
+	streamA := newSource(clientA, dirA, sortA)
+	defer streamA.close()
+	streamB := newSource(clientB, dirB, sortB)
+	defer streamB.close()
 
 	// collect subdirectories for recursive comparison
 	type dirPair struct{ a, b string }
@@ -411,12 +571,13 @@ func compareDirectory(ctx context.Context,
 		}
 	}
 
-	// Both channels are closed: close happens-before the receive of the zero
-	// value, so stream.err is visible here without additional synchronisation.
-	if err := streamA.err; err != nil && err != context.Canceled {
+	// Both sources are fully drained here. err() blocks on the load goroutine's
+	// completion signal (channel close), so readErr is visible without extra
+	// synchronisation.
+	if err := streamA.err(); err != nil && err != context.Canceled {
 		return fmt.Errorf("list %s on filer A: %v", dirA, err)
 	}
-	if err := streamB.err; err != nil && err != context.Canceled {
+	if err := streamB.err(); err != nil && err != context.Canceled {
 		return fmt.Errorf("list %s on filer B: %v", dirB, err)
 	}
 
@@ -442,7 +603,7 @@ func compareDirectory(ctx context.Context,
 			go func() {
 				defer wg.Done()
 				for pair := range jobs {
-					if err := compareDirectory(ctx, clientA, clientB, pair.a, pair.b, isActivePassive, cutoffTime, sem, result); err != nil {
+					if err := compareDirectory(ctx, clientA, clientB, pair.a, pair.b, isActivePassive, cutoffTime, sortA, sortB, sem, result); err != nil {
 						select {
 						case errCh <- err:
 						default:
@@ -464,7 +625,6 @@ func compareDirectory(ctx context.Context,
 
 	return nil
 }
-
 
 func compareEntries(dir string, entryA, entryB *filer_pb.Entry, result *VerifyResult) {
 	result.fileCount.Add(1)

--- a/weed/command/filer_sync_verify_test.go
+++ b/weed/command/filer_sync_verify_test.go
@@ -39,7 +39,7 @@ func (s *verifyTestStream) RecvMsg(_ any) error          { return nil }
 // verifyTestInnerClient is the SeaweedFilerClient passed to fn inside WithFilerClient.
 type verifyTestInnerClient struct {
 	filer_pb.SeaweedFilerClient // embed for unimplemented RPCs
-	entriesByDir map[string][]*filer_pb.Entry
+	entriesByDir                map[string][]*filer_pb.Entry
 }
 
 func (c *verifyTestInnerClient) ListEntries(_ context.Context, in *filer_pb.ListEntriesRequest, _ ...grpc.CallOption) (grpc.ServerStreamingClient[filer_pb.ListEntriesResponse], error) {
@@ -57,6 +57,7 @@ type verifyTestFilerClient struct {
 	inFlight     atomic.Int64
 	peakFlight   atomic.Int64
 	delay        time.Duration
+	onList       func() // called at the start of each listing, if set
 }
 
 func (c *verifyTestFilerClient) WithFilerClient(_ bool, fn func(filer_pb.SeaweedFilerClient) error) error {
@@ -68,6 +69,9 @@ func (c *verifyTestFilerClient) WithFilerClient(_ bool, fn func(filer_pb.Seaweed
 		if n <= peak || c.peakFlight.CompareAndSwap(peak, n) {
 			break
 		}
+	}
+	if c.onList != nil {
+		c.onList()
 	}
 	if c.delay > 0 {
 		time.Sleep(c.delay)
@@ -110,7 +114,7 @@ func TestVerifySyncMissingFile(t *testing.T) {
 	result := &VerifyResult{}
 	sem := make(chan struct{}, verifySyncConcurrency)
 	err := compareDirectory(context.Background(), clientA, clientB,
-		"/root", "/root", false, time.Time{}, sem, result)
+		"/root", "/root", false, time.Time{}, false, false, sem, result)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -139,7 +143,7 @@ func TestVerifySyncOnlyInB(t *testing.T) {
 		result := &VerifyResult{}
 		sem := make(chan struct{}, verifySyncConcurrency)
 		if err := compareDirectory(context.Background(), clientA, clientB,
-			"/root", "/root", false, time.Time{}, sem, result); err != nil {
+			"/root", "/root", false, time.Time{}, false, false, sem, result); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if got := result.onlyInB.Load(); got != 1 {
@@ -151,7 +155,7 @@ func TestVerifySyncOnlyInB(t *testing.T) {
 		result := &VerifyResult{}
 		sem := make(chan struct{}, verifySyncConcurrency)
 		if err := compareDirectory(context.Background(), clientA, clientB,
-			"/root", "/root", true, time.Time{}, sem, result); err != nil {
+			"/root", "/root", true, time.Time{}, false, false, sem, result); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if got := result.onlyInB.Load(); got != 0 {
@@ -177,7 +181,7 @@ func TestVerifySyncSizeMismatch(t *testing.T) {
 	result := &VerifyResult{}
 	sem := make(chan struct{}, verifySyncConcurrency)
 	err := compareDirectory(context.Background(), clientA, clientB,
-		"/root", "/root", false, time.Time{}, sem, result)
+		"/root", "/root", false, time.Time{}, false, false, sem, result)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -215,7 +219,7 @@ func TestVerifySyncConcurrencyBound(t *testing.T) {
 	result := &VerifyResult{}
 	sem := make(chan struct{}, verifySyncConcurrency)
 	if err := compareDirectory(context.Background(), clientA, clientB,
-		"/root", "/root", false, time.Time{}, sem, result); err != nil {
+		"/root", "/root", false, time.Time{}, false, false, sem, result); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -259,7 +263,7 @@ func TestVerifySyncETagMismatch(t *testing.T) {
 	result := &VerifyResult{}
 	sem := make(chan struct{}, verifySyncConcurrency)
 	if err := compareDirectory(context.Background(), clientA, clientB,
-		"/root", "/root", false, time.Time{}, sem, result); err != nil {
+		"/root", "/root", false, time.Time{}, false, false, sem, result); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if got := result.etagMismatch.Load(); got != 1 {
@@ -298,7 +302,7 @@ func TestVerifySyncCutoffTime(t *testing.T) {
 		result := &VerifyResult{}
 		sem := make(chan struct{}, verifySyncConcurrency)
 		if err := compareDirectory(context.Background(), clientA, clientB,
-			"/", "/", false, cutoff, sem, result); err != nil {
+			"/", "/", false, cutoff, false, false, sem, result); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if got := result.skippedRecent.Load(); got != 1 {
@@ -319,7 +323,7 @@ func TestVerifySyncCutoffTime(t *testing.T) {
 		result := &VerifyResult{}
 		sem := make(chan struct{}, verifySyncConcurrency)
 		if err := compareDirectory(context.Background(), clientA, clientB,
-			"/", "/", false, cutoff, sem, result); err != nil {
+			"/", "/", false, cutoff, false, false, sem, result); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if got := result.missingCount.Load(); got != 1 {
@@ -337,7 +341,7 @@ func TestVerifySyncCutoffTime(t *testing.T) {
 		result := &VerifyResult{}
 		sem := make(chan struct{}, verifySyncConcurrency)
 		if err := compareDirectory(context.Background(), clientA, clientB,
-			"/", "/", false, cutoff, sem, result); err != nil {
+			"/", "/", false, cutoff, false, false, sem, result); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if got := result.skippedRecent.Load(); got != 1 {
@@ -358,7 +362,7 @@ func TestVerifySyncCutoffTime(t *testing.T) {
 		result := &VerifyResult{}
 		sem := make(chan struct{}, verifySyncConcurrency)
 		if err := compareDirectory(context.Background(), clientA, clientB,
-			"/", "/", false, cutoff, sem, result); err != nil {
+			"/", "/", false, cutoff, false, false, sem, result); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if got := result.onlyInB.Load(); got != 1 {
@@ -392,7 +396,7 @@ func TestVerifySyncCutoffMatchedFileBSideRecent(t *testing.T) {
 	result := &VerifyResult{}
 	sem := make(chan struct{}, verifySyncConcurrency)
 	if err := compareDirectory(context.Background(), clientA, clientB,
-		"/", "/", false, cutoff, sem, result); err != nil {
+		"/", "/", false, cutoff, false, false, sem, result); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if got := result.skippedRecent.Load(); got != 1 {
@@ -422,8 +426,8 @@ func TestVerifySyncMissingDirRecursesEvenWithRecentMtime(t *testing.T) {
 
 	clientA := &verifyTestFilerClient{
 		entriesByDir: map[string][]*filer_pb.Entry{
-			"/":        {recentDir},
-			"/subdir":  {oldChild},
+			"/":       {recentDir},
+			"/subdir": {oldChild},
 		},
 	}
 	clientB := &verifyTestFilerClient{
@@ -435,7 +439,7 @@ func TestVerifySyncMissingDirRecursesEvenWithRecentMtime(t *testing.T) {
 	result := &VerifyResult{}
 	sem := make(chan struct{}, verifySyncConcurrency)
 	if err := compareDirectory(context.Background(), clientA, clientB,
-		"/", "/", false, cutoff, sem, result); err != nil {
+		"/", "/", false, cutoff, false, false, sem, result); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	// Expect: directory MISSING + recursed-old-file MISSING = 2 missing.
@@ -454,21 +458,21 @@ func TestVerifySyncMissingDirRecursesEvenWithRecentMtime(t *testing.T) {
 func TestVerifySyncRootPath(t *testing.T) {
 	clientA := &verifyTestFilerClient{
 		entriesByDir: map[string][]*filer_pb.Entry{
-			"/":      {verifyDirEntry("data")},
-			"/data":  {verifyFileEntry("file.txt", 42)},
+			"/":     {verifyDirEntry("data")},
+			"/data": {verifyFileEntry("file.txt", 42)},
 		},
 	}
 	clientB := &verifyTestFilerClient{
 		entriesByDir: map[string][]*filer_pb.Entry{
-			"/":      {verifyDirEntry("data")},
-			"/data":  {verifyFileEntry("file.txt", 42)},
+			"/":     {verifyDirEntry("data")},
+			"/data": {verifyFileEntry("file.txt", 42)},
 		},
 	}
 
 	result := &VerifyResult{}
 	sem := make(chan struct{}, verifySyncConcurrency)
 	if err := compareDirectory(context.Background(), clientA, clientB,
-		"/", "/", false, time.Time{}, sem, result); err != nil {
+		"/", "/", false, time.Time{}, false, false, sem, result); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if result.missingCount.Load() != 0 || result.sizeMismatch.Load() != 0 {
@@ -519,7 +523,7 @@ func TestVerifySyncNoDeadlockDeepTree(t *testing.T) {
 		result := &VerifyResult{}
 		sem := make(chan struct{}, verifySyncConcurrency)
 		done <- compareDirectory(context.Background(), clientA, clientB,
-			"/root", "/root", false, time.Time{}, sem, result)
+			"/root", "/root", false, time.Time{}, false, false, sem, result)
 	}()
 
 	select {
@@ -529,5 +533,162 @@ func TestVerifySyncNoDeadlockDeepTree(t *testing.T) {
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatal("compareDirectory did not complete within 10s — possible deadlock")
+	}
+}
+
+// TestVerifySyncByteOrderSkew reproduces the maas-dfs #165 collation skew: two
+// filers return the SAME name set in DIFFERENT order. Filer A (old, e.g. 4.25)
+// lists in locale collation (case-insensitive); filer B (new, e.g. 4.34, with
+// upstream PR #9824) lists in byte order (uppercase before lowercase). The mock
+// returns each side's slice order verbatim.
+//
+// Without client-side re-sort (sortA=sortB=false) the streaming merge desyncs
+// and reports spurious MISSING + ONLY_IN_B. Re-sorting the old side (or both)
+// brings both to byte order and yields zero diffs.
+func TestVerifySyncByteOrderSkew(t *testing.T) {
+	// locale order (case-insensitive): lowercase mixes in among uppercase.
+	localeOrder := []*filer_pb.Entry{
+		verifyFileEntry("sk-4", 10),
+		verifyFileEntry("sk-8", 10),
+		verifyFileEntry("sk-mmsJ", 10),
+		verifyFileEntry("sk-nFGE", 10),
+		verifyFileEntry("sk-RH0Z", 10),
+		verifyFileEntry("sk-Xp", 10),
+		verifyFileEntry("sk-Z06", 10),
+	}
+	// byte order: uppercase (R,X,Z) sort before lowercase (m,n).
+	byteOrder := []*filer_pb.Entry{
+		verifyFileEntry("sk-4", 10),
+		verifyFileEntry("sk-8", 10),
+		verifyFileEntry("sk-RH0Z", 10),
+		verifyFileEntry("sk-Xp", 10),
+		verifyFileEntry("sk-Z06", 10),
+		verifyFileEntry("sk-mmsJ", 10),
+		verifyFileEntry("sk-nFGE", 10),
+	}
+
+	newClients := func() (*verifyTestFilerClient, *verifyTestFilerClient) {
+		a := &verifyTestFilerClient{
+			entriesByDir: map[string][]*filer_pb.Entry{"/root": localeOrder},
+		}
+		b := &verifyTestFilerClient{
+			entriesByDir: map[string][]*filer_pb.Entry{"/root": byteOrder},
+		}
+		return a, b
+	}
+
+	t.Run("no sort reproduces false diffs", func(t *testing.T) {
+		clientA, clientB := newClients()
+		result := &VerifyResult{}
+		sem := make(chan struct{}, verifySyncConcurrency)
+		if err := compareDirectory(context.Background(), clientA, clientB,
+			"/root", "/root", false, time.Time{}, false, false, sem, result); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// sk-RH0Z, sk-Xp, sk-Z06 fall on the wrong side of the merge cursor.
+		if got := result.missingCount.Load(); got != 3 {
+			t.Errorf("missingCount = %d, want 3 (skew false positives)", got)
+		}
+		if got := result.onlyInB.Load(); got != 3 {
+			t.Errorf("onlyInB = %d, want 3 (skew false positives)", got)
+		}
+	})
+
+	t.Run("sort both yields zero diffs", func(t *testing.T) {
+		clientA, clientB := newClients()
+		result := &VerifyResult{}
+		sem := make(chan struct{}, verifySyncConcurrency)
+		if err := compareDirectory(context.Background(), clientA, clientB,
+			"/root", "/root", false, time.Time{}, true, true, sem, result); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := result.missingCount.Load(); got != 0 {
+			t.Errorf("missingCount = %d, want 0", got)
+		}
+		if got := result.onlyInB.Load(); got != 0 {
+			t.Errorf("onlyInB = %d, want 0", got)
+		}
+	})
+
+	t.Run("sort only the old (A) side yields zero diffs", func(t *testing.T) {
+		// Real green->blue case: A is pre-4.32 (re-sorted), B is 4.32+ (already
+		// byte ordered, streamed as-is). Re-sorting A alone converges both.
+		clientA, clientB := newClients()
+		result := &VerifyResult{}
+		sem := make(chan struct{}, verifySyncConcurrency)
+		if err := compareDirectory(context.Background(), clientA, clientB,
+			"/root", "/root", false, time.Time{}, true, false, sem, result); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := result.missingCount.Load(); got != 0 {
+			t.Errorf("missingCount = %d, want 0", got)
+		}
+		if got := result.onlyInB.Load(); got != 0 {
+			t.Errorf("onlyInB = %d, want 0", got)
+		}
+	})
+}
+
+// TestVersionListsByteOrdered checks the boundary around the 4.32 threshold,
+// where upstream PR #9824 began forcing byte-lexicographic list order.
+func TestVersionListsByteOrdered(t *testing.T) {
+	cases := []struct {
+		major, minor int32
+		want         bool
+	}{
+		{4, 31, false}, // pre-#9824: locale order possible
+		{4, 32, true},  // first release with #9824
+		{4, 34, true},
+		{5, 0, true},   // newer major
+		{3, 99, false}, // older major
+		{0, 0, false},  // field absent / unparseable → treat as old
+	}
+	for _, c := range cases {
+		if got := versionListsByteOrdered(c.major, c.minor); got != c.want {
+			t.Errorf("versionListsByteOrdered(%d, %d) = %v, want %v",
+				c.major, c.minor, got, c.want)
+		}
+	}
+}
+
+// TestVerifySyncSortedSourcesListConcurrently guards against re-serializing the
+// two directory listings. When both sides need a client-side re-sort
+// (sortedEntrySource), their loads must run concurrently — not A fully then B.
+// A shared gate releases only once both listings are in-flight at the same time;
+// if they were sequential the first would block on the gate and time out.
+func TestVerifySyncSortedSourcesListConcurrently(t *testing.T) {
+	var started atomic.Int32
+	var timedOut atomic.Bool
+	release := make(chan struct{})
+	gate := func() {
+		if started.Add(1) == 2 {
+			close(release) // both listings reached the gate → proceed
+		}
+		select {
+		case <-release:
+		case <-time.After(3 * time.Second):
+			timedOut.Store(true) // only one listing ever in-flight → serialized
+		}
+	}
+
+	entries := []*filer_pb.Entry{verifyFileEntry("a", 1), verifyFileEntry("b", 1)}
+	clientA := &verifyTestFilerClient{
+		entriesByDir: map[string][]*filer_pb.Entry{"/root": entries},
+		onList:       gate,
+	}
+	clientB := &verifyTestFilerClient{
+		entriesByDir: map[string][]*filer_pb.Entry{"/root": entries},
+		onList:       gate,
+	}
+
+	result := &VerifyResult{}
+	sem := make(chan struct{}, verifySyncConcurrency)
+	// sortA=sortB=true → both sides use sortedEntrySource.
+	if err := compareDirectory(context.Background(), clientA, clientB,
+		"/root", "/root", false, time.Time{}, true, true, sem, result); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if timedOut.Load() {
+		t.Fatal("sorted sources listed sequentially: both listings were not in-flight at once")
 	}
 }


### PR DESCRIPTION
<!-- Upstream PR draft for seaweedfs/seaweedfs. NOT part of the PR diff — copy the sections below into the GitHub PR description. Base: upstream/master. Suggested title: filer.sync.verify: align pre-4.32 listings to byte order before compare -->

# What problem are we solving?

`filer.sync.verify` walks two filers' directory listings in lockstep (sorted-merge). Its only precondition is that both sides return entries in the **same order**: equal names pair up, and `eA.Name < eB.Name` is just the tie-breaker for a name present on one side only.

This held while both filers ran the same version, but it breaks when the two clusters being compared run **different versions**. Since #9824 (4.32) the filer forces `ORDER BY name COLLATE "C"` (byte order) regardless of the SQL `name` column collation, whereas a pre-4.32 filer whose `filemeta.name` column uses a locale collation lists in case-insensitive order. The two sides then return the **same name set in a different order**, the merge desyncs, and entries are reported as spurious `MISSING` / `ONLY_IN_B` (the recursive counter then walks whole subtrees). A real 4.25 → 4.34 comparison produced ~24k false `MISSING` with no actual data loss.

# How are we solving the problem?

4.32+ already lists in byte order, so we **align the older side to that same order**: query each filer's version via `GetFilerConfiguration` (`MajorVersion`/`MinorVersion`, set since 3.71), and for any side older than 4.32 buffer its directory entries and re-sort them client-side in byte order before the merge. 4.32+ sides keep streaming; a mixed pair buffers only the older side. Detection failure sorts defensively. Automatic — no new flags, and identical behavior when both sides are 4.32+.

Implementation: an `entrySource` interface backs both the existing `entryStream` (streaming) and a new `sortedEntrySource` (buffer + `sort.Slice` by `Name`, using the same `<` the merge uses); `versionListsByteOrdered` / `filerNeedsByteOrderSort` decide per side. Additive, touching only `weed/command/filer_sync_verify.go` (+ tests).

# How is the PR tested?

- Unit tests: version boundary (4.31 → re-sort; 4.32 / 4.34 / 5.0 → no; 3.99 / 0.0 → re-sort) and a byte-order skew reproduction — same set in locale vs byte order yields false `MISSING` + `ONLY_IN_B` without re-sort, zero diffs with re-sort on both or only the older side.
- `go build ./...`, `go test ./weed/command/`, and `gofmt` clean.
- Live 4.25 → 4.34 run: the ~24k false `MISSING` collapse to the small set of genuine differences.

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sync verification for directory listings by accounting for filer version–dependent ordering, reducing false mismatch reports when entries are returned in different orders.
  * Added safer fallback behavior: automatically sorts entries when version/order assumptions can’t be confirmed.
  * Updated verification output to display the detected versions per side and whether re-sorting is enabled.

* **Tests**
  * Added regression tests covering byte-order skew scenarios, version-based ordering behavior, and concurrent verification listing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->