### PR TITLE
fix: convert inline filer content before append

### DIFF
--- a/weed/server/filer_server_handlers_write_autochunk.go
+++ b/weed/server/filer_server_handlers_write_autochunk.go
@@ -231,6 +231,10 @@ func (fs *FilerServer) fixFilePath(ctx context.Context, r *http.Request, fileNam
 }
 
 func (fs *FilerServer) saveMetaData(ctx context.Context, r *http.Request, fileName string, contentType string, so *operation.StorageOption, md5bytes []byte, fileChunks []*filer_pb.FileChunk, chunkOffset int64, content []byte) (filerResult *FilerPostResult, replyerr error) {
+	return fs.saveMetaDataWithSaveFunc(ctx, r, fileName, contentType, so, md5bytes, fileChunks, chunkOffset, content, fs.saveAsChunk(ctx, so))
+}
+
+func (fs *FilerServer) saveMetaDataWithSaveFunc(ctx context.Context, r *http.Request, fileName string, contentType string, so *operation.StorageOption, md5bytes []byte, fileChunks []*filer_pb.FileChunk, chunkOffset int64, content []byte, saveFunc filer.SaveDataAsChunkFunctionType) (filerResult *FilerPostResult, replyerr error) {
 
 	// detect file mode
 	modeStr := r.URL.Query().Get("mode")
@@ -272,10 +276,14 @@ func (fs *FilerServer) saveMetaData(ctx context.Context, r *http.Request, fileNa
 		}
 		newChunks = append(entry.GetChunks(), fileChunks...)
 
-		// TODO
 		if len(entry.Content) > 0 {
-			replyerr = fmt.Errorf("append to small file is not supported yet")
-			return
+			inlineChunk, saveErr := saveFunc(bytes.NewReader(entry.Content), fileName, 0, time.Now().UnixNano(), uint64(len(entry.Content)))
+			if saveErr != nil {
+				replyerr = fmt.Errorf("save inline content as chunk: %w", saveErr)
+				return
+			}
+			entry.Content = nil
+			newChunks = append([]*filer_pb.FileChunk{inlineChunk}, newChunks...)
 		}
 
 	} else {

--- a/weed/server/filer_server_handlers_write_autochunk_test.go
+++ b/weed/server/filer_server_handlers_write_autochunk_test.go
@@ -1,0 +1,94 @@
+package weed_server
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/filer"
+	"github.com/seaweedfs/seaweedfs/weed/operation"
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+)
+
+func TestSaveMetaDataAppendsToInlineContent(t *testing.T) {
+	store := newRenameTestStore()
+	store.entries["/small.txt"] = &filer.Entry{
+		FullPath: util.FullPath("/small.txt"),
+		Attr: filer.Attr{
+			Mtime:    time.Unix(100, 0),
+			Crtime:   time.Unix(100, 0),
+			Mode:     0644,
+			FileSize: 5,
+		},
+		Content: []byte("hello"),
+	}
+
+	server := &FilerServer{
+		filer:  newRenameTestFiler(store),
+		option: &FilerOption{MaxMB: 1},
+	}
+	appendChunk := &filer_pb.FileChunk{FileId: "2,append", Offset: 0, Size: 6}
+	var savedData []byte
+	var savedName string
+	var savedOffset int64
+	var savedSize uint64
+	var savedTsNs int64
+
+	r := httptest.NewRequest(http.MethodPut, "/small.txt?op=append&skipCheckParentDir=true", nil)
+	result, err := server.saveMetaDataWithSaveFunc(
+		context.Background(),
+		r,
+		"small.txt",
+		"",
+		&operation.StorageOption{},
+		nil,
+		[]*filer_pb.FileChunk{appendChunk},
+		6,
+		nil,
+		func(reader io.Reader, name string, offset int64, tsNs int64, expectedDataSize uint64) (*filer_pb.FileChunk, error) {
+			var readErr error
+			savedData, readErr = io.ReadAll(reader)
+			if readErr != nil {
+				return nil, readErr
+			}
+			savedName = name
+			savedOffset = offset
+			savedSize = expectedDataSize
+			savedTsNs = tsNs
+			return &filer_pb.FileChunk{FileId: "1,inline", Offset: offset, Size: expectedDataSize, ModifiedTsNs: tsNs}, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("saveMetaDataWithSaveFunc: %v", err)
+	}
+	if result.Size != 11 {
+		t.Fatalf("result size = %d, want 11", result.Size)
+	}
+	if string(savedData) != "hello" || savedName != "small.txt" || savedOffset != 0 || savedSize != 5 || savedTsNs == 0 {
+		t.Fatalf("inline save got data=%q name=%q offset=%d size=%d ts=%d", string(savedData), savedName, savedOffset, savedSize, savedTsNs)
+	}
+
+	updated, err := store.FindEntry(context.Background(), "/small.txt")
+	if err != nil {
+		t.Fatalf("find updated entry: %v", err)
+	}
+	if len(updated.Content) != 0 {
+		t.Fatalf("updated content length = %d, want 0", len(updated.Content))
+	}
+	if updated.FileSize != 11 {
+		t.Fatalf("updated file size = %d, want 11", updated.FileSize)
+	}
+	if len(updated.Chunks) != 2 {
+		t.Fatalf("updated chunks = %d, want 2: %+v", len(updated.Chunks), updated.Chunks)
+	}
+	if chunk := updated.Chunks[0]; chunk.FileId != "1,inline" || chunk.Offset != 0 || chunk.Size != 5 {
+		t.Fatalf("inline chunk = %+v, want fileId=1,inline offset=0 size=5", chunk)
+	}
+	if chunk := updated.Chunks[1]; chunk.FileId != "2,append" || chunk.Offset != 5 || chunk.Size != 6 {
+		t.Fatalf("append chunk = %+v, want fileId=2,append offset=5 size=6", chunk)
+	}
+}


### PR DESCRIPTION
# What problem are we solving?

Appending to a small file stored inline in filer metadata currently fails with:

append to small file is not supported yet
This happens because the existing entry still has `Content` set, while the append path expects normal volume chunks.

# How are we solving the problem?

When updating an existing entry that still has inline content, convert that inline content into a normal chunk at offset `0` before merging it with the newly uploaded chunks.

This keeps the existing append flow intact:
- append chunks are still shifted by the current file size
- inline content is cleared after being saved as a chunk
- chunk merge / manifest logic continues to run through the existing path

A focused regression test was added for appending to an inline small file.


# How is the PR tested?

```bash
go test ./weed/server -run TestSaveMetaDataAppendsToInlineContent -count=1
go test ./weed/server
git diff --check
```

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Appending or writing at an offset now works for files with existing inline content instead of returning an error.
  * Inline content is automatically converted into chunked storage and preserved as part of the updated file.
  * File size and chunk ordering are updated correctly after the append/write operation.

* **Tests**
  * Added coverage for appending to a file that starts with inline content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->