### PR TITLE
rust volume: pin rustls to aws-lc-rs so TLS gRPC startup doesn't panic

### DIFF
--- a/seaweed-volume/src/main.rs
+++ b/seaweed-volume/src/main.rs
@@ -7,7 +7,7 @@ use seaweed_volume::metrics;
 use seaweed_volume::pb::volume_server_pb::volume_server_server::VolumeServerServer;
 use seaweed_volume::security::tls::{
     build_rustls_server_config, build_rustls_server_config_with_grpc_client_auth,
-    GrpcClientAuthPolicy, TlsPolicy,
+    install_default_crypto_provider, GrpcClientAuthPolicy, TlsPolicy,
 };
 use seaweed_volume::security::{Guard, SigningKey};
 #[cfg(unix)]
@@ -39,6 +39,8 @@ const GRPC_MAX_HEADER_LIST_SIZE: u32 = 8 * 1024 * 1024;
 const GRPC_MAX_CONCURRENT_STREAMS: u32 = 1000;
 
 fn main() {
+    install_default_crypto_provider();
+
     // Initialize tracing
     tracing_subscriber::fmt()
         .with_env_filter(

--- a/seaweed-volume/src/security/tls.rs
+++ b/seaweed-volume/src/security/tls.rs
@@ -118,6 +118,13 @@ impl ClientCertVerifier for CommonNameVerifier {
     }
 }
 
+// aws-lc-rs and ring both get linked transitively, so rustls can't auto-select
+// a provider and tonic's client TLS panics on first use. Pin the default to
+// aws-lc-rs, matching the server config. Idempotent.
+pub fn install_default_crypto_provider() {
+    let _ = aws_lc_rs::default_provider().install_default();
+}
+
 pub fn build_rustls_server_config(
     cert_path: &str,
     key_path: &str,

--- a/seaweed-volume/src/server/grpc_client.rs
+++ b/seaweed-volume/src/server/grpc_client.rs
@@ -164,6 +164,21 @@ mod tests {
     use crate::config::{NeedleMapKind, ReadMode, VolumeServerConfig};
     use crate::security::tls::TlsPolicy;
 
+    const TEST_CERT_PEM: &str = "-----BEGIN CERTIFICATE-----\nMIIBPDCB76ADAgECAhRuRPQgeAu43BT/M7EfAWSdapVdYDAFBgMrZXAwFDESMBAG\nA1UEAwwJbG9jYWxob3N0MB4XDTI2MDcwNTE2MTUyOVoXDTM2MDcwMjE2MTUyOVow\nFDESMBAGA1UEAwwJbG9jYWxob3N0MCowBQYDK2VwAyEAr/3bNIFI+8V32oCiY6y+\nXRFmZpdNQ2g//VtRkT+nQg+jUzBRMB0GA1UdDgQWBBTsy9tLf1zPiXCQfgci6zNi\ndEzRSjAfBgNVHSMEGDAWgBTsy9tLf1zPiXCQfgci6zNidEzRSjAPBgNVHRMBAf8E\nBTADAQH/MAUGAytlcANBAIvsdw0IbvOBBkb9cd7BfMJfIP9pQQrAL03pCRWJFnFh\nSysaLVgFXI4T078IiaM874oO+iB+5vNbWEpc7CkGow4=\n-----END CERTIFICATE-----\n";
+    const TEST_KEY_PEM: &str = "-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIHbyn71Kk+Y7KT3sBctit7uZpErpoH6qDbFj6P8qGaZH\n-----END PRIVATE KEY-----\n";
+
+    #[test]
+    fn test_build_grpc_endpoint_with_tls_resolves_crypto_provider() {
+        crate::security::tls::install_default_crypto_provider();
+        let tls = super::OutgoingGrpcTlsConfig {
+            cert_pem: TEST_CERT_PEM.to_string(),
+            key_pem: TEST_KEY_PEM.to_string(),
+            ca_pem: TEST_CERT_PEM.to_string(),
+        };
+        let endpoint = build_grpc_endpoint("127.0.0.1:19333", Some(&tls)).unwrap();
+        assert_eq!(endpoint.uri().scheme_str(), Some("https"));
+    }
+
     fn sample_config() -> VolumeServerConfig {
         VolumeServerConfig {
             port: 8080,


### PR DESCRIPTION
The Rust volume server panics on startup the moment it dials a master over TLS:

```
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
Call CryptoProvider::install_default() before this point to select a provider manually,
or make sure exactly one of the 'aws-lc-rs' and 'ring' features is enabled.
...
rustls::client::client_conn::ClientConfig::builder_with_protocol_versions
tonic::transport::channel::service::tls::TlsConnector::new
seaweed_volume::server::grpc_client::build_grpc_endpoint
```

Both `aws-lc-rs` (via rustls default features / reqwest) and `ring` (via quinn) get
linked transitively, so rustls can't auto-select a provider. The server-side config
already builds explicitly on `aws-lc-rs` and is fine; the client path goes through
tonic's `ClientTlsConfig`, which relies on the process-default provider and panics
when it's ambiguous.

Install `aws-lc-rs` as the process default in `main()`, matching the provider the
server config uses. Rust-volume-only; Go's crypto/tls has no provider selection so
there's nothing to mirror.

Verified: the new unit test reproduces the panic on the exact `build_grpc_endpoint`
path (before) and passes (after); the built binary now reaches the master heartbeat
loop instead of aborting at startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS startup reliability by ensuring the required crypto provider is available before the app initializes.
  * Fixed gRPC endpoint setup over TLS so secure connections are built consistently and use the correct `https` scheme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->