### PR TITLE
fix: avoid duplicate volume.list parent headers

### DIFF
--- a/weed/shell/command_volume_list.go
+++ b/weed/shell/command_volume_list.go
@@ -224,12 +224,17 @@ func (c *commandVolumeList) writeDataCenterInfo(writer io.Writer, t *master_pb.D
 		return strings.Compare(a.Id, b.Id)
 	})
 	dataCenterInfoFound := false
+	dataCenterHeaderPrinted := false
 	for _, r := range t.RackInfos {
 		if *c.rack != "" && *c.rack != r.Id {
 			continue
 		}
 		s.add(c.writeRackInfo(writer, r, verbosityLevel, func() {
+			if dataCenterHeaderPrinted {
+				return
+			}
 			output(verbosityLevel >= 1, writer, "  DataCenter %s%s\n", t.Id, diskInfosToString(t.DiskInfos))
+			dataCenterHeaderPrinted = true
 		}))
 		if !dataCenterInfoFound && !s.isEmpty() {
 			dataCenterInfoFound = true
@@ -245,13 +250,18 @@ func (c *commandVolumeList) writeRackInfo(writer io.Writer, t *master_pb.RackInf
 		return strings.Compare(a.Id, b.Id)
 	})
 	rackInfoFound := false
+	rackHeaderPrinted := false
 	for _, dn := range t.DataNodeInfos {
 		if *c.dataNode != "" && *c.dataNode != dn.Id {
 			continue
 		}
 		s.add(c.writeDataNodeInfo(writer, dn, verbosityLevel, func() {
 			outCenterInfo()
+			if rackHeaderPrinted {
+				return
+			}
 			output(verbosityLevel >= 2, writer, "    Rack %s%s\n", t.Id, diskInfosToString(t.DiskInfos))
+			rackHeaderPrinted = true
 		}))
 		if !rackInfoFound && !s.isEmpty() {
 			rackInfoFound = true

--- a/weed/shell/command_volume_list_test.go
+++ b/weed/shell/command_volume_list_test.go
@@ -194,6 +194,34 @@ func TestWriteDataNodeInfo_SplitsCollapsedDisksByPhysicalDiskId(t *testing.T) {
 	}
 }
 
+func TestWriteTopologyInfo_PrintsParentHeadersOnce(t *testing.T) {
+	topo := topoFromNodes(
+		volNode("node1:8081", &master_pb.VolumeInformationMessage{Id: 1, Collection: "c"}),
+		volNode("node2:8081", &master_pb.VolumeInformationMessage{Id: 2, Collection: "c"}),
+	)
+	topo.DiskInfos = map[string]*master_pb.DiskInfo{"hdd": {Type: "hdd"}}
+	topo.DataCenterInfos[0].DiskInfos = map[string]*master_pb.DiskInfo{"hdd": {Type: "hdd"}}
+	topo.DataCenterInfos[0].RackInfos[0].DiskInfos = map[string]*master_pb.DiskInfo{"hdd": {Type: "hdd"}}
+
+	c := &commandVolumeList{}
+	fs := flag.NewFlagSet("volume.list", flag.ContinueOnError)
+	c.collectionPattern = fs.String("collection", "", "")
+	c.dataCenter = fs.String("dataCenter", "", "")
+	c.rack = fs.String("rack", "", "")
+	c.dataNode = fs.String("dataNode", "", "")
+	c.readonly = fs.Bool("readonly", false, "")
+	c.writable = fs.Bool("writable", false, "")
+	c.volumeId = fs.Uint64("volumeId", 0, "")
+
+	var dcBuf bytes.Buffer
+	c.writeTopologyInfo(&dcBuf, topo, 30000, 1)
+	assert.Equal(t, 1, strings.Count(dcBuf.String(), "  DataCenter dc1 hdd("))
+
+	var rackBuf bytes.Buffer
+	c.writeTopologyInfo(&rackBuf, topo, 30000, 2)
+	assert.Equal(t, 1, strings.Count(rackBuf.String(), "    Rack rack1 hdd("))
+}
+
 // volNode builds a single-node topology from (volumeId, collection) pairs so the
 // duplicate-detection tests can describe a cluster compactly.
 func volNode(nodeId string, volumes ...*master_pb.VolumeInformationMessage) *master_pb.DataNodeInfo {


### PR DESCRIPTION
# What problem are we solving?

`volume.list -v=1` may print the same DataCenter summary multiple times when one DataCenter has multiple matching DataNodes.

The same parent-header callback pattern can also duplicate Rack summaries with `volume.list -v=2`.

# How are we solving the problem?

Add one-time guards when printing DataCenter and Rack headers, matching the existing DataNode header behavior.

This keeps parent headers printed once per matching parent instead of once per matching child.

# How is the PR tested?

- `go test ./weed/shell -count=1`

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.

<img width="926" height="1127" alt="image" src="https://github.com/user-attachments/assets/7fd60085-e9e4-446d-92fc-515fd8cf9337" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved volume topology output so data center and rack headers are no longer repeated during nested listings.
  * Preserved the expected hierarchy display while making the rendered output cleaner and easier to read.

* **Tests**
  * Added coverage to verify parent headers appear only once when printing topology information at different verbosity levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->