### PR TITLE
util: don't let the activity timeout clobber externally-set conn deadlines

### DIFF
--- a/weed/util/net_timeout.go
+++ b/weed/util/net_timeout.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"net"
+	"sync"
 	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
@@ -32,19 +33,61 @@ func (l *Listener) Accept() (net.Conn, error) {
 // Conn wraps a net.Conn and implements a "no activity timeout".
 // Any activity (read or write) resets the deadline, so the connection
 // only times out when there's no activity in either direction.
+//
+// Callers may also set deadlines directly — net/http's server does this
+// to interrupt a blocked read (abortPendingRead sets a deadline in the
+// past) and to enforce its own Read/Write timeouts. The activity
+// extension must never overwrite such an externally-set deadline, or the
+// interrupt is lost and the read stays blocked until the activity
+// timeout fires (wedging connection drain on shutdown for up to the full
+// idle timeout). mu serializes deadline updates, and while an external
+// deadline is in force the activity extension is suspended; it resumes
+// once the caller clears the deadline (sets the zero time).
 type Conn struct {
 	net.Conn
 	Timeout  time.Duration
 	isClosed bool
+
+	mu                    sync.Mutex
+	externalReadDeadline  bool
+	externalWriteDeadline bool
+}
+
+func (c *Conn) SetDeadline(t time.Time) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.externalReadDeadline = !t.IsZero()
+	c.externalWriteDeadline = !t.IsZero()
+	return c.Conn.SetDeadline(t)
+}
+
+func (c *Conn) SetReadDeadline(t time.Time) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.externalReadDeadline = !t.IsZero()
+	return c.Conn.SetReadDeadline(t)
+}
+
+func (c *Conn) SetWriteDeadline(t time.Time) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.externalWriteDeadline = !t.IsZero()
+	return c.Conn.SetWriteDeadline(t)
 }
 
 // extendDeadline extends the connection deadline from now.
-// This implements "no activity timeout" - any activity keeps the connection alive.
+// This implements "no activity timeout" - any activity keeps the
+// connection alive in both directions (a long write-only response must
+// keep the read deadline alive too, or net/http's background read would
+// time out and cancel the in-flight request). Suspended while an
+// externally-set deadline is in force.
 func (c *Conn) extendDeadline() error {
-	if c.Timeout > 0 {
-		return c.Conn.SetDeadline(time.Now().Add(c.Timeout))
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.Timeout <= 0 || c.externalReadDeadline || c.externalWriteDeadline {
+		return nil
 	}
-	return nil
+	return c.Conn.SetDeadline(time.Now().Add(c.Timeout))
 }
 
 func (c *Conn) Read(b []byte) (count int, e error) {

--- a/weed/util/net_timeout.go
+++ b/weed/util/net_timeout.go
@@ -41,8 +41,9 @@ func (l *Listener) Accept() (net.Conn, error) {
 // interrupt is lost and the read stays blocked until the activity
 // timeout fires (wedging connection drain on shutdown for up to the full
 // idle timeout). mu serializes deadline updates, and while an external
-// deadline is in force the activity extension is suspended; it resumes
-// once the caller clears the deadline (sets the zero time).
+// deadline is in force on a direction the activity extension for that
+// direction is suspended; it resumes once the caller clears the deadline
+// (sets the zero time).
 type Conn struct {
 	net.Conn
 	Timeout  time.Duration
@@ -79,15 +80,29 @@ func (c *Conn) SetWriteDeadline(t time.Time) error {
 // This implements "no activity timeout" - any activity keeps the
 // connection alive in both directions (a long write-only response must
 // keep the read deadline alive too, or net/http's background read would
-// time out and cancel the in-flight request). Suspended while an
-// externally-set deadline is in force.
+// time out and cancel the in-flight request). Each direction is extended
+// independently: an externally-managed deadline on one side (e.g. a
+// server WriteTimeout) must not leave the other side's deadline stale.
 func (c *Conn) extendDeadline() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if c.Timeout <= 0 || c.externalReadDeadline || c.externalWriteDeadline {
+	if c.Timeout <= 0 {
 		return nil
 	}
-	return c.Conn.SetDeadline(time.Now().Add(c.Timeout))
+	if !c.externalReadDeadline && !c.externalWriteDeadline {
+		return c.Conn.SetDeadline(time.Now().Add(c.Timeout))
+	}
+	if !c.externalReadDeadline {
+		if err := c.Conn.SetReadDeadline(time.Now().Add(c.Timeout)); err != nil {
+			return err
+		}
+	}
+	if !c.externalWriteDeadline {
+		if err := c.Conn.SetWriteDeadline(time.Now().Add(c.Timeout)); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (c *Conn) Read(b []byte) (count int, e error) {


### PR DESCRIPTION
## What

`util.Conn` (the `-idleTimeout` wrapper every volume/filer HTTP listener uses) extended the connection deadline unconditionally at the start of every Read/Write. Go's HTTP server also sets deadlines directly on the same conn — notably `abortPendingRead` sets a deadline in the past to interrupt the pending background read after each response. The activity extension raced with and silently overwrote that interrupt, leaving the read blocked — and the server's `conn.serve` goroutine stuck in `abortPendingRead` — until the full `-idleTimeout` (default 30s) expired.

Fix: track externally-set deadlines (`SetDeadline`/`SetReadDeadline`/`SetWriteDeadline` overrides), suspend the activity extension while one is in force (resumes when the caller clears it with the zero time), and serialize deadline updates with a mutex. Activity still extends both directions at once: a long write-only response must keep the read deadline alive too, or the server's background read times out and cancels the in-flight request.

## Impact

Wedged connections count as *active*, so the volume server's graceful HTTP drain (`httpdown`, StopTimeout 30s) waited out its **entire 30s timeout on every shutdown** that followed recent HTTP traffic — likely the cause of "volume server is slow to stop" reports in general.

Found while chasing a FUSE-integration CI teardown hang: a SIGQUIT goroutine dump of a hung `weed mini` showed the interrupt hook blocked in `httpdown.(*server).Stop` with paired `abortPendingRead` / blocked-`Read` goroutines on filer→volume keep-alive connections.

## Verification

On a Linux box, the full FUSE integration suite against binaries with this fix: every test's teardown dropped from ~28–30s to ~1–2s (e.g. TestStressOperations 30.65s → 6.70s total), all tests pass. The same suite reproduced the hang 100% without the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection timeout handling to respect externally set read/write deadlines.
  * Stopped activity-based timeout logic from overwriting caller-defined deadlines.
  * Enhanced deadline extension behavior so multiple timeout settings no longer interfere with each other.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->