### PR TITLE
s3api: optimize encodePath memory allocations

### DIFF
--- a/weed/s3api/auth_signature_v4.go
+++ b/weed/s3api/auth_signature_v4.go
@@ -1076,6 +1076,19 @@ func getSignedHeaders(signedHeaders http.Header) string {
 // if object matches reserved string, no need to encode them
 var reservedObjectNames = regexp.MustCompile("^[a-zA-Z0-9-_.~/]+$")
 
+// pathHexTable is used for manual percent-encoding in encodePath to avoid
+// the allocations of hex.EncodeToString + strings.ToUpper.
+const pathHexTable = "0123456789ABCDEF"
+
+// isPathUnreservedChar reports whether s is an RFC 3986 §2.3 unreserved
+// character (or '/') that does not need percent-encoding in an object path.
+func isPathUnreservedChar(s rune) bool {
+	return 'A' <= s && s <= 'Z' ||
+		'a' <= s && s <= 'z' ||
+		'0' <= s && s <= '9' ||
+		s == '-' || s == '_' || s == '.' || s == '~' || s == '/'
+}
+
 // encodePath encodes the strings from UTF-8 byte representations to HTML hex escape sequences
 //
 // This is necessary since regular url.Parse() and url.Encode() functions do not support UTF-8
@@ -1087,29 +1100,41 @@ func encodePath(pathName string) string {
 	if reservedObjectNames.MatchString(pathName) {
 		return pathName
 	}
-	var encodedPathname string
+
+	// Fast path: if nothing needs encoding, return the input unchanged
+	// (zero allocation). This is the common case for ASCII object keys.
+	needEncode := false
 	for _, s := range pathName {
-		if 'A' <= s && s <= 'Z' || 'a' <= s && s <= 'z' || '0' <= s && s <= '9' { // §2.3 Unreserved characters (mark)
-			encodedPathname = encodedPathname + string(s)
+		if !isPathUnreservedChar(s) {
+			needEncode = true
+			break
+		}
+	}
+	if !needEncode {
+		return pathName
+	}
+
+	// Slow path: preallocated Builder + manual hex encoding.
+	var buf strings.Builder
+	buf.Grow(len(pathName) * 3) // encoded form is at most 3x the byte length
+	for _, s := range pathName {
+		if isPathUnreservedChar(s) { // §2.3 Unreserved characters (mark)
+			buf.WriteRune(s)
 		} else {
-			switch s {
-			case '-', '_', '.', '~', '/': // §2.3 Unreserved characters (mark)
-				encodedPathname = encodedPathname + string(s)
-			default:
-				runeLen := utf8.RuneLen(s)
-				if runeLen < 0 {
-					return pathName
-				}
-				u := make([]byte, runeLen)
-				utf8.EncodeRune(u, s)
-				for _, r := range u {
-					hex := hex.EncodeToString([]byte{r})
-					encodedPathname = encodedPathname + "%" + strings.ToUpper(hex)
-				}
+			runeLen := utf8.RuneLen(s)
+			if runeLen < 0 {
+				return pathName
+			}
+			u := make([]byte, runeLen)
+			utf8.EncodeRune(u, s)
+			for _, r := range u {
+				buf.WriteByte('%')
+				buf.WriteByte(pathHexTable[r>>4])
+				buf.WriteByte(pathHexTable[r&0x0f])
 			}
 		}
 	}
-	return encodedPathname
+	return buf.String()
 }
 
 // getSignature final signature in hexadecimal form.

--- a/weed/s3api/auth_signature_v4.go
+++ b/weed/s3api/auth_signature_v4.go
@@ -1097,12 +1097,10 @@ func isPathUnreservedChar(s rune) bool {
 // This function on the other hand is a direct replacement for url.Encode() technique to support
 // pretty much every UTF-8 character.
 func encodePath(pathName string) string {
-	if reservedObjectNames.MatchString(pathName) {
-		return pathName
-	}
-
-	// Fast path: if nothing needs encoding, return the input unchanged
-	// (zero allocation). This is the common case for ASCII object keys.
+	// Fast path: if every character is unreserved, the encoded form equals the
+	// input, so return it unchanged with zero allocation. This is the common
+	// case for ASCII object keys and avoids the regexp engine on the SigV4 hot
+	// path, where encodePath runs on every authenticated request.
 	needEncode := false
 	for _, s := range pathName {
 		if !isPathUnreservedChar(s) {

--- a/weed/s3api/s3_encodepath_test.go
+++ b/weed/s3api/s3_encodepath_test.go
@@ -1,0 +1,120 @@
+package s3api
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// encodePathOld is the original implementation, kept only in tests as a
+// reference to prove the optimized encodePath produces identical output.
+func encodePathOld(pathName string) string {
+	if reservedObjectNames.MatchString(pathName) {
+		return pathName
+	}
+	var encodedPathname string
+	for _, s := range pathName {
+		if 'A' <= s && s <= 'Z' || 'a' <= s && s <= 'z' || '0' <= s && s <= '9' {
+			encodedPathname = encodedPathname + string(s)
+		} else {
+			switch s {
+			case '-', '_', '.', '~', '/':
+				encodedPathname = encodedPathname + string(s)
+			default:
+				runeLen := utf8.RuneLen(s)
+				if runeLen < 0 {
+					return pathName
+				}
+				u := make([]byte, runeLen)
+				utf8.EncodeRune(u, s)
+				for _, r := range u {
+					h := hex.EncodeToString([]byte{r})
+					encodedPathname = encodedPathname + "%" + strings.ToUpper(h)
+				}
+			}
+		}
+	}
+	return encodedPathname
+}
+
+// TestEncodePath checks encodePath against explicit expected outputs.
+func TestEncodePath(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"/bucket/file.txt", "/bucket/file.txt"},
+		{"/a-b_c.d~e/f", "/a-b_c.d~e/f"},
+		{"", ""},
+		{"/", "/"},
+		{"/中", "/%E4%B8%AD"},
+		{"/a b", "/a%20b"},
+		{"/a&b=c", "/a%26b%3Dc"},
+	}
+	for _, c := range cases {
+		if got := encodePath(c.in); got != c.want {
+			t.Errorf("encodePath(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestEncodePathEqual verifies the optimized encodePath produces byte-for-byte
+// identical output to the original implementation across many inputs.
+func TestEncodePathEqual(t *testing.T) {
+	cases := []string{
+		"/bucket/file.txt",
+		"/my-bucket/data/2026/07/file.parquet",
+		"/我的存储桶/数据仓库/文件.数据",
+		"/bucket/项目数据/report-分析.parquet",
+		"/path with spaces/and&symbols=test/文件.txt",
+		"/emoji/😀/file.txt", // 4-byte UTF-8 rune
+		"/",
+		"/a",
+		"",
+		"/纯中文路径没有斜杠结尾/文件名",
+		"/mixed混合/path路径/2026年/data.csv",
+	}
+	for _, p := range cases {
+		if got, want := encodePath(p), encodePathOld(p); got != want {
+			t.Errorf("mismatch for %q:\n  optimized=%q\n  original =%q", p, got, want)
+		}
+	}
+}
+
+// benchPaths covers different path types for benchmarking.
+var benchPaths = []string{
+	"/bucket/file.txt", // short ASCII
+	"/my-bucket/data/2026/07/07/service/module/submodule/very/long/path/to/object/file-name-1234567890.parquet", // long ASCII
+	"/我的存储桶/数据仓库/2026年07月/业务数据/用户行为分析/长长的中文文件路径/这是一个很长的中文对象名称文件.数据",                                             // long non-ASCII
+	"/bucket/项目数据/2026/报表/月度统计/user-behavior-分析报告-统计数据-长文件名称-1234567890.parquet",                                // mixed
+}
+
+func benchLabel(p string) string {
+	if p == "" {
+		return "<empty>"
+	}
+	if len(p) > 20 {
+		return p[:20] + "..."
+	}
+	return p
+}
+
+// BenchmarkEncodePath benchmarks the original vs optimized implementation.
+func BenchmarkEncodePath(b *testing.B) {
+	for _, p := range benchPaths {
+		label := benchLabel(p)
+		b.Run("Old/"+label, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = encodePathOld(p)
+			}
+		})
+		b.Run("New/"+label, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = encodePath(p)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What problem are we solving?

`encodePath` is called by `getCanonicalRequest` on every S3 request during
SigV4 signature verification. It builds its result via string concatenation
in a loop (`s = s + string(c)`), which is O(n²) in allocations. For each
non-ASCII (e.g. Chinese) byte it additionally calls `make` +
`hex.EncodeToString` + `strings.ToUpper`, resulting in ~10 allocations per
character.

Under high request rates with long, non-ASCII object keys, this makes
`encodePath` a major source of heap allocations, causing high GC pressure and
elevated S3 request latency.

`go tool pprof` on the filer's `alloc_space` profile shows `s3api.encodePath`
allocation source (~28% of all allocated bytes). 

```
(pprof) top
Showing nodes accounting for 17886.52GB, 67.49% of 26500.85GB total
Dropped 1589 nodes (cum <= 132.50GB)
Showing top 10 nodes out of 244
      flat  flat%   sum%        cum   cum%
 7429.85GB 28.04% 28.04%  7446.64GB 28.10%  github.com/seaweedfs/seaweedfs/weed/s3api.encodePath
 3656.21GB 13.80% 41.83%  3656.21GB 13.80%  bytes.growSlice
 1761.62GB  6.65% 48.48%  1761.62GB  6.65%  github.com/seaweedfs/seaweedfs/weed/util/mem.init.0.func1
 1412.20GB  5.33% 53.81%  1412.20GB  5.33%  github.com/valyala/bytebufferpool.(*ByteBuffer).Write
```


`encodePath` is called by `getCanonicalRequest` during SigV4 signature
verification, i.e. on every authenticated S3 request.

## How are we solving the problem?

Rewrite `encodePath` to avoid the O(n²) concatenation and per-byte
allocations:

* use a preallocated `strings.Builder` (`Grow(len*3)`)
* encode hex manually via a lookup table (avoids `hex.EncodeToString` +
  `strings.ToUpper`)

The output is byte-for-byte identical to the original implementation,
verified by `TestEncodePath` and `TestEncodePathEqual` (covering ASCII,
Chinese, mixed, special characters, emoji, empty and edge cases).

## Single-call benchmark

| path | allocs/op | B/op | ns/op |
|------|-----------|------|-------|
| long Chinese (old) | 261 | 35810 | 8893 |
| long Chinese (new) | 1 | 480 | 1154 |
| pure ASCII | 0 | 0 | (no regression) |

## Load test (50M calls, identical count, 10 CPU)

| Metric | Old | New | Improvement |
|--------|-----|-----|-------------|
| GC count | 128,364 | 1,676 | 76.6x |
| GC pause total | 13,070 ms | 431 ms | 30.3x |
| Total alloc | 1,227 GB | 20 GB | 60.5x |
| Allocations per call | 212 | 1 | 212x |
| Throughput | 191K ops/s | 4.09M ops/s | 21.4x |

## How is the PR tested?
```
go test -run "BenchmarkEncodePath" -v ./weed/s3api/
go test -bench=BenchmarkEncodePath -benchmem -run=^$ ./weed/s3api/
```
All existing s3api signature tests pass. Correctness is guaranteed by
`TestEncodePathEqual`, which asserts the new implementation produces output
identical to the original for a wide range of inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SigV4-compatible path encoding by updating percent-encoding rules for RFC 3986 “unreserved” characters, improving handling of special characters and non-ASCII paths.
* **Tests**
  * Added new unit tests validating path-encoding output for explicit and wide-ranging UTF-8 inputs.
  * Added benchmarks to compare correctness and measure performance/allocation behavior over representative paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->