### PR TITLE
fix(weed/worker/tasks/balance): dropped test error

### DIFF
--- a/weed/worker/tasks/balance/plugin_handler_test.go
+++ b/weed/worker/tasks/balance/plugin_handler_test.go
@@ -503,6 +503,9 @@ func TestExecuteDispatchesBatchPath(t *testing.T) {
 	err = handler.Execute(context.Background(), &plugin_pb.ExecuteJobRequest{
 		Job: job,
 	}, sender)
+	if err != nil {
+		t.Fatalf("handler.Execute: %v", err)
+	}
 
 	// Expect an error since no real volume servers exist
 	// But verify the batch path was taken by checking the assigned message


### PR DESCRIPTION
This fixes a dropped test `err` in `weed/worker/tasks/balance`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved an existing test to fail immediately if a batch execution returns an error, making regressions easier to catch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->