### PR TITLE
[filer] applyStorageDefaultsToEntry before CreateEntry

### DIFF
--- a/weed/server/filer_grpc_server.go
+++ b/weed/server/filer_grpc_server.go
@@ -361,6 +361,26 @@ func (fs *FilerServer) ObjectTransactionBatch(ctx context.Context, req *filer_pb
 	return resp, nil
 }
 
+func (fs *FilerServer) applyStorageDefaultsToEntry(entry *filer.Entry) {
+	if entry.IsDirectory() {
+		return
+	}
+
+	if entry.Remote != nil {
+		return
+	}
+
+	if entry.TtlSec != 0 {
+		return
+	}
+	ctx := context.Background()
+	so, err := fs.detectStorageOption(ctx, string(entry.FullPath), "", "", entry.TtlSec, "", "", "", "")
+	if err != nil {
+		glog.WarningfCtx(ctx, "detectStorageOption: %v", err)
+	}
+	entry.TtlSec = so.TtlSeconds
+}
+
 // applyObjectMutation applies a single mutation while the transaction's path
 // lock is held. PUT entries are expected to be fully prepared by the caller
 // (chunks resolved); mutations here are metadata-scoped. A DELETE of an absent
@@ -373,6 +393,7 @@ func (fs *FilerServer) applyObjectMutation(ctx context.Context, m *filer_pb.Obje
 			return fmt.Errorf("PUT requires an entry")
 		}
 		newEntry := filer.FromPbEntry(m.Directory, m.Entry)
+		fs.applyStorageDefaultsToEntry(newEntry)
 		return fs.filer.CreateEntry(ctx, newEntry, nil, false, fromOtherCluster, signatures, false, fs.filer.MaxFilenameLength)
 
 	case filer_pb.ObjectMutation_DELETE:

--- a/weed/server/filer_grpc_server.go
+++ b/weed/server/filer_grpc_server.go
@@ -361,7 +361,7 @@ func (fs *FilerServer) ObjectTransactionBatch(ctx context.Context, req *filer_pb
 	return resp, nil
 }
 
-func (fs *FilerServer) applyStorageDefaultsToEntry(entry *filer.Entry) {
+func (fs *FilerServer) applyStorageDefaultsToEntry(ctx context.Context, entry *filer.Entry) {
 	if entry.IsDirectory() {
 		return
 	}
@@ -373,10 +373,10 @@ func (fs *FilerServer) applyStorageDefaultsToEntry(entry *filer.Entry) {
 	if entry.TtlSec != 0 {
 		return
 	}
-	ctx := context.Background()
 	so, err := fs.detectStorageOption(ctx, string(entry.FullPath), "", "", entry.TtlSec, "", "", "", "")
 	if err != nil {
 		glog.WarningfCtx(ctx, "detectStorageOption: %v", err)
+		return
 	}
 	entry.TtlSec = so.TtlSeconds
 }

--- a/weed/server/filer_grpc_server.go
+++ b/weed/server/filer_grpc_server.go
@@ -361,24 +361,30 @@ func (fs *FilerServer) ObjectTransactionBatch(ctx context.Context, req *filer_pb
 	return resp, nil
 }
 
-func (fs *FilerServer) applyStorageDefaultsToEntry(ctx context.Context, entry *filer.Entry) {
+func (fs *FilerServer) applyStorageDefaultsToEntry(ctx context.Context, entry *filer.Entry) error {
 	if entry.IsDirectory() {
-		return
+		entry.Attr.TtlSec = 0
+		return nil
 	}
 
-	if entry.Remote != nil {
-		return
+	if entry.IsInRemoteOnly() {
+		entry.Attr.TtlSec = 0
+		return nil
 	}
 
 	if entry.TtlSec != 0 {
-		return
+		return nil
 	}
 	so, err := fs.detectStorageOption(ctx, string(entry.FullPath), "", "", entry.TtlSec, "", "", "", "")
 	if err != nil {
 		glog.WarningfCtx(ctx, "detectStorageOption: %v", err)
-		return
+		return err
+	}
+	if so == nil {
+		return nil
 	}
 	entry.TtlSec = so.TtlSeconds
+	return nil
 }
 
 // applyObjectMutation applies a single mutation while the transaction's path
@@ -393,7 +399,9 @@ func (fs *FilerServer) applyObjectMutation(ctx context.Context, m *filer_pb.Obje
 			return fmt.Errorf("PUT requires an entry")
 		}
 		newEntry := filer.FromPbEntry(m.Directory, m.Entry)
-		fs.applyStorageDefaultsToEntry(ctx, newEntry)
+		if err := fs.applyStorageDefaultsToEntry(ctx, newEntry); err != nil {
+			return err
+		}
 		return fs.filer.CreateEntry(ctx, newEntry, nil, false, fromOtherCluster, signatures, false, fs.filer.MaxFilenameLength)
 
 	case filer_pb.ObjectMutation_DELETE:

--- a/weed/server/filer_grpc_server.go
+++ b/weed/server/filer_grpc_server.go
@@ -173,19 +173,11 @@ func (fs *FilerServer) CreateEntry(ctx context.Context, req *filer_pb.CreateEntr
 		return &filer_pb.CreateEntryResponse{}, fmt.Errorf("CreateEntry cleanupChunks %s %s: %v", req.Directory, req.Entry.Name, err2)
 	}
 
-	so, err := fs.detectStorageOption(ctx, string(util.NewFullPath(req.Directory, req.Entry.Name)), "", "", 0, "", "", "", "")
-	if err != nil {
-		return nil, err
-	}
 	newEntry := filer.FromPbEntry(req.Directory, req.Entry)
 	newEntry.Chunks = chunks
-	// Don't apply TTL to remote entries - they're managed by remote storage
-	if newEntry.Remote == nil {
-		if newEntry.TtlSec == 0 {
-			newEntry.TtlSec = so.TtlSeconds
-		}
-	} else {
-		newEntry.TtlSec = 0
+	so, err := fs.applyStorageDefaultsToEntry(ctx, newEntry)
+	if err != nil {
+		return nil, err
 	}
 
 	// Serialize concurrent mutations to the same path on this filer so the

--- a/weed/server/filer_grpc_server.go
+++ b/weed/server/filer_grpc_server.go
@@ -382,10 +382,11 @@ func (fs *FilerServer) applyObjectMutation(ctx context.Context, m *filer_pb.Obje
 			return fmt.Errorf("PUT requires an entry")
 		}
 		newEntry := filer.FromPbEntry(m.Directory, m.Entry)
-		if _, err := fs.applyStorageDefaultsToEntry(ctx, newEntry); err != nil {
+		so, err := fs.applyStorageDefaultsToEntry(ctx, newEntry)
+		if err != nil {
 			return err
 		}
-		return fs.filer.CreateEntry(ctx, newEntry, nil, false, fromOtherCluster, signatures, false, fs.filer.MaxFilenameLength)
+		return fs.filer.CreateEntry(ctx, newEntry, nil, false, fromOtherCluster, signatures, false, so.MaxFileNameLength)
 
 	case filer_pb.ObjectMutation_DELETE:
 		fullpath := util.NewFullPath(m.Directory, m.Name)

--- a/weed/server/filer_grpc_server.go
+++ b/weed/server/filer_grpc_server.go
@@ -361,30 +361,21 @@ func (fs *FilerServer) ObjectTransactionBatch(ctx context.Context, req *filer_pb
 	return resp, nil
 }
 
-func (fs *FilerServer) applyStorageDefaultsToEntry(ctx context.Context, entry *filer.Entry) error {
-	if entry.IsDirectory() {
-		entry.Attr.TtlSec = 0
-		return nil
-	}
-
-	if entry.IsInRemoteOnly() {
-		entry.Attr.TtlSec = 0
-		return nil
-	}
-
-	if entry.TtlSec != 0 {
-		return nil
-	}
-	so, err := fs.detectStorageOption(ctx, string(entry.FullPath), "", "", entry.TtlSec, "", "", "", "")
+// applyStorageDefaultsToEntry enforces the path's storage rule (read-only
+// prefixes reject the write) and fills in the rule TTL when the entry carries
+// none. Remote entries never expire locally; the remote storage owns their
+// lifecycle.
+func (fs *FilerServer) applyStorageDefaultsToEntry(ctx context.Context, entry *filer.Entry) (*operation.StorageOption, error) {
+	so, err := fs.detectStorageOption(ctx, string(entry.FullPath), "", "", 0, "", "", "", "")
 	if err != nil {
-		glog.WarningfCtx(ctx, "detectStorageOption: %v", err)
-		return err
+		return nil, err
 	}
-	if so == nil {
-		return nil
+	if entry.Remote != nil {
+		entry.TtlSec = 0
+	} else if entry.TtlSec == 0 {
+		entry.TtlSec = so.TtlSeconds
 	}
-	entry.TtlSec = so.TtlSeconds
-	return nil
+	return so, nil
 }
 
 // applyObjectMutation applies a single mutation while the transaction's path
@@ -399,7 +390,7 @@ func (fs *FilerServer) applyObjectMutation(ctx context.Context, m *filer_pb.Obje
 			return fmt.Errorf("PUT requires an entry")
 		}
 		newEntry := filer.FromPbEntry(m.Directory, m.Entry)
-		if err := fs.applyStorageDefaultsToEntry(ctx, newEntry); err != nil {
+		if _, err := fs.applyStorageDefaultsToEntry(ctx, newEntry); err != nil {
 			return err
 		}
 		return fs.filer.CreateEntry(ctx, newEntry, nil, false, fromOtherCluster, signatures, false, fs.filer.MaxFilenameLength)

--- a/weed/server/filer_grpc_server.go
+++ b/weed/server/filer_grpc_server.go
@@ -393,7 +393,7 @@ func (fs *FilerServer) applyObjectMutation(ctx context.Context, m *filer_pb.Obje
 			return fmt.Errorf("PUT requires an entry")
 		}
 		newEntry := filer.FromPbEntry(m.Directory, m.Entry)
-		fs.applyStorageDefaultsToEntry(newEntry)
+		fs.applyStorageDefaultsToEntry(ctx, newEntry)
 		return fs.filer.CreateEntry(ctx, newEntry, nil, false, fromOtherCluster, signatures, false, fs.filer.MaxFilenameLength)
 
 	case filer_pb.ObjectMutation_DELETE:

--- a/weed/server/filer_grpc_server_object_txn_ttl_test.go
+++ b/weed/server/filer_grpc_server_object_txn_ttl_test.go
@@ -163,41 +163,45 @@ func TestObjectTransactionPutClearsTTLForRemoteEntry(t *testing.T) {
 }
 
 func TestObjectTransactionPutFailsOnReadOnlyStorageConfig(t *testing.T) {
-	fs, store := newTxnTestServer(nil)
+	// An explicit TTL must not bypass the read-only rule.
+	for _, ttlSec := range []int32{0, 7200} {
+		fs, store := newTxnTestServer(nil)
 
-	mustSetObjectTxnStorageConf(t, fs, &filer_pb.FilerConf_PathConf{
-		LocationPrefix: "/buckets/video/",
-		ReadOnly:       true,
-	})
+		mustSetObjectTxnStorageConf(t, fs, &filer_pb.FilerConf_PathConf{
+			LocationPrefix: "/buckets/video/",
+			ReadOnly:       true,
+		})
 
-	now := time.Unix(1700000000, 0)
+		now := time.Unix(1700000000, 0)
 
-	resp, err := fs.ObjectTransaction(context.Background(), &filer_pb.ObjectTransactionRequest{
-		LockKey: "/buckets/video/readonly.mp4",
-		Mutations: []*filer_pb.ObjectMutation{
-			{
-				Type:      filer_pb.ObjectMutation_PUT,
-				Directory: "/buckets/video",
-				Entry: &filer_pb.Entry{
-					Name: "readonly.mp4",
-					Attributes: &filer_pb.FuseAttributes{
-						Crtime:   now.Unix(),
-						Mtime:    now.Unix(),
-						FileMode: 0644,
-						FileSize: 123,
+		resp, err := fs.ObjectTransaction(context.Background(), &filer_pb.ObjectTransactionRequest{
+			LockKey: "/buckets/video/readonly.mp4",
+			Mutations: []*filer_pb.ObjectMutation{
+				{
+					Type:      filer_pb.ObjectMutation_PUT,
+					Directory: "/buckets/video",
+					Entry: &filer_pb.Entry{
+						Name: "readonly.mp4",
+						Attributes: &filer_pb.FuseAttributes{
+							Crtime:   now.Unix(),
+							Mtime:    now.Unix(),
+							FileMode: 0644,
+							FileSize: 123,
+							TtlSec:   ttlSec,
+						},
 					},
 				},
 			},
-		},
-	})
-	if err != nil {
-		t.Fatalf("ObjectTransaction transport error: %v", err)
-	}
-	if resp.Error == "" {
-		t.Fatalf("ObjectTransaction should report read-only storage config error")
-	}
+		})
+		if err != nil {
+			t.Fatalf("TtlSec=%d: ObjectTransaction transport error: %v", ttlSec, err)
+		}
+		if resp.Error == "" {
+			t.Fatalf("TtlSec=%d: ObjectTransaction should report read-only storage config error", ttlSec)
+		}
 
-	if _, ok := store.entries["/buckets/video/readonly.mp4"]; ok {
-		t.Fatalf("read-only storage config must not create the entry")
+		if _, ok := store.entries["/buckets/video/readonly.mp4"]; ok {
+			t.Fatalf("TtlSec=%d: read-only storage config must not create the entry", ttlSec)
+		}
 	}
 }

--- a/weed/server/filer_grpc_server_object_txn_ttl_test.go
+++ b/weed/server/filer_grpc_server_object_txn_ttl_test.go
@@ -162,6 +162,46 @@ func TestObjectTransactionPutClearsTTLForRemoteEntry(t *testing.T) {
 	}
 }
 
+func TestObjectTransactionPutHonorsMaxFileNameLengthRule(t *testing.T) {
+	fs, store := newTxnTestServer(nil)
+
+	mustSetObjectTxnStorageConf(t, fs, &filer_pb.FilerConf_PathConf{
+		LocationPrefix:    "/buckets/video/",
+		MaxFileNameLength: 8,
+	})
+
+	now := time.Unix(1700000000, 0)
+
+	resp, err := fs.ObjectTransaction(context.Background(), &filer_pb.ObjectTransactionRequest{
+		LockKey: "/buckets/video/toolong.mp4",
+		Mutations: []*filer_pb.ObjectMutation{
+			{
+				Type:      filer_pb.ObjectMutation_PUT,
+				Directory: "/buckets/video",
+				Entry: &filer_pb.Entry{
+					Name: "toolong.mp4",
+					Attributes: &filer_pb.FuseAttributes{
+						Crtime:   now.Unix(),
+						Mtime:    now.Unix(),
+						FileMode: 0644,
+						FileSize: 123,
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ObjectTransaction transport error: %v", err)
+	}
+	if resp.Error == "" {
+		t.Fatalf("ObjectTransaction should reject a name longer than the rule's max_file_name_length")
+	}
+
+	if _, ok := store.entries["/buckets/video/toolong.mp4"]; ok {
+		t.Fatalf("over-long name must not create the entry")
+	}
+}
+
 func TestObjectTransactionPutFailsOnReadOnlyStorageConfig(t *testing.T) {
 	// An explicit TTL must not bypass the read-only rule.
 	for _, ttlSec := range []int32{0, 7200} {

--- a/weed/server/filer_grpc_server_object_txn_ttl_test.go
+++ b/weed/server/filer_grpc_server_object_txn_ttl_test.go
@@ -116,7 +116,7 @@ func TestObjectTransactionPutPreservesExplicitTTL(t *testing.T) {
 	}
 }
 
-func TestObjectTransactionPutDoesNotApplyStorageTTLToDirectoryOrRemoteEntry(t *testing.T) {
+func TestObjectTransactionPutClearsTTLForRemoteEntry(t *testing.T) {
 	fs, store := newTxnTestServer(nil)
 
 	mustSetObjectTxnStorageConf(t, fs, &filer_pb.FilerConf_PathConf{
@@ -127,22 +127,8 @@ func TestObjectTransactionPutDoesNotApplyStorageTTLToDirectoryOrRemoteEntry(t *t
 	now := time.Unix(1700000000, 0)
 
 	resp, err := fs.ObjectTransaction(context.Background(), &filer_pb.ObjectTransactionRequest{
-		LockKey: "/buckets/video/dir",
+		LockKey: "/buckets/video/remote",
 		Mutations: []*filer_pb.ObjectMutation{
-			{
-				Type:      filer_pb.ObjectMutation_PUT,
-				Directory: "/buckets/video",
-				Entry: &filer_pb.Entry{
-					Name:        "dir",
-					IsDirectory: true,
-					Attributes: &filer_pb.FuseAttributes{
-						Crtime:   now.Unix(),
-						Mtime:    now.Unix(),
-						FileMode: 0755 | (1 << 31),
-						TtlSec:   7200,
-					},
-				},
-			},
 			{
 				Type:      filer_pb.ObjectMutation_PUT,
 				Directory: "/buckets/video",
@@ -152,9 +138,10 @@ func TestObjectTransactionPutDoesNotApplyStorageTTLToDirectoryOrRemoteEntry(t *t
 						Crtime:   now.Unix(),
 						Mtime:    now.Unix(),
 						FileMode: 0644,
+						FileSize: 123,
 						TtlSec:   7200,
 					},
-					RemoteEntry: &filer_pb.RemoteEntry{},
+					RemoteEntry: &filer_pb.RemoteEntry{RemoteSize: 123},
 				},
 			},
 		},
@@ -166,19 +153,11 @@ func TestObjectTransactionPutDoesNotApplyStorageTTLToDirectoryOrRemoteEntry(t *t
 		t.Fatalf("ObjectTransaction response error: %q", resp.Error)
 	}
 
-	dirEntry := store.entries["/buckets/video/dir"]
-	if dirEntry == nil {
-		t.Fatalf("directory entry should be created")
-	}
-	if got := dirEntry.TtlSec; got != 0 {
-		t.Fatalf("directory TtlSec = %d, want 0", got)
-	}
-
-	remoteEntry := store.entries["/buckets/video/remote"]
-	if remoteEntry == nil {
+	entry := store.entries["/buckets/video/remote"]
+	if entry == nil {
 		t.Fatalf("remote entry should be created")
 	}
-	if got := remoteEntry.TtlSec; got != 0 {
+	if got := entry.TtlSec; got != 0 {
 		t.Fatalf("remote entry TtlSec = %d, want 0", got)
 	}
 }

--- a/weed/server/filer_grpc_server_object_txn_ttl_test.go
+++ b/weed/server/filer_grpc_server_object_txn_ttl_test.go
@@ -1,0 +1,224 @@
+package weed_server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+)
+
+func mustSetObjectTxnStorageConf(t *testing.T, fs *FilerServer, conf *filer_pb.FilerConf_PathConf) {
+	t.Helper()
+
+	if err := fs.filer.FilerConf.SetLocationConf(conf); err != nil {
+		t.Fatalf("SetLocationConf(%q): %v", conf.LocationPrefix, err)
+	}
+}
+
+func TestObjectTransactionPutAppliesConfiguredTTLAndExpires(t *testing.T) {
+	fs, store := newTxnTestServer(nil)
+
+	mustSetObjectTxnStorageConf(t, fs, &filer_pb.FilerConf_PathConf{
+		LocationPrefix: "/buckets/video/",
+		Ttl:            "1h",
+	})
+
+	old := time.Now().Add(-2 * time.Hour)
+
+	resp, err := fs.ObjectTransaction(context.Background(), &filer_pb.ObjectTransactionRequest{
+		LockKey: "/buckets/video/expired.mp4",
+		Mutations: []*filer_pb.ObjectMutation{
+			{
+				Type:      filer_pb.ObjectMutation_PUT,
+				Directory: "/buckets/video",
+				Entry: &filer_pb.Entry{
+					Name: "expired.mp4",
+					Attributes: &filer_pb.FuseAttributes{
+						Crtime:   old.Unix(),
+						Mtime:    old.Unix(),
+						FileMode: 0644,
+						FileSize: 123,
+						TtlSec:   0,
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ObjectTransaction transport error: %v", err)
+	}
+	if resp.Error != "" {
+		t.Fatalf("ObjectTransaction response error: %q", resp.Error)
+	}
+
+	entry := store.entries["/buckets/video/expired.mp4"]
+	if entry == nil {
+		t.Fatalf("PUT should create /buckets/video/expired.mp4")
+	}
+	if got := entry.TtlSec; got != 3600 {
+		t.Fatalf("TtlSec = %d, want 3600 from fs.configure storage rule", got)
+	}
+
+	_, err = fs.filer.FindEntry(context.Background(), util.FullPath("/buckets/video/expired.mp4"))
+	if err != filer_pb.ErrNotFound {
+		t.Fatalf("expired entry lookup error = %v, want %v", err, filer_pb.ErrNotFound)
+	}
+
+	if _, ok := store.entries["/buckets/video/expired.mp4"]; ok {
+		t.Fatalf("expired entry should be deleted from metadata store")
+	}
+}
+
+func TestObjectTransactionPutPreservesExplicitTTL(t *testing.T) {
+	fs, store := newTxnTestServer(nil)
+
+	mustSetObjectTxnStorageConf(t, fs, &filer_pb.FilerConf_PathConf{
+		LocationPrefix: "/buckets/video/",
+		Ttl:            "1h",
+	})
+
+	now := time.Unix(1700000000, 0)
+
+	resp, err := fs.ObjectTransaction(context.Background(), &filer_pb.ObjectTransactionRequest{
+		LockKey: "/buckets/video/lifecycle.mp4",
+		Mutations: []*filer_pb.ObjectMutation{
+			{
+				Type:      filer_pb.ObjectMutation_PUT,
+				Directory: "/buckets/video",
+				Entry: &filer_pb.Entry{
+					Name: "lifecycle.mp4",
+					Attributes: &filer_pb.FuseAttributes{
+						Crtime:   now.Unix(),
+						Mtime:    now.Unix(),
+						FileMode: 0644,
+						FileSize: 123,
+						TtlSec:   7200,
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ObjectTransaction transport error: %v", err)
+	}
+	if resp.Error != "" {
+		t.Fatalf("ObjectTransaction response error: %q", resp.Error)
+	}
+
+	entry := store.entries["/buckets/video/lifecycle.mp4"]
+	if entry == nil {
+		t.Fatalf("PUT should create /buckets/video/lifecycle.mp4")
+	}
+	if got := entry.TtlSec; got != 7200 {
+		t.Fatalf("TtlSec = %d, want explicit TTL 7200 to win over fs.configure", got)
+	}
+}
+
+func TestObjectTransactionPutDoesNotApplyStorageTTLToDirectoryOrRemoteEntry(t *testing.T) {
+	fs, store := newTxnTestServer(nil)
+
+	mustSetObjectTxnStorageConf(t, fs, &filer_pb.FilerConf_PathConf{
+		LocationPrefix: "/buckets/video/",
+		Ttl:            "1h",
+	})
+
+	now := time.Unix(1700000000, 0)
+
+	resp, err := fs.ObjectTransaction(context.Background(), &filer_pb.ObjectTransactionRequest{
+		LockKey: "/buckets/video/dir",
+		Mutations: []*filer_pb.ObjectMutation{
+			{
+				Type:      filer_pb.ObjectMutation_PUT,
+				Directory: "/buckets/video",
+				Entry: &filer_pb.Entry{
+					Name:        "dir",
+					IsDirectory: true,
+					Attributes: &filer_pb.FuseAttributes{
+						Crtime:   now.Unix(),
+						Mtime:    now.Unix(),
+						FileMode: 0755 | (1 << 31),
+						TtlSec:   7200,
+					},
+				},
+			},
+			{
+				Type:      filer_pb.ObjectMutation_PUT,
+				Directory: "/buckets/video",
+				Entry: &filer_pb.Entry{
+					Name: "remote",
+					Attributes: &filer_pb.FuseAttributes{
+						Crtime:   now.Unix(),
+						Mtime:    now.Unix(),
+						FileMode: 0644,
+						TtlSec:   7200,
+					},
+					RemoteEntry: &filer_pb.RemoteEntry{},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ObjectTransaction transport error: %v", err)
+	}
+	if resp.Error != "" {
+		t.Fatalf("ObjectTransaction response error: %q", resp.Error)
+	}
+
+	dirEntry := store.entries["/buckets/video/dir"]
+	if dirEntry == nil {
+		t.Fatalf("directory entry should be created")
+	}
+	if got := dirEntry.TtlSec; got != 0 {
+		t.Fatalf("directory TtlSec = %d, want 0", got)
+	}
+
+	remoteEntry := store.entries["/buckets/video/remote"]
+	if remoteEntry == nil {
+		t.Fatalf("remote entry should be created")
+	}
+	if got := remoteEntry.TtlSec; got != 0 {
+		t.Fatalf("remote entry TtlSec = %d, want 0", got)
+	}
+}
+
+func TestObjectTransactionPutFailsOnReadOnlyStorageConfig(t *testing.T) {
+	fs, store := newTxnTestServer(nil)
+
+	mustSetObjectTxnStorageConf(t, fs, &filer_pb.FilerConf_PathConf{
+		LocationPrefix: "/buckets/video/",
+		ReadOnly:       true,
+	})
+
+	now := time.Unix(1700000000, 0)
+
+	resp, err := fs.ObjectTransaction(context.Background(), &filer_pb.ObjectTransactionRequest{
+		LockKey: "/buckets/video/readonly.mp4",
+		Mutations: []*filer_pb.ObjectMutation{
+			{
+				Type:      filer_pb.ObjectMutation_PUT,
+				Directory: "/buckets/video",
+				Entry: &filer_pb.Entry{
+					Name: "readonly.mp4",
+					Attributes: &filer_pb.FuseAttributes{
+						Crtime:   now.Unix(),
+						Mtime:    now.Unix(),
+						FileMode: 0644,
+						FileSize: 123,
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ObjectTransaction transport error: %v", err)
+	}
+	if resp.Error == "" {
+		t.Fatalf("ObjectTransaction should report read-only storage config error")
+	}
+
+	if _, ok := store.entries["/buckets/video/readonly.mp4"]; ok {
+		t.Fatalf("read-only storage config must not create the entry")
+	}
+}


### PR DESCRIPTION
# What problem are we solving?

https://github.com/seaweedfs/seaweedfs/issues/10193

# How are we solving the problem?

https://github.com/seaweedfs/seaweedfs/issues/10193

# How is the PR tested?

no

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Object transaction PUTs now inherit the configured storage TTL when no TTL is explicitly set.
  * Explicit TTL values are preserved; remote entries now correctly clear stored TTL.
  * PUTs against read-only storage configurations are rejected without creating metadata entries.
  * PUTs now reject entries that exceed the configured maximum filename length, preventing metadata creation.
* **Tests**
  * Added coverage for configured TTL inheritance, explicit TTL overrides, remote-entry TTL clearing, read-only rejection, and max filename length enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->