### PR TITLE
filer: scope TUS HEAD/PATCH/DELETE against the session target path

### DIFF
--- a/weed/server/filer_server_handlers.go
+++ b/weed/server/filer_server_handlers.go
@@ -216,26 +216,16 @@ func (fs *FilerServer) maybeCheckJwtAuthorization(r *http.Request, isWrite bool)
 		return true
 	}
 
-	return fs.checkJwtAuthorization(r, isWrite, jwtScopedRequestPaths(r))
+	return fs.checkJwtAuthorization(r, isWrite, func() ([]string, error) { return jwtScopedRequestPaths(r), nil })
 }
 
 // checkJwtAuthorization verifies the request carries a valid filer JWT for the
-// requested access level and, for prefix-restricted tokens, that every path in
-// scopedPaths falls within the token's AllowedPrefixes. Callers whose write
-// target is not r.URL.Path — the TUS handler, whose URL points at the /.tus
-// route — pass the resolved filer path(s) here instead.
-func (fs *FilerServer) checkJwtAuthorization(r *http.Request, isWrite bool, scopedPaths []string) bool {
-	return fs.checkJwtAuthorizationScoped(r, isWrite, func() ([]string, error) { return scopedPaths, nil })
-}
-
-// checkJwtAuthorizationScoped is checkJwtAuthorization with the scoped paths
-// resolved lazily. resolveScopedPaths is only invoked for a prefix-restricted
-// token, so callers that must read extra state to name their target — the TUS
-// handler reads the session's stored path from the filer — pay for it only when
-// the prefix check will actually consult it. A resolver error denies the request:
-// a prefix-restricted token must not be authorized against a target the server
-// could not resolve.
-func (fs *FilerServer) checkJwtAuthorizationScoped(r *http.Request, isWrite bool, resolveScopedPaths func() ([]string, error)) bool {
+// requested access level and, for prefix-restricted tokens, that every resolved
+// path falls within AllowedPrefixes. resolveScopedPaths is invoked only for a
+// prefix-restricted token, so callers that read extra state to name their target
+// (the TUS handler reads the session's stored path) pay for it only when it is
+// consulted; a resolution error denies the request.
+func (fs *FilerServer) checkJwtAuthorization(r *http.Request, isWrite bool, resolveScopedPaths func() ([]string, error)) bool {
 
 	var signingKey security.SigningKey
 
@@ -274,9 +264,6 @@ func (fs *FilerServer) checkJwtAuthorizationScoped(r *http.Request, isWrite bool
 	}
 
 	if len(claims.AllowedPrefixes) > 0 {
-		// Copy and move name their source via a query parameter, not r.URL.Path.
-		// Scope every path the request reads or relocates, or a prefix-restricted
-		// token could reach data outside its allowed subtree.
 		scopedPaths, err := resolveScopedPaths()
 		if err != nil {
 			glog.V(1).Infof("jwt scope resolution failed from %s: %v", r.RemoteAddr, err)

--- a/weed/server/filer_server_handlers.go
+++ b/weed/server/filer_server_handlers.go
@@ -225,15 +225,17 @@ func (fs *FilerServer) maybeCheckJwtAuthorization(r *http.Request, isWrite bool)
 // target is not r.URL.Path — the TUS handler, whose URL points at the /.tus
 // route — pass the resolved filer path(s) here instead.
 func (fs *FilerServer) checkJwtAuthorization(r *http.Request, isWrite bool, scopedPaths []string) bool {
-	return fs.checkJwtAuthorizationScoped(r, isWrite, func() []string { return scopedPaths })
+	return fs.checkJwtAuthorizationScoped(r, isWrite, func() ([]string, error) { return scopedPaths, nil })
 }
 
 // checkJwtAuthorizationScoped is checkJwtAuthorization with the scoped paths
 // resolved lazily. resolveScopedPaths is only invoked for a prefix-restricted
 // token, so callers that must read extra state to name their target — the TUS
 // handler reads the session's stored path from the filer — pay for it only when
-// the prefix check will actually consult it.
-func (fs *FilerServer) checkJwtAuthorizationScoped(r *http.Request, isWrite bool, resolveScopedPaths func() []string) bool {
+// the prefix check will actually consult it. A resolver error denies the request:
+// a prefix-restricted token must not be authorized against a target the server
+// could not resolve.
+func (fs *FilerServer) checkJwtAuthorizationScoped(r *http.Request, isWrite bool, resolveScopedPaths func() ([]string, error)) bool {
 
 	var signingKey security.SigningKey
 
@@ -275,7 +277,12 @@ func (fs *FilerServer) checkJwtAuthorizationScoped(r *http.Request, isWrite bool
 		// Copy and move name their source via a query parameter, not r.URL.Path.
 		// Scope every path the request reads or relocates, or a prefix-restricted
 		// token could reach data outside its allowed subtree.
-		for _, p := range resolveScopedPaths() {
+		scopedPaths, err := resolveScopedPaths()
+		if err != nil {
+			glog.V(1).Infof("jwt scope resolution failed from %s: %v", r.RemoteAddr, err)
+			return false
+		}
+		for _, p := range scopedPaths {
 			if !anyComponentPrefixMatches(claims.AllowedPrefixes, p) {
 				glog.V(1).Infof("jwt path not allowed from %s: %v", r.RemoteAddr, p)
 				return false

--- a/weed/server/filer_server_handlers.go
+++ b/weed/server/filer_server_handlers.go
@@ -225,6 +225,15 @@ func (fs *FilerServer) maybeCheckJwtAuthorization(r *http.Request, isWrite bool)
 // target is not r.URL.Path — the TUS handler, whose URL points at the /.tus
 // route — pass the resolved filer path(s) here instead.
 func (fs *FilerServer) checkJwtAuthorization(r *http.Request, isWrite bool, scopedPaths []string) bool {
+	return fs.checkJwtAuthorizationScoped(r, isWrite, func() []string { return scopedPaths })
+}
+
+// checkJwtAuthorizationScoped is checkJwtAuthorization with the scoped paths
+// resolved lazily. resolveScopedPaths is only invoked for a prefix-restricted
+// token, so callers that must read extra state to name their target — the TUS
+// handler reads the session's stored path from the filer — pay for it only when
+// the prefix check will actually consult it.
+func (fs *FilerServer) checkJwtAuthorizationScoped(r *http.Request, isWrite bool, resolveScopedPaths func() []string) bool {
 
 	var signingKey security.SigningKey
 
@@ -266,7 +275,7 @@ func (fs *FilerServer) checkJwtAuthorization(r *http.Request, isWrite bool, scop
 		// Copy and move name their source via a query parameter, not r.URL.Path.
 		// Scope every path the request reads or relocates, or a prefix-restricted
 		// token could reach data outside its allowed subtree.
-		for _, p := range scopedPaths {
+		for _, p := range resolveScopedPaths() {
 			if !anyComponentPrefixMatches(claims.AllowedPrefixes, p) {
 				glog.V(1).Infof("jwt path not allowed from %s: %v", r.RemoteAddr, p)
 				return false

--- a/weed/server/filer_server_tus_handlers.go
+++ b/weed/server/filer_server_tus_handlers.go
@@ -53,8 +53,7 @@ func (fs *FilerServer) tusHandler(w http.ResponseWriter, r *http.Request) {
 	// Check if this is an upload location (contains upload ID after {tusPrefix}/.uploads/)
 	uploadsPrefix := tusPrefix + "/.uploads/"
 	if strings.HasPrefix(reqPath, uploadsPrefix) {
-		uploadID := strings.TrimPrefix(reqPath, uploadsPrefix)
-		uploadID = strings.Split(uploadID, "/")[0] // Get just the ID, not any trailing path
+		uploadID := fs.tusUploadID(reqPath)
 
 		switch r.Method {
 		case http.MethodHead:
@@ -82,20 +81,58 @@ func (fs *FilerServer) tusHandler(w http.ResponseWriter, r *http.Request) {
 
 // checkTusJwtAuthorization enforces filer JWT authorization for a TUS request.
 // HEAD reads the current offset (read access); POST/PATCH/DELETE mutate the
-// namespace (write access). Only creation (POST) names a new target path, taken
-// from the request URL, so prefix-restricted tokens are scoped against that
-// resolved filer path rather than the /.tus route. HEAD/PATCH/DELETE act on an
-// existing session addressed by an unguessable id, whose target was already
-// scope-checked at creation, so no further path scoping is applied to them.
+// namespace (write access). The prefix check for a prefix-restricted token is
+// scoped against the resolved filer target, not the /.tus route, so the caller's
+// AllowedPrefixes is enforced on every verb.
 func (fs *FilerServer) checkTusJwtAuthorization(r *http.Request) bool {
 	isWrite := r.Method != http.MethodHead
-	var scopedPaths []string
-	if r.Method == http.MethodPost {
+	return fs.checkJwtAuthorizationScoped(r, isWrite, func() []string {
+		return fs.tusScopedPaths(r)
+	})
+}
+
+// tusScopedPaths resolves the filer path(s) a TUS request must fall within for a
+// prefix-restricted token. Creation (POST) names a new target in the request URL.
+// HEAD/PATCH/DELETE act on an existing session addressed by an id in the URL;
+// their effective target is the session's stored TargetPath, which must be
+// re-checked here. The session id is not an authorization boundary against a
+// legitimate low-privilege tenant who holds a valid token and learns another
+// upload's id, so without this scoping such a tenant could read, overwrite, or
+// cancel a session whose target lies outside its own AllowedPrefixes.
+func (fs *FilerServer) tusScopedPaths(r *http.Request) []string {
+	switch r.Method {
+	case http.MethodPost:
 		if target := fs.tusTargetPath(r); target != "" && target != "/" {
-			scopedPaths = append(scopedPaths, target)
+			return []string{target}
+		}
+	case http.MethodHead, http.MethodPatch, http.MethodDelete:
+		uploadID := fs.tusUploadID(r.URL.Path)
+		if uploadID == "" {
+			return nil
+		}
+		session, err := fs.readTusSessionInfo(r.Context(), uploadID)
+		if err != nil {
+			// Unknown or unreadable session: leave the request unscoped so the
+			// handler resolves it to 404, rather than denying on a path we cannot
+			// determine.
+			return nil
+		}
+		if target := session.TargetPath; target != "" && target != "/" {
+			return []string{target}
 		}
 	}
-	return fs.checkJwtAuthorization(r, isWrite, scopedPaths)
+	return nil
+}
+
+// tusUploadID extracts the session id from a {TusBasePath}/.uploads/{id} request
+// path, returning "" when the path is not an uploads route. Shared by the request
+// router and the JWT scoping so both address the same session.
+func (fs *FilerServer) tusUploadID(reqPath string) string {
+	uploadsPrefix := fs.option.TusBasePath + "/.uploads/"
+	if !strings.HasPrefix(reqPath, uploadsPrefix) {
+		return ""
+	}
+	return strings.Split(strings.TrimPrefix(reqPath, uploadsPrefix), "/")[0]
 }
 
 // tusTargetPath resolves the filer path a TUS create request targets from the

--- a/weed/server/filer_server_tus_handlers.go
+++ b/weed/server/filer_server_tus_handlers.go
@@ -86,7 +86,7 @@ func (fs *FilerServer) tusHandler(w http.ResponseWriter, r *http.Request) {
 // AllowedPrefixes is enforced on every verb.
 func (fs *FilerServer) checkTusJwtAuthorization(r *http.Request) bool {
 	isWrite := r.Method != http.MethodHead
-	return fs.checkJwtAuthorizationScoped(r, isWrite, func() []string {
+	return fs.checkJwtAuthorizationScoped(r, isWrite, func() ([]string, error) {
 		return fs.tusScopedPaths(r)
 	})
 }
@@ -99,29 +99,33 @@ func (fs *FilerServer) checkTusJwtAuthorization(r *http.Request) bool {
 // legitimate low-privilege tenant who holds a valid token and learns another
 // upload's id, so without this scoping such a tenant could read, overwrite, or
 // cancel a session whose target lies outside its own AllowedPrefixes.
-func (fs *FilerServer) tusScopedPaths(r *http.Request) []string {
+//
+// A missing session leaves the request unscoped so the handler can answer 404,
+// but any other lookup failure (filer error, corrupt session) is returned so the
+// caller fails closed rather than authorizing against a target it could not read.
+func (fs *FilerServer) tusScopedPaths(r *http.Request) ([]string, error) {
 	switch r.Method {
 	case http.MethodPost:
 		if target := fs.tusTargetPath(r); target != "" && target != "/" {
-			return []string{target}
+			return []string{target}, nil
 		}
 	case http.MethodHead, http.MethodPatch, http.MethodDelete:
 		uploadID := fs.tusUploadID(r.URL.Path)
 		if uploadID == "" {
-			return nil
+			return nil, nil
 		}
 		session, err := fs.readTusSessionInfo(r.Context(), uploadID)
 		if err != nil {
-			// Unknown or unreadable session: leave the request unscoped so the
-			// handler resolves it to 404, rather than denying on a path we cannot
-			// determine.
-			return nil
+			if errors.Is(err, filer_pb.ErrNotFound) {
+				return nil, nil
+			}
+			return nil, err
 		}
 		if target := session.TargetPath; target != "" && target != "/" {
-			return []string{target}
+			return []string{target}, nil
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 // tusUploadID extracts the session id from a {TusBasePath}/.uploads/{id} request

--- a/weed/server/filer_server_tus_handlers.go
+++ b/weed/server/filer_server_tus_handlers.go
@@ -80,29 +80,20 @@ func (fs *FilerServer) tusHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // checkTusJwtAuthorization enforces filer JWT authorization for a TUS request.
-// HEAD reads the current offset (read access); POST/PATCH/DELETE mutate the
-// namespace (write access). The prefix check for a prefix-restricted token is
-// scoped against the resolved filer target, not the /.tus route, so the caller's
-// AllowedPrefixes is enforced on every verb.
+// HEAD is a read; POST/PATCH/DELETE are writes.
 func (fs *FilerServer) checkTusJwtAuthorization(r *http.Request) bool {
 	isWrite := r.Method != http.MethodHead
-	return fs.checkJwtAuthorizationScoped(r, isWrite, func() ([]string, error) {
+	return fs.checkJwtAuthorization(r, isWrite, func() ([]string, error) {
 		return fs.tusScopedPaths(r)
 	})
 }
 
-// tusScopedPaths resolves the filer path(s) a TUS request must fall within for a
-// prefix-restricted token. Creation (POST) names a new target in the request URL.
-// HEAD/PATCH/DELETE act on an existing session addressed by an id in the URL;
-// their effective target is the session's stored TargetPath, which must be
-// re-checked here. The session id is not an authorization boundary against a
-// legitimate low-privilege tenant who holds a valid token and learns another
-// upload's id, so without this scoping such a tenant could read, overwrite, or
-// cancel a session whose target lies outside its own AllowedPrefixes.
-//
-// A missing session leaves the request unscoped so the handler can answer 404,
-// but any other lookup failure (filer error, corrupt session) is returned so the
-// caller fails closed rather than authorizing against a target it could not read.
+// tusScopedPaths returns the filer path(s) a prefix-restricted token must be
+// allowed to reach. POST names its target in the URL; HEAD/PATCH/DELETE act on an
+// existing session whose stored TargetPath must be re-checked, since the session
+// id is not an authorization boundary against a tenant who already holds a token.
+// A missing session stays unscoped (handler answers 404); any other lookup error
+// is returned so the caller fails closed.
 func (fs *FilerServer) tusScopedPaths(r *http.Request) ([]string, error) {
 	switch r.Method {
 	case http.MethodPost:
@@ -128,9 +119,8 @@ func (fs *FilerServer) tusScopedPaths(r *http.Request) ([]string, error) {
 	return nil, nil
 }
 
-// tusUploadID extracts the session id from a {TusBasePath}/.uploads/{id} request
-// path, returning "" when the path is not an uploads route. Shared by the request
-// router and the JWT scoping so both address the same session.
+// tusUploadID extracts the session id from a {TusBasePath}/.uploads/{id} path, or
+// "" when the path is not an uploads route.
 func (fs *FilerServer) tusUploadID(reqPath string) string {
 	uploadsPrefix := fs.option.TusBasePath + "/.uploads/"
 	if !strings.HasPrefix(reqPath, uploadsPrefix) {

--- a/weed/server/filer_server_tus_idor_test.go
+++ b/weed/server/filer_server_tus_idor_test.go
@@ -15,8 +15,9 @@ import (
 
 // newTusIDORTestServer builds a FilerServer backed by an in-memory store seeded
 // with TUS sessions (uploadID -> stored TargetPath), so the JWT check can resolve
-// a session's target the way the real handler does.
-func newTusIDORTestServer(t *testing.T, writeKey, readKey string, sessions map[string]string) *FilerServer {
+// a session's target the way the real handler does. The store is returned so a
+// test can seed additional (e.g. corrupt) session entries.
+func newTusIDORTestServer(t *testing.T, writeKey, readKey string, sessions map[string]string) (*FilerServer, *renameTestStore) {
 	t.Helper()
 	store := newRenameTestStore()
 	fs := &FilerServer{
@@ -29,12 +30,11 @@ func newTusIDORTestServer(t *testing.T, writeKey, readKey string, sessions map[s
 		if err != nil {
 			t.Fatalf("marshal session %s: %v", uploadID, err)
 		}
-		infoPath := util.FullPath(fs.tusSessionInfoPath(uploadID))
-		if err := store.InsertEntry(context.Background(), &filer.Entry{FullPath: infoPath, Content: data}); err != nil {
+		if err := store.InsertEntry(context.Background(), &filer.Entry{FullPath: util.FullPath(fs.tusSessionInfoPath(uploadID)), Content: data}); err != nil {
 			t.Fatalf("seed session %s: %v", uploadID, err)
 		}
 	}
-	return fs
+	return fs, store
 }
 
 // TestFilerServer_checkTusJwtAuthorization_CrossPrefixSessionHijack reproduces
@@ -45,10 +45,19 @@ func TestFilerServer_checkTusJwtAuthorization_CrossPrefixSessionHijack(t *testin
 	const writeKey = "write-secret"
 	const readKey = "read-secret"
 
-	fs := newTusIDORTestServer(t, writeKey, readKey, map[string]string{
+	fs, store := newTusIDORTestServer(t, writeKey, readKey, map[string]string{
 		"victim-session": "/buckets/secret/victim.bin",
 		"own-session":    "/buckets/allowed/own.bin",
 	})
+
+	// A session whose .info is unreadable (corrupt JSON) must fail closed rather
+	// than authorize a prefix-restricted token against a target we cannot resolve.
+	if err := store.InsertEntry(context.Background(), &filer.Entry{
+		FullPath: util.FullPath(fs.tusSessionInfoPath("corrupt-session")),
+		Content:  []byte("{not valid json"),
+	}); err != nil {
+		t.Fatalf("seed corrupt session: %v", err)
+	}
 
 	attackerWrite := signFilerToken(t, writeKey, []string{"/buckets/allowed"}, nil)
 	attackerRead := signFilerToken(t, readKey, []string{"/buckets/allowed"}, nil)
@@ -78,6 +87,11 @@ func TestFilerServer_checkTusJwtAuthorization_CrossPrefixSessionHijack(t *testin
 		// An unknown session leaves the request unscoped so the handler can answer
 		// 404, rather than being denied on a path that cannot be resolved.
 		{"patch unknown session allowed", http.MethodPatch, "/.tus/.uploads/does-not-exist", attackerWrite, true},
+
+		// A corrupt/unreadable session fails closed: the target cannot be resolved
+		// so a prefix-restricted token must be denied, not authorized.
+		{"patch corrupt session denied", http.MethodPatch, "/.tus/.uploads/corrupt-session", attackerWrite, false},
+		{"head corrupt session denied", http.MethodHead, "/.tus/.uploads/corrupt-session", attackerRead, false},
 	}
 
 	for _, tt := range tests {
@@ -98,7 +112,7 @@ func TestFilerServer_tusHandler_CrossPrefixPatchRejected(t *testing.T) {
 	const writeKey = "write-secret"
 	const readKey = "read-secret"
 
-	fs := newTusIDORTestServer(t, writeKey, readKey, map[string]string{
+	fs, _ := newTusIDORTestServer(t, writeKey, readKey, map[string]string{
 		"victim-session": "/buckets/secret/victim.bin",
 	})
 	attacker := signFilerToken(t, writeKey, []string{"/buckets/allowed"}, nil)

--- a/weed/server/filer_server_tus_idor_test.go
+++ b/weed/server/filer_server_tus_idor_test.go
@@ -1,0 +1,118 @@
+package weed_server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/filer"
+	"github.com/seaweedfs/seaweedfs/weed/security"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+)
+
+// newTusIDORTestServer builds a FilerServer backed by an in-memory store seeded
+// with TUS sessions (uploadID -> stored TargetPath), so the JWT check can resolve
+// a session's target the way the real handler does.
+func newTusIDORTestServer(t *testing.T, writeKey, readKey string, sessions map[string]string) *FilerServer {
+	t.Helper()
+	store := newRenameTestStore()
+	fs := &FilerServer{
+		filer:      newRenameTestFiler(store),
+		filerGuard: security.NewGuard(nil, writeKey, 0, readKey, 0),
+		option:     &FilerOption{TusBasePath: "/.tus"},
+	}
+	for uploadID, targetPath := range sessions {
+		data, err := json.Marshal(&TusSession{ID: uploadID, TargetPath: targetPath, Size: 46})
+		if err != nil {
+			t.Fatalf("marshal session %s: %v", uploadID, err)
+		}
+		infoPath := util.FullPath(fs.tusSessionInfoPath(uploadID))
+		if err := store.InsertEntry(context.Background(), &filer.Entry{FullPath: infoPath, Content: data}); err != nil {
+			t.Fatalf("seed session %s: %v", uploadID, err)
+		}
+	}
+	return fs
+}
+
+// TestFilerServer_checkTusJwtAuthorization_CrossPrefixSessionHijack reproduces
+// GHSA-99q7-x53r-6j4g: a prefix-restricted token acting on another tenant's
+// existing TUS session (HEAD/PATCH/DELETE) must be scoped against the session's
+// stored TargetPath, not authorized on signature and method alone.
+func TestFilerServer_checkTusJwtAuthorization_CrossPrefixSessionHijack(t *testing.T) {
+	const writeKey = "write-secret"
+	const readKey = "read-secret"
+
+	fs := newTusIDORTestServer(t, writeKey, readKey, map[string]string{
+		"victim-session": "/buckets/secret/victim.bin",
+		"own-session":    "/buckets/allowed/own.bin",
+	})
+
+	attackerWrite := signFilerToken(t, writeKey, []string{"/buckets/allowed"}, nil)
+	attackerRead := signFilerToken(t, readKey, []string{"/buckets/allowed"}, nil)
+
+	tests := []struct {
+		name             string
+		method           string
+		path             string
+		token            string
+		expectAuthorized bool
+	}{
+		// The IDOR: a token scoped to /buckets/allowed must not act on a session
+		// whose target is /buckets/secret, regardless of the verb.
+		{"patch victim session denied", http.MethodPatch, "/.tus/.uploads/victim-session", attackerWrite, false},
+		{"delete victim session denied", http.MethodDelete, "/.tus/.uploads/victim-session", attackerWrite, false},
+		{"head victim session denied", http.MethodHead, "/.tus/.uploads/victim-session", attackerRead, false},
+
+		// The same token acting on its own in-prefix session is still allowed.
+		{"patch own session allowed", http.MethodPatch, "/.tus/.uploads/own-session", attackerWrite, true},
+		{"delete own session allowed", http.MethodDelete, "/.tus/.uploads/own-session", attackerWrite, true},
+		{"head own session allowed", http.MethodHead, "/.tus/.uploads/own-session", attackerRead, true},
+
+		// An unrestricted token (no AllowedPrefixes) keeps working and triggers no
+		// session lookup.
+		{"patch unrestricted allowed", http.MethodPatch, "/.tus/.uploads/victim-session", signFilerToken(t, writeKey, nil, nil), true},
+
+		// An unknown session leaves the request unscoped so the handler can answer
+		// 404, rather than being denied on a path that cannot be resolved.
+		{"patch unknown session allowed", http.MethodPatch, "/.tus/.uploads/does-not-exist", attackerWrite, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			req.Header.Set("Authorization", "Bearer "+tt.token)
+			if got := fs.checkTusJwtAuthorization(req); got != tt.expectAuthorized {
+				t.Errorf("checkTusJwtAuthorization(%s %s) = %v, want %v", tt.method, tt.path, got, tt.expectAuthorized)
+			}
+		})
+	}
+}
+
+// TestFilerServer_tusHandler_CrossPrefixPatchRejected drives the full handler:
+// an attacker PATCH against another tenant's session must be rejected with 401
+// before any bytes are written to the session's target path.
+func TestFilerServer_tusHandler_CrossPrefixPatchRejected(t *testing.T) {
+	const writeKey = "write-secret"
+	const readKey = "read-secret"
+
+	fs := newTusIDORTestServer(t, writeKey, readKey, map[string]string{
+		"victim-session": "/buckets/secret/victim.bin",
+	})
+	attacker := signFilerToken(t, writeKey, []string{"/buckets/allowed"}, nil)
+
+	req := httptest.NewRequest(http.MethodPatch, "/.tus/.uploads/victim-session", strings.NewReader("PWNED-BY-CROSS-PREFIX-TUS-SESSION-HIJACK"))
+	req.Header.Set("Tus-Resumable", TusVersion)
+	req.Header.Set("Upload-Offset", "0")
+	req.Header.Set("Content-Type", "application/offset+octet-stream")
+	req.Header.Set("Authorization", "Bearer "+attacker)
+
+	rec := httptest.NewRecorder()
+	fs.tusHandler(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("cross-prefix PATCH = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}

--- a/weed/server/filer_server_tus_session.go
+++ b/weed/server/filer_server_tus_session.go
@@ -189,7 +189,7 @@ func (fs *FilerServer) readTusSessionInfo(ctx context.Context, uploadID string) 
 	entry, err := fs.filer.FindEntry(ctx, infoPath)
 	if err != nil {
 		if err == filer_pb.ErrNotFound {
-			return nil, fmt.Errorf("TUS upload session not found: %s", uploadID)
+			return nil, fmt.Errorf("TUS upload session not found: %s: %w", uploadID, filer_pb.ErrNotFound)
 		}
 		return nil, fmt.Errorf("find session: %w", err)
 	}

--- a/weed/server/filer_server_tus_session.go
+++ b/weed/server/filer_server_tus_session.go
@@ -182,8 +182,7 @@ func (fs *FilerServer) saveTusSession(ctx context.Context, session *TusSession) 
 }
 
 // readTusSessionInfo reads and decodes a session's .info file without listing its
-// chunks. It is the cheap lookup the authorization check uses, which only needs
-// the stored TargetPath to scope a prefix-restricted token.
+// chunks, the cheap lookup the authorization check needs for the stored TargetPath.
 func (fs *FilerServer) readTusSessionInfo(ctx context.Context, uploadID string) (*TusSession, error) {
 	infoPath := util.FullPath(fs.tusSessionInfoPath(uploadID))
 	entry, err := fs.filer.FindEntry(ctx, infoPath)

--- a/weed/server/filer_server_tus_session.go
+++ b/weed/server/filer_server_tus_session.go
@@ -181,8 +181,10 @@ func (fs *FilerServer) saveTusSession(ctx context.Context, session *TusSession) 
 	return nil
 }
 
-// getTusSession retrieves a TUS session by upload ID, including chunks from directory listing
-func (fs *FilerServer) getTusSession(ctx context.Context, uploadID string) (*TusSession, error) {
+// readTusSessionInfo reads and decodes a session's .info file without listing its
+// chunks. It is the cheap lookup the authorization check uses, which only needs
+// the stored TargetPath to scope a prefix-restricted token.
+func (fs *FilerServer) readTusSessionInfo(ctx context.Context, uploadID string) (*TusSession, error) {
 	infoPath := util.FullPath(fs.tusSessionInfoPath(uploadID))
 	entry, err := fs.filer.FindEntry(ctx, infoPath)
 	if err != nil {
@@ -195,6 +197,15 @@ func (fs *FilerServer) getTusSession(ctx context.Context, uploadID string) (*Tus
 	var session TusSession
 	if err := json.Unmarshal(entry.Content, &session); err != nil {
 		return nil, fmt.Errorf("unmarshal session: %w", err)
+	}
+	return &session, nil
+}
+
+// getTusSession retrieves a TUS session by upload ID, including chunks from directory listing
+func (fs *FilerServer) getTusSession(ctx context.Context, uploadID string) (*TusSession, error) {
+	session, err := fs.readTusSessionInfo(ctx, uploadID)
+	if err != nil {
+		return nil, err
 	}
 
 	// Load chunks from directory listing with pagination (atomic read, no race condition)
@@ -248,7 +259,7 @@ func (fs *FilerServer) getTusSession(ctx context.Context, uploadID string) (*Tus
 		session.Offset = contiguousEnd
 	}
 
-	return &session, nil
+	return session, nil
 }
 
 // saveTusChunk stores the chunk info as a separate file entry


### PR DESCRIPTION
## Problem

`checkTusJwtAuthorization` enforced `allowed_prefixes` scoping only on session creation (`POST`). For the verbs that act on an *existing* TUS session — `HEAD`, `PATCH`, `DELETE` — the scoped-path list stayed empty, so `checkJwtAuthorization` never ran the prefix check and authorized the request on signature and method alone.

The session id was treated as the boundary ("unguessable, target already scope-checked at creation"). That holds against an unauthenticated attacker, but not against a legitimate low-privilege tenant who already holds a valid filer write JWT and learns another upload's session id (leaked `Location` header, logs, a shared upload link). Such a tenant, scoped to `/buckets/allowed`, could:

- `PATCH` attacker-controlled bytes into a victim's session whose `TargetPath` is `/buckets/secret/...`; on completion the file lands at the victim's path with the attacker's content — a cross-prefix arbitrary write to a path the token's own `allowed_prefixes` forbids.
- `DELETE` other tenants' in-progress sessions (DoS).
- `HEAD` them to read upload offset and declared size (info disclosure).

Direct writes and session *creation* against `/buckets/secret` are correctly denied for the same token, which is what makes this an IDOR rather than expected access.

This addresses GHSA-99q7-x53r-6j4g. It only affects deployments that set `jwt.filer_signing.key` and use `allowed_prefixes` to segregate tenants.

## Fix

Resolve the effective target for `HEAD`/`PATCH`/`DELETE` from the session's stored `TargetPath` and scope the prefix check against it, exactly as `POST` scopes the create target. The scoped paths are resolved lazily (`checkJwtAuthorizationScoped`), so the extra session read happens only for a prefix-restricted token — unrestricted tokens and deployments with no signing key touch no additional state. An unknown/unreadable session stays unscoped so the handler still returns 404 rather than denying on a path it cannot determine.

## Tests

`weed/server/filer_server_tus_idor_test.go` seeds a session whose target is outside the token's prefix and asserts a `/buckets/allowed` token is denied on `HEAD`/`PATCH`/`DELETE` of a `/buckets/secret` session, while its own in-prefix session and unrestricted tokens still pass. A handler-level test drives `tusHandler` end-to-end and confirms the cross-prefix `PATCH` is rejected with 401 before any bytes are written. Both fail on the pre-fix code and pass after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened JWT authorization for session-based TUS uploads by enforcing restricted path prefixes tied to each upload session.
  - PATCH/DELETE/HEAD requests are now checked against the session’s stored target path to prevent cross-prefix session hijacking.
  - Requests for unknown or missing sessions are no longer incorrectly denied by authorization, while restricted tokens still fail closed if session metadata can’t be read.

- **Tests**
  - Added IDOR regression coverage for cross-prefix attempts and unknown/corrupt session authorization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->