### PR TITLE
s3: keep empty-folder cleanup out of the multipart .uploads staging tree

### DIFF
--- a/weed/filer/empty_folder_cleanup/empty_folder_cleaner.go
+++ b/weed/filer/empty_folder_cleanup/empty_folder_cleaner.go
@@ -128,6 +128,11 @@ func (efc *EmptyFolderCleaner) OnDeleteEvent(directory string, entryName string,
 		return
 	}
 
+	// Never queue the S3 multipart staging area; the upload lifecycle owns it.
+	if isMultipartUploadsPath(efc.bucketPath, directory) {
+		return
+	}
+
 	// Check if we own this folder
 	if !efc.ownsFolder(directory) {
 		glog.V(4).Infof("EmptyFolderCleaner: not owner of %s, skipping", directory)
@@ -239,6 +244,15 @@ func (efc *EmptyFolderCleaner) processCleanupQueue() {
 
 // executeCleanup performs the actual cleanup of an empty folder
 func (efc *EmptyFolderCleaner) executeCleanup(folder string, triggeredBy string) {
+	// The bucket-shared .uploads staging tree holds in-progress multipart uploads.
+	// Deleting <bucket>/.uploads (reached here directly or via the parent cascade
+	// below) races a concurrent CreateMultipartUpload: the new upload's marker row
+	// is inserted between the emptiness check and the folder delete, then wiped,
+	// so the upload silently vanishes. Leave this tree to the upload lifecycle.
+	if isMultipartUploadsPath(efc.bucketPath, folder) {
+		return
+	}
+
 	efc.mu.Lock()
 
 	// Quick check: if we have cached count and it's > 0, skip
@@ -420,6 +434,20 @@ func isUnderPath(child, parent string) bool {
 		return true
 	}
 	return child[len(parent)] == '/'
+}
+
+// isMultipartUploadsPath reports whether directory is the S3 multipart staging
+// root <bucket>/.uploads or anything beneath it.
+func isMultipartUploadsPath(bucketPath, directory string) bool {
+	if bucketPath == "" {
+		return false
+	}
+	dir, ok := util.ExtractBucketPath(bucketPath, directory, true)
+	if !ok {
+		return false
+	}
+	first, _, _ := strings.Cut(strings.TrimPrefix(directory, dir+"/"), "/")
+	return first == s3_constants.MultipartUploadsFolder
 }
 
 // isUnderBucketPath checks if directory is inside a bucket (under /buckets/<bucket>/...)

--- a/weed/filer/empty_folder_cleanup/empty_folder_cleaner.go
+++ b/weed/filer/empty_folder_cleanup/empty_folder_cleaner.go
@@ -446,7 +446,8 @@ func isMultipartUploadsPath(bucketPath, directory string) bool {
 	if !ok {
 		return false
 	}
-	first, _, _ := strings.Cut(strings.TrimPrefix(directory, dir+"/"), "/")
+	// requireChild guarantees directory starts with dir + "/", so slice past it.
+	first, _, _ := strings.Cut(directory[len(dir)+1:], "/")
 	return first == s3_constants.MultipartUploadsFolder
 }
 

--- a/weed/filer/empty_folder_cleanup/empty_folder_cleaner_test.go
+++ b/weed/filer/empty_folder_cleanup/empty_folder_cleaner_test.go
@@ -104,6 +104,102 @@ func Test_isUnderBucketPath(t *testing.T) {
 	}
 }
 
+func Test_isMultipartUploadsPath(t *testing.T) {
+	uploads := s3_constants.MultipartUploadsFolder
+	tests := []struct {
+		name       string
+		directory  string
+		bucketPath string
+		expected   bool
+	}{
+		{"staging root", "/buckets/mybucket/" + uploads, "/buckets", true},
+		{"upload marker dir", "/buckets/mybucket/" + uploads + "/abc123", "/buckets", true},
+		{"nested under staging", "/buckets/mybucket/" + uploads + "/abc123/hashstates", "/buckets", true},
+		{"normal folder", "/buckets/mybucket/folder", "/buckets", false},
+		{"registry own uploads dir", "/buckets/mybucket/docker/registry/v2/_uploads/x", "/buckets", false},
+		{"bucket itself", "/buckets/mybucket", "/buckets", false},
+		{"outside buckets", "/other/" + uploads, "/buckets", false},
+		{"empty bucket path", "/buckets/mybucket/" + uploads, "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isMultipartUploadsPath(tt.bucketPath, tt.directory); got != tt.expected {
+				t.Errorf("isMultipartUploadsPath(%q, %q) = %v, want %v", tt.bucketPath, tt.directory, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestEmptyFolderCleaner_OnDeleteEvent_skipsMultipartUploads(t *testing.T) {
+	lockRing := lock_manager.NewLockRing(5 * time.Second)
+	lockRing.SetSnapshot([]pb.ServerAddress{"filer1:8888"}, 0)
+
+	cleaner := &EmptyFolderCleaner{
+		lockRing:     lockRing,
+		host:         "filer1:8888",
+		bucketPath:   "/buckets",
+		enabled:      true,
+		folderCounts: make(map[string]*folderState),
+		cleanupQueue: NewCleanupQueue(1000, 10*time.Minute),
+		stopCh:       make(chan struct{}),
+	}
+
+	now := time.Now()
+	uploads := "/buckets/mybucket/" + s3_constants.MultipartUploadsFolder
+	cleaner.OnDeleteEvent(uploads, "abc123", true, now)
+	cleaner.OnDeleteEvent(uploads+"/abc123", "0001.part", false, now)
+	if cleaner.GetPendingCleanupCount() != 0 {
+		t.Fatalf("multipart staging paths must not be queued, got %d pending", cleaner.GetPendingCleanupCount())
+	}
+
+	// A normal folder is still queued, proving the guard is scoped to .uploads.
+	cleaner.OnDeleteEvent("/buckets/mybucket/folder", "file.txt", false, now)
+	if cleaner.GetPendingCleanupCount() != 1 {
+		t.Fatalf("normal folder should be queued, got %d pending", cleaner.GetPendingCleanupCount())
+	}
+
+	cleaner.Stop()
+}
+
+func TestEmptyFolderCleaner_executeCleanup_skipsMultipartUploads(t *testing.T) {
+	lockRing := lock_manager.NewLockRing(5 * time.Second)
+	lockRing.SetSnapshot([]pb.ServerAddress{"filer1:8888"}, 0)
+
+	var deleted []string
+	mock := &mockFilerOps{
+		countFn:  func(util.FullPath) (int, error) { return 0, nil },
+		deleteFn: func(p util.FullPath) error { deleted = append(deleted, string(p)); return nil },
+	}
+
+	cleaner := &EmptyFolderCleaner{
+		filer:                 mock,
+		lockRing:              lockRing,
+		host:                  "filer1:8888",
+		bucketPath:            "/buckets",
+		enabled:               true,
+		maxCountCheck:         DefaultMaxCountCheck,
+		cacheExpiry:           DefaultCacheExpiry,
+		folderCounts:          make(map[string]*folderState),
+		bucketCleanupPolicies: make(map[string]*bucketCleanupPolicyState),
+		cleanupQueue:          NewCleanupQueue(1000, 10*time.Minute),
+		stopCh:                make(chan struct{}),
+	}
+
+	uploads := "/buckets/mybucket/" + s3_constants.MultipartUploadsFolder
+	cleaner.executeCleanup(uploads, "abc123")
+	cleaner.executeCleanup(uploads+"/abc123", "0001.part")
+	if len(deleted) != 0 {
+		t.Fatalf("multipart staging paths must not be deleted, got %v", deleted)
+	}
+
+	// An empty normal folder is deleted, proving the guard did not disable cleanup.
+	cleaner.executeCleanup("/buckets/mybucket/folder", "file.txt")
+	if len(deleted) != 1 || deleted[0] != "/buckets/mybucket/folder" {
+		t.Fatalf("normal empty folder should be deleted, got %v", deleted)
+	}
+}
+
 func Test_autoRemoveEmptyFoldersEnabled(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
Fixes #10270.

## Problem

Docker Registry v3 pushes to the S3 gateway fail intermittently with `Path not found: .../data` (PATCH), `NoSuchUpload` (flush), and `InvalidArgument: Copy Source must mention the source bucket and key` (commit). This is not a leftover of #10207 — that change only reclassified *transient* store errors. Here the upload metadata is genuinely deleted, so retries can't help.

The registry records each in-progress blob upload as a marker directory `/buckets/<bucket>/.uploads/<uploadId>`. The async `EmptyFolderCleaner` deletes the bucket-shared `.uploads` directory once it looks empty (reached directly, or via the eager parent cascade after an `<uploadId>` dir is removed). That delete is `DeleteEntryMetaAndData(.uploads, isRecursive=false)`: it lists children (sees empty), then runs the bulk `DeleteFolderChildren(.uploads)` (`DELETE ... WHERE directory='.../.uploads'`).

A concurrent `CreateMultipartUpload` inserts `{directory:'.../.uploads', name:<uploadId>}`. If that insert commits **between** the emptiness check and the bulk delete, the new upload's marker row is wiped — no error to the client or the cleaner. The upload then no longer exists: `ListMultipartUploads` omits it (registry resume → PathNotFound), and `UploadPart`/`CompleteMultipartUpload`/`CopyObject` fail. `CreateEntry` holds no directory lock, so the interleave is reachable for any filer store; it bites under sustained concurrent upload traffic, hence "intermittent".

## Fix

Skip the `.uploads` staging subtree in the cleaner — both when queuing (`OnDeleteEvent`) and in the delete path (`executeCleanup`, which also covers the parent cascade). The multipart upload lifecycle (create/complete/abort) owns that tree; a persistent empty `.uploads` per bucket is harmless. Normal empty-folder cleanup is unchanged.

## Verification

Reproduced with `registry:3.0.0` + `skopeo` → `seaweedfs:4.38` on a MariaDB filer store.

- Before: a create→marker-check→abort churn caught **160 clobbered uploads in ~70s** (uploads the gateway acknowledged whose `.uploads/<id>` marker was already deleted), and reproduced the exact registry errors including the verbatim `InvalidArgument: Copy Source must mention the source bucket and key: sourcebucket/sourcekey.`
- After (this branch): **119,898 creates, 0 clobbered**; the cleaner never deletes `.uploads`. A normal empty folder is still reclaimed.

`go test ./weed/filer/empty_folder_cleanup/` passes (new tests cover the predicate, the queue skip, and the delete-path skip).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty-folder cleanup now skips multipart upload staging paths, helping prevent accidental removal of in-progress upload data.
  * Delete events for these staging locations no longer trigger cleanup processing.
  * Cleanup operations also avoid deleting multipart upload directories during cascades.

* **Tests**
  * Added coverage for multipart upload path detection and cleanup behavior to verify staging paths are preserved while normal empty folders are still handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->