### PR TITLE
s3: answer directory-path probes like AWS so Flink savepoints restore

### DIFF
--- a/weed/s3api/s3_constants/s3_actions.go
+++ b/weed/s3api/s3_constants/s3_actions.go
@@ -21,4 +21,5 @@ const (
 	MultipartUploadsFolder          = ".uploads"
 	VersionsFolder                  = ".versions"
 	FolderMimeType                  = "httpd/unix-directory"
+	DirectoryMimeType               = "application/x-directory"
 )

--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -427,10 +427,17 @@ func (s3a *S3ApiServer) serveDirectoryContent(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	// Set content type - use stored MIME type or default
+	// Set content type - use stored MIME type or default. A directory without a stored
+	// mime and without data of its own answers application/x-directory, the marker type
+	// Hadoop-style clients (e.g. flink-s3-fs-presto) require to classify the path as a
+	// directory; defaulting to octet-stream makes them treat it as a 0-byte file.
 	contentType := entry.Attributes.Mime
 	if contentType == "" {
-		contentType = "application/octet-stream"
+		if entry.IsDirectoryKeyObject() {
+			contentType = "application/octet-stream"
+		} else {
+			contentType = s3_constants.DirectoryMimeType
+		}
 	}
 	w.Header().Set("Content-Type", contentType)
 

--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -362,6 +362,13 @@ func (s3a *S3ApiServer) hasChildren(ctx context.Context, bucket, prefix string) 
 	return true
 }
 
+// isBareDirectory reports whether entry is a directory carrying no object data of its own.
+// Such a path is not an S3 object: GET/HEAD answer 404 like AWS does for a prefix, and
+// Hadoop-style clients then discover the directory through their LIST fallback.
+func isBareDirectory(entry *filer_pb.Entry) bool {
+	return entry != nil && entry.IsDirectory && filer.FileSize(entry) == 0
+}
+
 // checkDirectoryObject checks if the object is a directory object (ends with "/") and if it exists
 // Returns: (entry, isDirectoryObject, error)
 // - entry: the directory entry if found and is a directory
@@ -691,7 +698,7 @@ func (s3a *S3ApiServer) GetObjectHandler(w http.ResponseWriter, r *http.Request)
 			} else if errors.Is(versionsErr, filer_pb.ErrNotFound) {
 				// .versions/ doesn't exist (confirmed not found), check regular path for null version
 				regularEntry, regularErr := s3a.getEntry(bucketDir, normalizedObject)
-				if regularErr == nil && regularEntry != nil {
+				if regularErr == nil && regularEntry != nil && !isBareDirectory(regularEntry) {
 					// Found object at regular path - this is the null version
 					entry = regularEntry
 					targetVersionId = "null"
@@ -789,6 +796,13 @@ func (s3a *S3ApiServer) GetObjectHandler(w http.ResponseWriter, r *http.Request)
 	if objectEntryForSSE == nil {
 		glog.Errorf("GetObjectHandler: objectEntryForSSE is nil for %s/%s (should not happen)", bucket, object)
 		s3err.WriteErrorResponse(w, r, s3err.ErrInternalError)
+		return
+	}
+
+	// A bare directory path is not an object: 404 like AWS instead of an empty 200,
+	// so Hadoop-style clients fall back to LIST discovery. HEAD and ranged GET already 404.
+	if !strings.HasSuffix(object, "/") && isBareDirectory(objectEntryForSSE) {
+		s3err.WriteErrorResponse(w, r, s3err.ErrNoSuchKey)
 		return
 	}
 
@@ -2216,7 +2230,7 @@ func (s3a *S3ApiServer) HeadObjectHandler(w http.ResponseWriter, r *http.Request
 			} else if errors.Is(versionsErr, filer_pb.ErrNotFound) {
 				// .versions/ doesn't exist (confirmed not found), check regular path for null version
 				regularEntry, regularErr := s3a.getEntry(bucketDir, normalizedObject)
-				if regularErr == nil && regularEntry != nil {
+				if regularErr == nil && regularEntry != nil && !isBareDirectory(regularEntry) {
 					// Found object at regular path - this is the null version
 					entry = regularEntry
 					targetVersionId = "null"
@@ -2355,7 +2369,7 @@ func (s3a *S3ApiServer) HeadObjectHandler(w http.ResponseWriter, r *http.Request
 		if objectEntryForSSE.Attributes != nil {
 			isZeroByteFile := objectEntryForSSE.Attributes.FileSize == 0 && !objectEntryForSSE.IsDirectory
 			// A directory with data (a promoted file) is retrievable; empty directories 404 for LIST fallback.
-			if objectEntryForSSE.IsDirectory && filer.FileSize(objectEntryForSSE) == 0 {
+			if isBareDirectory(objectEntryForSSE) {
 				s3err.WriteErrorResponse(w, r, s3err.ErrNoSuchKey)
 				return
 			}

--- a/weed/s3api/s3api_object_handlers_dir_test.go
+++ b/weed/s3api/s3api_object_handlers_dir_test.go
@@ -1,0 +1,49 @@
+package s3api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+)
+
+func TestServeDirectoryContentContentType(t *testing.T) {
+	s3a := &S3ApiServer{}
+
+	tests := []struct {
+		name     string
+		entry    *filer_pb.Entry
+		wantType string
+	}{
+		{
+			name:     "bare directory answers the directory marker type",
+			entry:    &filer_pb.Entry{Name: "savepoint", IsDirectory: true, Attributes: &filer_pb.FuseAttributes{}},
+			wantType: "application/x-directory",
+		},
+		{
+			name:     "promoted file with data keeps octet-stream",
+			entry:    &filer_pb.Entry{Name: "promoted", IsDirectory: true, Content: []byte("data"), Attributes: &filer_pb.FuseAttributes{FileSize: 4}},
+			wantType: "application/octet-stream",
+		},
+		{
+			name:     "stored mime is echoed verbatim",
+			entry:    &filer_pb.Entry{Name: "marker", IsDirectory: true, Attributes: &filer_pb.FuseAttributes{Mime: "httpd/unix-directory"}},
+			wantType: "httpd/unix-directory",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodHead, "/bucket/dir/", nil)
+			rec := httptest.NewRecorder()
+			s3a.serveDirectoryContent(rec, req, tt.entry)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200", rec.Code)
+			}
+			if got := rec.Header().Get("Content-Type"); got != tt.wantType {
+				t.Fatalf("Content-Type = %q, want %q", got, tt.wantType)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Flink savepoint restore against SeaweedFS failed with `NoSuchKey` on the savepoint directory path (`GET .../savepoint-xxx` -> `directory object ... cannot be retrieved`), even though `savepoint-xxx/_metadata` existed.

Flink never reads the directory path on AWS. Its filesystem layer classifies the path first, and only then reads `_metadata` itself:

- `flink-s3-fs-presto` (all released Flink 1.x bundle presto 0.272): `HEAD key` -> on 404, `HEAD key/` -> on 404, `LIST prefix=key/`. A 200 on either HEAD is a directory **only if** Content-Type is `application/x-directory`; anything else means "0-byte file".
- `flink-s3-fs-hadoop` (s3a): `HEAD key` -> on 404, `LIST prefix=key/`. Any 200 on the bare key means "file".

SeaweedFS answered these probes in ways that flipped both connectors into "0-byte file":

1. `HEAD key/` on a real directory returned `application/octet-stream` (the default when the filer entry has no stored mime) — presto misclassifies.
2. On versioned buckets, the null-version fallback adopted a filer directory as a 0-byte object, so `HEAD key` returned 200 — both connectors misclassify.
3. Plain `GET key` on a bare directory returned an empty 200 while ranged GET and HEAD returned 404.

Once misclassified as a file, Flink reads the directory key directly (presto: ranged GET -> 404; s3a: 0-length status -> instant EOF), and the savepoint's base directory is also computed wrong, so relative state handles would not resolve.

## Changes

- A directory with no stored mime and no data of its own answers `application/x-directory` on trailing-slash GET/HEAD. Stored mimes still echo verbatim; a file promoted to a directory keeps octet-stream for its data.
- A bare directory path (no trailing slash) answers 404 on GET and HEAD consistently — including the versioned null-version fallback and the plain-GET empty-200 path — which is what AWS answers for a prefix. Clients then discover the directory through their LIST fallback, which already works.

## Behavior after

| request on `savepoint-xxx` (only `savepoint-xxx/_metadata` exists) | before | after |
|---|---|---|
| HEAD bare key, non-versioned | 404 | 404 |
| HEAD bare key, versioned | 200 len=0 | 404 |
| GET bare key (plain) | 200 empty | 404 |
| GET bare key (ranged) | 404 | 404 |
| HEAD/GET `savepoint-xxx/` | 200 `application/octet-stream` | 200 `application/x-directory` |

Both Flink connectors now classify the savepoint path as a directory and restore via `_metadata`, on versioned and non-versioned buckets. Verified end-to-end by simulating both connectors' exact probe sequences plus regression checks (promoted files still serve their data, empty files still 200, explicit markers echo their stored mime, s3fs LIST-fallback behavior unchanged).

An earlier revision of this PR instead served `_metadata` content on GET of the directory path. That is withdrawn: it only rescues self-contained savepoints (Flink still computes the wrong base directory for relative state handles) and cannot help s3a at all (a 0-length status never issues a GET). Fixing the classification makes every Hadoop-style client work with no special-cased filenames.

Fixes #10222


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory handling in object requests so empty directory entries are treated more like AWS/S3-compatible behavior.
  * Requests for bare directories now return `404 NoSuchKey` when accessing them without a trailing slash, helping directory discovery tools work correctly.
  * Head requests now use the same directory detection rules for more consistent responses.

* **New Features**
  * Added clearer default `Content-Type` handling for directory entries, including a dedicated directory MIME type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->