### PR TITLE
test(seaweed-volume): cover type=replicate fan-out writes on the Rust volume server

### DIFF
--- a/seaweed-volume/tests/http_integration.rs
+++ b/seaweed-volume/tests/http_integration.rs
@@ -39,8 +39,25 @@ fn test_state_with_guard(
     whitelist: Vec<String>,
     signing_key: Vec<u8>,
 ) -> (Arc<VolumeServerState>, TempDir) {
+    build_test_state(whitelist, signing_key, None, String::new())
+}
+
+/// Build a test state with volume 1 created using the given replica placement
+/// (e.g. "001" for a two-copy volume) and master URL. An empty master URL plus
+/// a None placement is the single-copy default used by most tests.
+fn build_test_state(
+    whitelist: Vec<String>,
+    signing_key: Vec<u8>,
+    replication: Option<&str>,
+    master_url: String,
+) -> (Arc<VolumeServerState>, TempDir) {
     let tmp = TempDir::new().expect("failed to create temp dir");
     let dir = tmp.path().to_str().unwrap();
+
+    let replica_placement = replication.map(|s| {
+        seaweed_volume::storage::super_block::ReplicaPlacement::from_string(s)
+            .expect("invalid replica placement")
+    });
 
     let mut store = Store::new(NeedleMapKind::InMemory);
     store
@@ -57,7 +74,7 @@ fn test_state_with_guard(
         .add_volume(
             VolumeId(1),
             "",
-            None,
+            replica_placement,
             None,
             0,
             DiskType::HardDrive,
@@ -100,7 +117,7 @@ fn test_state_with_guard(
         ),
         read_mode: seaweed_volume::config::ReadMode::Local,
         allow_untrusted_remote_endpoints: false,
-        master_url: String::new(),
+        master_url,
         master_urls: Vec::new(),
         seed_master_set: std::collections::HashSet::new(),
         current_master_url: tokio::sync::RwLock::new(String::new()),
@@ -677,4 +694,142 @@ async fn admin_router_serves_volume_ui_static_assets() {
     );
     let body = body_bytes(response).await;
     assert!(body.len() > 1000);
+}
+
+// ============================================================================
+// Replicated (fan-out) writes
+//
+// A chunked S3 upload has the gateway write every replica holder directly with
+// `type=replicate` instead of relaying through the primary volume. Each holder
+// must accept the copy and store it locally without re-replicating. These tests
+// pin that contract on the Rust volume server.
+// ============================================================================
+
+/// Raw-body `type=replicate` write is stored and reads back.
+#[tokio::test]
+async fn replicate_write_raw_body_is_stored() {
+    let (state, _tmp) = test_state();
+    let uri = "/1,01637037d6?type=replicate";
+    let payload = b"fan-out replica bytes";
+
+    let app = build_admin_router(state.clone());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(uri)
+                .body(Body::from(payload.to_vec()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let app = build_admin_router(state.clone());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/1,01637037d6")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(body_bytes(response).await, payload);
+}
+
+/// Multipart `type=replicate` write (the shape the Go gateway uploader sends)
+/// is stored and reads back.
+#[tokio::test]
+async fn replicate_write_multipart_body_is_stored() {
+    let (state, _tmp) = test_state();
+    let boundary = "----replicateboundary";
+    let payload = b"fan-out replica bytes";
+    let mut body = Vec::new();
+    body.extend_from_slice(format!("--{}\r\n", boundary).as_bytes());
+    body.extend_from_slice(
+        b"Content-Disposition: form-data; name=\"file\"; filename=\"chunk\"\r\n",
+    );
+    body.extend_from_slice(b"Content-Type: application/octet-stream\r\n\r\n");
+    body.extend_from_slice(payload);
+    body.extend_from_slice(format!("\r\n--{}--\r\n", boundary).as_bytes());
+
+    let app = build_admin_router(state.clone());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/1,01637037d6?type=replicate")
+                .header(
+                    "Content-Type",
+                    format!("multipart/form-data; boundary={}", boundary),
+                )
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let app = build_admin_router(state.clone());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/1,01637037d6")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(body_bytes(response).await, payload);
+}
+
+/// On a multi-copy volume, a `type=replicate` write must store locally without
+/// re-replicating: it must not contact the master, even an unreachable one.
+/// A plain write to the same volume does attempt replication and fails against
+/// the dead master, which proves the `type=replicate` flag is what suppresses
+/// the fan-out (not a disabled replication path).
+#[tokio::test]
+async fn replicate_write_does_not_re_replicate() {
+    // master_url points at a closed port; any lookup attempt fails fast.
+    let dead_master = "127.0.0.1:1".to_string();
+    let (state, _tmp) = build_test_state(Vec::new(), Vec::new(), Some("001"), dead_master);
+
+    // type=replicate: stored locally, no master lookup -> 201.
+    let app = build_admin_router(state.clone());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/1,01637037d6?type=replicate")
+                .body(Body::from(b"replicated copy".to_vec()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::CREATED,
+        "replicate write must not depend on the master"
+    );
+
+    // plain write: tries to fan out to the dead master and fails.
+    let app = build_admin_router(state.clone());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/1,02637037d7")
+                .body(Body::from(b"primary copy".to_vec()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "plain write to a multi-copy volume must attempt replication"
+    );
 }

--- a/seaweed-volume/tests/http_integration.rs
+++ b/seaweed-volume/tests/http_integration.rs
@@ -793,8 +793,9 @@ async fn replicate_write_multipart_body_is_stored() {
 /// the fan-out (not a disabled replication path).
 #[tokio::test]
 async fn replicate_write_does_not_re_replicate() {
-    // master_url points at a closed port; any lookup attempt fails fast.
-    let dead_master = "127.0.0.1:1".to_string();
+    // Port 0 is rejected by the socket layer immediately, so a stray lookup
+    // fails fast instead of hanging on a connect timeout in firewalled CI.
+    let dead_master = "127.0.0.1:0".to_string();
     let (state, _tmp) = build_test_state(Vec::new(), Vec::new(), Some("001"), dead_master);
 
     // type=replicate: stored locally, no master lookup -> 201.


### PR DESCRIPTION
## Summary

#10078 has the S3 gateway fan out a chunked upload to every replica holder directly with `type=replicate` instead of relaying through the primary volume. #10137 reports that the Rust volume server (`weed-volume`) rejects those fan-out copies and adds a Go-side Go/Rust probe to skip fan-out for Rust holders.

That premise does not hold on current code: the Rust volume server already accepts `type=replicate` writes (the `post_handler` writes locally and skips re-replication when `is_replicate`), so the gateway fan-out works against Rust holders unchanged. This PR pins that contract with integration tests instead of working around it in the gateway.

## What the tests cover

- `replicate_write_raw_body_is_stored` — raw-body `?type=replicate` write is stored and reads back.
- `replicate_write_multipart_body_is_stored` — multipart body (the shape the Go uploader sends) is stored and reads back.
- `replicate_write_does_not_re_replicate` — on a two-copy (`001`) volume a `type=replicate` write stores locally without contacting the master, while a plain write to the same volume does attempt the fan-out (and fails against an unreachable master). This proves the `type=replicate` flag is what suppresses re-replication.

`build_test_state` is generalized to take a replica placement and master URL; `test_state_with_guard` keeps its old behavior.

## Verification

Beyond the unit tests, I ran a real cluster — OSS `weed` master + filer + S3 gateway with two `weed-volume` (Rust) nodes at replication `001` — and exercised every replicated-write path:

- 5 MB S3 PUT (chunked) round-trips with matching MD5; both holders end with equal per-volume file counts.
- Gateway logged the actual fan-out path: `upload_chunked.go:305 replica fan-out: writing chunk 6,01d07dda2b to 2 holders [127.0.0.1:8081 127.0.0.1:8082]` — there is no single-write fallback, so the PUT succeeding confirms Rust accepted both copies.
- Rust-as-primary replication (`do_replicated_request`) lands on the peer.
- With JWT signing on, a valid token is accepted on both holders and a missing/wrong token is rejected (401).

With this confirmed, the Go/Rust auto-detection in #10137 is not needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for replicated (fan-out) writes in HTTP uploads, working for both raw-body and multipart/form-data submissions.
* **Bug Fixes**
  * On multi-copy volumes, replicated writes now succeed locally even when the master is unreachable, while standard writes correctly surface errors when replication is required.
* **Tests**
  * Added integration coverage for replicated fan-out write and read-back behavior across request types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->