### PR TITLE
fix(fuse-tests): don't declare the FUSE mount ready before it is mounted

### DIFF
--- a/test/fuse_integration/framework_test.go
+++ b/test/fuse_integration/framework_test.go
@@ -333,11 +333,19 @@ func (f *FuseTestFramework) waitForService(addr string, timeout time.Duration) e
 	return fmt.Errorf("service at %s not ready within timeout", addr)
 }
 
-// waitForMount waits for the FUSE mount to be ready
+// waitForMount waits for the FUSE mount to be ready. A stat/ReadDir probe
+// alone is not enough: the bare mount point directory passes both before the
+// mount process finishes starting, letting tests race ahead and write to the
+// local disk underneath the mount. The mount point's device ID differing from
+// its parent's confirms a filesystem is actually mounted there.
 func (f *FuseTestFramework) waitForMount(timeout time.Duration) error {
+	parentDev, err := deviceID(filepath.Dir(f.mountPoint))
+	if err != nil {
+		return fmt.Errorf("stat mount point parent: %v", err)
+	}
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		if _, err := os.Stat(f.mountPoint); err == nil {
+		if dev, err := deviceID(f.mountPoint); err == nil && dev != parentDev {
 			if _, err := os.ReadDir(f.mountPoint); err == nil {
 				return nil
 			}
@@ -345,6 +353,15 @@ func (f *FuseTestFramework) waitForMount(timeout time.Duration) error {
 		time.Sleep(100 * time.Millisecond)
 	}
 	return fmt.Errorf("mount point not ready within timeout")
+}
+
+// deviceID returns the device ID of the filesystem containing path.
+func deviceID(path string) (uint64, error) {
+	var st syscall.Stat_t
+	if err := syscall.Stat(path, &st); err != nil {
+		return 0, err
+	}
+	return uint64(st.Dev), nil
 }
 
 // findWeedBinary locates the weed binary.


### PR DESCRIPTION
## What

`waitForMount` probed the mount point with stat+ReadDir — checks a bare, not-yet-mounted local directory also passes — so `Setup` could return before the `weed mount` process finished mounting. It now additionally requires the mount point's device ID to differ from its parent directory's, which confirms a filesystem is actually mounted there, and keeps the ReadDir probe as a liveness check.

## Why

A FUSE integration CI run caught the long-standing `TestConcurrentFileOperations/ConcurrentReadWrite` ENOENT flake with the diagnostics from 6cbcdf488 in place, and the captured timeline shows the race directly (cold runner, slow mount startup):

- 19:18:21.15 — first two subtests run and "pass" (writing to the local disk underneath the mount point)
- 19:18:21.17 — ConcurrentReadWrite creates its file the same way; last write ~21.37
- 19:18:21.383 — `mount_std.go: mounted` (per the mount's own glog timestamps) — the mount activates and shadows everything written so far
- 19:18:21.43 — AssertFileExists goes through FUSE: ENOENT through 1.5s of retries, ReadDir of the mount root returns 0 entries, and the lookupEntry diagnostic never fired — the mount never saw any of those files

This also explains the original flake signature: stat returning ENOENT for a path all writers had just succeeded against.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mount readiness checks to ensure FUSE mounts are fully active before tests proceed.
  * Reduced false-positive readiness detection by verifying the mount point is a real filesystem mount, not just an accessible directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->