### PR TITLE
docs(scrub): correct backwards FULL/LOCAL mode comments in Rust

### DIFF
--- a/seaweed-volume/src/server/grpc_server.rs
+++ b/seaweed-volume/src/server/grpc_server.rs
@@ -3826,7 +3826,7 @@ impl VolumeServer for VolumeGrpcService {
                     .ok_or_else(|| Status::not_found(format!("volume id {} not found", vid.0)))?;
                 total_volumes += 1;
 
-                // INDEX mode (1) calls scrub_index; LOCAL (2) and FULL (3) call scrub
+                // INDEX mode (1) calls scrub_index; FULL (2) and LOCAL (3) call scrub
                 let scrub_result = if mode == 1 {
                     v.scrub_index()
                 } else {
@@ -3942,7 +3942,7 @@ impl VolumeServer for VolumeGrpcService {
                     }
                 }
                 2 | 3 => {
-                    // LOCAL (2) / FULL (3): verify EC shard data
+                    // FULL (2) / LOCAL (3): verify EC shard data
                     let files = ecv.walk_ecx_stats().map(|(f, _, _)| f).unwrap_or(0);
 
                     // After cross-disk reconciliation, an EcVolume can


### PR DESCRIPTION
Two inline comments in the Rust volume server inverted the scrub mode numbering. The proto enum is `FULL=2, LOCAL=3`, but `scrub_volume` and `scrub_ec_volume` both annotated it as `LOCAL (2) / FULL (3)`. Harmless today since modes 2 and 3 run the same code, but a trap once the two modes diverge.

https://claude.ai/code/session_015EE9Sc9EvNp8BCVva4RKdo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified inline comments so the scrub mode descriptions match the actual behavior shown to users.
  * No functional changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->