### PR TITLE
feat(k8s): filer HTTP + gRPC ingress for the Helm chart

### DIFF
--- a/k8s/charts/seaweedfs/templates/filer/filer-ingress.yaml
+++ b/k8s/charts/seaweedfs/templates/filer/filer-ingress.yaml
@@ -1,6 +1,8 @@
-{{- /* Filer ingress works for both normal mode (filer.enabled) and all-in-one mode (allInOne.enabled) */}}
+{{- /* Filer ingresses work for both normal mode (filer.enabled) and all-in-one mode (allInOne.enabled) */}}
 {{- $filerEnabled := or .Values.filer.enabled .Values.allInOne.enabled }}
-{{- if and $filerEnabled .Values.filer.ingress.enabled }}
+
+{{- /* HTTP Ingress */}}
+{{- if and $filerEnabled .Values.filer.ingresses.http.enabled }}
 {{- /* Determine service name based on deployment mode */}}
 {{- $serviceName := ternary (include "seaweedfs.componentName" (list . "all-in-one")) (include "seaweedfs.componentName" (list . "filer")) .Values.allInOne.enabled }}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
@@ -12,9 +14,9 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  name: ingress-{{ include "seaweedfs.fullname" . }}-filer
+  name: ingress-{{ include "seaweedfs.fullname" . }}-filer-http
   namespace: {{ .Release.Namespace }}
-  {{- with .Values.filer.ingress.annotations }}
+  {{- with .Values.filer.ingresses.http.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -25,14 +27,14 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: filer
 spec:
-  ingressClassName: {{ .Values.filer.ingress.className | quote }}
+  ingressClassName: {{ .Values.filer.ingresses.http.className | quote }}
   tls:
-    {{ .Values.filer.ingress.tls | default list | toYaml | nindent 6}}
+    {{ .Values.filer.ingresses.http.tls | default list | toYaml | nindent 6}}
   rules:
   - http:
       paths:
-      - path: {{ .Values.filer.ingress.path | quote }}
-        pathType: {{ .Values.filer.ingress.pathType | quote }}
+      - path: {{ .Values.filer.ingresses.http.path | quote }}
+        pathType: {{ .Values.filer.ingresses.http.pathType | quote }}
         backend:
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
           service:
@@ -43,7 +45,58 @@ spec:
           serviceName: {{ $serviceName }}
           servicePort: {{ .Values.filer.port }}
 {{- end }}
-{{- if .Values.filer.ingress.host }}
-    host: {{ .Values.filer.ingress.host }}
+{{- if .Values.filer.ingresses.http.host }}
+    host: {{ .Values.filer.ingresses.http.host }}
+{{- end }}
+{{- end }}
+
+---
+
+{{- /* gRPC Ingress */}}
+{{- if and $filerEnabled .Values.filer.ingresses.grpc.enabled }}
+{{- /* Determine service name based on deployment mode */}}
+{{- $serviceName := ternary (include "seaweedfs.componentName" (list . "all-in-one")) (include "seaweedfs.componentName" (list . "filer")) .Values.allInOne.enabled }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: ingress-{{ include "seaweedfs.fullname" . }}-filer-grpc
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.filer.ingresses.grpc.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: filer
+spec:
+  ingressClassName: {{ .Values.filer.ingresses.grpc.className | quote }}
+  tls:
+    {{ .Values.filer.ingresses.grpc.tls | default list | toYaml | nindent 6}}
+  rules:
+  - http:
+      paths:
+      - path: {{ .Values.filer.ingresses.grpc.path | quote }}
+        pathType: {{ .Values.filer.ingresses.grpc.pathType | quote }}
+        backend:
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+          service:
+            name: {{ $serviceName }}
+            port:
+              number: {{ .Values.filer.grpcPort }}
+{{- else }}
+          serviceName: {{ $serviceName }}
+          servicePort: {{ .Values.filer.grpcPort }}
+{{- end }}
+{{- if .Values.filer.ingresses.grpc.host }}
+    host: {{ .Values.filer.ingresses.grpc.host }}
 {{- end }}
 {{- end }}

--- a/k8s/charts/seaweedfs/templates/filer/filer-ingress.yaml
+++ b/k8s/charts/seaweedfs/templates/filer/filer-ingress.yaml
@@ -16,8 +16,11 @@ kind: Ingress
 metadata:
   name: ingress-{{ include "seaweedfs.fullname" . }}-filer-http
   namespace: {{ .Release.Namespace }}
-  {{- with .Values.filer.ingresses.http.annotations }}
   annotations:
+  {{- if and (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) .Values.filer.ingresses.http.className }}
+    kubernetes.io/ingress.class: {{ .Values.filer.ingresses.http.className }}
+  {{- end }}
+  {{- with .Values.filer.ingresses.http.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
@@ -27,14 +30,21 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: filer
 spec:
+  {{- if and (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) .Values.filer.ingresses.http.className }}
   ingressClassName: {{ .Values.filer.ingresses.http.className | quote }}
+  {{- end }}
   tls:
     {{ .Values.filer.ingresses.http.tls | default list | toYaml | nindent 6}}
   rules:
-  - http:
+  - {{- if .Values.filer.ingresses.http.host }}
+    host: {{ .Values.filer.ingresses.http.host | quote }}
+    {{- end }}
+    http:
       paths:
       - path: {{ .Values.filer.ingresses.http.path | quote }}
+        {{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
         pathType: {{ .Values.filer.ingresses.http.pathType | quote }}
+        {{- end }}
         backend:
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
           service:
@@ -44,9 +54,6 @@ spec:
 {{- else }}
           serviceName: {{ $serviceName }}
           servicePort: {{ .Values.filer.port }}
-{{- end }}
-{{- if .Values.filer.ingresses.http.host }}
-    host: {{ .Values.filer.ingresses.http.host }}
 {{- end }}
 {{- end }}
 
@@ -67,8 +74,11 @@ kind: Ingress
 metadata:
   name: ingress-{{ include "seaweedfs.fullname" . }}-filer-grpc
   namespace: {{ .Release.Namespace }}
-  {{- with .Values.filer.ingresses.grpc.annotations }}
   annotations:
+  {{- if and (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) .Values.filer.ingresses.grpc.className }}
+    kubernetes.io/ingress.class: {{ .Values.filer.ingresses.grpc.className }}
+  {{- end }}
+  {{- with .Values.filer.ingresses.grpc.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
@@ -78,14 +88,21 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: filer
 spec:
+  {{- if and (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) .Values.filer.ingresses.grpc.className }}
   ingressClassName: {{ .Values.filer.ingresses.grpc.className | quote }}
+  {{- end }}
   tls:
     {{ .Values.filer.ingresses.grpc.tls | default list | toYaml | nindent 6}}
   rules:
-  - http:
+  - {{- if .Values.filer.ingresses.grpc.host }}
+    host: {{ .Values.filer.ingresses.grpc.host | quote }}
+    {{- end }}
+    http:
       paths:
       - path: {{ .Values.filer.ingresses.grpc.path | quote }}
+        {{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
         pathType: {{ .Values.filer.ingresses.grpc.pathType | quote }}
+        {{- end }}
         backend:
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
           service:
@@ -95,8 +112,5 @@ spec:
 {{- else }}
           serviceName: {{ $serviceName }}
           servicePort: {{ .Values.filer.grpcPort }}
-{{- end }}
-{{- if .Values.filer.ingresses.grpc.host }}
-    host: {{ .Values.filer.ingresses.grpc.host }}
 {{- end }}
 {{- end }}

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -824,30 +824,41 @@ filer:
   #   allowPrivilegeEscalation: false
   containerSecurityContext: {}
 
-  ingress:
-    enabled: false
-    className: ""
-    # host: false for "*" hostname
-    host: "seaweedfs.cluster.local"
-    path: "/sw-filer/?(.*)"
-    pathType: ImplementationSpecific
-    annotations: {}
-      # nginx.ingress.kubernetes.io/backend-protocol: GRPC
-      # nginx.ingress.kubernetes.io/auth-type: "basic"
-      # nginx.ingress.kubernetes.io/auth-secret: "default/ingress-basic-auth-secret"
-      # nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required - SW-Filer'
-      # nginx.ingress.kubernetes.io/service-upstream: "true"
-      # nginx.ingress.kubernetes.io/rewrite-target: /$1
-      # nginx.ingress.kubernetes.io/use-regex: "true"
-      # nginx.ingress.kubernetes.io/enable-rewrite-log: "true"
-      # nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      # nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
-      # nginx.ingress.kubernetes.io/configuration-snippet: |
-      #   sub_filter '<head>' '<head> <base href="/sw-filer/">'; #add base url
-      #   sub_filter '="/' '="./';                               #make absolute paths to relative
-      #   sub_filter '=/' '=./';
-      #   sub_filter '/seaweedfsstatic' './seaweedfsstatic';
-      #   sub_filter_once off;
+  ingresses:
+    http:
+      enabled: false
+      className: ""
+      # host: false for "*" hostname
+      host: "seaweedfs.cluster.local"
+      path: "/sw-filer/?(.*)"
+      pathType: ImplementationSpecific
+      annotations: {}
+        # nginx.ingress.kubernetes.io/backend-protocol: GRPC
+        # nginx.ingress.kubernetes.io/auth-type: "basic"
+        # nginx.ingress.kubernetes.io/auth-secret: "default/ingress-basic-auth-secret"
+        # nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required - SW-Filer'
+        # nginx.ingress.kubernetes.io/service-upstream: "true"
+        # nginx.ingress.kubernetes.io/rewrite-target: /$1
+        # nginx.ingress.kubernetes.io/use-regex: "true"
+        # nginx.ingress.kubernetes.io/enable-rewrite-log: "true"
+        # nginx.ingress.kubernetes.io/ssl-redirect: "false"
+        # nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+        # nginx.ingress.kubernetes.io/configuration-snippet: |
+        #   sub_filter '<head>' '<head> <base href="/sw-filer/">'; #add base url
+        #   sub_filter '="/' '="./';                               #make absolute paths to relative
+        #   sub_filter '=/' '=./';
+        #   sub_filter '/seaweedfsstatic' './seaweedfsstatic';
+        #   sub_filter_once off;
+      tls: []
+    grpc:
+      enabled: false
+      className: ""
+      host: "seaweedfs.cluster.local"
+      path: "/sw-filer/?(.*)"
+      pathType: ImplementationSpecific
+      annotations:
+        nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+      tls: []
 
   # extraEnvVars is a list of extra environment variables to set with the stateful set.
   extraEnvironmentVars:

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -857,7 +857,14 @@ filer:
       path: "/sw-filer/?(.*)"
       pathType: ImplementationSpecific
       annotations:
+        # Ingress terminates TLS and re-originates gRPC (HTTP/2) to the filer.
         nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+        # For end-to-end mTLS (the filer's own TLS reaches the client, not
+        # terminated at the edge), drop backend-protocol above and use TLS
+        # passthrough instead:
+        #   nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+        # Passthrough routes by SNI (set `host` above), ignores `path`, and
+        # requires ingress-nginx to run with --enable-ssl-passthrough.
       tls: []
 
   # extraEnvVars is a list of extra environment variables to set with the stateful set.

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -854,8 +854,10 @@ filer:
       enabled: false
       className: ""
       host: "seaweedfs.cluster.local"
-      path: "/sw-filer/?(.*)"
-      pathType: ImplementationSpecific
+      # gRPC methods are called at /<package>.<Service>/<Method>, so route the
+      # whole host, not the HTTP UI's regex path.
+      path: "/"
+      pathType: Prefix
       annotations:
         # Ingress terminates TLS and re-originates gRPC (HTTP/2) to the filer.
         nginx.ingress.kubernetes.io/backend-protocol: "GRPC"


### PR DESCRIPTION
Adds gRPC ingress support to the filer Helm chart on the standard `Ingress` kind, so it stays consistent with the chart's other ingresses (master, volume, s3) and needs no controller-specific CRD:

- HTTP Ingress + a separate gRPC Ingress (nginx `backend-protocol: GRPC`), driven off a new `filer.ingresses.{http,grpc}` structure
- For end-to-end mTLS gRPC (TLS not terminated at the edge), the gRPC ingress documents the nginx `ssl-passthrough` annotation — SNI-based L4 passthrough, no CRD required

Focused re-scope of #10197 (templates + values by @MorezMartin, preserved via cherry-pick). Dropped from that PR: the `filer_source.go` replication JWT change (`SetJwtSigningKeys` had no caller, and the `?proxyChunkId=` path doesn't check an inbound JWT) and unrelated values.yaml whitespace churn. The original's Traefik `IngressRouteTCP` was replaced with the portable `ssl-passthrough` approach to keep the chart controller-agnostic.

Verified with `helm template` (http/grpc; standalone + all-in-one) and `helm lint`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate Filer ingress settings for HTTP and gRPC, allowing independent exposure and configuration.
  * You can now enable/config HTTP and gRPC routes separately (host, path, TLS, and annotations).

* **Changes**
  * Updated the chart configuration structure to use distinct `http` and `grpc` ingress sections.
  * HTTP and gRPC ingresses are created as separate resources with distinct names (HTTP UI vs gRPC endpoint).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->