### PR TITLE
fix: merge filer service annotations to avoid duplicate keys in Helm

### DIFF
--- a/k8s/charts/seaweedfs/templates/filer/filer-service.yaml
+++ b/k8s/charts/seaweedfs/templates/filer/filer-service.yaml
@@ -2,8 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   name: {{ include "seaweedfs.componentName" (list . "filer") }}
   namespace: {{ .Release.Namespace }}
   labels:
@@ -12,8 +10,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: filer
-{{- if .Values.filer.annotations }}
   annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+{{- if .Values.filer.annotations }}
     {{- toYaml .Values.filer.annotations | nindent 4 }}
 {{- end }}
 spec:


### PR DESCRIPTION
## Problem
The filer-service.yaml Helm template had two separate `annotations:` blocks in the metadata section:
1. A hardcoded annotation on line 5
2. A conditional block (lines 15-18) for user-provided annotations from values

When users supplied additional annotations via the values file, Helm would fail with a duplicate key error during post-render processing.

## Solution
Reorganize the metadata section to use a single `annotations:` block that:
- Contains the hardcoded `service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"` annotation
- Conditionally appends user-provided annotations from `.Values.filer.annotations`

This approach mirrors the pattern already used in master-service.yaml and prevents YAML key duplication.

## Testing
The fix resolves the Helm post-render error when supplying custom annotations via:
```yaml
filer:
  annotations:
    key1: value1
    key2: value2
```

Verified the template now matches the working pattern from master-service.yaml.

## Checklist
- [x] Addresses issue #10292
- [x] Follows existing pattern in master-service.yaml
- [x] No breaking changes to existing deployments
- [x] Verified against other service templates for consistency

Fixes #10292