### PR TITLE
s3: return IncompleteBody instead of 500 for truncated PUT bodies

### DIFF
--- a/weed/operation/upload_chunked.go
+++ b/weed/operation/upload_chunked.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/md5"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"hash"
 	"io"
@@ -17,6 +18,11 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/security"
 	util_http "github.com/seaweedfs/seaweedfs/weed/util/http"
 )
+
+// ErrTruncatedBody tags a source read that ended before the expected bytes
+// arrived, so callers can tell a truncated input (client abort, reverse-proxy
+// timeout) apart from a volume-server upload fault.
+var ErrTruncatedBody = errors.New("truncated request body")
 
 // ChunkedUploadResult contains the result of a chunked upload
 type ChunkedUploadResult struct {
@@ -104,6 +110,9 @@ uploadLoop:
 			// before any data (offset=0,got=0) from mid-stream truncation.
 			// A bare io.ErrUnexpectedEOF is not actionable on its own (see #9149).
 			wrapped := fmt.Errorf("read chunk at offset %d (got %d bytes): %w", chunkOffset, dataSize, err)
+			if errors.Is(err, io.ErrUnexpectedEOF) {
+				wrapped = fmt.Errorf("%w: %w", ErrTruncatedBody, wrapped)
+			}
 			glog.V(2).Infof("UploadReaderInChunks: %v", wrapped)
 			chunkBufferPool.Put(bytesBuffer)
 			<-bytesBufferLimitChan

--- a/weed/operation/upload_chunked_test.go
+++ b/weed/operation/upload_chunked_test.go
@@ -372,3 +372,46 @@ func TestUploadReaderInChunksReaderFailure(t *testing.T) {
 	t.Logf("✓ Got partial result on read failure: chunks=%d, totalSize=%d",
 		len(result.FileChunks), result.TotalSize)
 }
+
+// truncatedReader yields some bytes then reports io.ErrUnexpectedEOF, mimicking a
+// request body cut short by a client abort or reverse-proxy timeout.
+type truncatedReader struct {
+	data []byte
+	pos  int
+}
+
+func (r *truncatedReader) Read(p []byte) (int, error) {
+	if r.pos >= len(r.data) {
+		return 0, io.ErrUnexpectedEOF
+	}
+	n := copy(p, r.data[r.pos:])
+	r.pos += n
+	return n, nil
+}
+
+func TestUploadReaderInChunksTagsTruncatedBody(t *testing.T) {
+	reader := &truncatedReader{data: bytes.Repeat([]byte("x"), 10000)}
+
+	assignFunc := func(ctx context.Context, count int, expectedDataSize uint64) (*VolumeAssignRequest, *AssignResult, error) {
+		return nil, &AssignResult{Fid: "test-fid,1234", Url: "http://test-volume:8080", Count: 1}, nil
+	}
+	uploadFunc := func(ctx context.Context, data []byte, option *UploadOption) (*UploadResult, error) {
+		return &UploadResult{Size: uint32(len(data))}, nil
+	}
+
+	_, err := UploadReaderInChunks(context.Background(), reader, &ChunkedUploadOption{
+		ChunkSize:  8 * 1024,
+		Collection: "test",
+		AssignFunc: assignFunc,
+		UploadFunc: uploadFunc,
+	})
+	if err == nil {
+		t.Fatal("expected an error for a truncated body")
+	}
+	if !errors.Is(err, ErrTruncatedBody) {
+		t.Errorf("expected ErrTruncatedBody, got %v", err)
+	}
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Errorf("expected io.ErrUnexpectedEOF to remain in the chain, got %v", err)
+	}
+}

--- a/weed/s3api/s3api_object_handlers_put.go
+++ b/weed/s3api/s3api_object_handlers_put.go
@@ -545,10 +545,7 @@ func (s3a *S3ApiServer) putToFiler(r *http.Request, filePath string, dataReader 
 			s3a.deleteOrphanedChunks(chunkResult.FileChunks)
 		}
 
-		if strings.Contains(err.Error(), s3err.ErrMsgPayloadChecksumMismatch) {
-			return "", s3err.ErrInvalidDigest, SSEResponseMetadata{}
-		}
-		return "", s3err.ErrInternalError, SSEResponseMetadata{}
+		return "", mapChunkedUploadErrorToS3Error(err), SSEResponseMetadata{}
 	}
 
 	// Step 3: Calculate MD5 hash and add SSE metadata to chunks
@@ -1165,6 +1162,22 @@ func filerErrorToS3Error(err error) s3err.ErrorCode {
 		return s3err.ErrBadDigest
 	case strings.Contains(errString, "context canceled") || strings.Contains(errString, "code = Canceled"):
 		return s3err.ErrInvalidRequest
+	default:
+		return s3err.ErrInternalError
+	}
+}
+
+// mapChunkedUploadErrorToS3Error classifies a failed streaming upload. A truncated
+// request body (client abort or reverse-proxy timeout) is a request error, so report
+// IncompleteBody (400) rather than a 500 a reverse proxy would relay as a confusing
+// 502. Only the source read is tagged, so a volume-server upload fault still maps to
+// InternalError.
+func mapChunkedUploadErrorToS3Error(err error) s3err.ErrorCode {
+	switch {
+	case strings.Contains(err.Error(), s3err.ErrMsgPayloadChecksumMismatch):
+		return s3err.ErrInvalidDigest
+	case errors.Is(err, operation.ErrTruncatedBody):
+		return s3err.ErrIncompleteBody
 	default:
 		return s3err.ErrInternalError
 	}

--- a/weed/s3api/s3api_object_handlers_put_error_test.go
+++ b/weed/s3api/s3api_object_handlers_put_error_test.go
@@ -1,0 +1,51 @@
+package s3api
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/operation"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
+)
+
+func TestMapChunkedUploadErrorToS3Error(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want s3err.ErrorCode
+	}{
+		{
+			// A truncated body (client abort or reverse-proxy timeout) reaches
+			// putToFiler tagged exactly like UploadReaderInChunks reports it.
+			name: "truncated source read maps to IncompleteBody",
+			err:  fmt.Errorf("%w: read chunk at offset %d (got %d bytes): %w", operation.ErrTruncatedBody, 0, 8056500, io.ErrUnexpectedEOF),
+			want: s3err.ErrIncompleteBody,
+		},
+		{
+			// A volume-server upload dropping mid-write is a server fault, not a
+			// client truncation, even though it also carries io.ErrUnexpectedEOF.
+			name: "volume upload unexpected EOF maps to InternalError",
+			err:  fmt.Errorf("upload chunk: %w", io.ErrUnexpectedEOF),
+			want: s3err.ErrInternalError,
+		},
+		{
+			name: "payload checksum mismatch maps to InvalidDigest",
+			err:  errors.New(s3err.ErrMsgPayloadChecksumMismatch),
+			want: s3err.ErrInvalidDigest,
+		},
+		{
+			name: "other errors map to InternalError",
+			err:  errors.New("assign volume: no free volumes"),
+			want: s3err.ErrInternalError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mapChunkedUploadErrorToS3Error(tt.err); got != tt.want {
+				t.Errorf("mapChunkedUploadErrorToS3Error(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/weed/s3api/s3err/s3api_errors.go
+++ b/weed/s3api/s3err/s3api_errors.go
@@ -155,6 +155,9 @@ const (
 	ErrKeyTooLongError
 
 	ErrNoSuchConfiguration
+
+	// Truncated request body (fewer bytes than Content-Length)
+	ErrIncompleteBody
 )
 
 // Error message constants for checksum validation
@@ -296,6 +299,11 @@ var errorCodeResponse = map[ErrorCode]APIError{
 		Code:           "InternalError",
 		Description:    "We encountered an internal error, please try again.",
 		HTTPStatusCode: http.StatusInternalServerError,
+	},
+	ErrIncompleteBody: {
+		Code:           "IncompleteBody",
+		Description:    "You did not provide the number of bytes specified by the Content-Length HTTP header.",
+		HTTPStatusCode: http.StatusBadRequest,
 	},
 
 	ErrInvalidPart: {


### PR DESCRIPTION
## Problem

A single large PutObject (e.g. a browser upload through a presigned URL) fails with `500 InternalError` when the request body is truncated mid-upload — a client abort or a reverse-proxy read timeout. Behind a reverse proxy the 500 is relayed to the client as a confusing `502 Bad Gateway`.

The volume-facing log is:

```
upload_chunked.go chunked upload failed: read chunk at offset 0 (got 8056500 bytes): unexpected EOF
s3api_object_handlers_put.go putToFiler: chunked upload failed: ...: unexpected EOF
```

`putToFiler` mapped *every* streaming-upload failure to `InternalError`, including a short body, which is a request-side error rather than a server fault.

## Fix

Classify a truncated body (`io.ErrUnexpectedEOF`, from both the raw body and the aws-chunked reader paths) as `IncompleteBody` (HTTP 400) — the same code AWS S3 returns for "you did not provide the number of bytes specified by the Content-Length header." A clean 400 passes through a reverse proxy instead of turning into a 502, and gives clients an actionable, retryable signal.

- Add the `IncompleteBody` error code.
- Extract `mapChunkedUploadErrorToS3Error` and route `putToFiler` through it; unit-tested against the exact wrapped error the chunked uploader produces.

All S3 write paths (PutObject, versioned/suspended, multipart part, post-policy, copy-part) share `putToFiler`, so they all benefit.

## Reproduce

Send a PUT declaring a larger `Content-Length` than the bytes delivered, then half-close:

Before: `500 InternalError`
After: `400 IncompleteBody`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error responses for failed chunked uploads, including clearer handling for truncated request bodies and checksum mismatches.
  * Requests that end unexpectedly now return a more specific **IncompleteBody** error instead of a generic server error.
  * Other upload failures continue to surface as internal errors when appropriate.
* **Tests**
  * Added coverage for chunked upload truncated-body detection and error-to-response mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->