### PR TITLE
filer: keep the internal .system folder out of the per-bucket store path

### DIFF
--- a/weed/filer/abstract_sql/abstract_sql_store.go
+++ b/weed/filer/abstract_sql/abstract_sql_store.go
@@ -129,6 +129,14 @@ func (store *AbstractSqlStore) getTxOrDB(ctx context.Context, fullpath util.Full
 		shortPath = util.FullPath(bucketAndObjectKey[t:])
 	}
 
+	// Dot-prefixed entries directly under /buckets (e.g. .system) are internal
+	// folders, not S3 buckets; keep them in the default table by full path.
+	if strings.HasPrefix(bucket, ".") {
+		bucket = DEFAULT_TABLE
+		shortPath = fullpath
+		return
+	}
+
 	if isValidBucket(bucket) {
 		store.dbsLock.Lock()
 		defer store.dbsLock.Unlock()

--- a/weed/filer/abstract_sql/abstract_sql_store_test.go
+++ b/weed/filer/abstract_sql/abstract_sql_store_test.go
@@ -1,0 +1,53 @@
+package abstract_sql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/util"
+)
+
+// The bucket owner index lives at /buckets/.system/owners/<owner>/<bucket>.
+// .system is an internal folder, not an S3 bucket, so getTxOrDB must route it
+// to the default table rather than reject it as an invalid bucket name.
+func TestGetTxOrDBInternalSystemFolder(t *testing.T) {
+	store := &AbstractSqlStore{SupportBucketTable: true}
+	ctx := context.Background()
+
+	cases := []struct {
+		path          string
+		isForChildren bool
+	}{
+		{"/buckets/.system/owners", false},
+		{"/buckets/.system/owners/foo/bucket1", false},
+		{"/buckets/.system/owners/foo", true},
+	}
+	for _, c := range cases {
+		_, bucket, shortPath, err := store.getTxOrDB(ctx, util.FullPath(c.path), c.isForChildren)
+		if err != nil {
+			t.Errorf("getTxOrDB(%s): unexpected error: %v", c.path, err)
+		}
+		if bucket != DEFAULT_TABLE {
+			t.Errorf("getTxOrDB(%s): bucket = %q, want %q", c.path, bucket, DEFAULT_TABLE)
+		}
+		if string(shortPath) != c.path {
+			t.Errorf("getTxOrDB(%s): shortPath = %q, want %q", c.path, shortPath, c.path)
+		}
+	}
+}
+
+func TestGetTxOrDBRealBucket(t *testing.T) {
+	store := &AbstractSqlStore{SupportBucketTable: true, dbs: map[string]bool{"mybucket": true}}
+	ctx := context.Background()
+
+	_, bucket, shortPath, err := store.getTxOrDB(ctx, util.FullPath("/buckets/mybucket/dir/file.txt"), false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bucket != "mybucket" {
+		t.Errorf("bucket = %q, want mybucket", bucket)
+	}
+	if string(shortPath) != "/dir/file.txt" {
+		t.Errorf("shortPath = %q, want /dir/file.txt", shortPath)
+	}
+}

--- a/weed/filer/arangodb/helpers.go
+++ b/weed/filer/arangodb/helpers.go
@@ -77,6 +77,11 @@ func extractBucket(fullpath util.FullPath) (string, string) {
 		bucket = bucketAndObjectKey[:t]
 		shortPath = string(util.FullPath(bucketAndObjectKey[t:]))
 	}
+	// Dot-prefixed entries directly under /buckets (e.g. .system) are internal
+	// folders, not S3 buckets; keep them in the default collection.
+	if strings.HasPrefix(bucket, ".") {
+		return "", string(fullpath)
+	}
 	return bucket, shortPath
 }
 

--- a/weed/filer/leveldb3/leveldb3_store.go
+++ b/weed/filer/leveldb3/leveldb3_store.go
@@ -118,6 +118,13 @@ func (store *LevelDB3Store) findDB(fullpath weed_util.FullPath, isForChildren bo
 		shortPath = weed_util.FullPath(bucketAndObjectKey[t:])
 	}
 
+	// Dot-prefixed entries directly under /buckets (e.g. .system) are internal
+	// folders, not S3 buckets; keep them in the default DB by full path.
+	if strings.HasPrefix(bucket, ".") {
+		store.dbsLock.RUnlock()
+		return defaultDB, DEFAULT, fullpath, nil
+	}
+
 	if db, found := store.dbs[bucket]; found {
 		store.dbsLock.RUnlock()
 		return db, bucket, shortPath, nil

--- a/weed/filer/ydb/ydb_store.go
+++ b/weed/filer/ydb/ydb_store.go
@@ -468,6 +468,12 @@ func (store *YdbStore) getPrefix(ctx context.Context, dir *string) (tablePathPre
 			return
 		}
 
+		// Dot-prefixed entries directly under /buckets (e.g. .system) are internal
+		// folders, not S3 buckets; keep them under the default prefix.
+		if strings.HasPrefix(bucket, ".") {
+			return
+		}
+
 		store.dbsLock.Lock()
 		defer store.dbsLock.Unlock()
 


### PR DESCRIPTION
Bucket-table filer stores split `/buckets/<bucket>/...` into a per-bucket table (or DB/collection) by reading the first path segment under `/buckets`. The ListBuckets owner index lives at `/buckets/.system/owners/<owner>/<bucket>`, so `.system` was run through the bucket-name validator and rejected:

```
create file directory:"/buckets/.system/owners" ... : invalid bucket name .system
```

On the postgres/mysql backends this hard-errored on every owner-index write, flooding the filer log. Reads and writes of real data kept working, but clients saw stale bucket-index warnings from the failed metadata updates.

Dot-prefixed entries directly under `/buckets` are internal folders, never valid buckets — the S3 layer already treats them that way (`getBucketEntry`, `ensureParentDirectoryEntry`). This routes them to the default store by their full path in every bucket-aware store, so `.system` behaves like any other non-bucket entry instead of erroring (SQL), or spawning a stray table/collection/DB (leveldb3/arangodb) or a redundant `DescribeTable` per op (ydb).

Regression test added in `abstract_sql`; verified end-to-end against a real bucket-table sqlite store.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of internal folders under `/buckets` that start with a dot, such as `.system`.
  * These entries are now kept in the default storage area instead of being treated as regular buckets.
  * This prevents invalid bucket handling and makes path resolution work correctly for internal system folders.
  * Added test coverage to verify both internal folder routing and normal bucket behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->