### PR TITLE
fix(remote/gcs): tolerate already-deleted object in DeleteFile

### DIFF
--- a/weed/remote_storage/gcs/gcs_storage_client.go
+++ b/weed/remote_storage/gcs/gcs_storage_client.go
@@ -283,6 +283,9 @@ func (gcs *gcsRemoteStorageClient) UpdateFileMetadata(loc *remote_pb.RemoteStora
 func (gcs *gcsRemoteStorageClient) DeleteFile(loc *remote_pb.RemoteStorageLocation) (err error) {
 	key := loc.Path[1:]
 	if err = gcs.client.Bucket(loc.Bucket).Object(key).Delete(context.Background()); err != nil {
+		if errors.Is(err, storage.ErrObjectNotExist) {
+			return remote_storage.ErrRemoteObjectNotFound
+		}
 		return fmt.Errorf("gcs delete %s%s: %v", loc.Bucket, key, err)
 	}
 	return


### PR DESCRIPTION
## What

`gcsRemoteStorageClient.DeleteFile` now maps GCS's `storage.ErrObjectNotExist` to `remote_storage.ErrRemoteObjectNotFound`, instead of returning a generic wrapped error.

## Why

`StatFile` in the same client already performs this mapping, and the filer's `maybeDeleteFromRemote` (`weed/filer/filer_lazy_remote.go`) depends on the `ErrRemoteObjectNotFound` sentinel to treat an already-gone remote object as success — so the local filer entry is still deleted:

```go
if err := client.DeleteFile(objectLoc); err != nil {
    if errors.Is(err, remote_storage.ErrRemoteObjectNotFound) {
        return true, nil // already gone → still remove the filer entry
    }
    return false, fmt.Errorf("delete remote file %s: %w", entry.FullPath, err)
}
```

But `DeleteFile` never produced that sentinel for GCS, so a `404 No such object` came back as a generic error and the whole delete failed. In a lazy remote-mount setup where the backing object can be removed out-of-band (e.g. an application that owns the bucket deletes it directly), deleting the corresponding filer entry then fails and the S3 gateway returns `500 InternalError` — leaving dangling metadata that can never be cleared.

The S3 and Azure remote clients already map their not-found errors to `ErrRemoteObjectNotFound`; this brings GCS's `DeleteFile` in line.

## Test

The filer-level behaviour is already covered by `TestDeleteEntryMetaAndData_RemoteDeleteNotFoundStillDeletesMetadata` (`weed/filer/filer_lazy_remote_test.go`), which stubs the remote client returning `ErrRemoteObjectNotFound` and asserts the filer entry is still deleted. This change makes the real GCS client produce that sentinel on a 404. Consistent with the existing `gcs_storage_client_test.go` convention, no live-GCS test is added (the concrete `*storage.Client` isn't mockable without an emulator, and `StatFile`'s mapping is likewise unit-tested only at the filer layer).

`go build ./weed/remote_storage/gcs/`, `go test ./weed/remote_storage/gcs/` and `go test ./weed/filer/` all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file deletion handling for cloud storage so missing remote objects are reported as “not found” instead of a generic delete error.
  * Other deletion failures still return a clear error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->