### PR TITLE
feat(k8s): add Traefik IngressRouteTCP for gRPC with TLS passthrough

### DIFF
--- a/k8s/charts/seaweedfs/templates/filer/filer-grpc-ingressroutetcp.yaml
+++ b/k8s/charts/seaweedfs/templates/filer/filer-grpc-ingressroutetcp.yaml
@@ -1,0 +1,48 @@
+{{- /* ========================================================================
+     Traefik IngressRouteTCP for gRPC
+     ========================================================================
+     Généré uniquement quand :
+       - className contient "traefik"
+       - gRPC ingress est activé
+
+     Deux modes selon global.seaweedfs.enableSecurity :
+       - false : IngressRouteTCP classique, Traefik envoie h2c vers le pod
+       - true  : TLS passthrough, le TLS traverse Traefik intact jusqu'au pod
+     ========================================================================= */}}
+
+{{- $grpcEnabled := or .Values.filer.ingresses.grpc.enabled .Values.allInOne.enabled }}
+{{- $isTraefik := hasPrefix "traefik" (default "" .Values.filer.ingresses.grpc.className) }}
+{{- $securityEnabled := .Values.global.seaweedfs.enableSecurity }}
+{{- $shouldRender := and $grpcEnabled $isTraefik }}
+
+{{- if $shouldRender }}
+apiVersion: traefik.io/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-filer-grpc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "seaweedfs.name" . }}
+    helm.sh/chart: {{ include "seaweedfs.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: filer
+    app.kubernetes.io/part-of: seaweedfs
+spec:
+  {{- if $securityEnabled }}
+  tls:
+    passthrough: true
+  {{- end }}
+  entryPoints:
+    {{- /* Entrypoint Traefik pour le gRPC */}}
+    {{- with .Values.filer.ingresses.grpc.entryPoint }}
+    - {{ . | quote }}
+    {{- else }}
+    - filer-grpc
+    {{- end }}
+  routes:
+    - match: HostSNI(`{{ .Values.filer.ingresses.grpc.host }}`)
+      services:
+        - name: {{ include "seaweedfs.componentName" (list . "filer-client") }}
+          port: {{ .Values.filer.grpcPort }}
+{{- end }}

--- a/k8s/charts/seaweedfs/templates/filer/filer-grpc-ingressroutetcp.yaml
+++ b/k8s/charts/seaweedfs/templates/filer/filer-grpc-ingressroutetcp.yaml
@@ -1,48 +1,47 @@
-{{- /* ========================================================================
-     Traefik IngressRouteTCP for gRPC
-     ========================================================================
-     Généré uniquement quand :
-       - className contient "traefik"
-       - gRPC ingress est activé
+{{- /* Traefik IngressRouteTCP for the filer gRPC port. Rendered instead of the
+       standard Ingress when the gRPC ingress className starts with "traefik",
+       since a Kubernetes Ingress can't do raw TCP/gRPC passthrough.
 
-     Deux modes selon global.seaweedfs.enableSecurity :
-       - false : IngressRouteTCP classique, Traefik envoie h2c vers le pod
-       - true  : TLS passthrough, le TLS traverse Traefik intact jusqu'au pod
-     ========================================================================= */}}
+       global.seaweedfs.enableSecurity controls the mode:
+         false: plain TCP, Traefik forwards h2c to the pod. A non-TLS TCP
+                router can only match HostSNI(`*`) (SNI needs TLS).
+         true:  TLS passthrough, matched by SNI so it can route on the host. */}}
 
-{{- $grpcEnabled := or .Values.filer.ingresses.grpc.enabled .Values.allInOne.enabled }}
+{{- $filerEnabled := or .Values.filer.enabled .Values.allInOne.enabled }}
 {{- $isTraefik := hasPrefix "traefik" (default "" .Values.filer.ingresses.grpc.className) }}
 {{- $securityEnabled := .Values.global.seaweedfs.enableSecurity }}
-{{- $shouldRender := and $grpcEnabled $isTraefik }}
 
-{{- if $shouldRender }}
+{{- if and $filerEnabled .Values.filer.ingresses.grpc.enabled $isTraefik }}
+{{- $serviceName := ternary (include "seaweedfs.componentName" (list . "all-in-one")) (include "seaweedfs.componentName" (list . "filer")) .Values.allInOne.enabled }}
 apiVersion: traefik.io/v1alpha1
 kind: IngressRouteTCP
 metadata:
   name: {{ include "seaweedfs.fullname" . }}-filer-grpc
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: {{ include "seaweedfs.name" . }}
-    helm.sh/chart: {{ include "seaweedfs.chart" . }}
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: filer
-    app.kubernetes.io/part-of: seaweedfs
 spec:
   {{- if $securityEnabled }}
   tls:
     passthrough: true
   {{- end }}
   entryPoints:
-    {{- /* Entrypoint Traefik pour le gRPC */}}
     {{- with .Values.filer.ingresses.grpc.entryPoint }}
     - {{ . | quote }}
     {{- else }}
     - filer-grpc
     {{- end }}
   routes:
+    {{- if $securityEnabled }}
     - match: HostSNI(`{{ .Values.filer.ingresses.grpc.host }}`)
+    {{- else }}
+    - match: HostSNI(`*`)
+    {{- end }}
       services:
-        - name: {{ include "seaweedfs.componentName" (list . "filer-client") }}
+        - name: {{ $serviceName }}
           port: {{ .Values.filer.grpcPort }}
 {{- end }}

--- a/k8s/charts/seaweedfs/templates/filer/filer-ingress.yaml
+++ b/k8s/charts/seaweedfs/templates/filer/filer-ingress.yaml
@@ -59,8 +59,8 @@ spec:
 
 ---
 
-{{- /* gRPC Ingress */}}
-{{- if and $filerEnabled .Values.filer.ingresses.grpc.enabled }}
+{{- /* gRPC Ingress (standard Kubernetes Ingress, NOT for Traefik) */}}
+{{- if and $filerEnabled .Values.filer.ingresses.grpc.enabled (not (hasPrefix "traefik" (default "" .Values.filer.ingresses.grpc.className))) }}
 {{- /* Determine service name based on deployment mode */}}
 {{- $serviceName := ternary (include "seaweedfs.componentName" (list . "all-in-one")) (include "seaweedfs.componentName" (list . "filer")) .Values.allInOne.enabled }}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}


### PR DESCRIPTION
## Summary

Re-introduce Traefik support for the gRPC filer ingress that was lost when #10205 was merged.

## The Problem

The original chart shipped with an `IngressRouteTCP` for the gRPC port (TLS passthrough). However, after #10205 was merged and modified, the chart only renders standard Kubernetes Ingresses — which do not support raw TCP/gRPC passthrough natively.

We spent considerable effort trying to make Traefik work with standard Ingress + `ServersTransport` + `TLSOption` CRDs. Unfortunately, this approach proved fragile:

1. **Two services required** — we had to split the filer into separate HTTP (8888) and gRPC (18888) services because Traefik annotations on a single service affected all ports.
2. **Still failed** — even with two services, we encountered `connection reset by peer` errors and `unknown TLS options` bugs. See our abandoned attempt in [feature/filer-grpc-traefik-termination](https://github.com/MorezMartin/seaweedfs/tree/feature/filer-grpc-traefik-termination).
3. **Unnecessary complexity** — 2 CRDs (TLSOption + ServersTransport), service annotations, namespace-prefixed CRD references, and Traefik had to terminate then re-encrypt TLS.

## The Solution

A single `IngressRouteTCP` CRD with optional TLS passthrough:

- **`enableSecurity: false`** (default): plain TCP, Traefik sends h2c directly to the filer pod
- **`enableSecurity: true`**: TLS passthrough — the TLS connection traverses Traefik intact to the filer pod (same behaviour as the original chart)

No `ServersTransport`, no `TLSOption`, no service annotations, no `values.yaml` structure changes.

## What Changed

**1 file added:** `templates/filer/filer-grpc-ingressroutetcp.yaml`

The IngressRouteTCP is rendered **only** when:
- `filer.ingresses.grpc.enabled: true` (or `allInOne.enabled: true`)
- `filer.ingresses.grpc.className` contains `"traefik"`

Entry point defaults to `filer-grpc` but is configurable via `values.filer.ingresses.grpc.entryPoint`.

## Usage

```yaml
# Enable TLS passthrough for gRPC mTLS
global:
  seaweedfs:
    enableSecurity: true

filer:
  ingresses:
    grpc:
      enabled: true
      className: traefik
      host: filer.sw.example.com
```

This is fully backward compatible — non-Traefik users and `enableSecurity: false` deployments are unaffected.

## Thanks

Chris, thank you for the excellent work on the chart and for keeping it controller-agnostic. We hope this keeps the door open for Traefik users without complicating the chart further.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for exposing the filer gRPC endpoint via Traefik using TCP routing.
  * Added conditional TLS passthrough and SNI-based matching for secure gRPC access when security is enabled.
* **Behavior Change**
  * Updated gRPC ingress rendering: the standard Kubernetes Ingress is used only when the gRPC ingress class is not prefixed with `traefik`; otherwise, Traefik’s TCP `IngressRouteTCP` is used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->