### PR TITLE
log_buffer: cap the shared-snapshot race test's heap

### DIFF
--- a/weed/util/log_buffer/shared_snapshot_test.go
+++ b/weed/util/log_buffer/shared_snapshot_test.go
@@ -2,6 +2,7 @@ package log_buffer
 
 import (
 	"fmt"
+	"runtime/debug"
 	"sync"
 	"testing"
 	"time"
@@ -85,6 +86,12 @@ func TestSharedSnapshotSurvivesRecycle(t *testing.T) {
 // and recycling windows. Every delivered entry must unmarshal cleanly with the
 // expected payload — corruption here means a reader saw recycled bytes.
 func TestSharedSnapshotConcurrentIntegrity(t *testing.T) {
+	// The writer below is deliberately unthrottled, so transient marshal garbage
+	// scales with host speed; on linux/386 a fast runner can hit the 4GB
+	// address-space ceiling. Cap the heap so the GC paces the writer instead.
+	prevLimit := debug.SetMemoryLimit(1 << 30)
+	defer debug.SetMemoryLimit(prevLimit)
+
 	lb := NewLogBuffer("test", time.Hour, func(*LogBuffer, time.Time, time.Time, []byte, int64, int64) {}, nil, nil)
 	defer lb.ShutdownLogBuffer()
 


### PR DESCRIPTION
TestSharedSnapshotConcurrentIntegrity runs an unthrottled writer for the two seconds its lagging readers verify entries, so its transient marshal garbage scales with how fast the host is. The GC pacer allows roughly twice the live set before collecting, and on a fast runner that balloons the heap by gigabytes between cycles. On amd64 nobody notices; on the linux/386 test job the process walks into the 4GB address-space ceiling and dies with runtime out of memory - the failure is intermittent because a slower or contended runner produces less in two seconds and squeaks under.

Cap the heap at 1GB for the duration of the test so the GC paces the writer instead of the address space. The seal-and-recycle race under test keeps running at full intensity for the whole window.

Verified with GOGC=off (worst-case pacing): the uncapped binary peaks at 1.6GB RSS on an M-series laptop, the capped one holds at 1.0GB. The capped test also passes as a real linux/386 binary under Docker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved the stability of a concurrent integrity test by temporarily limiting memory usage during execution.
  * Restored the previous memory limit after the test completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->