### PR TITLE
ec: expose force_deleted_needles_check in ScrubEcVolume RPC and shell

### DIFF
--- a/seaweed-volume/proto/volume_server.proto
+++ b/seaweed-volume/proto/volume_server.proto
@@ -708,6 +708,7 @@ message ScrubEcVolumeRequest {
     VolumeScrubMode mode = 1;
     // optional list of volume IDs to scrub. if empty, all EC volumes for the server are scrubbed.
     repeated uint32 volume_ids = 2;
+    bool force_deleted_needles_check = 3; // FULL mode only; may report false positives when EC indexes disagree
 }
 message ScrubEcVolumeResponse {
     uint64 total_volumes = 1;

--- a/weed/pb/volume_server.proto
+++ b/weed/pb/volume_server.proto
@@ -711,6 +711,7 @@ message ScrubEcVolumeRequest {
     VolumeScrubMode mode = 1;
     // optional list of volume IDs to scrub. if empty, all EC volumes for the server are scrubbed.
     repeated uint32 volume_ids = 2;
+    bool force_deleted_needles_check = 3; // FULL mode only; may report false positives when EC indexes disagree
 }
 message ScrubEcVolumeResponse {
     uint64 total_volumes = 1;

--- a/weed/pb/volume_server_pb/volume_server.pb.go
+++ b/weed/pb/volume_server_pb/volume_server.pb.go
@@ -6018,9 +6018,10 @@ type ScrubEcVolumeRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	Mode  VolumeScrubMode        `protobuf:"varint,1,opt,name=mode,proto3,enum=volume_server_pb.VolumeScrubMode" json:"mode,omitempty"`
 	// optional list of volume IDs to scrub. if empty, all EC volumes for the server are scrubbed.
-	VolumeIds     []uint32 `protobuf:"varint,2,rep,packed,name=volume_ids,json=volumeIds,proto3" json:"volume_ids,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	VolumeIds                []uint32 `protobuf:"varint,2,rep,packed,name=volume_ids,json=volumeIds,proto3" json:"volume_ids,omitempty"`
+	ForceDeletedNeedlesCheck bool     `protobuf:"varint,3,opt,name=force_deleted_needles_check,json=forceDeletedNeedlesCheck,proto3" json:"force_deleted_needles_check,omitempty"` // FULL mode only; may report false positives when EC indexes disagree
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
 }
 
 func (x *ScrubEcVolumeRequest) Reset() {
@@ -6065,6 +6066,13 @@ func (x *ScrubEcVolumeRequest) GetVolumeIds() []uint32 {
 		return x.VolumeIds
 	}
 	return nil
+}
+
+func (x *ScrubEcVolumeRequest) GetForceDeletedNeedlesCheck() bool {
+	if x != nil {
+		return x.ForceDeletedNeedlesCheck
+	}
+	return false
 }
 
 type ScrubEcVolumeResponse struct {
@@ -7510,11 +7518,12 @@ const file_volume_server_proto_rawDesc = "" +
 	"\vtotal_files\x18\x02 \x01(\x04R\n" +
 	"totalFiles\x12*\n" +
 	"\x11broken_volume_ids\x18\x03 \x03(\rR\x0fbrokenVolumeIds\x12\x18\n" +
-	"\adetails\x18\x04 \x03(\tR\adetails\"l\n" +
+	"\adetails\x18\x04 \x03(\tR\adetails\"\xab\x01\n" +
 	"\x14ScrubEcVolumeRequest\x125\n" +
 	"\x04mode\x18\x01 \x01(\x0e2!.volume_server_pb.VolumeScrubModeR\x04mode\x12\x1d\n" +
 	"\n" +
-	"volume_ids\x18\x02 \x03(\rR\tvolumeIds\"\xf0\x01\n" +
+	"volume_ids\x18\x02 \x03(\rR\tvolumeIds\x12=\n" +
+	"\x1bforce_deleted_needles_check\x18\x03 \x01(\bR\x18forceDeletedNeedlesCheck\"\xf0\x01\n" +
 	"\x15ScrubEcVolumeResponse\x12#\n" +
 	"\rtotal_volumes\x18\x01 \x01(\x04R\ftotalVolumes\x12\x1f\n" +
 	"\vtotal_files\x18\x02 \x01(\x04R\n" +

--- a/weed/server/volume_grpc_scrub.go
+++ b/weed/server/volume_grpc_scrub.go
@@ -93,6 +93,9 @@ func (vs *VolumeServer) ScrubVolume(ctx context.Context, req *volume_server_pb.S
 }
 
 func (vs *VolumeServer) ScrubEcVolume(ctx context.Context, req *volume_server_pb.ScrubEcVolumeRequest) (*volume_server_pb.ScrubEcVolumeResponse, error) {
+	if err := vs.checkGrpcAdminAuth(ctx); err != nil {
+		return nil, err
+	}
 	if req.GetForceDeletedNeedlesCheck() && req.GetMode() != volume_server_pb.VolumeScrubMode_FULL {
 		return nil, fmt.Errorf("deleted needle checks are only supported for FULL scrubs")
 	}

--- a/weed/server/volume_grpc_scrub.go
+++ b/weed/server/volume_grpc_scrub.go
@@ -93,6 +93,10 @@ func (vs *VolumeServer) ScrubVolume(ctx context.Context, req *volume_server_pb.S
 }
 
 func (vs *VolumeServer) ScrubEcVolume(ctx context.Context, req *volume_server_pb.ScrubEcVolumeRequest) (*volume_server_pb.ScrubEcVolumeResponse, error) {
+	if req.GetForceDeletedNeedlesCheck() && req.GetMode() != volume_server_pb.VolumeScrubMode_FULL {
+		return nil, fmt.Errorf("deleted needle checks are only supported for FULL scrubs")
+	}
+
 	vids := []needle.VolumeId{}
 	if len(req.GetVolumeIds()) == 0 {
 		for _, l := range vs.store.Locations {
@@ -124,8 +128,7 @@ func (vs *VolumeServer) ScrubEcVolume(ctx context.Context, req *volume_server_pb
 		case volume_server_pb.VolumeScrubMode_LOCAL:
 			files, shardInfos, serrs = v.ScrubLocal()
 		case volume_server_pb.VolumeScrubMode_FULL:
-			// TODO: expose force_deleted_needles_check in the RPC and weed shell.
-			files, shardInfos, serrs = vs.store.ScrubEcVolume(v.VolumeId, false)
+			files, shardInfos, serrs = vs.store.ScrubEcVolume(v.VolumeId, req.GetForceDeletedNeedlesCheck())
 		case volume_server_pb.VolumeScrubMode_CHECKSUM:
 			// Verify each local shard's raw bytes against the bitrot sidecar,
 			// exercising cold parity shards. Read-only. ChecksumScrub's first

--- a/weed/shell/command_ec_scrub.go
+++ b/weed/shell/command_ec_scrub.go
@@ -20,11 +20,12 @@ func init() {
 }
 
 type commandEcVolumeScrub struct {
-	env               *CommandEnv
-	volumeServerAddrs []pb.ServerAddress
-	volumeIDs         []uint32
-	mode              volume_server_pb.VolumeScrubMode
-	grpcDialOption    grpc.DialOption
+	env                      *CommandEnv
+	volumeServerAddrs        []pb.ServerAddress
+	volumeIDs                []uint32
+	mode                     volume_server_pb.VolumeScrubMode
+	forceDeletedNeedlesCheck bool
+	grpcDialOption           grpc.DialOption
 }
 
 func (c *commandEcVolumeScrub) Name() string {
@@ -52,6 +53,7 @@ func (c *commandEcVolumeScrub) Do(args []string, commandEnv *CommandEnv, writer 
 	mode := volScrubCommand.String("mode", "local", "scrubbing mode (index/local/full/checksum)")
 	maxParallelization := volScrubCommand.Int("maxParallelization", DefaultMaxParallelization, "run up to X tasks in parallel, whenever possible")
 	showDetails := volScrubCommand.Bool("details", false, "display scrub result details, if available")
+	forceDeletedNeedlesCheck := volScrubCommand.Bool("forceDeletedNeedlesCheck", false, "force strict verification of deleted needles (full mode only); may report false positives when EC indexes disagree")
 
 	if err = volScrubCommand.Parse(args); err != nil {
 		return err
@@ -104,6 +106,7 @@ func (c *commandEcVolumeScrub) Do(args []string, commandEnv *CommandEnv, writer 
 	}
 	fmt.Fprintf(writer, "using %s mode\n", c.mode.String())
 	c.env = commandEnv
+	c.forceDeletedNeedlesCheck = *forceDeletedNeedlesCheck
 
 	return c.scrubEcVolumes(writer, *maxParallelization, *showDetails)
 }
@@ -125,8 +128,9 @@ func (c *commandEcVolumeScrub) scrubEcVolumes(writer io.Writer, maxParallelizati
 
 			err := operation.WithVolumeServerClient(false, addr, c.env.option.GrpcDialOption, func(volumeServerClient volume_server_pb.VolumeServerClient) error {
 				res, err := volumeServerClient.ScrubEcVolume(context.Background(), &volume_server_pb.ScrubEcVolumeRequest{
-					Mode:      c.mode,
-					VolumeIds: c.volumeIDs,
+					Mode:                     c.mode,
+					VolumeIds:                c.volumeIDs,
+					ForceDeletedNeedlesCheck: c.forceDeletedNeedlesCheck,
 				})
 				if err != nil {
 					return err

--- a/weed/shell/command_ec_scrub.go
+++ b/weed/shell/command_ec_scrub.go
@@ -107,6 +107,9 @@ func (c *commandEcVolumeScrub) Do(args []string, commandEnv *CommandEnv, writer 
 	fmt.Fprintf(writer, "using %s mode\n", c.mode.String())
 	c.env = commandEnv
 	c.forceDeletedNeedlesCheck = *forceDeletedNeedlesCheck
+	if c.forceDeletedNeedlesCheck && c.mode != volume_server_pb.VolumeScrubMode_FULL {
+		return fmt.Errorf("deleted needle checks are only supported for FULL scrubs")
+	}
 
 	return c.scrubEcVolumes(writer, *maxParallelization, *showDetails)
 }


### PR DESCRIPTION
Replaces #10153 with a minimal rebase onto current master.

#10130 left the deleted-needle check on EC FULL scrubs wired to a hardcoded `false` with a TODO to expose it. This does that:

- `ScrubEcVolumeRequest.force_deleted_needles_check` in both the Go and Rust protos.
- `weed shell ec.scrub -forceDeletedNeedlesCheck` (off by default; it can report false positives when EC indexes disagree, so it's opt-in for spotting index inconsistencies).
- The RPC rejects the flag for non-FULL modes.

`store.ScrubEcVolume(vid, forceDeletedNeedlesCheck)` already supports the parameter; only the RPC and shell plumbing were missing.

The Rust volume server parses the new field and ignores it: its FULL scrub verifies shards via RS parity rather than per-needle reads, so there's no behavior to change there.

### Why a new PR

#10153's branch was cut from an older master, so its diff also dragged in unrelated Rust-proto drift (`unsafe_ignore_sidecar`, `DiskStatus.error`) and would have reverted a comment update that has since landed on master. This branch is a clean rebase: the net change is the one proto field plus its plumbing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `forceDeletedNeedlesCheck` flag for EC scrub operations.
  * The setting is available via the `ec.scrub` command and included in scrub requests.

* **Bug Fixes**
  * EC scrub now validates that the deleted-needle check option is allowed only with `FULL` mode (otherwise returns an error).
  * Full EC scrubs now honor the requested deleted-needle check setting, instead of always disabling it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->