### PR TITLE
filer: default cassandra2 timeout and ydb prefix so env-var configs match the scaffold

### DIFF
--- a/weed/filer/cassandra2/cassandra_store.go
+++ b/weed/filer/cassandra2/cassandra_store.go
@@ -31,6 +31,8 @@ func (store *Cassandra2Store) GetName() string {
 }
 
 func (store *Cassandra2Store) Initialize(configuration util.Configuration, prefix string) (err error) {
+	// Without this, an env-var config that omits the key drops cluster.Timeout to 0.
+	configuration.SetDefault(prefix+"connection_timeout_millisecond", 600)
 	enableHostVerification := true
 	if val := configuration.GetString(prefix + "ssl_enable_host_verification"); val != "" {
 		enableHostVerification = configuration.GetBool(prefix + "ssl_enable_host_verification")

--- a/weed/filer/ydb/ydb_store.go
+++ b/weed/filer/ydb/ydb_store.go
@@ -33,6 +33,7 @@ const (
 	defaultMinPartitionsCount     = 5
 	defaultMaxPartitionsCount     = 1000
 	defaultMaxListChunk           = 2000
+	defaultTablePathPrefix        = "seaweedfs"
 )
 
 var (
@@ -64,6 +65,7 @@ func (store *YdbStore) GetName() string {
 }
 
 func (store *YdbStore) Initialize(configuration util.Configuration, prefix string) (err error) {
+	configuration.SetDefault(prefix+"prefix", defaultTablePathPrefix)
 	configuration.SetDefault(prefix+"partitionBySizeEnabled", defaultPartitionBySizeEnabled)
 	configuration.SetDefault(prefix+"partitionSizeMb", defaultPartitionSizeMb)
 	configuration.SetDefault(prefix+"partitionByLoadEnabled", defaultPartitionByLoadEnabled)


### PR DESCRIPTION
The scaffold `filer.toml` documents values that aren't backed by a runtime `SetDefault`, so a store configured entirely through `WEED_<STORE>_*` env vars (or a minimal toml) reads them back empty and silently diverges from the documented behavior. Two such fields, fixed to match how the SQL stores already default `enableUpsert`/`connection_max_idle`:

- **cassandra2 `connection_timeout_millisecond`**: scaffold documents `600` ("default: 600ms"), but with no default an env-var config that omits it read back `0` and set `cluster.Timeout = 0`, dropping the client-side timeout entirely. Default it to 600.
- **ydb `prefix`**: scaffold shows `prefix = "seaweedfs"`; omitting it landed tables at the database root instead of under a `seaweedfs/` sub-path. Default it to `"seaweedfs"`.

Both are `SetDefault` calls, so an explicit config value still wins. Verified `go build`/`go vet` (ydb with `-tags ydb`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storage initialization defaults so setups without explicit timeout or path prefix settings now start with sensible fallback values.
  * Cassandra-backed deployments now avoid an unset connection timeout, reducing the chance of slow or failed startup.
  * YDB-backed deployments now use a default table path prefix when none is configured, helping prevent configuration-related initialization issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->