### PR TITLE
fix(shell): print markVolumeWritable/markVolumeReadonly based on the writable flag

### DIFF
--- a/weed/shell/command_volume_move.go
+++ b/weed/shell/command_volume_move.go
@@ -233,7 +233,11 @@ func markVolumeWritable(grpcDialOption grpc.DialOption, volumeId needle.VolumeId
 }
 
 func markVolumeReplicaWritable(grpcDialOption grpc.DialOption, volumeId needle.VolumeId, location wdclient.Location, writable, persist bool) error {
-	fmt.Printf("markVolumeReadonly %d on %s ...\n", volumeId, location.Url)
+	if writable {
+		fmt.Printf("markVolumeWritable %d on %s ...\n", volumeId, location.Url)
+	} else {
+		fmt.Printf("markVolumeReadonly %d on %s persist=%v ...\n", volumeId, location.Url, persist)
+	}
 	return markVolumeWritable(grpcDialOption, volumeId, location.ServerAddress(), writable, persist)
 }
 


### PR DESCRIPTION
## Problem

`markVolumeReplicaWritable` always prints `markVolumeReadonly`, no matter
what the `writable` flag is. When `volume.tier.move` restores the replicas
to writable after moving a volume, the log says the opposite of what
happened. `writable = true`
```go
if err = markVolumeReplicasWritable(commandEnv.option.GrpcDialOption, vid, locations, true, false); err != nil {
			glog.Errorf("mark volume %d as writable on %s: %v", vid, locations[0].Url, err)
}
```

## Fix

Print the action that is actually taken:

- `writable=true` → `markVolumeWritable ...`
- `writable=false` → `markVolumeReadonly ... persist=<v>`

`persist` is only shown on the readonly side, because only
`MarkVolumeReadonly` treats it as an option — `MarkVolumeWritable` always
persists.

## Testing

Log-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell progress messages when changing replica write status.
  * Read-only status updates now include the persisted-state value, making command output clearer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->