### PR TITLE
s3.bucket.list: measure quota usage by logical size

### DIFF
--- a/weed/shell/command_s3_bucket_list.go
+++ b/weed/shell/command_s3_bucket_list.go
@@ -64,14 +64,15 @@ func (c *commandS3BucketList) Do(args []string, commandEnv *CommandEnv, writer i
 			return nil
 		}
 		collection := getCollectionName(commandEnv, entry.Name)
-		var collectionSize, fileCount float64
+		var collectionSize, logicalSize, fileCount float64
 		if collectionInfo, found := collectionInfos[collection]; found {
 			collectionSize = collectionInfo.Size
+			logicalSize = collectionInfo.LogicalSize()
 			fileCount = collectionInfo.FileCount - collectionInfo.DeleteCount
 		}
-		fmt.Fprintf(writer, "  %s\tsize:%.0f\tchunk:%.0f", entry.Name, collectionSize, fileCount)
+		fmt.Fprintf(writer, "  %s\tsize:%.0f\tlogical:%.0f\tchunk:%.0f", entry.Name, collectionSize, logicalSize, fileCount)
 		if entry.Quota > 0 {
-			fmt.Fprintf(writer, "\tquota:%d\tusage:%.2f%%", entry.Quota, float64(collectionSize)*100/float64(entry.Quota))
+			fmt.Fprintf(writer, "\tquota:%d\tusage:%.2f%%", entry.Quota, logicalSize*100/float64(entry.Quota))
 		}
 		// Show bucket owner (use %q to escape special characters)
 		if entry.Extended != nil {


### PR DESCRIPTION
## What

`s3.bucket.list` computed its `usage:` percentage from the raw collection size, which still includes deleted-but-not-yet-vacuumed bytes. Quota enforcement (`s3.bucket.quota.enforce`) and the admin UI both measure quota against the logical (live) size, so a healthy bucket whose garbage sits below the vacuum threshold can list as over 100% while enforcement and the admin UI correctly report it under quota.

This changes `s3.bucket.list` to compute `usage:` from `CollectionInfo.LogicalSize()` — the same measure quota enforcement uses — and prints the logical size next to the raw size so both views stay visible.

## Verification

Uploaded 10 x 4MiB files to a bucket with a 40MiB quota, then deleted 2 (garbage stays below the vacuum threshold):

```
testbkt	size:41943720	logical:33555072	chunk:8	quota:41943040	usage:80.00%
```

Previously this data would print `usage:100.00%` (41943720/41943040) despite only 32MiB being live.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bucket listings now include an additional **logical** size column.
  * Quota usage percentages now reflect logical size when available.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->