### PR TITLE
fix(ec): detect truncated .ecx instead of treating it as clean EOF

### DIFF
--- a/weed/storage/erasure_coding/ec_decoder.go
+++ b/weed/storage/erasure_coding/ec_decoder.go
@@ -150,12 +150,13 @@ func iterateEcxFile(baseFileName string, processNeedleFn func(key types.NeedleId
 
 	buf := make([]byte, types.NeedleMapEntrySize)
 	for {
-		n, err := ecxFile.Read(buf)
-		if n != types.NeedleMapEntrySize {
-			if err == io.EOF {
-				return nil
-			}
-			return err
+		// .ecx is a sealed index: a partial trailing record means corruption, not a torn append.
+		_, err := io.ReadFull(ecxFile, buf)
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("read ecx %s.ecx: %w", baseFileName, err)
 		}
 		key, offset, size := idx.IdxFileEntry(buf)
 		if processNeedleFn != nil {

--- a/weed/storage/erasure_coding/ec_decoder_test.go
+++ b/weed/storage/erasure_coding/ec_decoder_test.go
@@ -73,6 +73,22 @@ func TestHasLiveNeedles_EmptyFileIsFalse(t *testing.T) {
 	}
 }
 
+func TestHasLiveNeedles_TruncatedEcxErrors(t *testing.T) {
+	dir := t.TempDir()
+
+	base := filepath.Join(dir, "foo_1")
+
+	entry := makeNeedleMapEntry(types.NeedleId(1), types.Offset{}, types.TombstoneFileSize)
+	truncated := append(entry, entry[:types.NeedleIdSize]...)
+	if err := os.WriteFile(base+".ecx", truncated, 0644); err != nil {
+		t.Fatalf("write ecx: %v", err)
+	}
+
+	if _, err := erasure_coding.HasLiveNeedles(base); err == nil {
+		t.Fatalf("expected error for truncated ecx")
+	}
+}
+
 func makeNeedleMapEntry(key types.NeedleId, offset types.Offset, size types.Size) []byte {
 	b := make([]byte, types.NeedleIdSize+types.OffsetSize+types.SizeSize)
 	types.NeedleIdToBytes(b[0:types.NeedleIdSize], key)


### PR DESCRIPTION
## What

`iterateEcxFile` used a bare `Read` and treated any short read as a clean EOF, so a `.ecx` with a partial trailing record silently iterated the readable prefix and returned nil.

Unlike `.ecj` (an append-only journal where a torn tail is an unacknowledged delete), `.ecx` is a sealed index written once at encode time — a partial trailing record means corruption, not a torn append, and should surface as an error.

## Why it matters

`iterateEcxFile` sits on the decode path (`VolumeEcShardsToVolume` → `HasLiveNeedles` / `FindDatFileSize`). Silently accepting a truncated `.ecx` can:

- make `FindDatFileSize` miss trailing entries and undersize the rebuilt `.dat`
- make `HasLiveNeedles` miss the only live entry and skip decoding entirely
- let `WriteIdxFileFromEcIndex` copy the garbage tail into the generated `.idx`

This is the same class of issue as the truncated-shard fix in #9938: a truncated input silently producing an apparently-successful output.

## Fix

Use `io.ReadFull`: a clean `io.EOF` ends iteration; a partial trailing record (`io.ErrUnexpectedEOF`) or any real read error is returned to the caller.

## Test

Added `TestHasLiveNeedles_TruncatedEcxErrors`: a `.ecx` with one full entry plus a partial trailing record now returns an error instead of silently succeeding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of erasure-coding index files so incomplete trailing records are now treated as corruption instead of being accepted.
  * Added clearer read errors with file context to make malformed index issues easier to diagnose.

* **Tests**
  * Added coverage for truncated erasure-coding index files to ensure they return an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->