### PR TITLE
volume server: route VolumeMarkReadonly to raft leader

### DIFF
--- a/weed/operation/lookup_raft_leader.go
+++ b/weed/operation/lookup_raft_leader.go
@@ -25,10 +25,12 @@ func LookupRaftLeaderMaster(ctx context.Context, masters []pb.ServerAddress, grp
 		if err := ctx.Err(); err != nil {
 			return "", err
 		}
+		// The same timeout ctx drives both the RPC and WithMasterServerClient's
+		// connection-invalidation decision, so a self-inflicted 5s timeout leaves
+		// callCtx.Err() != nil and does not poison the shared master connection.
+		callCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		var leader pb.ServerAddress
-		err := WithMasterServerClient(ctx, false, peer, grpcDialOption, func(client master_pb.SeaweedClient) error {
-			callCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-			defer cancel()
+		err := WithMasterServerClient(callCtx, false, peer, grpcDialOption, func(client master_pb.SeaweedClient) error {
 			resp, err := client.GetMasterConfiguration(callCtx, &master_pb.GetMasterConfigurationRequest{})
 			if err != nil {
 				return err
@@ -39,6 +41,7 @@ func LookupRaftLeaderMaster(ctx context.Context, masters []pb.ServerAddress, grp
 			leader = pb.ServerAddress(resp.Leader)
 			return nil
 		})
+		cancel()
 		if err == nil && leader != "" {
 			return leader, nil
 		}

--- a/weed/operation/lookup_raft_leader.go
+++ b/weed/operation/lookup_raft_leader.go
@@ -1,0 +1,48 @@
+package operation
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb"
+	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
+	"google.golang.org/grpc"
+)
+
+// LookupRaftLeaderMaster returns the current raft leader by querying configured
+// master peers. Followers answer GetMasterConfiguration with the leader address;
+// topology mutations such as VolumeMarkReadonly must run on that node.
+//
+// The volume server's heartbeat peer (GetMaster) may still be a follower after an
+// election until the heartbeat loop reconnects.
+func LookupRaftLeaderMaster(ctx context.Context, masters []pb.ServerAddress, grpcDialOption grpc.DialOption) (pb.ServerAddress, error) {
+	if len(masters) == 0 {
+		return "", fmt.Errorf("no master peers configured")
+	}
+	var lastErr error
+	for _, peer := range masters {
+		var leader pb.ServerAddress
+		err := WithMasterServerClient(ctx, false, peer, grpcDialOption, func(client master_pb.SeaweedClient) error {
+			callCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			defer cancel()
+			resp, err := client.GetMasterConfiguration(callCtx, &master_pb.GetMasterConfigurationRequest{})
+			if err != nil {
+				return err
+			}
+			if resp.Leader == "" {
+				return fmt.Errorf("master %s returned empty leader", peer)
+			}
+			leader = pb.ServerAddress(resp.Leader)
+			return nil
+		})
+		if err == nil && leader != "" {
+			return leader, nil
+		}
+		lastErr = err
+	}
+	if lastErr != nil {
+		return "", fmt.Errorf("lookup raft leader from %d master peer(s): %w", len(masters), lastErr)
+	}
+	return "", fmt.Errorf("lookup raft leader: no leader from %d master peer(s)", len(masters))
+}

--- a/weed/operation/lookup_raft_leader.go
+++ b/weed/operation/lookup_raft_leader.go
@@ -22,6 +22,9 @@ func LookupRaftLeaderMaster(ctx context.Context, masters []pb.ServerAddress, grp
 	}
 	var lastErr error
 	for _, peer := range masters {
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
 		var leader pb.ServerAddress
 		err := WithMasterServerClient(ctx, false, peer, grpcDialOption, func(client master_pb.SeaweedClient) error {
 			callCtx, cancel := context.WithTimeout(ctx, 5*time.Second)

--- a/weed/operation/lookup_raft_leader_test.go
+++ b/weed/operation/lookup_raft_leader_test.go
@@ -2,6 +2,7 @@ package operation
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"testing"
@@ -77,5 +78,22 @@ func TestLookupRaftLeaderMasterNoPeers(t *testing.T) {
 	_, err := LookupRaftLeaderMaster(context.Background(), nil, nil)
 	if err == nil {
 		t.Fatal("expected error for empty peers")
+	}
+}
+
+func TestLookupRaftLeaderMasterCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := LookupRaftLeaderMaster(
+		ctx,
+		[]pb.ServerAddress{"127.0.0.1:1"},
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err == nil {
+		t.Fatal("expected error for canceled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
 	}
 }

--- a/weed/operation/lookup_raft_leader_test.go
+++ b/weed/operation/lookup_raft_leader_test.go
@@ -1,0 +1,81 @@
+package operation
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb"
+	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+type fakeLeaderConfigServer struct {
+	master_pb.UnimplementedSeaweedServer
+	leader string
+}
+
+func (s *fakeLeaderConfigServer) GetMasterConfiguration(_ context.Context, _ *master_pb.GetMasterConfigurationRequest) (*master_pb.GetMasterConfigurationResponse, error) {
+	return &master_pb.GetMasterConfigurationResponse{Leader: s.leader}, nil
+}
+
+func startFakeMasterServer(t *testing.T, srv master_pb.SeaweedServer) pb.ServerAddress {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	grpcServer := grpc.NewServer()
+	master_pb.RegisterSeaweedServer(grpcServer, srv)
+	go func() { _ = grpcServer.Serve(lis) }()
+	t.Cleanup(grpcServer.GracefulStop)
+
+	_, port, _ := net.SplitHostPort(lis.Addr().String())
+	return pb.ServerAddress(fmt.Sprintf("127.0.0.1:0.%s", port))
+}
+
+func TestLookupRaftLeaderMasterFromFollower(t *testing.T) {
+	follower := startFakeMasterServer(t, &fakeLeaderConfigServer{
+		leader: "leader.example.com:9333.19333",
+	})
+
+	leader, err := LookupRaftLeaderMaster(
+		context.Background(),
+		[]pb.ServerAddress{follower},
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if got, want := leader.ToHttpAddress(), "leader.example.com:9333"; got != want {
+		t.Fatalf("leader = %q, want %q", got, want)
+	}
+}
+
+func TestLookupRaftLeaderMasterTriesNextPeer(t *testing.T) {
+	down := pb.ServerAddress("127.0.0.1:1")
+	peer := startFakeMasterServer(t, &fakeLeaderConfigServer{
+		leader: "leader.example.com:9333.19333",
+	})
+
+	leader, err := LookupRaftLeaderMaster(
+		context.Background(),
+		[]pb.ServerAddress{down, peer},
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if got, want := leader.ToHttpAddress(), "leader.example.com:9333"; got != want {
+		t.Fatalf("leader = %q, want %q", got, want)
+	}
+}
+
+func TestLookupRaftLeaderMasterNoPeers(t *testing.T) {
+	_, err := LookupRaftLeaderMaster(context.Background(), nil, nil)
+	if err == nil {
+		t.Fatal("expected error for empty peers")
+	}
+}

--- a/weed/server/volume_grpc_admin.go
+++ b/weed/server/volume_grpc_admin.go
@@ -280,8 +280,9 @@ func (vs *VolumeServer) makeVolumeWritable(ctx context.Context, v *storage.Volum
 }
 
 func (vs *VolumeServer) notifyMasterVolumeReadonly(ctx context.Context, v *storage.Volume, isReadOnly bool) error {
-	if grpcErr := pb.WithMasterClient(context.Background(), false, vs.GetMaster(ctx), vs.grpcDialOption, false, func(client master_pb.SeaweedClient) error {
-		_, err := client.VolumeMarkReadonly(context.Background(), &master_pb.VolumeMarkReadonlyRequest{
+	master := vs.lookupRaftLeaderMaster(ctx)
+	if grpcErr := pb.WithMasterClient(ctx, false, master, vs.grpcDialOption, false, func(client master_pb.SeaweedClient) error {
+		_, err := client.VolumeMarkReadonly(ctx, &master_pb.VolumeMarkReadonlyRequest{
 			Ip:               vs.store.Ip,
 			Port:             uint32(vs.store.Port),
 			VolumeId:         uint32(v.Id),
@@ -296,8 +297,8 @@ func (vs *VolumeServer) notifyMasterVolumeReadonly(ctx context.Context, v *stora
 		}
 		return nil
 	}); grpcErr != nil {
-		glog.V(0).Infof("connect to %s: %v", vs.GetMaster(context.Background()), grpcErr)
-		return fmt.Errorf("grpc VolumeMarkReadonly with master %s: %v", vs.GetMaster(context.Background()), grpcErr)
+		glog.V(0).Infof("connect to %s: %v", master, grpcErr)
+		return fmt.Errorf("grpc VolumeMarkReadonly with master %s: %v", master, grpcErr)
 	}
 	return nil
 }

--- a/weed/server/volume_grpc_admin.go
+++ b/weed/server/volume_grpc_admin.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"google.golang.org/grpc/codes"
@@ -279,8 +280,25 @@ func (vs *VolumeServer) makeVolumeWritable(ctx context.Context, v *storage.Volum
 	return nil
 }
 
+func isNotLeaderErr(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "Not current leader")
+}
+
 func (vs *VolumeServer) notifyMasterVolumeReadonly(ctx context.Context, v *storage.Volume, isReadOnly bool) error {
-	master := vs.lookupRaftLeaderMaster(ctx)
+	master := vs.GetMaster(ctx)
+	err := vs.volumeMarkReadonlyOnMaster(ctx, master, v, isReadOnly)
+	if err != nil && isNotLeaderErr(err) {
+		leader, lookupErr := vs.lookupRaftLeaderMaster(ctx)
+		if lookupErr != nil {
+			return fmt.Errorf("heartbeat master %s rejected mark-readonly and leader lookup failed: %w", master, lookupErr)
+		}
+		master = leader
+		err = vs.volumeMarkReadonlyOnMaster(ctx, master, v, isReadOnly)
+	}
+	return err
+}
+
+func (vs *VolumeServer) volumeMarkReadonlyOnMaster(ctx context.Context, master pb.ServerAddress, v *storage.Volume, isReadOnly bool) error {
 	if grpcErr := pb.WithMasterClient(ctx, false, master, vs.grpcDialOption, false, func(client master_pb.SeaweedClient) error {
 		_, err := client.VolumeMarkReadonly(ctx, &master_pb.VolumeMarkReadonlyRequest{
 			Ip:               vs.store.Ip,

--- a/weed/server/volume_grpc_client_to_master.go
+++ b/weed/server/volume_grpc_client_to_master.go
@@ -1,6 +1,7 @@
 package weed_server
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -16,8 +17,6 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/storage/backend"
 	"github.com/seaweedfs/seaweedfs/weed/storage/erasure_coding"
 
-	"context"
-
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
 	"github.com/seaweedfs/seaweedfs/weed/util"
@@ -25,6 +24,25 @@ import (
 
 func (vs *VolumeServer) GetMaster(ctx context.Context) pb.ServerAddress {
 	return vs.getCurrentMaster()
+}
+
+// lookupRaftLeaderMaster resolves the raft leader for topology mutations. The
+// heartbeat peer from GetMaster may still be a follower after an election.
+func (vs *VolumeServer) lookupRaftLeaderMaster(ctx context.Context) pb.ServerAddress {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	leader, err := operation.LookupRaftLeaderMaster(ctx, vs.SeedMasterNodes, vs.grpcDialOption)
+	if err != nil {
+		glog.V(0).Infof("volume server %s:%d: %v; using heartbeat master", vs.store.Ip, vs.store.Port, err)
+		return vs.GetMaster(ctx)
+	}
+	current := vs.getCurrentMaster()
+	if !leader.Equals(current) {
+		glog.V(0).Infof("volume server %s:%d raft leader is %v (heartbeat master %v)", vs.store.Ip, vs.store.Port, leader, current)
+		vs.setCurrentMaster(leader)
+	}
+	return leader
 }
 
 // getCurrentMaster returns vs.currentMaster under a read lock so callers
@@ -262,10 +280,10 @@ func (vs *VolumeServer) doHeartbeatWithRetry(masterAddress pb.ServerAddress, grp
 		case first := <-vs.store.NewEcShardsChan:
 			shards := util.DrainChannel(vs.store.NewEcShardsChan, first)
 			deltaBeat := &master_pb.Heartbeat{
-				Ip:           ip,
-				Port:         port,
-				DataCenter:   dataCenter,
-				Rack:         rack,
+				Ip:          ip,
+				Port:        port,
+				DataCenter:  dataCenter,
+				Rack:        rack,
 				NewEcShards: shards,
 			}
 			for _, s := range shards {
@@ -295,10 +313,10 @@ func (vs *VolumeServer) doHeartbeatWithRetry(masterAddress pb.ServerAddress, grp
 		case first := <-vs.store.DeletedEcShardsChan:
 			shards := util.DrainChannel(vs.store.DeletedEcShardsChan, first)
 			deltaBeat := &master_pb.Heartbeat{
-				Ip:               ip,
-				Port:             port,
-				DataCenter:       dataCenter,
-				Rack:             rack,
+				Ip:              ip,
+				Port:            port,
+				DataCenter:      dataCenter,
+				Rack:            rack,
 				DeletedEcShards: shards,
 			}
 			for _, s := range shards {

--- a/weed/server/volume_grpc_client_to_master.go
+++ b/weed/server/volume_grpc_client_to_master.go
@@ -2,6 +2,7 @@ package weed_server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -11,6 +12,8 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/stats"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/security"
@@ -26,23 +29,38 @@ func (vs *VolumeServer) GetMaster(ctx context.Context) pb.ServerAddress {
 	return vs.getCurrentMaster()
 }
 
-// lookupRaftLeaderMaster resolves the raft leader for topology mutations. The
-// heartbeat peer from GetMaster may still be a follower after an election.
-func (vs *VolumeServer) lookupRaftLeaderMaster(ctx context.Context) pb.ServerAddress {
+// lookupRaftLeaderMaster resolves the raft leader for topology mutations via
+// GetMasterConfiguration on configured peers. It does not update currentMaster;
+// the heartbeat loop owns that field and reconnects when the stream reports a
+// different leader than the connected peer.
+func (vs *VolumeServer) lookupRaftLeaderMaster(ctx context.Context) (pb.ServerAddress, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	leader, err := operation.LookupRaftLeaderMaster(ctx, vs.SeedMasterNodes, vs.grpcDialOption)
 	if err != nil {
-		glog.V(0).Infof("volume server %s:%d: %v; using heartbeat master", vs.store.Ip, vs.store.Port, err)
-		return vs.GetMaster(ctx)
+		if isContextDoneErr(err) {
+			glog.V(1).Infof("volume server %s:%d: raft leader lookup: %v", vs.store.Ip, vs.store.Port, err)
+		} else {
+			glog.V(0).Infof("volume server %s:%d: raft leader lookup: %v", vs.store.Ip, vs.store.Port, err)
+		}
+		return "", err
 	}
 	current := vs.getCurrentMaster()
 	if !leader.Equals(current) {
-		glog.V(0).Infof("volume server %s:%d raft leader is %v (heartbeat master %v)", vs.store.Ip, vs.store.Port, leader, current)
-		vs.setCurrentMaster(leader)
+		glog.V(1).Infof("volume server %s:%d: raft leader %v (heartbeat peer %v)", vs.store.Ip, vs.store.Port, leader, current)
 	}
-	return leader
+	return leader, nil
+}
+
+func isContextDoneErr(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	if st, ok := status.FromError(err); ok {
+		return st.Code() == codes.Canceled || st.Code() == codes.DeadlineExceeded
+	}
+	return false
 }
 
 // getCurrentMaster returns vs.currentMaster under a read lock so callers

--- a/weed/server/volume_grpc_client_to_master_test.go
+++ b/weed/server/volume_grpc_client_to_master_test.go
@@ -1,0 +1,62 @@
+package weed_server
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb"
+	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
+	"github.com/seaweedfs/seaweedfs/weed/storage"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func TestLookupRaftLeaderMasterDoesNotUpdateCurrentMaster(t *testing.T) {
+	follower := startFakeMasterServerForLeaderLookup(t, &fakeLeaderConfigServer{
+		leader: "leader.example.com:9333.19333",
+	})
+	heartbeatPeer := pb.ServerAddress("10.0.0.1:9333")
+	vs := &VolumeServer{
+		SeedMasterNodes: []pb.ServerAddress{follower},
+		grpcDialOption:  grpc.WithTransportCredentials(insecure.NewCredentials()),
+		store:           &storage.Store{Ip: "127.0.0.1", Port: 8080},
+	}
+	vs.setCurrentMaster(heartbeatPeer)
+
+	leader, err := vs.lookupRaftLeaderMaster(context.Background())
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if got, want := leader.ToHttpAddress(), "leader.example.com:9333"; got != want {
+		t.Fatalf("leader = %q, want %q", got, want)
+	}
+	if got := vs.getCurrentMaster(); got != heartbeatPeer {
+		t.Fatalf("currentMaster = %v, want unchanged %v", got, heartbeatPeer)
+	}
+}
+
+type fakeLeaderConfigServer struct {
+	master_pb.UnimplementedSeaweedServer
+	leader string
+}
+
+func (s *fakeLeaderConfigServer) GetMasterConfiguration(_ context.Context, _ *master_pb.GetMasterConfigurationRequest) (*master_pb.GetMasterConfigurationResponse, error) {
+	return &master_pb.GetMasterConfigurationResponse{Leader: s.leader}, nil
+}
+
+func startFakeMasterServerForLeaderLookup(t *testing.T, srv master_pb.SeaweedServer) pb.ServerAddress {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	grpcServer := grpc.NewServer()
+	master_pb.RegisterSeaweedServer(grpcServer, srv)
+	go func() { _ = grpcServer.Serve(lis) }()
+	t.Cleanup(grpcServer.GracefulStop)
+
+	_, port, _ := net.SplitHostPort(lis.Addr().String())
+	return pb.ServerAddress(fmt.Sprintf("127.0.0.1:0.%s", port))
+}


### PR DESCRIPTION
## Problem

With HA masters (`-master.peers` / multiple `-master` on volume servers), `weed shell volume.mark`
fails after raft leader election:

```
error: set volume 7 readonly=true on master ctl-a:9333:
  raft.Server: Not current leader
```

while `cluster/status` on ctl-b reports `IsLeader: true`.

`weed shell` connects to the leader, but `volume.mark` goes through the volume server, which
calls `VolumeMarkReadonly` on `vs.GetMaster()` — the heartbeat peer, which may still be a
follower until the heartbeat stream redirects.

This breaks `volume.tier.move` (which marks replicas read-only before copying) and automation
that marks volumes read-only across elections.

## Fix

`notifyMasterVolumeReadonly` tries the heartbeat peer (`GetMaster`) first. If the master
returns `Not current leader`, resolve the raft leader via `GetMasterConfiguration` on
configured `-master` peers (followers already return `Leader`) and retry on that address.

`currentMaster` is **not** updated by leader lookup — the heartbeat loop owns that field and
reconnects when the stream reports a different leader than the connected peer.

Adds `operation.LookupRaftLeaderMaster` with unit tests.

## Test plan

- [x] `go test ./weed/operation -run LookupRaftLeader`
- [x] `go test ./weed/server -run LookupRaftLeaderMasterDoesNotUpdate`
- [x] `go test ./weed/operation ./weed/server` (CI build tags)
- [x] `go test ./test/multi_master/...` (failover suite)
- [x] `go vet` / `go build` with CI tags


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced leader discovery by trying multiple configured master peers until the Raft leader is resolved.
* **Bug Fixes**
  * Improved read-only volume marking reliability by retrying the request against the resolved Raft leader when the master is not the current leader.
* **Tests**
  * Added automated coverage for leader resolution (including peer fallback), error cases (no peers), context cancellation propagation, and ensuring the current master setting remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->