### PR TITLE
fix(filer): use DROP TABLE IF EXISTS in SQL stores

### DIFF
--- a/weed/filer/mysql/mysql_store.go
+++ b/weed/filer/mysql/mysql_store.go
@@ -72,7 +72,7 @@ func (store *MysqlStore) initialize(dsn string, upsertQuery string, enableUpsert
 	}
 	gen := &SqlGenMysql{
 		CreateTableSqlTemplate: "",
-		DropTableSqlTemplate:   "DROP TABLE `%s`",
+		DropTableSqlTemplate:   "DROP TABLE IF EXISTS `%s`",
 		UpsertQueryTemplate:    upsertQuery,
 	}
 	store.SqlGenerator = gen

--- a/weed/filer/mysql2/mysql2_store.go
+++ b/weed/filer/mysql2/mysql2_store.go
@@ -65,7 +65,7 @@ func (store *MysqlStore2) initialize(createTable, upsertQuery string, enableUpse
 	}
 	gen := &mysql.SqlGenMysql{
 		CreateTableSqlTemplate: createTable,
-		DropTableSqlTemplate:   "DROP TABLE `%s`",
+		DropTableSqlTemplate:   "DROP TABLE IF EXISTS `%s`",
 		UpsertQueryTemplate:    upsertQuery,
 	}
 	store.SqlGenerator = gen

--- a/weed/filer/postgres/postgres_store.go
+++ b/weed/filer/postgres/postgres_store.go
@@ -64,7 +64,7 @@ func (store *PostgresStore) initialize(upsertQuery string, enableUpsert bool, us
 	}
 	gen := &SqlGenPostgres{
 		CreateTableSqlTemplate: "",
-		DropTableSqlTemplate:   `drop table "%s"`,
+		DropTableSqlTemplate:   `drop table if exists "%s"`,
 		UpsertQueryTemplate:    upsertQuery,
 	}
 	store.SqlGenerator = gen

--- a/weed/filer/postgres2/postgres2_store.go
+++ b/weed/filer/postgres2/postgres2_store.go
@@ -70,7 +70,7 @@ func (store *PostgresStore2) initialize(createTable, upsertQuery string, enableU
 	}
 	gen := &postgres.SqlGenPostgres{
 		CreateTableSqlTemplate: createTable,
-		DropTableSqlTemplate:   `drop table "%s"`,
+		DropTableSqlTemplate:   `drop table if exists "%s"`,
 		UpsertQueryTemplate:    upsertQuery,
 	}
 	store.SqlGenerator = gen

--- a/weed/filer/sqlite/sqlite_store.go
+++ b/weed/filer/sqlite/sqlite_store.go
@@ -54,7 +54,7 @@ func (store *SqliteStore) initialize(dbFile, createTable, upsertQuery string) (e
 	store.SupportBucketTable = true
 	store.SqlGenerator = &mysql.SqlGenMysql{
 		CreateTableSqlTemplate: createTable,
-		DropTableSqlTemplate:   "drop table `%s`",
+		DropTableSqlTemplate:   "drop table if exists `%s`",
 		UpsertQueryTemplate:    upsertQuery,
 	}
 


### PR DESCRIPTION
Fixes #10157

## Problem

When a bucket is deleted with multiple filer replicas, every replica receives the deletion event and runs `DROP TABLE "<bucket>"` against the shared SQL database. The first replica succeeds; the rest hit an undefined-table error — postgres `42P01`, mysql `1051`. That error propagates out of `DeleteFolderChildren` and panics the filer. On restart the same pending DROP re-runs, so the filer crash-loops. The reporter saw a single bucket deletion crash-loop 3 filers for ~9 minutes, taking the S3 gateway offline.

## Fix

Make the drop idempotent with `DROP TABLE IF EXISTS`. The issue calls out `postgres2` and `postgres`, but `mysql`, `mysql2`, and `sqlite` carry the same bare `DROP TABLE` and the same race, so all five are fixed together.

`DROP TABLE IF EXISTS` is standard SQL, supported by every postgres/mysql/sqlite version SeaweedFS targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Drop-table operations now ignore missing tables across supported database backends, reducing failures during cleanup or initialization.
  * Improved compatibility for environments where tables may already be absent before a drop is issued.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->