### PR TITLE
fix(shell): wait for EC mount heartbeats before encode rebalance

### DIFF
--- a/weed/shell/command_ec_encode.go
+++ b/weed/shell/command_ec_encode.go
@@ -307,11 +307,7 @@ func processEcEncodeBatch(commandEnv *CommandEnv, writer io.Writer, volumeIds []
 	// while other nodes of this disk type exist. Keeps the .dat so the operator
 	// can recover; without this gate a silent no-op rebalance is catastrophic.
 	if applyBalancing {
-		postTopo, _, err := collectTopologyInfo(commandEnv, 0)
-		if err != nil {
-			return fmt.Errorf("fetch topology after rebalance: %w", err)
-		}
-		if err := assertEcShardsNotSingleNode(postTopo, volumeIds, diskType); err != nil {
+		if err := waitEcShardsNotSingleNode(commandEnv, volumeIds, diskType); err != nil {
 			return err
 		}
 	}
@@ -720,30 +716,30 @@ func classifyNodeLiveness(pingErr error) nodeLiveness {
 	return nodeLivenessUnknown
 }
 
-// maxEcShardsPerNode returns the highest number of EC shards of vid observed on
-// any single data node for diskType. Used to detect a fully clumped placement
-// (all TotalShardsCount on one node) after encode rebalance.
-func maxEcShardsPerNode(topo *master_pb.TopologyInfo, vid needle.VolumeId, diskType types.DiskType) int {
-	max := 0
+// ecShardSpread returns, for vid on diskType, how many distinct shards are
+// visible anywhere in topo and the largest distinct-shard count on any single
+// data node. Bits are unioned per node: a multi-disk node reports one
+// EcShardInfos entry per physical disk, and a shard moving between its disks
+// may momentarily appear in two entries.
+func ecShardSpread(topo *master_pb.TopologyInfo, vid needle.VolumeId, diskType types.DiskType) (visibleShards, maxShardsOnOneNode int) {
+	var union erasure_coding.ShardBits
 	eachDataNode(topo, func(_ DataCenterId, _ RackId, dn *master_pb.DataNodeInfo) {
-		if dn.DiskInfos == nil {
-			return
-		}
 		diskInfo := dn.DiskInfos[string(diskType)]
 		if diskInfo == nil {
 			return
 		}
-		n := 0
+		var nodeBits erasure_coding.ShardBits
 		for _, eci := range diskInfo.EcShardInfos {
 			if needle.VolumeId(eci.Id) == vid {
-				n += erasure_coding.GetShardCount(eci)
+				nodeBits = erasure_coding.ShardBits(uint32(nodeBits) | eci.EcIndexBits)
 			}
 		}
-		if n > max {
-			max = n
+		union = erasure_coding.ShardBits(uint32(union) | uint32(nodeBits))
+		if n := nodeBits.Count(); n > maxShardsOnOneNode {
+			maxShardsOnOneNode = n
 		}
 	})
-	return max
+	return union.Count(), maxShardsOnOneNode
 }
 
 // countNodesWithDiskType counts data nodes that advertise diskType. Used to
@@ -752,9 +748,6 @@ func maxEcShardsPerNode(topo *master_pb.TopologyInfo, vid needle.VolumeId, diskT
 func countNodesWithDiskType(topo *master_pb.TopologyInfo, diskType types.DiskType) int {
 	n := 0
 	eachDataNode(topo, func(_ DataCenterId, _ RackId, dn *master_pb.DataNodeInfo) {
-		if dn.DiskInfos == nil {
-			return
-		}
 		if dn.DiskInfos[string(diskType)] != nil {
 			n++
 		}
@@ -762,23 +755,48 @@ func countNodesWithDiskType(topo *master_pb.TopologyInfo, diskType types.DiskTyp
 	return n
 }
 
-// assertEcShardsNotSingleNode fails if any volume still has all EC shards on
-// one node while multiple nodes of diskType exist. That placement is EC with
-// zero node-loss protection; refusing to delete the source .dat is the only
-// safe response. Single-node clusters are skipped (nothing to spread to).
+// assertEcShardsNotSingleNode fails if, for any volume, every shard visible in
+// topo sits on one data node while multiple nodes of diskType exist. That
+// placement is EC with zero node-loss protection; refusing to delete the
+// source .dat is the only safe response. Judged against the visible shard set
+// rather than TotalShardsCount so a degraded-but-recoverable view (10-13
+// shards, all on the generation host) cannot slip past the gate. Single-node
+// clusters are skipped (nothing to spread to).
 func assertEcShardsNotSingleNode(topo *master_pb.TopologyInfo, volumeIds []needle.VolumeId, diskType types.DiskType) error {
 	if countNodesWithDiskType(topo, diskType) < 2 {
 		return nil
 	}
-	total := erasure_coding.TotalShardsCount
 	for _, vid := range volumeIds {
-		max := maxEcShardsPerNode(topo, vid, diskType)
-		if max >= total {
-			return fmt.Errorf("volume %d: after rebalance all %d EC shards still sit on one node; refusing to delete the source .dat (zero node-loss protection). Re-run with an explicit 'ec.balance -collection <c> -diskType %s -apply' once topology is settled, or investigate why internal EcBalance produced no moves",
-				vid, total, diskType.ReadableString())
+		visible, maxOnOneNode := ecShardSpread(topo, vid, diskType)
+		if visible > 0 && maxOnOneNode >= visible {
+			return fmt.Errorf("volume %d: after rebalance all %d visible EC shards still sit on one node; refusing to delete the source .dat (zero node-loss protection). Re-run with an explicit 'ec.balance -collection <c> -diskType %s -apply' once topology is settled, or investigate why internal EcBalance produced no moves",
+				vid, visible, diskType.ReadableString())
 		}
 	}
 	return nil
+}
+
+// waitEcShardsNotSingleNode polls assertEcShardsNotSingleNode. Right after a
+// real rebalance the master can still hold the source node's stale entry (its
+// unmount delta heartbeat has not landed), which looks exactly like a clump;
+// only a placement that stays clumped across the retries is refused.
+func waitEcShardsNotSingleNode(commandEnv *CommandEnv, volumeIds []needle.VolumeId, diskType types.DiskType) error {
+	var lastErr error
+	for attempt := 0; attempt < ecTopologyPollAttempts; attempt++ {
+		topo, _, err := collectTopologyInfo(commandEnv, 0)
+		if err != nil {
+			return fmt.Errorf("fetch topology after rebalance: %w", err)
+		}
+		if lastErr = assertEcShardsNotSingleNode(topo, volumeIds, diskType); lastErr == nil {
+			return nil
+		}
+		if attempt < ecTopologyPollAttempts-1 {
+			glog.V(0).Infof("EC shard spread check failed (attempt %d/%d), waiting for shard moves to reach the master: %v",
+				attempt+1, ecTopologyPollAttempts, lastErr)
+			time.Sleep(ecTopologyPollInterval)
+		}
+	}
+	return lastErr
 }
 
 // EC shard placements reach the master via volume-server delta heartbeats, so

--- a/weed/shell/command_ec_encode.go
+++ b/weed/shell/command_ec_encode.go
@@ -276,17 +276,17 @@ func processEcEncodeBatch(commandEnv *CommandEnv, writer io.Writer, volumeIds []
 		return fmt.Errorf("ec encode for volumes %v: %w", volumeIds, err)
 	}
 
-	// EcBalance plans from the master's VolumeList. Mount reports new EC shards
-	// to the master asynchronously (volume server NewEcShardsChan → delta
-	// heartbeat → IncrementalSyncDataNodeEcShards). Without waiting, Plan often
-	// sees ZERO shards for the just-mounted volume, returns an empty move list,
-	// and succeeds silently — then verifyEcShardsBeforeDelete waits for the same
-	// heartbeats, passes, and the original .dat is deleted with all 14 shards
-	// still on the generation host (zero disk-loss protection). Observed live
-	// on 4.39 (storage-trd). Reuse the verify poll before rebalance so the plan
-	// sees the clumped shards.
+	// EcBalance plans from the master's VolumeList, but mount reports new EC
+	// shards to the master asynchronously (volume server NewEcShardsChan →
+	// delta heartbeat → IncrementalSyncDataNodeEcShards). Without waiting, the
+	// plan often sees zero shards for the just-mounted volume and succeeds with
+	// an empty move list — then the pre-delete verification waits for the same
+	// heartbeats, passes, and the original .dat is deleted with all shards
+	// still on the generation host. All shards were just generated, so demand
+	// full visibility here: a partial view would make the plan skip the
+	// invisible shards.
 	if applyBalancing {
-		if err := verifyEcShardsBeforeDelete(commandEnv, volumeIds, diskType); err != nil {
+		if err := verifyEcShardsBeforeDelete(commandEnv, volumeIds, diskType, true); err != nil {
 			return fmt.Errorf("EC shards not visible in topology before rebalance: %w", err)
 		}
 	}
@@ -299,7 +299,7 @@ func processEcEncodeBatch(commandEnv *CommandEnv, writer io.Writer, volumeIds []
 	if err := EcBalance(commandEnv, balanceCollections, "", rp, diskType, maxParallelization, applyBalancing, skippedNodes); err != nil {
 		return fmt.Errorf("re-balance ec shards for collection(s) %v: %w", balanceCollections, err)
 	}
-	if err := verifyEcShardsBeforeDelete(commandEnv, volumeIds, diskType); err != nil {
+	if err := verifyEcShardsBeforeDelete(commandEnv, volumeIds, diskType, false); err != nil {
 		return fmt.Errorf("verify EC shards before deleting originals: %w", err)
 	}
 	// Defense in depth: even after a successful (or empty) plan, refuse to
@@ -781,7 +781,15 @@ func assertEcShardsNotSingleNode(topo *master_pb.TopologyInfo, volumeIds []needl
 	return nil
 }
 
-func verifyEcShardsBeforeDelete(commandEnv *CommandEnv, volumeIds []needle.VolumeId, diskType types.DiskType) error {
+// EC shard placements reach the master via volume-server delta heartbeats, so
+// topology reads right after generate/mount/move can be stale. Polls of the
+// master topology retry on this schedule before concluding anything.
+const (
+	ecTopologyPollAttempts = 10
+	ecTopologyPollInterval = 2 * time.Second
+)
+
+func verifyEcShardsBeforeDelete(commandEnv *CommandEnv, volumeIds []needle.VolumeId, diskType types.DiskType, requireFull bool) error {
 	// Shard relocations from the preceding EC balance reach the master via
 	// volume-server heartbeats, so freshly distributed shards may not all be
 	// visible in the master topology immediately. Poll a few times before
@@ -790,9 +798,12 @@ func verifyEcShardsBeforeDelete(commandEnv *CommandEnv, volumeIds []needle.Volum
 	// recoverable threshold (dataShards) aborts the deletion; a recoverable
 	// but degraded set proceeds with a warning, since the missing shards can
 	// be rebuilt from the survivors while keeping the source next to live
-	// shards is the more dangerous mixed state.
-	const maxAttempts = 10
-	const retryInterval = 2 * time.Second
+	// shards is the more dangerous mixed state. With requireFull the degraded
+	// acceptance is off and every shard must be visible — the bar before
+	// rebalance planning, where all shards were just generated and an
+	// incomplete view would make the plan skip the invisible ones.
+	const maxAttempts = ecTopologyPollAttempts
+	const retryInterval = ecTopologyPollInterval
 
 	var lastErr error
 	var lastDegraded []string
@@ -845,6 +856,9 @@ func verifyEcShardsBeforeDelete(commandEnv *CommandEnv, volumeIds []needle.Volum
 	if lastErr != nil {
 		glog.Errorf("EC shard verification failed after %d attempts: %v", maxAttempts, lastErr)
 		return lastErr
+	}
+	if requireFull {
+		return fmt.Errorf("EC shards still missing from master topology after %d attempts: %v", maxAttempts, lastDegraded)
 	}
 	glog.Warningf("EC shard set incomplete but recoverable after %d attempts, proceeding with source deletion (rebuild missing shards with ec.rebuild): %v",
 		maxAttempts, lastDegraded)

--- a/weed/shell/command_ec_encode.go
+++ b/weed/shell/command_ec_encode.go
@@ -275,6 +275,22 @@ func processEcEncodeBatch(commandEnv *CommandEnv, writer io.Writer, volumeIds []
 	if err != nil {
 		return fmt.Errorf("ec encode for volumes %v: %w", volumeIds, err)
 	}
+
+	// EcBalance plans from the master's VolumeList. Mount reports new EC shards
+	// to the master asynchronously (volume server NewEcShardsChan → delta
+	// heartbeat → IncrementalSyncDataNodeEcShards). Without waiting, Plan often
+	// sees ZERO shards for the just-mounted volume, returns an empty move list,
+	// and succeeds silently — then verifyEcShardsBeforeDelete waits for the same
+	// heartbeats, passes, and the original .dat is deleted with all 14 shards
+	// still on the generation host (zero disk-loss protection). Observed live
+	// on 4.39 (storage-trd). Reuse the verify poll before rebalance so the plan
+	// sees the clumped shards.
+	if applyBalancing {
+		if err := verifyEcShardsBeforeDelete(commandEnv, volumeIds, diskType); err != nil {
+			return fmt.Errorf("EC shards not visible in topology before rebalance: %w", err)
+		}
+	}
+
 	// EcBalance works at collection scope. In batch mode this intentionally
 	// rebalances each collection after every batch so source volumes can be
 	// safely verified and deleted without waiting for all batches to finish.
@@ -285,6 +301,19 @@ func processEcEncodeBatch(commandEnv *CommandEnv, writer io.Writer, volumeIds []
 	}
 	if err := verifyEcShardsBeforeDelete(commandEnv, volumeIds, diskType); err != nil {
 		return fmt.Errorf("verify EC shards before deleting originals: %w", err)
+	}
+	// Defense in depth: even after a successful (or empty) plan, refuse to
+	// delete the source if rebalance left every shard of a volume on one node
+	// while other nodes of this disk type exist. Keeps the .dat so the operator
+	// can recover; without this gate a silent no-op rebalance is catastrophic.
+	if applyBalancing {
+		postTopo, _, err := collectTopologyInfo(commandEnv, 0)
+		if err != nil {
+			return fmt.Errorf("fetch topology after rebalance: %w", err)
+		}
+		if err := assertEcShardsNotSingleNode(postTopo, volumeIds, diskType); err != nil {
+			return err
+		}
 	}
 	fmt.Printf("Deleting original volumes after EC encoding...\n")
 	if err := doDeleteVolumesWithLocations(commandEnv, volumeIds, volumeLocationsMap, maxParallelization); err != nil {
@@ -689,6 +718,67 @@ func classifyNodeLiveness(pingErr error) nodeLiveness {
 		return nodeDown
 	}
 	return nodeLivenessUnknown
+}
+
+// maxEcShardsPerNode returns the highest number of EC shards of vid observed on
+// any single data node for diskType. Used to detect a fully clumped placement
+// (all TotalShardsCount on one node) after encode rebalance.
+func maxEcShardsPerNode(topo *master_pb.TopologyInfo, vid needle.VolumeId, diskType types.DiskType) int {
+	max := 0
+	eachDataNode(topo, func(_ DataCenterId, _ RackId, dn *master_pb.DataNodeInfo) {
+		if dn.DiskInfos == nil {
+			return
+		}
+		diskInfo := dn.DiskInfos[string(diskType)]
+		if diskInfo == nil {
+			return
+		}
+		n := 0
+		for _, eci := range diskInfo.EcShardInfos {
+			if needle.VolumeId(eci.Id) == vid {
+				n += erasure_coding.GetShardCount(eci)
+			}
+		}
+		if n > max {
+			max = n
+		}
+	})
+	return max
+}
+
+// countNodesWithDiskType counts data nodes that advertise diskType. Used to
+// skip the single-node clump gate on true single-node clusters where rebalance
+// cannot spread shards.
+func countNodesWithDiskType(topo *master_pb.TopologyInfo, diskType types.DiskType) int {
+	n := 0
+	eachDataNode(topo, func(_ DataCenterId, _ RackId, dn *master_pb.DataNodeInfo) {
+		if dn.DiskInfos == nil {
+			return
+		}
+		if dn.DiskInfos[string(diskType)] != nil {
+			n++
+		}
+	})
+	return n
+}
+
+// assertEcShardsNotSingleNode fails if any volume still has all EC shards on
+// one node while multiple nodes of diskType exist. That placement is EC with
+// zero node-loss protection; refusing to delete the source .dat is the only
+// safe response. Single-node clusters are skipped (nothing to spread to).
+func assertEcShardsNotSingleNode(topo *master_pb.TopologyInfo, volumeIds []needle.VolumeId, diskType types.DiskType) error {
+	if countNodesWithDiskType(topo, diskType) < 2 {
+		return nil
+	}
+	total := erasure_coding.TotalShardsCount
+	for _, vid := range volumeIds {
+		max := maxEcShardsPerNode(topo, vid, diskType)
+		if max >= total {
+			return fmt.Errorf("volume %d: after rebalance all %d EC shards still sit on one node; refusing to delete the source .dat (zero node-loss protection). Re-run with an explicit 'ec.balance -collection <c> -diskType %s -apply' once topology is settled, or investigate why internal EcBalance produced no moves",
+				vid, total, diskType.ReadableString())
+		}
+	}
+	return nil
 }
 
 func verifyEcShardsBeforeDelete(commandEnv *CommandEnv, volumeIds []needle.VolumeId, diskType types.DiskType) error {

--- a/weed/shell/command_ec_encode_test.go
+++ b/weed/shell/command_ec_encode_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
 	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
+	"github.com/seaweedfs/seaweedfs/weed/storage/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -269,4 +270,142 @@ func TestChunkEcEncodeVolumeIds(t *testing.T) {
 	}, chunkEcEncodeVolumeIds(vids, 2))
 
 	assert.Equal(t, [][]needle.VolumeId{vids}, chunkEcEncodeVolumeIds(vids, 0))
+}
+
+// allFourteenBits is EcIndexBits for shards 0..13 (standard 10+4).
+const allFourteenBits = uint32((1 << 14) - 1)
+
+// hddKey is the DiskInfos map key for the default HDD disk type. SeaweedFS
+// normalizes both "" and "hdd" to types.HardDriveType (empty string).
+const hddKey = ""
+
+// topoWithClumpedEcVolume models the storage-trd failure mode: all 14 shards of
+// vid on nodeA, with a second empty node that could have received them.
+func topoWithClumpedEcVolume(vid uint32, collection string) *master_pb.TopologyInfo {
+	return &master_pb.TopologyInfo{
+		DataCenterInfos: []*master_pb.DataCenterInfo{{
+			Id: "dc1",
+			RackInfos: []*master_pb.RackInfo{{
+				Id: "rack1",
+				DataNodeInfos: []*master_pb.DataNodeInfo{
+					{
+						Id: "nodeA:8080",
+						DiskInfos: map[string]*master_pb.DiskInfo{
+							hddKey: {
+								Type:            hddKey,
+								MaxVolumeCount:  100,
+								FreeVolumeCount: 50,
+								EcShardInfos: []*master_pb.VolumeEcShardInformationMessage{{
+									Id:          vid,
+									Collection:  collection,
+									EcIndexBits: allFourteenBits,
+								}},
+							},
+						},
+					},
+					{
+						Id: "nodeB:8080",
+						DiskInfos: map[string]*master_pb.DiskInfo{
+							hddKey: {
+								Type:            hddKey,
+								MaxVolumeCount:  100,
+								FreeVolumeCount: 50,
+							},
+						},
+					},
+				},
+			}},
+		}},
+	}
+}
+
+func TestMaxEcShardsPerNode_Clumped(t *testing.T) {
+	topo := topoWithClumpedEcVolume(2059, "ec1c")
+	assert.Equal(t, 14, maxEcShardsPerNode(topo, needle.VolumeId(2059), types.HardDriveType))
+	assert.Equal(t, 0, maxEcShardsPerNode(topo, needle.VolumeId(9999), types.HardDriveType))
+}
+
+func TestMaxEcShardsPerNode_Spread(t *testing.T) {
+	// 7 shards on A, 7 on B — not a single-node clump.
+	halfA := uint32((1 << 7) - 1)           // shards 0..6
+	halfB := uint32(((1 << 14) - 1) ^ halfA) // shards 7..13
+	topo := &master_pb.TopologyInfo{
+		DataCenterInfos: []*master_pb.DataCenterInfo{{
+			Id: "dc1",
+			RackInfos: []*master_pb.RackInfo{{
+				Id: "rack1",
+				DataNodeInfos: []*master_pb.DataNodeInfo{
+					{Id: "nodeA:8080", DiskInfos: map[string]*master_pb.DiskInfo{
+						hddKey: {Type: hddKey, EcShardInfos: []*master_pb.VolumeEcShardInformationMessage{
+							{Id: 1, Collection: "c", EcIndexBits: halfA},
+						}},
+					}},
+					{Id: "nodeB:8080", DiskInfos: map[string]*master_pb.DiskInfo{
+						hddKey: {Type: hddKey, EcShardInfos: []*master_pb.VolumeEcShardInformationMessage{
+							{Id: 1, Collection: "c", EcIndexBits: halfB},
+						}},
+					}},
+				},
+			}},
+		}},
+	}
+	assert.Equal(t, 7, maxEcShardsPerNode(topo, needle.VolumeId(1), types.HardDriveType))
+}
+
+func TestAssertEcShardsNotSingleNode_RefusesClump(t *testing.T) {
+	topo := topoWithClumpedEcVolume(2059, "ec1c")
+	err := assertEcShardsNotSingleNode(topo, []needle.VolumeId{2059}, types.HardDriveType)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "all 14 EC shards still sit on one node")
+	assert.Contains(t, err.Error(), "refusing to delete")
+}
+
+func TestAssertEcShardsNotSingleNode_AllowsSpread(t *testing.T) {
+	halfA := uint32((1 << 7) - 1)
+	halfB := uint32(((1 << 14) - 1) ^ halfA)
+	topo := &master_pb.TopologyInfo{
+		DataCenterInfos: []*master_pb.DataCenterInfo{{
+			Id: "dc1",
+			RackInfos: []*master_pb.RackInfo{{
+				Id: "rack1",
+				DataNodeInfos: []*master_pb.DataNodeInfo{
+					{Id: "nodeA:8080", DiskInfos: map[string]*master_pb.DiskInfo{
+						hddKey: {Type: hddKey, EcShardInfos: []*master_pb.VolumeEcShardInformationMessage{
+							{Id: 1, Collection: "c", EcIndexBits: halfA},
+						}},
+					}},
+					{Id: "nodeB:8080", DiskInfos: map[string]*master_pb.DiskInfo{
+						hddKey: {Type: hddKey, EcShardInfos: []*master_pb.VolumeEcShardInformationMessage{
+							{Id: 1, Collection: "c", EcIndexBits: halfB},
+						}},
+					}},
+				},
+			}},
+		}},
+	}
+	assert.NoError(t, assertEcShardsNotSingleNode(topo, []needle.VolumeId{1}, types.HardDriveType))
+}
+
+func TestAssertEcShardsNotSingleNode_SkipsSingleNodeCluster(t *testing.T) {
+	// True single-node install: rebalance cannot spread; do not refuse delete.
+	topo := &master_pb.TopologyInfo{
+		DataCenterInfos: []*master_pb.DataCenterInfo{{
+			Id: "dc1",
+			RackInfos: []*master_pb.RackInfo{{
+				Id: "rack1",
+				DataNodeInfos: []*master_pb.DataNodeInfo{{
+					Id: "only:8080",
+					DiskInfos: map[string]*master_pb.DiskInfo{
+						hddKey: {
+							Type: hddKey,
+							EcShardInfos: []*master_pb.VolumeEcShardInformationMessage{{
+								Id: 1, Collection: "c", EcIndexBits: allFourteenBits,
+							}},
+						},
+					},
+				}},
+			}},
+		}},
+	}
+	assert.NoError(t, assertEcShardsNotSingleNode(topo, []needle.VolumeId{1}, types.HardDriveType))
 }

--- a/weed/shell/command_ec_encode_test.go
+++ b/weed/shell/command_ec_encode_test.go
@@ -275,12 +275,12 @@ func TestChunkEcEncodeVolumeIds(t *testing.T) {
 // allFourteenBits is EcIndexBits for shards 0..13 (standard 10+4).
 const allFourteenBits = uint32((1 << 14) - 1)
 
-// hddKey is the DiskInfos map key for the default HDD disk type. SeaweedFS
-// normalizes both "" and "hdd" to types.HardDriveType (empty string).
+// hddKey is the DiskInfos map key for the default HDD disk type: the master
+// normalizes disk type strings, so HDD is keyed by the empty string.
 const hddKey = ""
 
-// topoWithClumpedEcVolume models the storage-trd failure mode: all 14 shards of
-// vid on nodeA, with a second empty node that could have received them.
+// topoWithClumpedEcVolume models the failure mode: all 14 shards of vid on
+// nodeA, with a second empty node that could have received them.
 func topoWithClumpedEcVolume(vid uint32, collection string) *master_pb.TopologyInfo {
 	return &master_pb.TopologyInfo{
 		DataCenterInfos: []*master_pb.DataCenterInfo{{
@@ -319,15 +319,44 @@ func topoWithClumpedEcVolume(vid uint32, collection string) *master_pb.TopologyI
 	}
 }
 
-func TestMaxEcShardsPerNode_Clumped(t *testing.T) {
+func TestEcShardSpread_Clumped(t *testing.T) {
 	topo := topoWithClumpedEcVolume(2059, "ec1c")
-	assert.Equal(t, 14, maxEcShardsPerNode(topo, needle.VolumeId(2059), types.HardDriveType))
-	assert.Equal(t, 0, maxEcShardsPerNode(topo, needle.VolumeId(9999), types.HardDriveType))
+	visible, maxOnOneNode := ecShardSpread(topo, needle.VolumeId(2059), types.HardDriveType)
+	assert.Equal(t, 14, visible)
+	assert.Equal(t, 14, maxOnOneNode)
+	visible, maxOnOneNode = ecShardSpread(topo, needle.VolumeId(9999), types.HardDriveType)
+	assert.Equal(t, 0, visible)
+	assert.Equal(t, 0, maxOnOneNode)
 }
 
-func TestMaxEcShardsPerNode_Spread(t *testing.T) {
+func TestEcShardSpread_MultiDiskNodeUnionsBits(t *testing.T) {
+	// One node, two physical disks, with shard 0 reported by both entries
+	// mid-move: bits must union, not sum.
+	topo := &master_pb.TopologyInfo{
+		DataCenterInfos: []*master_pb.DataCenterInfo{{
+			Id: "dc1",
+			RackInfos: []*master_pb.RackInfo{{
+				Id: "rack1",
+				DataNodeInfos: []*master_pb.DataNodeInfo{{
+					Id: "nodeA:8080",
+					DiskInfos: map[string]*master_pb.DiskInfo{
+						hddKey: {Type: hddKey, EcShardInfos: []*master_pb.VolumeEcShardInformationMessage{
+							{Id: 1, Collection: "c", EcIndexBits: uint32(0b0011)}, // shards 0,1
+							{Id: 1, Collection: "c", EcIndexBits: uint32(0b0101)}, // shards 0,2
+						}},
+					},
+				}},
+			}},
+		}},
+	}
+	visible, maxOnOneNode := ecShardSpread(topo, needle.VolumeId(1), types.HardDriveType)
+	assert.Equal(t, 3, visible)
+	assert.Equal(t, 3, maxOnOneNode)
+}
+
+func TestEcShardSpread_Spread(t *testing.T) {
 	// 7 shards on A, 7 on B — not a single-node clump.
-	halfA := uint32((1 << 7) - 1)           // shards 0..6
+	halfA := uint32((1 << 7) - 1)            // shards 0..6
 	halfB := uint32(((1 << 14) - 1) ^ halfA) // shards 7..13
 	topo := &master_pb.TopologyInfo{
 		DataCenterInfos: []*master_pb.DataCenterInfo{{
@@ -349,15 +378,27 @@ func TestMaxEcShardsPerNode_Spread(t *testing.T) {
 			}},
 		}},
 	}
-	assert.Equal(t, 7, maxEcShardsPerNode(topo, needle.VolumeId(1), types.HardDriveType))
+	visible, maxOnOneNode := ecShardSpread(topo, needle.VolumeId(1), types.HardDriveType)
+	assert.Equal(t, 14, visible)
+	assert.Equal(t, 7, maxOnOneNode)
 }
 
 func TestAssertEcShardsNotSingleNode_RefusesClump(t *testing.T) {
 	topo := topoWithClumpedEcVolume(2059, "ec1c")
 	err := assertEcShardsNotSingleNode(topo, []needle.VolumeId{2059}, types.HardDriveType)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "all 14 EC shards still sit on one node")
+	assert.Contains(t, err.Error(), "all 14 visible EC shards still sit on one node")
 	assert.Contains(t, err.Error(), "refusing to delete")
+}
+
+func TestAssertEcShardsNotSingleNode_RefusesDegradedClump(t *testing.T) {
+	// Only 12 of 14 shards visible (heartbeat lag), all on nodeA: still a
+	// clump. The gate must judge against the visible set, not TotalShardsCount.
+	topo := topoWithClumpedEcVolume(2059, "ec1c")
+	topo.DataCenterInfos[0].RackInfos[0].DataNodeInfos[0].DiskInfos[hddKey].EcShardInfos[0].EcIndexBits = uint32((1 << 12) - 1)
+	err := assertEcShardsNotSingleNode(topo, []needle.VolumeId{2059}, types.HardDriveType)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "all 12 visible EC shards still sit on one node")
 }
 
 func TestAssertEcShardsNotSingleNode_AllowsSpread(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #10300.

`ec.encode` with default `-rebalance=true` could leave all 14 EC shards on the generation host, then delete the original `.dat` (zero node-loss protection). Observed live on 4.39 as intermittent.

**Cause:** `EcBalance` plans from the master `VolumeList`. Mount reports shards asynchronously via `NewEcShardsChan` delta heartbeats. Planning before those land often yields an empty move list; `verifyEcShardsBeforeDelete` then waits for the same lag, succeeds, and the source is deleted while still clumped.

**Fix (when `-rebalance` is true):**
1. Poll for shards in topology **before** `EcBalance` (reuse the existing verify wait).
2. After rebalance, **refuse to delete** the source if every shard of a volume still sits on one node while other nodes of that disk type exist.

Worker auto-EC path is unaffected (`Place` + distribute; no post-encode shell `EcBalance`).

## Test plan

- [x] Unit tests: `TestMaxEcShardsPerNode_*`, `TestAssertEcShardsNotSingleNode_{RefusesClump,AllowsSpread,SkipsSingleNodeCluster}`
- [x] `go test ./weed/shell/ -run 'TestMaxEcShardsPerNode|TestAssertEcShardsNotSingleNode'`
- [ ] Reviewer: optional live encode on multi-node cluster — confirm move lines appear and max shards/node &lt; 14 before source delete

## Notes

Single-node clusters skip the post-rebalance clump gate (nothing to spread to). `-rebalance=false` keeps prior behavior (no wait-before-balance, no clump refuse).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved erasure-coded volume rebalancing safety by verifying EC shard visibility before applying changes.
  * Added stricter post-rebalance checks to prevent deletion when EC shards remain concentrated on a single node.
  * Enhanced behavior for single-node clusters where the distribution safeguard is not enforced.
* **Tests**
  * Added new EC shard visibility/spread and deletion-safety test coverage, including clumped, partially degraded, and distributed layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->