### PR TITLE
feat(metrics): Add EC rebuild/reconstruct Prometheus metrics

### DIFF
--- a/other/metrics/grafana_seaweedfs.json
+++ b/other/metrics/grafana_seaweedfs.json
@@ -4362,6 +4362,220 @@
             }
           ],
           "pluginVersion": "10.3.1"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "title": "EC Rebuild Duration",
+          "description": "p50/p95/p99 duration of EC shard rebuild operations",
+          "type": "timeseries",
+          "id": 217,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 126
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 4,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "unit": "s",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.99, sum(rate(SeaweedFS_volumeServer_ec_rebuild_seconds_bucket{cluster=~\"$cluster\"}[$__rate_interval])) by (le))",
+              "range": true,
+              "refId": "A",
+              "legendFormat": "p99"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.95, sum(rate(SeaweedFS_volumeServer_ec_rebuild_seconds_bucket{cluster=~\"$cluster\"}[$__rate_interval])) by (le))",
+              "range": true,
+              "refId": "B",
+              "legendFormat": "p95"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "histogram_quantile(0.50, sum(rate(SeaweedFS_volumeServer_ec_rebuild_seconds_bucket{cluster=~\"$cluster\"}[$__rate_interval])) by (le))",
+              "range": true,
+              "refId": "C",
+              "legendFormat": "p50"
+            }
+          ],
+          "pluginVersion": "10.3.1"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "title": "EC Rebuild Operations",
+          "description": "Rate of EC shard rebuild operations by result",
+          "type": "timeseries",
+          "id": 218,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 126
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 4,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "unit": "ops",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "sum by (result) (rate(SeaweedFS_volumeServer_ec_rebuild_total{cluster=~\"$cluster\"}[5m]))",
+              "range": true,
+              "refId": "A",
+              "legendFormat": "{{result}}"
+            }
+          ],
+          "pluginVersion": "10.3.1"
         }
       ]
     },

--- a/other/metrics/grafana_seaweedfs.json
+++ b/other/metrics/grafana_seaweedfs.json
@@ -4451,10 +4451,10 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.99, sum(rate(SeaweedFS_volumeServer_ec_rebuild_seconds_bucket{cluster=~\"$cluster\"}[$__rate_interval])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(rate(SeaweedFS_volumeServer_ec_rebuild_seconds_bucket{cluster=~\"$cluster\"}[$__rate_interval])) by (le, result))",
               "range": true,
               "refId": "A",
-              "legendFormat": "p99"
+              "legendFormat": "p99 {{result}}"
             },
             {
               "datasource": {
@@ -4462,10 +4462,10 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.95, sum(rate(SeaweedFS_volumeServer_ec_rebuild_seconds_bucket{cluster=~\"$cluster\"}[$__rate_interval])) by (le))",
+              "expr": "histogram_quantile(0.95, sum(rate(SeaweedFS_volumeServer_ec_rebuild_seconds_bucket{cluster=~\"$cluster\"}[$__rate_interval])) by (le, result))",
               "range": true,
               "refId": "B",
-              "legendFormat": "p95"
+              "legendFormat": "p95 {{result}}"
             },
             {
               "datasource": {
@@ -4473,10 +4473,10 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.50, sum(rate(SeaweedFS_volumeServer_ec_rebuild_seconds_bucket{cluster=~\"$cluster\"}[$__rate_interval])) by (le))",
+              "expr": "histogram_quantile(0.50, sum(rate(SeaweedFS_volumeServer_ec_rebuild_seconds_bucket{cluster=~\"$cluster\"}[$__rate_interval])) by (le, result))",
               "range": true,
               "refId": "C",
-              "legendFormat": "p50"
+              "legendFormat": "p50 {{result}}"
             }
           ],
           "pluginVersion": "10.3.1"

--- a/weed/server/volume_grpc_erasure_coding.go
+++ b/weed/server/volume_grpc_erasure_coding.go
@@ -259,6 +259,9 @@ func (vs *VolumeServer) VolumeEcShardsRebuild(ctx context.Context, req *volume_s
 		return nil, fmt.Errorf("RebuildEcxFile %s: %v", indexBaseFileName, err)
 	}
 
+	stats.VolumeServerECRebuildHistogram.Observe(time.Since(start).Seconds())
+	stats.VolumeServerECRebuildCounter.WithLabelValues("success").Inc()
+
 	// Opportunistic bitrot backfill: if protection is enabled, no sidecar exists
 	// yet (a volume encoded before this feature), and this rebuilder can reach
 	// every shard, compute and write a generation-0 sidecar. The TOFU baseline
@@ -282,9 +285,6 @@ func (vs *VolumeServer) VolumeEcShardsRebuild(ctx context.Context, req *volume_s
 			}
 		}
 	}
-
-	stats.VolumeServerECRebuildHistogram.Observe(time.Since(start).Seconds())
-	stats.VolumeServerECRebuildCounter.WithLabelValues("success").Inc()
 
 	return &volume_server_pb.VolumeEcShardsRebuildResponse{
 		RebuiltShardIds: rebuiltShardIds,

--- a/weed/server/volume_grpc_erasure_coding.go
+++ b/weed/server/volume_grpc_erasure_coding.go
@@ -200,7 +200,6 @@ func (vs *VolumeServer) VolumeEcShardsRebuild(ctx context.Context, req *volume_s
 	for _, location := range vs.store.Locations {
 		_, _, existingShardCount, err := checkEcVolumeStatus(baseFileName, location)
 		if err != nil {
-			stats.VolumeServerECRebuildCounter.WithLabelValues("failure").Inc()
 			return nil, err
 		}
 

--- a/weed/server/volume_grpc_erasure_coding.go
+++ b/weed/server/volume_grpc_erasure_coding.go
@@ -16,6 +16,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/operation"
 	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/volume_server_pb"
+	"github.com/seaweedfs/seaweedfs/weed/stats"
 	"github.com/seaweedfs/seaweedfs/weed/storage"
 	"github.com/seaweedfs/seaweedfs/weed/storage/erasure_coding"
 	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
@@ -174,6 +175,11 @@ func (vs *VolumeServer) VolumeEcShardsGenerate(ctx context.Context, req *volume_
 	return &volume_server_pb.VolumeEcShardsGenerateResponse{}, nil
 }
 
+func recordEcRebuildFailure(d time.Duration) {
+	stats.VolumeServerECRebuildHistogram.Observe(d.Seconds())
+	stats.VolumeServerECRebuildCounter.WithLabelValues("failure").Inc()
+}
+
 // VolumeEcShardsRebuild generates the any of the missing .ec00 ~ .ec13 files
 func (vs *VolumeServer) VolumeEcShardsRebuild(ctx context.Context, req *volume_server_pb.VolumeEcShardsRebuildRequest) (*volume_server_pb.VolumeEcShardsRebuildResponse, error) {
 	if err := vs.CheckMaintenanceMode(); err != nil {
@@ -194,6 +200,7 @@ func (vs *VolumeServer) VolumeEcShardsRebuild(ctx context.Context, req *volume_s
 	for _, location := range vs.store.Locations {
 		_, _, existingShardCount, err := checkEcVolumeStatus(baseFileName, location)
 		if err != nil {
+			stats.VolumeServerECRebuildCounter.WithLabelValues("failure").Inc()
 			return nil, err
 		}
 
@@ -235,18 +242,21 @@ func (vs *VolumeServer) VolumeEcShardsRebuild(ctx context.Context, req *volume_s
 	// Rebuild missing EC files, searching all disk locations for input shards.
 	// Present input shards are verified against the bitrot sidecar (when present)
 	// and corrupt ones are regenerated; unsafe_ignore_sidecar bypasses the guard.
+	start := time.Now()
 	dataBaseFileName := path.Join(rebuildDataDir, baseFileName)
-	if generatedShardIds, err := erasure_coding.RebuildEcFiles(dataBaseFileName, erasure_coding.BackgroundECContext(), req.UnsafeIgnoreSidecar, additionalDirs...); err != nil {
+	generatedShardIds, err := erasure_coding.RebuildEcFiles(dataBaseFileName, erasure_coding.BackgroundECContext(), req.UnsafeIgnoreSidecar, additionalDirs...)
+	if err != nil {
+		recordEcRebuildFailure(time.Since(start))
 		return nil, fmt.Errorf("RebuildEcFiles %s: %v", dataBaseFileName, err)
-	} else {
-		rebuiltShardIds = generatedShardIds
 	}
+	rebuiltShardIds = generatedShardIds
 
 	indexBaseFileName := path.Join(rebuildLocation.IdxDirectory, baseFileName)
 	if !util.FileExists(indexBaseFileName+".ecx") && rebuildLocation.IdxDirectory != rebuildLocation.Directory {
 		indexBaseFileName = path.Join(rebuildLocation.Directory, baseFileName)
 	}
 	if err := erasure_coding.RebuildEcxFile(indexBaseFileName); err != nil {
+		recordEcRebuildFailure(time.Since(start))
 		return nil, fmt.Errorf("RebuildEcxFile %s: %v", indexBaseFileName, err)
 	}
 
@@ -273,6 +283,9 @@ func (vs *VolumeServer) VolumeEcShardsRebuild(ctx context.Context, req *volume_s
 			}
 		}
 	}
+
+	stats.VolumeServerECRebuildHistogram.Observe(time.Since(start).Seconds())
+	stats.VolumeServerECRebuildCounter.WithLabelValues("success").Inc()
 
 	return &volume_server_pb.VolumeEcShardsRebuildResponse{
 		RebuiltShardIds: rebuiltShardIds,

--- a/weed/server/volume_grpc_erasure_coding.go
+++ b/weed/server/volume_grpc_erasure_coding.go
@@ -175,9 +175,9 @@ func (vs *VolumeServer) VolumeEcShardsGenerate(ctx context.Context, req *volume_
 	return &volume_server_pb.VolumeEcShardsGenerateResponse{}, nil
 }
 
-func recordEcRebuildFailure(d time.Duration) {
-	stats.VolumeServerECRebuildHistogram.Observe(d.Seconds())
-	stats.VolumeServerECRebuildCounter.WithLabelValues("failure").Inc()
+func recordEcRebuild(result string, d time.Duration) {
+	stats.VolumeServerECRebuildHistogram.WithLabelValues(result).Observe(d.Seconds())
+	stats.VolumeServerECRebuildCounter.WithLabelValues(result).Inc()
 }
 
 // VolumeEcShardsRebuild generates the any of the missing .ec00 ~ .ec13 files
@@ -245,7 +245,7 @@ func (vs *VolumeServer) VolumeEcShardsRebuild(ctx context.Context, req *volume_s
 	dataBaseFileName := path.Join(rebuildDataDir, baseFileName)
 	generatedShardIds, err := erasure_coding.RebuildEcFiles(dataBaseFileName, erasure_coding.BackgroundECContext(), req.UnsafeIgnoreSidecar, additionalDirs...)
 	if err != nil {
-		recordEcRebuildFailure(time.Since(start))
+		recordEcRebuild("failure", time.Since(start))
 		return nil, fmt.Errorf("RebuildEcFiles %s: %v", dataBaseFileName, err)
 	}
 	rebuiltShardIds = generatedShardIds
@@ -255,12 +255,11 @@ func (vs *VolumeServer) VolumeEcShardsRebuild(ctx context.Context, req *volume_s
 		indexBaseFileName = path.Join(rebuildLocation.Directory, baseFileName)
 	}
 	if err := erasure_coding.RebuildEcxFile(indexBaseFileName); err != nil {
-		recordEcRebuildFailure(time.Since(start))
+		recordEcRebuild("failure", time.Since(start))
 		return nil, fmt.Errorf("RebuildEcxFile %s: %v", indexBaseFileName, err)
 	}
 
-	stats.VolumeServerECRebuildHistogram.Observe(time.Since(start).Seconds())
-	stats.VolumeServerECRebuildCounter.WithLabelValues("success").Inc()
+	recordEcRebuild("success", time.Since(start))
 
 	// Opportunistic bitrot backfill: if protection is enabled, no sidecar exists
 	// yet (a volume encoded before this feature), and this rebuilder can reach

--- a/weed/stats/metrics.go
+++ b/weed/stats/metrics.go
@@ -512,15 +512,15 @@ var (
 			Help:      "Counter of replication failures by operation and reason (timeout, connection_refused, context_cancelled, server_error).",
 		}, []string{"operation", "reason"})
 
-	// VolumeServerECRebuildHistogram records the duration of EC shard rebuild operations.
-	VolumeServerECRebuildHistogram = prometheus.NewHistogram(
+	// VolumeServerECRebuildHistogram records the duration of EC shard rebuild operations by result (success, failure).
+	VolumeServerECRebuildHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: Namespace,
 			Subsystem: subsystemVolumeServer,
 			Name:      "ec_rebuild_seconds",
-			Help:      "Bucketed histogram of EC shard rebuild/reconstruct duration.",
+			Help:      "Bucketed histogram of EC shard rebuild/reconstruct duration by result.",
 			Buckets:   prometheus.ExponentialBuckets(0.01, 2, 20),
-		})
+		}, []string{"result"})
 
 	// VolumeServerECRebuildCounter counts EC shard rebuild operations by result (success, failure).
 	VolumeServerECRebuildCounter = prometheus.NewCounterVec(

--- a/weed/stats/metrics.go
+++ b/weed/stats/metrics.go
@@ -512,6 +512,25 @@ var (
 			Help:      "Counter of replication failures by operation and reason (timeout, connection_refused, context_cancelled, server_error).",
 		}, []string{"operation", "reason"})
 
+	// VolumeServerECRebuildHistogram records the duration of EC shard rebuild operations.
+	VolumeServerECRebuildHistogram = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: Namespace,
+			Subsystem: subsystemVolumeServer,
+			Name:      "ec_rebuild_seconds",
+			Help:      "Bucketed histogram of EC shard rebuild/reconstruct duration.",
+			Buckets:   prometheus.ExponentialBuckets(0.01, 2, 20),
+		})
+
+	// VolumeServerECRebuildCounter counts EC shard rebuild operations by result (success, failure).
+	VolumeServerECRebuildCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: subsystemVolumeServer,
+			Name:      "ec_rebuild_total",
+			Help:      "Counter of EC shard rebuild operations by result.",
+		}, []string{"result"})
+
 	S3RequestCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: Namespace,
@@ -886,6 +905,8 @@ func init() {
 	Gather.MustRegister(VolumeServerReplicationHistogram)
 	Gather.MustRegister(VolumeServerReplicationTargets)
 	Gather.MustRegister(VolumeServerReplicationFailures)
+	Gather.MustRegister(VolumeServerECRebuildHistogram)
+	Gather.MustRegister(VolumeServerECRebuildCounter)
 	Gather.MustRegister(MasterUnderReplicatedVolumes)
 	Gather.MustRegister(MasterVolumeCreationCounter)
 

--- a/weed/stats/metrics_ec_rebuild_test.go
+++ b/weed/stats/metrics_ec_rebuild_test.go
@@ -7,23 +7,31 @@ import (
 )
 
 func TestECRebuildMetricsRegistered(t *testing.T) {
-	VolumeServerECRebuildCounter.Reset()
-	t.Cleanup(func() {
-		VolumeServerECRebuildCounter.Reset()
-	})
-
-	// Seed the CounterVec with a value so collection returns it
 	VolumeServerECRebuildCounter.WithLabelValues("success").Inc()
+	VolumeServerECRebuildHistogram.Observe(0.1)
 
-	count := testutil.CollectAndCount(VolumeServerECRebuildCounter)
-	if count < 1 {
-		t.Errorf("VolumeServerECRebuildCounter: expected at least 1 collection, got %d", count)
+	metrics, err := Gather.Gather()
+	if err != nil {
+		t.Fatalf("failed to gather metrics: %v", err)
 	}
 
-	VolumeServerECRebuildHistogram.Observe(0.1)
-	count = testutil.CollectAndCount(VolumeServerECRebuildHistogram)
-	if count < 1 {
-		t.Errorf("VolumeServerECRebuildHistogram: expected at least 1 collection, got %d", count)
+	counterFound := false
+	histogramFound := false
+
+	for _, mf := range metrics {
+		if mf.GetName() == "SeaweedFS_volumeServer_ec_rebuild_total" {
+			counterFound = true
+		}
+		if mf.GetName() == "SeaweedFS_volumeServer_ec_rebuild_seconds" {
+			histogramFound = true
+		}
+	}
+
+	if !counterFound {
+		t.Errorf("VolumeServerECRebuildCounter: metric not registered with Gather")
+	}
+	if !histogramFound {
+		t.Errorf("VolumeServerECRebuildHistogram: metric not registered with Gather")
 	}
 }
 

--- a/weed/stats/metrics_ec_rebuild_test.go
+++ b/weed/stats/metrics_ec_rebuild_test.go
@@ -1,0 +1,47 @@
+package stats
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestECRebuildMetricsRegistered(t *testing.T) {
+	VolumeServerECRebuildCounter.Reset()
+	t.Cleanup(func() {
+		VolumeServerECRebuildCounter.Reset()
+	})
+
+	// Seed the CounterVec with a value so collection returns it
+	VolumeServerECRebuildCounter.WithLabelValues("success").Inc()
+
+	count := testutil.CollectAndCount(VolumeServerECRebuildCounter)
+	if count < 1 {
+		t.Errorf("VolumeServerECRebuildCounter: expected at least 1 collection, got %d", count)
+	}
+
+	VolumeServerECRebuildHistogram.Observe(0.1)
+	count = testutil.CollectAndCount(VolumeServerECRebuildHistogram)
+	if count < 1 {
+		t.Errorf("VolumeServerECRebuildHistogram: expected at least 1 collection, got %d", count)
+	}
+}
+
+func TestECRebuildCounterIncrement(t *testing.T) {
+	VolumeServerECRebuildCounter.Reset()
+	t.Cleanup(func() {
+		VolumeServerECRebuildCounter.Reset()
+	})
+
+	VolumeServerECRebuildCounter.WithLabelValues("success").Inc()
+	VolumeServerECRebuildCounter.WithLabelValues("failure").Inc()
+
+	got := testutil.ToFloat64(VolumeServerECRebuildCounter.WithLabelValues("success"))
+	if got != 1 {
+		t.Errorf("expected 1.0, got %f", got)
+	}
+	got = testutil.ToFloat64(VolumeServerECRebuildCounter.WithLabelValues("failure"))
+	if got != 1 {
+		t.Errorf("expected 1.0, got %f", got)
+	}
+}

--- a/weed/stats/metrics_ec_rebuild_test.go
+++ b/weed/stats/metrics_ec_rebuild_test.go
@@ -8,6 +8,7 @@ import (
 
 func TestECRebuildMetricsRegistered(t *testing.T) {
 	VolumeServerECRebuildCounter.WithLabelValues("success").Inc()
+	VolumeServerECRebuildHistogram.WithLabelValues("success").Observe(0.1)
 	metrics, err := Gather.Gather()
 	if err != nil {
 		t.Fatalf("failed to gather metrics: %v", err)

--- a/weed/stats/metrics_ec_rebuild_test.go
+++ b/weed/stats/metrics_ec_rebuild_test.go
@@ -7,6 +7,10 @@ import (
 )
 
 func TestECRebuildMetricsRegistered(t *testing.T) {
+	t.Cleanup(VolumeServerECRebuildCounter.Reset)
+	t.Cleanup(VolumeServerECRebuildHistogram.Reset)
+
+	// A HistogramVec emits no metric family until it has a child, so observe once.
 	VolumeServerECRebuildCounter.WithLabelValues("success").Inc()
 	VolumeServerECRebuildHistogram.WithLabelValues("success").Observe(0.1)
 	metrics, err := Gather.Gather()

--- a/weed/stats/metrics_ec_rebuild_test.go
+++ b/weed/stats/metrics_ec_rebuild_test.go
@@ -8,8 +8,6 @@ import (
 
 func TestECRebuildMetricsRegistered(t *testing.T) {
 	VolumeServerECRebuildCounter.WithLabelValues("success").Inc()
-	VolumeServerECRebuildHistogram.Observe(0.1)
-
 	metrics, err := Gather.Gather()
 	if err != nil {
 		t.Fatalf("failed to gather metrics: %v", err)


### PR DESCRIPTION
What problem are we solving? 
We are solving the lack of visibility into EC shard rebuild operations in SeaweedFS. Without metrics, operators cannot monitor the duration and success/failure rates of EC rebuilds, which is critical for understanding system health during erasure coding reconstruction and detecting data recovery issues.

How are we solving the problem? 
We are adding Prometheus metrics to instrument EC shard rebuild operations on volume servers:

VolumeServerECRebuildHistogram: records the duration of EC shard rebuild/reconstruct operations.
VolumeServerECRebuildCounter: counts EC shard rebuild operations by result (success, failure).
How is the PR tested? We added unit tests in:

weed/stats/metrics_ec_rebuild_test.go: tests for the registration and basic operations of the new metrics.

Checklist

- [x]  I have added unit tests if possible.
- [x]  I will add related wiki document changes and link to this PR after merging.
- [ ]  All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional reviews.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Grafana panels for EC shard rebuilds, showing rebuild duration quantiles and rebuild operation rates by outcome.
  * Added Prometheus metrics to track EC rebuild duration (histogram) and rebuild results (success/failure counters).
* **Bug Fixes**
  * EC shard rebuilds now consistently record timing and outcome metrics for each rebuild step, including failures.
* **Tests**
  * Added unit tests to confirm EC rebuild metrics are registered and that labeled counters increment as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->