### PR TITLE
fix(shell): pass collection in ec.shard.unmount --delete request

### DIFF
--- a/weed/shell/command_ec_shard_unmount.go
+++ b/weed/shell/command_ec_shard_unmount.go
@@ -24,6 +24,7 @@ const (
 
 type ecShard struct {
 	ShardID     uint32
+	Collection  string
 	NodeAddress string
 }
 
@@ -173,6 +174,7 @@ func (c *commandEcShardUnmount) liveShardsForVolume() []*ecShard {
 							for _, sid := range sinfo.Ids() {
 								shards = append(shards, &ecShard{
 									ShardID:     uint32(sid),
+									Collection:  eci.GetCollection(),
 									NodeAddress: nodeAddress,
 								})
 							}
@@ -264,8 +266,9 @@ func (c *commandEcShardUnmount) unmountShard(s *ecShard) error {
 		if c.delete {
 			c.write("Deleting shard %v for volume ID %d...\n", s, c.volumeID)
 			if _, err := vsc.VolumeEcShardsDelete(ctx, &volume_server_pb.VolumeEcShardsDeleteRequest{
-				VolumeId: c.volumeID,
-				ShardIds: []uint32{s.ShardID},
+				VolumeId:   c.volumeID,
+				Collection: s.Collection,
+				ShardIds:   []uint32{s.ShardID},
 			}); err != nil {
 				return err
 			}


### PR DESCRIPTION
## What

`ec.shard.unmount --delete` sends `VolumeEcShardsDeleteRequest` without the
`Collection` field. The volume server resolves shard files by collection:

    bName := erasure_coding.EcShardBaseFileName(req.Collection, int(req.VolumeId))

so for a volume in a non-default collection (e.g. `photos_123.ec00`), the
server looks for `123.ec00` instead.

## Impact

- Usually the wrong path doesn't exist, and the delete pass treats a missing
  file as a no-op — the RPC returns success, but the shard files stay on disk
  and can be re-mounted later.
- If a default-collection volume with the same id happens to exist on the
  node, its shard files get deleted instead.

The unmount step is unaffected (it resolves the volume from memory by id),
which makes the failure easy to miss: unmount succeeds, delete "succeeds",
files remain.

## Fix

Carry the collection from the live topology (`VolumeEcShardInformationMessage.Collection`)
into the resolved shards and pass it in the delete request, matching the other
`VolumeEcShardsDelete` callers in `command_ec_common.go`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved EC shard deletion so the system includes the shard collection when removing shards.
  - Better preserves the correct shard context from live volume topology, helping delete operations target the right data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->