### PR TITLE
test: keep mini-allocated ports below the ephemeral floor

### DIFF
--- a/test/testutil/ports.go
+++ b/test/testutil/ports.go
@@ -11,17 +11,21 @@ import (
 // GrpcPortOffset is the offset weed mini uses to derive gRPC ports from HTTP ports.
 const GrpcPortOffset = 10000
 
-// miniPortMin/miniPortMax bound the random HTTP port range for weed mini.
-// The cap keeps both the HTTP port and its +GrpcPortOffset gRPC counterpart
-// below 32768, the Linux default ephemeral floor (ip_local_port_range). Ports
-// inside the ephemeral range can be claimed as the source port of a transient
+// linuxEphemeralPortFloor is the Linux default ip_local_port_range lower bound.
+// Ports at or above it can be claimed as the source port of a transient
 // outbound connection during mini's own startup (e.g. volume dialing master
 // gRPC) in the window between allocation and the listener bind, surfacing as
-// "bind: address already in use". Keeping maxPort+GrpcPortOffset under 32768
-// removes that steal.
+// "bind: address already in use".
+const linuxEphemeralPortFloor = 32768
+
+// miniPortMin/miniPortMax bound the random HTTP port range for weed mini.
+// The cap keeps both the HTTP port and its +GrpcPortOffset gRPC counterpart
+// below linuxEphemeralPortFloor, out of the range the kernel draws ephemeral
+// source ports from, so the steal above cannot happen. Deriving the cap from
+// GrpcPortOffset keeps the two in lockstep if the offset ever changes.
 const (
 	miniPortMin = 10000
-	miniPortMax = 22768
+	miniPortMax = linuxEphemeralPortFloor - GrpcPortOffset
 )
 
 // miniDefaultPorts are the weed mini flag defaults (see weed/command/mini.go).

--- a/test/testutil/ports.go
+++ b/test/testutil/ports.go
@@ -11,6 +11,19 @@ import (
 // GrpcPortOffset is the offset weed mini uses to derive gRPC ports from HTTP ports.
 const GrpcPortOffset = 10000
 
+// miniPortMin/miniPortMax bound the random HTTP port range for weed mini.
+// The cap keeps both the HTTP port and its +GrpcPortOffset gRPC counterpart
+// below 32768, the Linux default ephemeral floor (ip_local_port_range). Ports
+// inside the ephemeral range can be claimed as the source port of a transient
+// outbound connection during mini's own startup (e.g. volume dialing master
+// gRPC) in the window between allocation and the listener bind, surfacing as
+// "bind: address already in use". Keeping maxPort+GrpcPortOffset under 32768
+// removes that steal.
+const (
+	miniPortMin = 10000
+	miniPortMax = 22768
+)
+
 // miniDefaultPorts are the weed mini flag defaults (see weed/command/mini.go).
 // A test only overrides services it uses; unspecified services still bind
 // these defaults, so allocation must avoid handing them out (or any value
@@ -83,8 +96,8 @@ func MustAllocatePorts(t *testing.T, count int) []int {
 // wrong port and hang.
 func AllocateMiniPorts(count int) ([]int, error) {
 	const (
-		minPort = 10000
-		maxPort = 55000
+		minPort = miniPortMin
+		maxPort = miniPortMax
 	)
 	reserved := reservedMiniPorts()
 	ports := make([]int, 0, count)
@@ -155,8 +168,8 @@ func MustFreeMiniPort(t *testing.T, name string) int {
 // allocated, so a mini gRPC port cannot be recycled as a regular port mid-batch.
 func AllocatePortSet(miniCount, regularCount int) (mini []int, regular []int, err error) {
 	const (
-		minPort = 10000
-		maxPort = 55000
+		minPort = miniPortMin
+		maxPort = miniPortMax
 	)
 	reserved := reservedMiniPorts()
 	mini = make([]int, 0, miniCount)

--- a/test/testutil/ports_test.go
+++ b/test/testutil/ports_test.go
@@ -31,7 +31,7 @@ func TestAllocateMiniPortsAvoidsMiniDefaults(t *testing.T) {
 // outbound connection that had grabbed 44204 as an ephemeral source port
 // during mini startup ("bind: address already in use").
 func TestAllocateMiniPortsBelowEphemeralFloor(t *testing.T) {
-	const ephemeralFloor = 32768
+	const ephemeralFloor = linuxEphemeralPortFloor
 	for iter := 0; iter < 200; iter++ {
 		ports, err := AllocateMiniPorts(4)
 		if err != nil {

--- a/test/testutil/ports_test.go
+++ b/test/testutil/ports_test.go
@@ -25,6 +25,27 @@ func TestAllocateMiniPortsAvoidsMiniDefaults(t *testing.T) {
 	}
 }
 
+// AllocateMiniPorts must keep every port it hands out, and that port's gRPC
+// counterpart, below 32768 - the Linux default ip_local_port_range floor.
+// A real failure: filer was allocated 44204, then lost the bind to a transient
+// outbound connection that had grabbed 44204 as an ephemeral source port
+// during mini startup ("bind: address already in use").
+func TestAllocateMiniPortsBelowEphemeralFloor(t *testing.T) {
+	const ephemeralFloor = 32768
+	for iter := 0; iter < 200; iter++ {
+		ports, err := AllocateMiniPorts(4)
+		if err != nil {
+			t.Fatalf("iter %d: AllocateMiniPorts: %v", iter, err)
+		}
+		for _, p := range ports {
+			if p+GrpcPortOffset >= ephemeralFloor {
+				t.Fatalf("iter %d: port %d (gRPC %d) reaches the ephemeral range floor %d",
+					iter, p, p+GrpcPortOffset, ephemeralFloor)
+			}
+		}
+	}
+}
+
 func TestAllocatePortSetNoGrpcCollision(t *testing.T) {
 	// Run a few iterations to catch the OS-recycles-just-closed-port race
 	// that previously hit regular ports when the mini gRPC offset was freed


### PR DESCRIPTION
RisingWave `TestRisingWaveIcebergDML` flaked with:

```
Filer listener error: listen tcp 0.0.0.0:44204: bind: address already in use
```

`testutil` allocates a free port by binding a throwaway listener, reading the number, then closing it before handing it to `weed mini`. The old range was `10000-55000`, so an allocated port (or its `+GrpcPortOffset` gRPC counterpart) could land inside the Linux ephemeral range (`ip_local_port_range` floor 32768). In the window between allocation-close and the filer binding, one of mini's own startup dials (volume->master gRPC, etc.) grabbed the not-yet-bound port `44204` as an outbound *source* port, so the filer could not bind it. `44204` sits right in that band.

Cap the range to `10000-22768` so both the HTTP port and its gRPC port stay below 32768, out of the range the kernel draws ephemeral source ports from. Fix is in the shared allocator, so it covers every `weed mini` test (RisingWave, Spark, s3 normal, multi-master), and still leaves ~12,700 candidate ports.

Added `TestAllocateMiniPortsBelowEphemeralFloor` as a regression guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved port allocation to reduce the chance of conflicts on Linux by keeping generated ports below the system ephemeral range.
  * Kept mini HTTP and gRPC port selection consistent with collision-avoidance behavior.
* **Tests**
  * Added coverage to verify allocated ports remain below the Linux ephemeral port floor across repeated runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->