### PR TITLE
fix(operation): auto-detect Go vs Rust volume servers for S3 chunk fan-out

### DIFF
--- a/seaweed-volume/src/server/handlers.rs
+++ b/seaweed-volume/src/server/handlers.rs
@@ -3024,6 +3024,10 @@ pub async fn status_handler(
         "Version".to_string(),
         serde_json::Value::from(crate::version::version()),
     );
+    m.insert(
+        "Implementation".to_string(),
+        serde_json::Value::from("rust"),
+    );
     m.insert("Volumes".to_string(), serde_json::Value::Array(volumes));
     m.insert(
         "DiskStatuses".to_string(),

--- a/weed/operation/upload_chunked.go
+++ b/weed/operation/upload_chunked.go
@@ -184,9 +184,10 @@ uploadLoop:
 			var uploadResultErr error
 
 			holders := chunkHolders(assignResult)
-			// Fan out to every holder, except for cipher: per-call encryption
-			// would give each replica different bytes, so keep its relay path.
-			if opt.UploadFunc == nil && !opt.Cipher && len(holders) > 1 {
+			// Gateway fan-out (PR #10078) writes every holder with type=replicate.
+			// Rust volume servers replicate on a normal primary write instead; fan-out
+			// causes cookie mismatch / invalid fid paths under cross-DC replication.
+			if opt.UploadFunc == nil && !opt.Cipher && chunkUploadReplicaFanoutEnabled(holders) {
 				uploadResult, uploadResultErr = uploadChunkToHolders(ctx, holders, assignResult.Fid, buf.Bytes(), jwt, chunkMd5B64, opt)
 			} else {
 				uploadOption := &UploadOption{
@@ -294,7 +295,8 @@ func chunkHolders(assignResult *AssignResult) []string {
 }
 
 // uploadChunkToHolders writes the chunk to every holder concurrently (each with
-// type=replicate). On the first failure it cancels the remaining uploads and
+// type=replicate). Used only when every holder is a Go volume server (PR #10078).
+// On the first failure it cancels the remaining uploads and
 // deletes any copies that already landed, so a partial fan-out leaves no
 // orphaned needle the caller cannot see.
 func uploadChunkToHolders(ctx context.Context, hosts []string, fid string, data []byte, jwt security.EncodedJwt, md5b64 string, opt *ChunkedUploadOption) (*UploadResult, error) {

--- a/weed/operation/upload_chunked_test.go
+++ b/weed/operation/upload_chunked_test.go
@@ -372,3 +372,101 @@ func TestUploadReaderInChunksReaderFailure(t *testing.T) {
 	t.Logf("✓ Got partial result on read failure: chunks=%d, totalSize=%d",
 		len(result.FileChunks), result.TotalSize)
 }
+
+// TestUploadReaderInChunksPrimaryWriteWhenMixedVolumeServers verifies that
+// replicated assigns use a single primary upload when any holder is not a Go
+// volume server (Rust servers replicate on the primary write).
+func TestUploadReaderInChunksPrimaryWriteWhenMixedVolumeServers(t *testing.T) {
+	var uploadPaths []string
+	var uploadMu sync.Mutex
+
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost || r.Method == http.MethodPut {
+			uploadMu.Lock()
+			uploadPaths = append(uploadPaths, r.URL.String())
+			uploadMu.Unlock()
+			fmt.Fprintf(w, `{"name":"f","size":7}`)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer primary.Close()
+	primaryHost := strings.TrimPrefix(primary.URL, "http://")
+
+	oldProbe := volumeServerImplementationProbe
+	defer func() {
+		volumeServerImplementationProbe = oldProbe
+		volumeServerKindCache = sync.Map{}
+	}()
+	volumeServerImplementationProbe = func(host string) string {
+		if host == primaryHost {
+			return volumeServerImplementationGo
+		}
+		return volumeServerImplementationRust
+	}
+
+	assignFunc := func(ctx context.Context, count int, expectedDataSize uint64) (*VolumeAssignRequest, *AssignResult, error) {
+		return nil, &AssignResult{
+			Fid: "3,01637037d6",
+			Url: primaryHost,
+			Replicas: []Location{
+				{Url: primaryHost},
+				{Url: "rust-volume:8080"},
+			},
+			Count: 1,
+		}, nil
+	}
+
+	_, err := UploadReaderInChunks(context.Background(), bytes.NewReader([]byte("payload")), &ChunkedUploadOption{
+		ChunkSize:       1024,
+		SmallFileLimit:  256,
+		SaveSmallInline: false,
+		AssignFunc:      assignFunc,
+	})
+	if err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	if len(uploadPaths) != 1 {
+		t.Fatalf("expected 1 primary upload, got %d: %v", len(uploadPaths), uploadPaths)
+	}
+	if !strings.HasPrefix(uploadPaths[0], "/3,01637037d6") {
+		t.Fatalf("expected primary fid path, got %q", uploadPaths[0])
+	}
+	if strings.Contains(uploadPaths[0], "type=replicate") {
+		t.Fatalf("primary upload must not use type=replicate: %q", uploadPaths[0])
+	}
+}
+
+func TestChunkUploadReplicaFanoutEnabled(t *testing.T) {
+	oldProbe := volumeServerImplementationProbe
+	defer func() { volumeServerImplementationProbe = oldProbe }()
+	volumeServerImplementationProbe = func(host string) string {
+		switch host {
+		case "go-a", "go-b":
+			return volumeServerImplementationGo
+		case "rust-a":
+			return volumeServerImplementationRust
+		default:
+			return ""
+		}
+	}
+
+	tests := []struct {
+		name    string
+		holders []string
+		want    bool
+	}{
+		{"single holder", []string{"go-a"}, false},
+		{"all go", []string{"go-a", "go-b"}, true},
+		{"mixed go and rust", []string{"go-a", "rust-a"}, false},
+		{"unknown implementation", []string{"go-a", "unknown:8080"}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			volumeServerKindCache = sync.Map{}
+			if got := chunkUploadReplicaFanoutEnabled(tc.holders); got != tc.want {
+				t.Fatalf("chunkUploadReplicaFanoutEnabled(%v) = %v, want %v", tc.holders, got, tc.want)
+			}
+		})
+	}
+}

--- a/weed/operation/upload_chunked_test.go
+++ b/weed/operation/upload_chunked_test.go
@@ -393,17 +393,18 @@ func TestUploadReaderInChunksPrimaryWriteWhenMixedVolumeServers(t *testing.T) {
 	defer primary.Close()
 	primaryHost := strings.TrimPrefix(primary.URL, "http://")
 
-	oldProbe := volumeServerImplementationProbe
+	oldProbe := getVolumeServerImplementationProbe()
+	volumeServerKindCache = sync.Map{}
 	defer func() {
-		volumeServerImplementationProbe = oldProbe
+		setVolumeServerImplementationProbe(oldProbe)
 		volumeServerKindCache = sync.Map{}
 	}()
-	volumeServerImplementationProbe = func(host string) string {
+	setVolumeServerImplementationProbe(func(host string) string {
 		if host == primaryHost {
 			return volumeServerImplementationGo
 		}
 		return volumeServerImplementationRust
-	}
+	})
 
 	assignFunc := func(ctx context.Context, count int, expectedDataSize uint64) (*VolumeAssignRequest, *AssignResult, error) {
 		return nil, &AssignResult{
@@ -438,9 +439,9 @@ func TestUploadReaderInChunksPrimaryWriteWhenMixedVolumeServers(t *testing.T) {
 }
 
 func TestChunkUploadReplicaFanoutEnabled(t *testing.T) {
-	oldProbe := volumeServerImplementationProbe
-	defer func() { volumeServerImplementationProbe = oldProbe }()
-	volumeServerImplementationProbe = func(host string) string {
+	oldProbe := getVolumeServerImplementationProbe()
+	defer func() { setVolumeServerImplementationProbe(oldProbe) }()
+	setVolumeServerImplementationProbe(func(host string) string {
 		switch host {
 		case "go-a", "go-b":
 			return volumeServerImplementationGo
@@ -449,7 +450,7 @@ func TestChunkUploadReplicaFanoutEnabled(t *testing.T) {
 		default:
 			return ""
 		}
-	}
+	})
 
 	tests := []struct {
 		name    string

--- a/weed/operation/volume_server_kind.go
+++ b/weed/operation/volume_server_kind.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	util_http "github.com/seaweedfs/seaweedfs/weed/util/http"
@@ -15,41 +17,85 @@ const (
 	volumeServerImplementationRust = "rust"
 )
 
-// volumeServerImplementationProbe, when non-nil, overrides the HTTP /status
-// probe (used in tests).
-var volumeServerImplementationProbe func(host string) string
+const volumeServerKindCacheTTL = 5 * time.Minute
 
-var volumeServerKindCache sync.Map // host -> string (go/rust/"")
+type probeWrapper struct {
+	f func(host string) string
+}
 
+type volumeServerKindCacheEntry struct {
+	implementation string
+	expiresAt      time.Time
+}
+
+var volumeServerImplementationProbe atomic.Value // stores *probeWrapper
+
+var volumeServerKindCache sync.Map // host -> volumeServerKindCacheEntry
+
+// setVolumeServerImplementationProbe overrides the HTTP /status probe (tests only).
+func setVolumeServerImplementationProbe(probe func(host string) string) {
+	if probe == nil {
+		volumeServerImplementationProbe.Store((*probeWrapper)(nil))
+		return
+	}
+	volumeServerImplementationProbe.Store(&probeWrapper{f: probe})
+}
+
+// getVolumeServerImplementationProbe returns the test probe override, if any.
+func getVolumeServerImplementationProbe() func(host string) string {
+	p := volumeServerImplementationProbe.Load()
+	if p == nil {
+		return nil
+	}
+	w, ok := p.(*probeWrapper)
+	if !ok || w == nil {
+		return nil
+	}
+	return w.f
+}
+
+// volumeServerImplementation returns the normalized Implementation value from a
+// volume server's /status endpoint (go, rust, or empty when unknown).
 func volumeServerImplementation(host string) string {
 	if host == "" {
 		return ""
 	}
+	now := time.Now()
 	if cached, ok := volumeServerKindCache.Load(host); ok {
-		return cached.(string)
+		entry := cached.(volumeServerKindCacheEntry)
+		if now.Before(entry.expiresAt) {
+			return entry.implementation
+		}
 	}
-	kind := probeVolumeServerImplementation(host)
-	volumeServerKindCache.Store(host, kind)
+	kind, err := probeVolumeServerImplementation(host)
+	if err != nil {
+		return ""
+	}
+	volumeServerKindCache.Store(host, volumeServerKindCacheEntry{
+		implementation: kind,
+		expiresAt:      now.Add(volumeServerKindCacheTTL),
+	})
 	return kind
 }
 
-func probeVolumeServerImplementation(host string) string {
-	if volumeServerImplementationProbe != nil {
-		return volumeServerImplementationProbe(host)
+// probeVolumeServerImplementation fetches /status and parses the Implementation field.
+func probeVolumeServerImplementation(host string) (string, error) {
+	if probe := getVolumeServerImplementationProbe(); probe != nil {
+		return probe(host), nil
 	}
 	body, _, err := util_http.Get(fmt.Sprintf("http://%s/status", host))
 	if err != nil {
 		glog.V(4).Infof("volume server %s status probe: %v", host, err)
-		return ""
+		return "", err
 	}
 	var status struct {
 		Implementation string `json:"Implementation"`
 	}
 	if err := json.Unmarshal(body, &status); err != nil {
 		glog.V(4).Infof("volume server %s status JSON: %v", host, err)
-		return ""
+		return "", err
 	}
-	return strings.ToLower(strings.TrimSpace(status.Implementation))
+	return strings.ToLower(strings.TrimSpace(status.Implementation)), nil
 }
 
 // chunkUploadReplicaFanoutEnabled reports whether chunked uploads should write

--- a/weed/operation/volume_server_kind.go
+++ b/weed/operation/volume_server_kind.go
@@ -83,7 +83,13 @@ func probeVolumeServerImplementation(host string) (string, error) {
 	if probe := getVolumeServerImplementationProbe(); probe != nil {
 		return probe(host), nil
 	}
-	body, _, err := util_http.Get(fmt.Sprintf("http://%s/status", host))
+	// Match upload/read paths: URLs are built with http:// but the process-wide
+	// HTTP client rewrites the scheme from security.toml [https.client].
+	statusURL, err := util_http.NormalizeUrl(fmt.Sprintf("http://%s/status", host))
+	if err != nil {
+		return "", err
+	}
+	body, _, err := util_http.Get(statusURL)
 	if err != nil {
 		glog.V(4).Infof("volume server %s status probe: %v", host, err)
 		return "", err

--- a/weed/operation/volume_server_kind.go
+++ b/weed/operation/volume_server_kind.go
@@ -1,0 +1,72 @@
+package operation
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/seaweedfs/seaweedfs/weed/glog"
+	util_http "github.com/seaweedfs/seaweedfs/weed/util/http"
+)
+
+const (
+	volumeServerImplementationGo   = "go"
+	volumeServerImplementationRust = "rust"
+)
+
+// volumeServerImplementationProbe, when non-nil, overrides the HTTP /status
+// probe (used in tests).
+var volumeServerImplementationProbe func(host string) string
+
+var volumeServerKindCache sync.Map // host -> string (go/rust/"")
+
+func volumeServerImplementation(host string) string {
+	if host == "" {
+		return ""
+	}
+	if cached, ok := volumeServerKindCache.Load(host); ok {
+		return cached.(string)
+	}
+	kind := probeVolumeServerImplementation(host)
+	volumeServerKindCache.Store(host, kind)
+	return kind
+}
+
+func probeVolumeServerImplementation(host string) string {
+	if volumeServerImplementationProbe != nil {
+		return volumeServerImplementationProbe(host)
+	}
+	body, _, err := util_http.Get(fmt.Sprintf("http://%s/status", host))
+	if err != nil {
+		glog.V(4).Infof("volume server %s status probe: %v", host, err)
+		return ""
+	}
+	var status struct {
+		Implementation string `json:"Implementation"`
+	}
+	if err := json.Unmarshal(body, &status); err != nil {
+		glog.V(4).Infof("volume server %s status JSON: %v", host, err)
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(status.Implementation))
+}
+
+// chunkUploadReplicaFanoutEnabled reports whether chunked uploads should write
+// every replica holder directly (PR #10078). Fan-out is enabled only when every
+// holder identifies as a Go volume server; Rust weed-volume replicates on the
+// primary write and rejects type=replicate uploads from gateways.
+func chunkUploadReplicaFanoutEnabled(holders []string) bool {
+	if len(holders) <= 1 {
+		return false
+	}
+	for _, host := range holders {
+		switch volumeServerImplementation(host) {
+		case volumeServerImplementationGo:
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/weed/operation/volume_server_kind_test.go
+++ b/weed/operation/volume_server_kind_test.go
@@ -1,0 +1,42 @@
+package operation
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	util_http "github.com/seaweedfs/seaweedfs/weed/util/http"
+)
+
+func TestProbeVolumeServerImplementation(t *testing.T) {
+	util_http.InitGlobalHttpClient()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/status" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"Implementation": "Rust"})
+	}))
+	defer srv.Close()
+	host := strings.TrimPrefix(srv.URL, "http://")
+
+	oldProbe := getVolumeServerImplementationProbe()
+	defer func() {
+		setVolumeServerImplementationProbe(oldProbe)
+		volumeServerKindCache = sync.Map{}
+	}()
+	setVolumeServerImplementationProbe(nil)
+	volumeServerKindCache = sync.Map{}
+
+	kind, err := probeVolumeServerImplementation(host)
+	if err != nil {
+		t.Fatalf("probeVolumeServerImplementation(%q): %v", host, err)
+	}
+	if kind != volumeServerImplementationRust {
+		t.Fatalf("got %q, want %q", kind, volumeServerImplementationRust)
+	}
+}

--- a/weed/server/volume_server_handlers_admin.go
+++ b/weed/server/volume_server_handlers_admin.go
@@ -38,6 +38,7 @@ func (vs *VolumeServer) statusHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Server", "SeaweedFS Volume "+version.VERSION)
 	m := make(map[string]interface{})
 	m["Version"] = version.Version()
+	m["Implementation"] = "go"
 	var ds []*volume_server_pb.DiskStatus
 	for _, loc := range vs.store.Locations {
 		if dir, e := filepath.Abs(loc.Directory); e == nil {


### PR DESCRIPTION
## Summary

Follow-up to #10078. @chrislusf's gateway fan-out is a nice win on all-Go clusters — the gateway writes every replica holder directly with `type=replicate` instead of making the primary volume relay. That model assumes each holder accepts replicate uploads, which is true for Go `weed volume` but not for `weed-volume` (Rust): Rust replicates on the **primary** write and rejects fan-out copies (`cookie mismatch`, `invalid URL path`).

This PR probes each holder's `GET /status` and reads a new **`Implementation`** field (`go` / `rust`, added to both volume server implementations). Chunked S3 uploads fan out only when **every** holder reports `go`; otherwise the gateway performs a single primary write and lets the volume server replicate as before. Results are cached per host.

Fixes mixed deployments (Go S3 gateway + Rust volume nodes) without an env var or manual config.

## Changes

- `weed/operation/volume_server_kind.go` — status probe + per-host cache + fan-out decision
- `weed/operation/upload_chunked.go` — use auto-detection instead of unconditional fan-out
- `weed/server/volume_server_handlers_admin.go` — `"Implementation": "go"` on `/status`
- `seaweed-volume/src/server/handlers.rs` — `"Implementation": "rust"` on `/status`

## Test plan

- [x] `go test ./weed/operation/ -run 'Upload|ChunkUpload'`
- [ ] S3 PUT on mixed Go ctl + Rust volume cluster (replication > 000)
- [ ] S3 PUT on all-Go cluster confirms fan-out still runs when all holders report `go`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Status responses now include an `Implementation` field indicating the server type (Go vs Rust), improving observability for mixed deployments.

* **Bug Fixes**
  * Improved chunked upload routing in mixed environments: replica fan-out is now enabled only under the correct conditions, avoiding incorrect `type=replicate` upload requests.

* **Tests**
  * Added unit tests covering mixed Go/Rust chunked upload behavior and the logic that determines when replica fan-out should be enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->