### PR TITLE
fix(rust-volume): parse master lookup when publicUrl is omitted

### DIFF
--- a/seaweed-volume/src/server/handlers.rs
+++ b/seaweed-volume/src/server/handlers.rs
@@ -356,10 +356,21 @@ fn parse_url_path(path: &str) -> Option<(VolumeId, NeedleId, Cookie)> {
 #[derive(Clone, Debug, Deserialize)]
 struct VolumeLocation {
     url: String,
-    #[serde(rename = "publicUrl")]
+    // Master often omits publicUrl when it matches url (Go json omitempty).
+    #[serde(rename = "publicUrl", default)]
     public_url: String,
     #[serde(rename = "grpcPort", default)]
     grpc_port: u32,
+}
+
+impl VolumeLocation {
+    fn public_or_url(&self) -> &str {
+        if self.public_url.is_empty() {
+            &self.url
+        } else {
+            &self.public_url
+        }
+    }
 }
 
 /// Master /dir/lookup response.
@@ -535,9 +546,13 @@ async fn do_replicated_request(
     .await
     .map_err(|e| format!("lookup volume failed: {}", e))?;
 
+    let self_http = to_http_address(&state.self_url);
     let remote_locations: Vec<_> = locations
         .into_iter()
-        .filter(|loc| loc.url != state.self_url && loc.public_url != state.self_url)
+        .filter(|loc| {
+            to_http_address(&loc.url) != self_http
+                && to_http_address(loc.public_or_url()) != self_http
+        })
         .collect();
 
     if remote_locations.is_empty() {
@@ -4020,6 +4035,26 @@ mod tests {
             response.headers().get(header::LOCATION).unwrap(),
             "http://volume.internal:8080/3,01637037d6?proxied=true"
         );
+    }
+
+    /// Master /dir/lookup often omits publicUrl when empty (Go `json:"publicUrl,omitempty"`).
+    /// Replication must still parse locations or every cross-DC write fails.
+    #[test]
+    fn test_lookup_result_deserializes_without_public_url() {
+        let body = r#"{
+            "volumeOrFileId": "9",
+            "locations": [
+                {"url": "volume-a.example:8080", "dataCenter": "dc-a", "grpcPort": 18080},
+                {"url": "volume-b.example:8080", "dataCenter": "dc-b", "grpcPort": 18080}
+            ]
+        }"#;
+        let result: LookupResult = serde_json::from_str(body).expect("parse lookup JSON");
+        let locations = result.locations.expect("locations");
+        assert_eq!(locations.len(), 2);
+        assert_eq!(locations[0].url, "volume-a.example:8080");
+        assert!(locations[0].public_url.is_empty());
+        assert_eq!(locations[0].public_or_url(), "volume-a.example:8080");
+        assert_eq!(locations[0].grpc_port, 18080);
     }
 
     /// Regression test for issue #9274.


### PR DESCRIPTION
## Problem

Rust volume servers (`weed-volume-large-disk`) fail cross-datacenter replication when the master returns `/dir/lookup` locations **without** `publicUrl`.

Go master JSON uses `publicUrl,omitempty`; when a data node does not advertise a separate public URL, the field is absent. The Rust client required `publicUrl` in `VolumeLocation`, so serde deserialization failed with:

```
lookup parse failed: error decoding response body
```

That blocks any RF>1 write path that depends on HTTP replication lookup, including filer metadata log writes and filer admin updates that replicate across volume servers.

Example master response shape (no `publicUrl` on locations):

```json
{
  "volumeOrFileId": "9",
  "locations": [
    {"url": "volume-a.example:8080", "dataCenter": "dc-a", "grpcPort": 18080},
    {"url": "volume-b.example:8080", "dataCenter": "dc-b", "grpcPort": 18080}
  ]
}
```

## Fix

- Mark `publicUrl` as `#[serde(default)]` on `VolumeLocation`
- Use `public_or_url()` when filtering out the local peer for replication
- Unit test deserializing master-shaped JSON without `publicUrl`

## Test plan

- [x] `cargo test` in `seaweed-volume/` (local)
- [ ] GitHub `rust-volume-server-tests` workflow
- [ ] Cross-DC replication smoke test: replicated PUT on a volume with `copy_count > 1` after master lookup omits `publicUrl`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved volume location handling when `publicUrl` is missing or empty, ensuring consistent fallback to the standard URL.
  * Updated replication peer filtering to avoid matching the current server by using the effective public/standard URL for comparisons.
* **Tests**
  * Added a regression test to verify lookup JSON without `publicUrl` deserializes correctly and that the derived “public or URL” value behaves as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->