### PR TITLE
feat: add collection pattern to delete empty volumes

### DIFF
--- a/weed/shell/command_volume_delete_empty.go
+++ b/weed/shell/command_volume_delete_empty.go
@@ -27,6 +27,7 @@ func (c *commandVolumeDeleteEmpty) Help() string {
 	return `delete empty volumes from all volume servers
 
 	volume.deleteEmpty -quietFor=24h -apply
+	volume.deleteEmpty -collectionPattern=important* -quietFor=24h -apply
 
 	This command deletes all empty volumes from one volume server.
 
@@ -41,6 +42,7 @@ func (c *commandVolumeDeleteEmpty) Do(args []string, commandEnv *CommandEnv, wri
 
 	volDeleteCommand := flag.NewFlagSet(c.Name(), flag.ContinueOnError)
 	quietPeriod := volDeleteCommand.Duration("quietFor", 24*time.Hour, "select empty volumes with no recent writes, avoid newly created ones")
+	collectionPattern := volDeleteCommand.String("collectionPattern", "", "match with wildcard characters '*' and '?'")
 	applyBalancing := volDeleteCommand.Bool("apply", false, "apply to delete empty volumes")
 	// TODO: remove this alias
 	applyBalancingAlias := volDeleteCommand.Bool("force", false, "apply to delete empty volumes (alias for -apply)")
@@ -67,7 +69,7 @@ func (c *commandVolumeDeleteEmpty) Do(args []string, commandEnv *CommandEnv, wri
 	eachDataNode(topologyInfo, func(dc DataCenterId, rack RackId, dn *master_pb.DataNodeInfo) {
 		for _, diskInfo := range dn.DiskInfos {
 			for _, v := range diskInfo.VolumeInfos {
-				if v.Size <= super_block.SuperBlockSize && v.ModifiedAtSecond > 0 && v.ModifiedAtSecond+quietSeconds < nowUnixSeconds {
+				if isEmptyVolumeDeleteCandidate(v, quietSeconds, nowUnixSeconds, *collectionPattern) {
 					if *applyBalancing {
 						log.Printf("deleting empty volume %d from %s", v.Id, dn.Id)
 						if deleteErr := deleteVolume(commandEnv.option.GrpcDialOption, needle.VolumeId(v.Id),
@@ -84,4 +86,11 @@ func (c *commandVolumeDeleteEmpty) Do(args []string, commandEnv *CommandEnv, wri
 	})
 
 	return
+}
+
+func isEmptyVolumeDeleteCandidate(v *master_pb.VolumeInformationMessage, quietSeconds, nowUnixSeconds int64, collectionPattern string) bool {
+	return matchesVolumeCollectionPattern(collectionPattern, v.Collection) &&
+		v.Size <= super_block.SuperBlockSize &&
+		v.ModifiedAtSecond > 0 &&
+		v.ModifiedAtSecond+quietSeconds < nowUnixSeconds
 }

--- a/weed/shell/command_volume_delete_empty_test.go
+++ b/weed/shell/command_volume_delete_empty_test.go
@@ -1,0 +1,41 @@
+package shell
+
+import (
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
+)
+
+func TestIsEmptyVolumeDeleteCandidateCollectionPattern(t *testing.T) {
+	now := int64(1000)
+	quietSeconds := int64(100)
+	quietEmptyVolume := &master_pb.VolumeInformationMessage{
+		Size:             0,
+		ModifiedAtSecond: now - quietSeconds - 1,
+		Collection:       "important-logs",
+	}
+
+	tests := []struct {
+		name       string
+		pattern    string
+		collection string
+		want       bool
+	}{
+		{name: "empty pattern matches named collection", pattern: "", collection: "important-logs", want: true},
+		{name: "wildcard matches collection", pattern: "important*", collection: "important-logs", want: true},
+		{name: "wildcard rejects collection", pattern: "important*", collection: "other-logs", want: false},
+		{name: "default pattern matches empty collection", pattern: CollectionDefault, collection: "", want: true},
+		{name: "default pattern rejects named collection", pattern: CollectionDefault, collection: "important-logs", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := *quietEmptyVolume
+			v.Collection = tt.collection
+			if got := isEmptyVolumeDeleteCandidate(&v, quietSeconds, now, tt.pattern); got != tt.want {
+				t.Fatalf("isEmptyVolumeDeleteCandidate(collection=%q, pattern=%q) = %v, want %v",
+					tt.collection, tt.pattern, got, tt.want)
+			}
+		})
+	}
+}

--- a/weed/shell/command_volume_list.go
+++ b/weed/shell/command_volume_list.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"path/filepath"
 	"slices"
 	"sort"
 	"strings"
@@ -15,6 +14,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/storage/erasure_coding"
 	"github.com/seaweedfs/seaweedfs/weed/storage/types"
 	"github.com/seaweedfs/seaweedfs/weed/util"
+	"github.com/seaweedfs/seaweedfs/weed/util/wildcard"
 
 	"io"
 )
@@ -325,8 +325,7 @@ func matchesVolumeCollectionPattern(pattern, collection string) bool {
 	if pattern == CollectionDefault {
 		return collection == ""
 	}
-	matched, _ := filepath.Match(pattern, collection)
-	return matched
+	return wildcard.MatchesWildcard(pattern, collection)
 }
 
 func (c *commandVolumeList) writeDiskInfo(writer io.Writer, t *master_pb.DiskInfo, verbosityLevel int, outNodeInfo func()) statistics {

--- a/weed/shell/command_volume_list.go
+++ b/weed/shell/command_volume_list.go
@@ -309,21 +309,24 @@ func (c *commandVolumeList) isNotMatchDiskInfo(readOnly bool, collection string,
 	if *c.writable && (readOnly || volumeSize == -1 || (c.volumeSizeLimitMb > 0 && uint64(volumeSize) >= c.volumeSizeLimitMb*util.MiByte)) {
 		return true
 	}
-	if *c.collectionPattern != "" {
-		var matched bool
-		if *c.collectionPattern == CollectionDefault {
-			matched = (collection == "")
-		} else {
-			matched, _ = filepath.Match(*c.collectionPattern, collection)
-		}
-		if !matched {
-			return true
-		}
+	if !matchesVolumeCollectionPattern(*c.collectionPattern, collection) {
+		return true
 	}
 	if *c.volumeId > 0 && *c.volumeId != uint64(volumeId) {
 		return true
 	}
 	return false
+}
+
+func matchesVolumeCollectionPattern(pattern, collection string) bool {
+	if pattern == "" {
+		return true
+	}
+	if pattern == CollectionDefault {
+		return collection == ""
+	}
+	matched, _ := filepath.Match(pattern, collection)
+	return matched
 }
 
 func (c *commandVolumeList) writeDiskInfo(writer io.Writer, t *master_pb.DiskInfo, verbosityLevel int, outNodeInfo func()) statistics {


### PR DESCRIPTION
# What problem are we solving?

`volume.deleteEmpty` can only scan all empty volumes today. Operators cannot limit the cleanup to a subset of collections, even though `volume.list` already supports filtering collections with `-collectionPattern`.

This makes dry-runs and targeted empty-volume cleanup harder on clusters with many collections.

# How are we solving the problem?

Add `-collectionPattern` to `volume.deleteEmpty`.

The new option uses the same wildcard semantics as `volume.list`:
- empty pattern matches all collections
- `*` and `?` are supported
- `_default` matches the unnamed/default collection

The existing `volume.list` collection matching logic is shared through a small helper so both commands stay consistent.

# How is the PR tested?

```bash
env GOCACHE=/private/tmp/seaweedfs-go-cache go test ./weed/shell -run 'TestIsEmptyVolumeDeleteCandidateCollectionPattern|TestWriteDataNodeInfo_SplitsCollapsedDisksByPhysicalDiskId' -count=1
env GOCACHE=/private/tmp/seaweedfs-go-cache go test ./weed/shell -count=1
git diff --cached --check
```

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `collectionPattern` option to empty-volume deletion to restrict deletions to collections matching a wildcard pattern.
  * Volume listing now applies consistent collection-pattern filtering.

* **Bug Fixes**
  * Improved matching for default vs named collections and correct handling of empty patterns during collection filtering.

* **Tests**
  * Added unit test coverage for collection-pattern matching across named, wildcard, and default collection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->