### PR TITLE
java client: fail cleanly when a chunk read returns short or empty data

### DIFF
--- a/other/java/client/src/main/java/seaweedfs/client/SeaweedRead.java
+++ b/other/java/client/src/main/java/seaweedfs/client/SeaweedRead.java
@@ -118,9 +118,9 @@ public class SeaweedRead {
         // The fetched chunk can be shorter than the view claims when a read briefly
         // returns an empty body (seen right after an append). Fail clearly instead of
         // letting ByteBuffer.put throw an opaque IndexOutOfBoundsException.
-        if (srcOffset < 0 || len < 0 || srcOffset + len > chunkData.length) {
+        if (srcOffset < 0 || len < 0 || srcOffset > chunkData.length - len) {
             throw new IOException("chunk " + chunkView.fileId + " returned " + chunkData.length
-                    + " bytes, need [" + srcOffset + "," + (srcOffset + len) + ")");
+                    + " bytes, need [" + srcOffset + "," + ((long) srcOffset + len) + ")");
         }
         buf.put(chunkData, srcOffset, len);
 
@@ -137,11 +137,11 @@ public class SeaweedRead {
                 String url = filerClient.getChunkUrl(chunkView.fileId, location.getUrl(), location.getPublicUrl());
                 try {
                     byte[] fetched = doFetchOneFullChunkData(chunkView, url);
-                    // An empty body for a chunk we are reading from is never valid;
-                    // treat it as a transient failure so the retry loop tries another
-                    // location and backs off, rather than caching an empty chunk.
-                    if (fetched.length == 0) {
-                        lastException = new IOException("empty response for chunk " + chunkView.fileId + " from " + url);
+                    // An empty (or null) body for a chunk we are reading from is never
+                    // valid; treat it as a transient failure so the retry loop tries
+                    // another location and backs off, rather than caching an empty chunk.
+                    if (fetched == null || fetched.length == 0) {
+                        lastException = new IOException("empty or null response for chunk " + chunkView.fileId + " from " + url);
                         continue;
                     }
                     data = fetched;

--- a/other/java/client/src/main/java/seaweedfs/client/SeaweedRead.java
+++ b/other/java/client/src/main/java/seaweedfs/client/SeaweedRead.java
@@ -111,10 +111,18 @@ public class SeaweedRead {
         }
 
         int len = (int) chunkView.size - (int) (startOffset - chunkView.logicOffset);
+        int srcOffset = (int) (startOffset - chunkView.logicOffset + chunkView.offset);
         LOG.debug("readChunkView fid:{} chunkData.length:{} chunkView.offset:{} chunkView[{};{}) startOffset:{}",
                 chunkView.fileId, chunkData.length, chunkView.offset, chunkView.logicOffset,
                 chunkView.logicOffset + chunkView.size, startOffset);
-        buf.put(chunkData, (int) (startOffset - chunkView.logicOffset + chunkView.offset), len);
+        // The fetched chunk can be shorter than the view claims when a read briefly
+        // returns an empty body (seen right after an append). Fail clearly instead of
+        // letting ByteBuffer.put throw an opaque IndexOutOfBoundsException.
+        if (srcOffset < 0 || len < 0 || srcOffset + len > chunkData.length) {
+            throw new IOException("chunk " + chunkView.fileId + " returned " + chunkData.length
+                    + " bytes, need [" + srcOffset + "," + (srcOffset + len) + ")");
+        }
+        buf.put(chunkData, srcOffset, len);
 
         return len;
     }
@@ -128,7 +136,15 @@ public class SeaweedRead {
             for (FilerProto.Location location : locations.getLocationsList()) {
                 String url = filerClient.getChunkUrl(chunkView.fileId, location.getUrl(), location.getPublicUrl());
                 try {
-                    data = doFetchOneFullChunkData(chunkView, url);
+                    byte[] fetched = doFetchOneFullChunkData(chunkView, url);
+                    // An empty body for a chunk we are reading from is never valid;
+                    // treat it as a transient failure so the retry loop tries another
+                    // location and backs off, rather than caching an empty chunk.
+                    if (fetched.length == 0) {
+                        lastException = new IOException("empty response for chunk " + chunkView.fileId + " from " + url);
+                        continue;
+                    }
+                    data = fetched;
                     lastException = null;
                     break;
                 } catch (IOException ioe) {

--- a/other/java/client/src/test/java/seaweedfs/client/SeaweedReadTest.java
+++ b/other/java/client/src/test/java/seaweedfs/client/SeaweedReadTest.java
@@ -4,11 +4,36 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
 public class SeaweedReadTest {
+
+    // A chunk fetch that briefly returns an empty body (observed right after an
+    // append) must not overrun the buffer with an opaque IndexOutOfBoundsException.
+    @Test
+    public void testReadChunkShorterThanViewFailsCleanly() throws IOException {
+        String fileId = "7,readchunkshort01";
+        SeaweedRead.volumeIdCache.setLocations("7",
+                FilerProto.Locations.newBuilder()
+                        .addLocations(FilerProto.Location.newBuilder().setUrl("localhost:0").build())
+                        .build());
+        // seed the chunk cache with an empty body so the fetch is skipped
+        SeaweedRead.chunkCache.setChunk(fileId, new byte[0]);
+
+        List<SeaweedRead.VisibleInterval> visibles = new ArrayList<>();
+        visibles.add(new SeaweedRead.VisibleInterval(0, 175, fileId, 1L, 0, true, null, false));
+
+        ByteBuffer buf = ByteBuffer.allocate(175);
+        try {
+            SeaweedRead.read(null, visibles, 0, buf, 175);
+            Assert.fail("expected IOException for a chunk shorter than its view");
+        } catch (IOException e) {
+            Assert.assertTrue(e.getMessage(), e.getMessage().contains(fileId));
+        }
+    }
 
     @Test
     public void testNonOverlappingVisibleIntervals() throws IOException {

--- a/other/java/client/src/test/java/seaweedfs/client/SeaweedReadTest.java
+++ b/other/java/client/src/test/java/seaweedfs/client/SeaweedReadTest.java
@@ -32,6 +32,7 @@ public class SeaweedReadTest {
             Assert.fail("expected IOException for a chunk shorter than its view");
         } catch (IOException e) {
             Assert.assertTrue(e.getMessage(), e.getMessage().contains(fileId));
+            Assert.assertTrue(e.getMessage(), e.getMessage().contains("[0,175)"));
         }
     }
 


### PR DESCRIPTION
Fixes #10268.

`SeaweedRead.readChunkView` copied `chunkView.size` bytes out of the fetched chunk using offsets derived from the chunk metadata, without checking the fetched length. When a full-chunk fetch briefly returned an empty body (observed right after an `appendToFile`, under load), `ByteBuffer.put` overran the source array and threw an opaque `IndexOutOfBoundsException` on `hadoop fs -tail`/`-text` (while `-cat` on the same file worked).

Two changes:
- `doFetchFullChunkData` now treats a zero-length response as a transient failure and retries another location / backs off, instead of caching an empty chunk. A chunk referenced by a read is never legitimately empty.
- `readChunkView` bounds-checks the copy against the actual fetched length and throws a clear `IOException` (with fileId and expected range) rather than overrunning the buffer.

Regression test `SeaweedReadTest#testReadChunkShorterThanViewFailsCleanly` reproduces the exact crash (`Range [0, 0 + 175) out of bounds for length 0`) via the chunk cache and asserts a clean failure after the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client read validation for chunk-to-view copying, returning a clear, descriptive error when the chunk is shorter than requested.
  * Updated retry behavior to treat null/empty fetched chunk data as a transient failure, so the client can try other locations instead of using invalid results.
* **Tests**
  * Added a new test to ensure reads fail cleanly with a helpful error message when fetched chunk data is shorter than the requested view interval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->