### PR TITLE
refract: reduce mem alloc while building str

### DIFF
--- a/weed/s3api/auth_signature_v4.go
+++ b/weed/s3api/auth_signature_v4.go
@@ -1123,9 +1123,9 @@ func encodePath(pathName string) string {
 			if runeLen < 0 {
 				return pathName
 			}
-			u := make([]byte, runeLen)
-			utf8.EncodeRune(u, s)
-			for _, r := range u {
+			var u [utf8.UTFMax]byte
+			utf8.EncodeRune(u[:], s)
+			for _, r := range u[:runeLen] {
 				buf.WriteByte('%')
 				buf.WriteByte(pathHexTable[r>>4])
 				buf.WriteByte(pathHexTable[r&0x0f])


### PR DESCRIPTION
# What problem are we solving?
reduce mem alloc while building str


# How are we solving the problem?
use var in stack instead of call make function

# How is the PR tested?
go test ./


# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved path encoding handling for signature generation by using a more efficient byte buffer approach.
  * No changes to request signing behavior or canonicalization results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->