### PR TITLE
filer: default the filemeta CREATE TABLE for postgres2/mysql2 when createTable is unset

### DIFF
--- a/weed/filer/mysql/mysql_sql_gen.go
+++ b/weed/filer/mysql/mysql_sql_gen.go
@@ -22,6 +22,10 @@ type SqlGenMysql struct {
 // is left for users to opt into via an explicit upsertQuery.
 const DefaultUpsertQuery = "INSERT INTO `%s` (`dirhash`,`name`,`directory`,`meta`) VALUES(?,?,?,?) ON DUPLICATE KEY UPDATE `meta` = VALUES(`meta`)"
 
+// DefaultCreateTableQuery is used when createTable is left unset; an empty
+// template would otherwise render as %!(EXTRA ...) garbage SQL.
+const DefaultCreateTableQuery = "CREATE TABLE IF NOT EXISTS `%s` (`dirhash` BIGINT NOT NULL, `name` VARCHAR(766) NOT NULL, `directory` TEXT NOT NULL, `meta` LONGBLOB, PRIMARY KEY (`dirhash`, `name`)) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin"
+
 var (
 	_ = abstract_sql.SqlGenerator(&SqlGenMysql{})
 )

--- a/weed/filer/mysql/mysql_sql_gen_test.go
+++ b/weed/filer/mysql/mysql_sql_gen_test.go
@@ -19,6 +19,17 @@ func TestDefaultUpsertQueryUsesOnDuplicateKey(t *testing.T) {
 	}
 }
 
+func TestDefaultCreateTableQueryRendersValidSql(t *testing.T) {
+	gen := &SqlGenMysql{CreateTableSqlTemplate: DefaultCreateTableQuery}
+	got := gen.GetSqlCreateTable("filemeta")
+	if strings.Contains(got, "%!") {
+		t.Fatalf("template rendered to malformed SQL, got: %s", got)
+	}
+	if !strings.Contains(got, "`filemeta`") {
+		t.Fatalf("expected backticked table name, got: %s", got)
+	}
+}
+
 func TestEmptyUpsertTemplateFallsBackToPlainInsert(t *testing.T) {
 	gen := &SqlGenMysql{}
 	got := gen.GetSqlInsert("filemeta")

--- a/weed/filer/mysql2/mysql2_store.go
+++ b/weed/filer/mysql2/mysql2_store.go
@@ -58,6 +58,9 @@ func (store *MysqlStore2) initialize(createTable, upsertQuery string, enableUpse
 	maxLifetimeSeconds int, interpolateParams bool) (err error) {
 
 	store.SupportBucketTable = true
+	if createTable == "" {
+		createTable = mysql.DefaultCreateTableQuery
+	}
 	if !enableUpsert {
 		upsertQuery = ""
 	} else if upsertQuery == "" {

--- a/weed/filer/postgres/postgres_sql_gen.go
+++ b/weed/filer/postgres/postgres_sql_gen.go
@@ -20,6 +20,10 @@ type SqlGenPostgres struct {
 // user enables upsert but does not provide their own template.
 const DefaultUpsertQuery = `INSERT INTO "%s" (dirhash,name,directory,meta) VALUES($1,$2,$3,$4) ON CONFLICT (dirhash, name) DO UPDATE SET directory=EXCLUDED.directory, meta=EXCLUDED.meta`
 
+// DefaultCreateTableQuery is used when createTable is left unset; an empty
+// template would otherwise render as %!(EXTRA ...) garbage SQL.
+const DefaultCreateTableQuery = `CREATE TABLE IF NOT EXISTS "%s" (dirhash BIGINT, name VARCHAR(65535), directory VARCHAR(65535), meta bytea, PRIMARY KEY (dirhash, name))`
+
 var (
 	_ = abstract_sql.SqlGenerator(&SqlGenPostgres{})
 )

--- a/weed/filer/postgres/postgres_sql_gen_test.go
+++ b/weed/filer/postgres/postgres_sql_gen_test.go
@@ -16,6 +16,17 @@ func TestDefaultUpsertQueryIsConflictSafe(t *testing.T) {
 	}
 }
 
+func TestDefaultCreateTableQueryRendersValidSql(t *testing.T) {
+	gen := &SqlGenPostgres{CreateTableSqlTemplate: DefaultCreateTableQuery}
+	got := gen.GetSqlCreateTable("filemeta")
+	if strings.Contains(got, "%!") {
+		t.Fatalf("template rendered to malformed SQL, got: %s", got)
+	}
+	if !strings.Contains(got, `"filemeta"`) {
+		t.Fatalf("expected quoted table name, got: %s", got)
+	}
+}
+
 func TestEmptyUpsertTemplateFallsBackToPlainInsert(t *testing.T) {
 	gen := &SqlGenPostgres{}
 	got := gen.GetSqlInsert("filemeta")

--- a/weed/filer/postgres2/postgres2_store.go
+++ b/weed/filer/postgres2/postgres2_store.go
@@ -63,6 +63,9 @@ func (store *PostgresStore2) Initialize(configuration util.Configuration, prefix
 func (store *PostgresStore2) initialize(createTable, upsertQuery string, enableUpsert bool, user, password, hostname string, port int, database, schema, sslmode, sslcert, sslkey, sslrootcert, sslcrl string, pgbouncerCompatible bool, maxIdle, maxOpen, maxLifetimeSeconds int) (err error) {
 
 	store.SupportBucketTable = true
+	if createTable == "" {
+		createTable = postgres.DefaultCreateTableQuery
+	}
 	if !enableUpsert {
 		upsertQuery = ""
 	} else if upsertQuery == "" {


### PR DESCRIPTION
A minimal `[postgres2]` (or `[mysql2]`) filer config that omits `createTable` fails to bootstrap:

```
failed to initialize store for postgres2: init table filemeta: ERROR: syntax error at or near "%!" (SQLSTATE 42601)
```

`GetSqlCreateTable` runs the template through `fmt.Sprintf(template, tableName)`. When `createTable` is empty, `fmt.Sprintf("", "filemeta")` renders `%!(EXTRA string=filemeta)`, which the server sends verbatim as SQL. Both `postgres2` and `mysql2` call `CreateTable` at init (they support per-bucket tables), so both hit this.

Fall back to a working default template when `createTable` is unset, mirroring the existing `DefaultUpsertQuery` handling. The defaults match the layouts already shipped in the scaffold `filer.toml`.

Reproduced against Postgres 16: pre-fix `Initialize` fails with the exact error above; post-fix the `filemeta` table and per-bucket tables are created. Unit tests assert the rendered SQL is well-formed (no `%!`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database setup so table-creation SQL is always populated when a custom statement isn’t provided.
  * Prevented malformed SQL from being generated during initialization for both MySQL and PostgreSQL storage backends.
  * Added coverage to verify default create-table statements render valid SQL with the expected table name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->