### PR TITLE
Add full scrubbing support for deleted needles on EC volumes (gRPC, `weed shell`)

### DIFF
--- a/seaweed-volume/proto/volume_server.proto
+++ b/seaweed-volume/proto/volume_server.proto
@@ -428,6 +428,7 @@ message VolumeEcShardsGenerateResponse {
 message VolumeEcShardsRebuildRequest {
     uint32 volume_id = 1;
     string collection = 2;
+    bool unsafe_ignore_sidecar = 3; // bypass the bitrot-sidecar fail-closed guard (operator override; distinct from ec.rebuild -force)
 }
 message VolumeEcShardsRebuildResponse {
     repeated uint32 rebuilt_shard_ids = 1;
@@ -442,6 +443,7 @@ message VolumeEcShardsCopyRequest {
     bool copy_ecj_file = 6;
     bool copy_vif_file = 7;
     uint32 disk_id = 8;  // Target disk ID for storing EC shards
+    bool copy_ecsum_file = 9; // copy the bitrot checksum sidecar (.ecsum) when present; tolerant of a missing source (no-op), since this non-2PC path has no Prepare backstop
 }
 message VolumeEcShardsCopyResponse {
 }
@@ -548,6 +550,7 @@ message DiskStatus {
     float percent_free = 5;
     float percent_used = 6;
     string disk_type = 7;
+    string error = 8;
 }
 
 message MemStatus {
@@ -586,6 +589,30 @@ message EcShardConfig {
     uint32 data_shards = 1;   // Number of data shards (e.g., 10)
     uint32 parity_shards = 2; // Number of parity shards (e.g., 4)
     int64 encode_ts_ns = 3;   // encode time (unix nanos); a read served from a shard of a different encode run is rejected
+}
+
+// EcBitrotProtection is the entire content of a bitrot checksum sidecar
+// (<base>.ecsum for the legacy generation, <base>.ecsum.v<N> for vacuum
+// generation N). On disk it is wrapped in a fixed header carrying a CRC32C
+// over this serialized payload (see weed/storage/erasure_coding/ec_bitrot.go).
+message EcBitrotProtection {
+    ChecksumAlgorithm algorithm = 1;       // CRC32C (Castagnoli)
+    uint32 block_size = 2;                  // bytes per checksum block; default 16777216 (16 MiB), a power-of-two multiple of 1 MiB
+    uint32 generation = 3;                  // EC vacuum generation these checksums describe (0 = legacy/fresh); must match the sidecar filename version
+    EcShardConfig ec_shard_config = 4;      // data/parity shard counts at encode time
+    repeated EcShardChecksums shards = 5;   // one entry per shard id in the active layout
+    bytes encode_uuid = 6;                  // random per-encode identity, for stale-sidecar detection across in-place re-encodes
+}
+
+message EcShardChecksums {
+    uint32 shard_id = 1;     // 0..MaxShardCount-1 (custom EC ratios go up to 32)
+    int64 covered_size = 2;  // shard byte length these checksums cover (must equal the on-disk shard length)
+    bytes block_crc32c = 3;  // packed little-endian uint32[] = ceil(covered_size/block_size) entries
+}
+
+enum ChecksumAlgorithm {
+    CHECKSUM_NONE = 0;
+    CHECKSUM_CRC32C = 1;
 }
 message OldVersionVolumeInfo {
     repeated RemoteFile files = 1;
@@ -664,6 +691,7 @@ enum VolumeScrubMode {
     INDEX = 1;
     FULL = 2;
     LOCAL = 3;
+    CHECKSUM = 4; // EC only: verify each local shard's raw bytes against the bitrot checksum sidecar
 }
 
 message ScrubVolumeRequest {
@@ -683,6 +711,7 @@ message ScrubEcVolumeRequest {
     VolumeScrubMode mode = 1;
     // optional list of volume IDs to scrub. if empty, all EC volumes for the server are scrubbed.
     repeated uint32 volume_ids = 2;
+    bool force_deleted_needles_check = 3;
 }
 message ScrubEcVolumeResponse {
     uint64 total_volumes = 1;

--- a/weed/pb/volume_server.proto
+++ b/weed/pb/volume_server.proto
@@ -711,6 +711,7 @@ message ScrubEcVolumeRequest {
     VolumeScrubMode mode = 1;
     // optional list of volume IDs to scrub. if empty, all EC volumes for the server are scrubbed.
     repeated uint32 volume_ids = 2;
+    bool force_deleted_needles_check = 3;
 }
 message ScrubEcVolumeResponse {
     uint64 total_volumes = 1;

--- a/weed/pb/volume_server_pb/volume_server.pb.go
+++ b/weed/pb/volume_server_pb/volume_server.pb.go
@@ -6018,9 +6018,10 @@ type ScrubEcVolumeRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	Mode  VolumeScrubMode        `protobuf:"varint,1,opt,name=mode,proto3,enum=volume_server_pb.VolumeScrubMode" json:"mode,omitempty"`
 	// optional list of volume IDs to scrub. if empty, all EC volumes for the server are scrubbed.
-	VolumeIds     []uint32 `protobuf:"varint,2,rep,packed,name=volume_ids,json=volumeIds,proto3" json:"volume_ids,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	VolumeIds                []uint32 `protobuf:"varint,2,rep,packed,name=volume_ids,json=volumeIds,proto3" json:"volume_ids,omitempty"`
+	ForceDeletedNeedlesCheck bool     `protobuf:"varint,3,opt,name=force_deleted_needles_check,json=forceDeletedNeedlesCheck,proto3" json:"force_deleted_needles_check,omitempty"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
 }
 
 func (x *ScrubEcVolumeRequest) Reset() {
@@ -6065,6 +6066,13 @@ func (x *ScrubEcVolumeRequest) GetVolumeIds() []uint32 {
 		return x.VolumeIds
 	}
 	return nil
+}
+
+func (x *ScrubEcVolumeRequest) GetForceDeletedNeedlesCheck() bool {
+	if x != nil {
+		return x.ForceDeletedNeedlesCheck
+	}
+	return false
 }
 
 type ScrubEcVolumeResponse struct {
@@ -7510,11 +7518,12 @@ const file_volume_server_proto_rawDesc = "" +
 	"\vtotal_files\x18\x02 \x01(\x04R\n" +
 	"totalFiles\x12*\n" +
 	"\x11broken_volume_ids\x18\x03 \x03(\rR\x0fbrokenVolumeIds\x12\x18\n" +
-	"\adetails\x18\x04 \x03(\tR\adetails\"l\n" +
+	"\adetails\x18\x04 \x03(\tR\adetails\"\xab\x01\n" +
 	"\x14ScrubEcVolumeRequest\x125\n" +
 	"\x04mode\x18\x01 \x01(\x0e2!.volume_server_pb.VolumeScrubModeR\x04mode\x12\x1d\n" +
 	"\n" +
-	"volume_ids\x18\x02 \x03(\rR\tvolumeIds\"\xf0\x01\n" +
+	"volume_ids\x18\x02 \x03(\rR\tvolumeIds\x12=\n" +
+	"\x1bforce_deleted_needles_check\x18\x03 \x01(\bR\x18forceDeletedNeedlesCheck\"\xf0\x01\n" +
 	"\x15ScrubEcVolumeResponse\x12#\n" +
 	"\rtotal_volumes\x18\x01 \x01(\x04R\ftotalVolumes\x12\x1f\n" +
 	"\vtotal_files\x18\x02 \x01(\x04R\n" +

--- a/weed/server/volume_grpc_scrub.go
+++ b/weed/server/volume_grpc_scrub.go
@@ -93,6 +93,10 @@ func (vs *VolumeServer) ScrubVolume(ctx context.Context, req *volume_server_pb.S
 }
 
 func (vs *VolumeServer) ScrubEcVolume(ctx context.Context, req *volume_server_pb.ScrubEcVolumeRequest) (*volume_server_pb.ScrubEcVolumeResponse, error) {
+	if req.GetForceDeletedNeedlesCheck() && req.GetMode() != volume_server_pb.VolumeScrubMode_FULL {
+		return nil, fmt.Errorf("deleted needle checks are only supported for FULL scrubs")
+	}
+
 	vids := []needle.VolumeId{}
 	if len(req.GetVolumeIds()) == 0 {
 		for _, l := range vs.store.Locations {
@@ -124,8 +128,7 @@ func (vs *VolumeServer) ScrubEcVolume(ctx context.Context, req *volume_server_pb
 		case volume_server_pb.VolumeScrubMode_LOCAL:
 			files, shardInfos, serrs = v.ScrubLocal()
 		case volume_server_pb.VolumeScrubMode_FULL:
-			// TODO: expose force_deleted_needles_check in the RPC and weed shell.
-			files, shardInfos, serrs = vs.store.ScrubEcVolume(v.VolumeId, false)
+			files, shardInfos, serrs = vs.store.ScrubEcVolume(v.VolumeId, req.GetForceDeletedNeedlesCheck())
 		case volume_server_pb.VolumeScrubMode_CHECKSUM:
 			// Verify each local shard's raw bytes against the bitrot sidecar,
 			// exercising cold parity shards. Read-only. ChecksumScrub's first

--- a/weed/shell/command_ec_scrub.go
+++ b/weed/shell/command_ec_scrub.go
@@ -21,10 +21,15 @@ func init() {
 
 type commandEcVolumeScrub struct {
 	env               *CommandEnv
+	grpcDialOption    grpc.DialOption
+
+	writer io.Writer
 	volumeServerAddrs []pb.ServerAddress
 	volumeIDs         []uint32
 	mode              volume_server_pb.VolumeScrubMode
-	grpcDialOption    grpc.DialOption
+	showDetails bool
+	forceDeletedNeedlesCheck bool
+	maxParallelization int
 }
 
 func (c *commandEcVolumeScrub) Name() string {
@@ -52,6 +57,7 @@ func (c *commandEcVolumeScrub) Do(args []string, commandEnv *CommandEnv, writer 
 	mode := volScrubCommand.String("mode", "local", "scrubbing mode (index/local/full/checksum)")
 	maxParallelization := volScrubCommand.Int("maxParallelization", DefaultMaxParallelization, "run up to X tasks in parallel, whenever possible")
 	showDetails := volScrubCommand.Bool("details", false, "display scrub result details, if available")
+	forceDeletedNeedlesCheck := volScrubCommand.Bool("forceDeletedNeedlesCheck", false, "forces strict verification of deleted needles; can cause false positives for EC volumes not fully matching local indexes")
 
 	if err = volScrubCommand.Parse(args); err != nil {
 		return err
@@ -59,6 +65,12 @@ func (c *commandEcVolumeScrub) Do(args []string, commandEnv *CommandEnv, writer 
 	if err = commandEnv.confirmIsLocked(args); err != nil {
 		return
 	}
+
+	c.env = commandEnv
+	c.writer = writer
+	c.maxParallelization = *maxParallelization
+	c.showDetails = *showDetails
+	c.forceDeletedNeedlesCheck = *forceDeletedNeedlesCheck
 
 	c.volumeServerAddrs = []pb.ServerAddress{}
 	if *nodesStr != "" {
@@ -103,30 +115,35 @@ func (c *commandEcVolumeScrub) Do(args []string, commandEnv *CommandEnv, writer 
 		return fmt.Errorf("unsupported scrubbing mode %q", *mode)
 	}
 	fmt.Fprintf(writer, "using %s mode\n", c.mode.String())
-	c.env = commandEnv
 
-	return c.scrubEcVolumes(writer, *maxParallelization, *showDetails)
+	return c.doScrub()
 }
 
-func (c *commandEcVolumeScrub) scrubEcVolumes(writer io.Writer, maxParallelization int, showDetails bool) error {
+
+func (c *commandEcVolumeScrub) write(format string, a ...any) {
+	fmt.Fprintf(c.writer, format, a...)
+}
+
+func (c *commandEcVolumeScrub) doScrub() error {
 	var brokenVolumesStr, brokenShardsStr []string
 	var details []string
 	var totalVolumes, brokenVolumes, brokenShards, totalFiles uint64
 	var mu sync.Mutex
 
-	ewg := NewErrorWaitGroup(maxParallelization)
+	ewg := NewErrorWaitGroup(c.maxParallelization)
 	count := 0
 	for _, addr := range c.volumeServerAddrs {
 		ewg.Add(func() error {
 			mu.Lock()
 			count++
-			fmt.Fprintf(writer, "Scrubbing %s (%d/%d)...\n", addr.String(), count, len(c.volumeServerAddrs))
+			c.write("Scrubbing %s (%d/%d)...\n", addr.String(), count, len(c.volumeServerAddrs))
 			mu.Unlock()
 
 			err := operation.WithVolumeServerClient(false, addr, c.env.option.GrpcDialOption, func(volumeServerClient volume_server_pb.VolumeServerClient) error {
 				res, err := volumeServerClient.ScrubEcVolume(context.Background(), &volume_server_pb.ScrubEcVolumeRequest{
 					Mode:      c.mode,
 					VolumeIds: c.volumeIDs,
+					ForceDeletedNeedlesCheck: c.forceDeletedNeedlesCheck,
 				})
 				if err != nil {
 					return err
@@ -158,15 +175,15 @@ func (c *commandEcVolumeScrub) scrubEcVolumes(writer io.Writer, maxParallelizati
 		return err
 	}
 
-	fmt.Fprintf(writer, "Scrubbed %d EC files and %d volumes on %d nodes\n", totalFiles, totalVolumes, len(c.volumeServerAddrs))
+	c.write("Scrubbed %d EC files and %d volumes on %d nodes\n", totalFiles, totalVolumes, len(c.volumeServerAddrs))
 	if brokenVolumes != 0 {
-		fmt.Fprintf(writer, "\nGot scrub failures on %d EC volumes and %d EC shards :(\n", brokenVolumes, brokenShards)
-		fmt.Fprintf(writer, "Affected volumes: %s\n", strings.Join(brokenVolumesStr, ", "))
+		c.write("\nGot scrub failures on %d EC volumes and %d EC shards :(\n", brokenVolumes, brokenShards)
+		c.write("Affected volumes: %s\n", strings.Join(brokenVolumesStr, ", "))
 		if len(brokenShardsStr) != 0 {
-			fmt.Fprintf(writer, "Affected shards:  %s\n", strings.Join(brokenShardsStr, ", "))
+			c.write("Affected shards:  %s\n", strings.Join(brokenShardsStr, ", "))
 		}
-		if showDetails && len(details) != 0 {
-			fmt.Fprintf(writer, "Details:\n\t%s\n", strings.Join(details, "\n\t"))
+		if c.showDetails && len(details) != 0 {
+			c.write("Details:\n\t%s\n", strings.Join(details, "\n\t"))
 		}
 	}
 	return nil


### PR DESCRIPTION
# What problem are we solving?

TODO cleanup for https://github.com/seaweedfs/seaweedfs/pull/10130.

# How are we solving the problem?

Provides the ability of forcing deleted needles checks in EC scrubs. This is disabled by default as it can lead to false
positives, but can be useful nevertheless useful to detect index inconsistencies.

# How is the PR tested?

New gRPC message field and shell flag, no tests affected.

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI and API option to control deleted-needle checking for EC scrubbing.
  * Introduced EC-only checksum scrub mode to verify data against checksum sidecar information.
  * Extended EC rebuild/copy requests with additional sidecar/checksum controls and added disk status error reporting.
* **Bug Fixes**
  * Scrub now validates deleted-needle checking requests and only allows them for FULL scrub mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->