### PR TITLE
feat(k8s): add certificates.dnsNames to inject custom SANs in cert-manager certs

### DIFF
--- a/k8s/charts/seaweedfs/templates/cert/admin-cert.yaml
+++ b/k8s/charts/seaweedfs/templates/cert/admin-cert.yaml
@@ -31,7 +31,7 @@ spec:
     - '*.{{ include "seaweedfs.fullname" . }}-admin.{{ .Release.Namespace }}.svc.cluster.local'
 {{- if .Values.certificates.dnsNames }}
 {{- range .Values.certificates.dnsNames }}
-    - {{ . }}
+    - {{ . | quote }}
 {{- end }}
 {{- end }}
 {{- if .Values.certificates.ipAddresses }}

--- a/k8s/charts/seaweedfs/templates/cert/admin-cert.yaml
+++ b/k8s/charts/seaweedfs/templates/cert/admin-cert.yaml
@@ -29,6 +29,11 @@ spec:
     - '*.{{ include "seaweedfs.fullname" . }}-admin.{{ .Release.Namespace }}'
     - '*.{{ include "seaweedfs.fullname" . }}-admin.{{ .Release.Namespace }}.svc'
     - '*.{{ include "seaweedfs.fullname" . }}-admin.{{ .Release.Namespace }}.svc.cluster.local'
+{{- if .Values.certificates.dnsNames }}
+{{- range .Values.certificates.dnsNames }}
+    - {{ . }}
+{{- end }}
+{{- end }}
 {{- if .Values.certificates.ipAddresses }}
   ipAddresses:
     {{- range .Values.certificates.ipAddresses }}

--- a/k8s/charts/seaweedfs/templates/cert/client-cert.yaml
+++ b/k8s/charts/seaweedfs/templates/cert/client-cert.yaml
@@ -23,6 +23,11 @@ spec:
     - '*.{{ .Release.Namespace }}'
     - '*.{{ .Release.Namespace }}.svc'
     - '*.{{ .Release.Namespace }}.svc.cluster.local'
+{{- if .Values.certificates.dnsNames }}
+{{- range .Values.certificates.dnsNames }}
+    - {{ . }}
+{{- end }}
+{{- end }}
     - '*.{{ include "seaweedfs.fullname" . }}-master'
     - '*.{{ include "seaweedfs.fullname" . }}-master.{{ .Release.Namespace }}'
     - '*.{{ include "seaweedfs.fullname" . }}-master.{{ .Release.Namespace }}.svc'

--- a/k8s/charts/seaweedfs/templates/cert/client-cert.yaml
+++ b/k8s/charts/seaweedfs/templates/cert/client-cert.yaml
@@ -25,7 +25,7 @@ spec:
     - '*.{{ .Release.Namespace }}.svc.cluster.local'
 {{- if .Values.certificates.dnsNames }}
 {{- range .Values.certificates.dnsNames }}
-    - {{ . }}
+    - {{ . | quote }}
 {{- end }}
 {{- end }}
     - '*.{{ include "seaweedfs.fullname" . }}-master'

--- a/k8s/charts/seaweedfs/templates/cert/filer-cert.yaml
+++ b/k8s/charts/seaweedfs/templates/cert/filer-cert.yaml
@@ -30,7 +30,7 @@ spec:
     - '*.{{ .Release.Namespace }}.svc.cluster.local'
 {{- if .Values.certificates.dnsNames }}
 {{- range .Values.certificates.dnsNames }}
-    - {{ . }}
+    - {{ . | quote }}
 {{- end }}
 {{- end }}
     - '*.{{ include "seaweedfs.fullname" . }}-master'

--- a/k8s/charts/seaweedfs/templates/cert/filer-cert.yaml
+++ b/k8s/charts/seaweedfs/templates/cert/filer-cert.yaml
@@ -28,6 +28,11 @@ spec:
     - '*.{{ .Release.Namespace }}'
     - '*.{{ .Release.Namespace }}.svc'
     - '*.{{ .Release.Namespace }}.svc.cluster.local'
+{{- if .Values.certificates.dnsNames }}
+{{- range .Values.certificates.dnsNames }}
+    - {{ . }}
+{{- end }}
+{{- end }}
     - '*.{{ include "seaweedfs.fullname" . }}-master'
     - '*.{{ include "seaweedfs.fullname" . }}-master.{{ .Release.Namespace }}'
     - '*.{{ include "seaweedfs.fullname" . }}-master.{{ .Release.Namespace }}.svc'

--- a/k8s/charts/seaweedfs/templates/cert/master-cert.yaml
+++ b/k8s/charts/seaweedfs/templates/cert/master-cert.yaml
@@ -30,7 +30,7 @@ spec:
     - '*.{{ .Release.Namespace }}.svc.cluster.local'
 {{- if .Values.certificates.dnsNames }}
 {{- range .Values.certificates.dnsNames }}
-    - {{ . }}
+    - {{ . | quote }}
 {{- end }}
 {{- end }}
     - '*.{{ include "seaweedfs.fullname" . }}-master'

--- a/k8s/charts/seaweedfs/templates/cert/master-cert.yaml
+++ b/k8s/charts/seaweedfs/templates/cert/master-cert.yaml
@@ -28,6 +28,11 @@ spec:
     - '*.{{ .Release.Namespace }}'
     - '*.{{ .Release.Namespace }}.svc'
     - '*.{{ .Release.Namespace }}.svc.cluster.local'
+{{- if .Values.certificates.dnsNames }}
+{{- range .Values.certificates.dnsNames }}
+    - {{ . }}
+{{- end }}
+{{- end }}
     - '*.{{ include "seaweedfs.fullname" . }}-master'
     - '*.{{ include "seaweedfs.fullname" . }}-master.{{ .Release.Namespace }}'
     - '*.{{ include "seaweedfs.fullname" . }}-master.{{ .Release.Namespace }}.svc'

--- a/k8s/charts/seaweedfs/templates/cert/volume-cert.yaml
+++ b/k8s/charts/seaweedfs/templates/cert/volume-cert.yaml
@@ -30,7 +30,7 @@ spec:
     - '*.{{ .Release.Namespace }}.svc.cluster.local'
 {{- if .Values.certificates.dnsNames }}
 {{- range .Values.certificates.dnsNames }}
-    - {{ . }}
+    - {{ . | quote }}
 {{- end }}
 {{- end }}
     - '*.{{ include "seaweedfs.fullname" . }}-master'

--- a/k8s/charts/seaweedfs/templates/cert/volume-cert.yaml
+++ b/k8s/charts/seaweedfs/templates/cert/volume-cert.yaml
@@ -28,6 +28,11 @@ spec:
     - '*.{{ .Release.Namespace }}'
     - '*.{{ .Release.Namespace }}.svc'
     - '*.{{ .Release.Namespace }}.svc.cluster.local'
+{{- if .Values.certificates.dnsNames }}
+{{- range .Values.certificates.dnsNames }}
+    - {{ . }}
+{{- end }}
+{{- end }}
     - '*.{{ include "seaweedfs.fullname" . }}-master'
     - '*.{{ include "seaweedfs.fullname" . }}-master.{{ .Release.Namespace }}'
     - '*.{{ include "seaweedfs.fullname" . }}-master.{{ .Release.Namespace }}.svc'

--- a/k8s/charts/seaweedfs/templates/cert/worker-cert.yaml
+++ b/k8s/charts/seaweedfs/templates/cert/worker-cert.yaml
@@ -29,6 +29,11 @@ spec:
     - '*.{{ include "seaweedfs.fullname" . }}-worker.{{ .Release.Namespace }}'
     - '*.{{ include "seaweedfs.fullname" . }}-worker.{{ .Release.Namespace }}.svc'
     - '*.{{ include "seaweedfs.fullname" . }}-worker.{{ .Release.Namespace }}.svc.cluster.local'
+{{- if .Values.certificates.dnsNames }}
+{{- range .Values.certificates.dnsNames }}
+    - {{ . }}
+{{- end }}
+{{- end }}
 {{- if .Values.certificates.ipAddresses }}
   ipAddresses:
     {{- range .Values.certificates.ipAddresses }}

--- a/k8s/charts/seaweedfs/templates/cert/worker-cert.yaml
+++ b/k8s/charts/seaweedfs/templates/cert/worker-cert.yaml
@@ -31,7 +31,7 @@ spec:
     - '*.{{ include "seaweedfs.fullname" . }}-worker.{{ .Release.Namespace }}.svc.cluster.local'
 {{- if .Values.certificates.dnsNames }}
 {{- range .Values.certificates.dnsNames }}
-    - {{ . }}
+    - {{ . | quote }}
 {{- end }}
 {{- end }}
 {{- if .Values.certificates.ipAddresses }}

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -1745,6 +1745,7 @@ cosi:
 
 certificates:
   commonName: "SeaweedFS CA"
+  dnsNames: []
   ipAddresses: []
   keyAlgorithm: RSA
   keySize: 2048


### PR DESCRIPTION
## Summary

Add `certificates.dnsNames` configuration option that allows users to inject custom Subject Alternative Names (SANs) into all cert-manager Certificate resources. This enables exposing SeaweedFS components under custom hostnames that aren't covered by the default wildcard patterns.

## Problem Solved

This PR addresses the inability to add custom DNS names to SeaweedFS certificate SANs. Without this change:

1. **Default certs only cover internal K8s DNS** — cert-manager generates certs with default SANs like `*.default.svc`, `*.default.svc.cluster.local`, and the pod's own hostname. Users deploying SeaweedFS behind custom DNS (e.g., `*.morez.org`, `*.mydomain.com`) cannot get the custom hostname into the cert SANs.
2. **No way to extend SANs** — even though the cert templates support custom hosts, the cert's `spec.x509.subject.names` only accepts the CN and not additional SANs. The x509 Subject Alternative Name field is separate from the Subject CommonName, and Traefik/ingress controllers validate TLS certs against the requested hostname using SANs.

## Changes

### values.yaml
- New field `certificates.dnsNames: []` — empty list by default, users can populate with custom hostnames (e.g., `- '*.mycustomhost.example.com'`)

### Cert templates (all 6)
- Admin, Client, Filer, Master, Volume, Worker cert templates
- Each cert now iterates over `.Values.certificates.dnsNames` and appends each entry to the `spec.x509.subject.names` list
- Uses conditional: only renders when the list is non-empty



## Use Case

When SeaweedFS is deployed with custom DNS names (e.g., `seaweedfs.marez.org`), the default cert only covers `*.default.svc` patterns. Adding dnsNames lets you inject the custom hostname into the cert SANs so Traefik can present the correct certificate.

## Related
- Addresses comments from the maintainer on the original PR (fix-grpc-filer) requesting separation of concerns
- dnsNames feature is independent of the gRPC ingress changes (see PR #10197)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Certificate templates now support adding custom DNS names through configuration.
  * This applies to admin, client, filer, master, volume, and worker certificates.
  * Existing default DNS entries remain in place, with optional extra names appended when provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->