### PR TITLE
filer: allow clearing a bucket read-only flag stuck after quota removal

### DIFF
--- a/weed/admin/dash/bucket_management.go
+++ b/weed/admin/dash/bucket_management.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/s3api"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
@@ -395,6 +396,14 @@ func (s *AdminServer) SetBucketQuota(bucketName string, quotaBytes int64, quotaE
 		})
 		if err != nil {
 			return fmt.Errorf("failed to update bucket quota: %w", err)
+		}
+
+		if quota <= 0 {
+			// with no active quota, quota enforcement can no longer clear a
+			// read-only flag it turned on, so lift it here
+			if _, err := filer.ClearBucketReadOnly(context.Background(), client, "/buckets", bucketName); err != nil {
+				return fmt.Errorf("failed to clear bucket read-only flag: %w", err)
+			}
 		}
 
 		return nil

--- a/weed/filer/filer_conf.go
+++ b/weed/filer/filer_conf.go
@@ -262,6 +262,44 @@ func (fc *FilerConf) ApplyBucketQuotaReadOnly(locationPrefix string, usedSize, q
 	return locConf.ReadOnly, true
 }
 
+// ClearReadOnly clears the read-only flag on the rule at exactly locationPrefix,
+// reporting whether the flag was set. This is the explicit unlock for a flag that
+// ApplyBucketQuotaReadOnly can no longer clear once the quota is gone.
+func (fc *FilerConf) ClearReadOnly(locationPrefix string) (changed bool) {
+	locConf, found := fc.GetLocationConf(locationPrefix)
+	if !found || !locConf.ReadOnly {
+		return false
+	}
+	locConf.ReadOnly = false
+	fc.SetLocationConf(locConf)
+	return true
+}
+
+// ClearBucketReadOnly lifts the read-only flag that quota enforcement may have
+// left on the bucket's path rule, saving the updated configuration back to the
+// filer. It reports whether anything was cleared.
+func ClearBucketReadOnly(ctx context.Context, client filer_pb.SeaweedFilerClient, bucketsPath, bucketName string) (changed bool, err error) {
+	data, err := ReadInsideFiler(ctx, client, DirectoryEtcSeaweedFS, FilerConfName)
+	if err == filer_pb.ErrNotFound || (err == nil && len(data) == 0) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("read %s/%s: %v", DirectoryEtcSeaweedFS, FilerConfName, err)
+	}
+	fc := NewFilerConf()
+	if err = fc.LoadFromBytes(data); err != nil {
+		return false, fmt.Errorf("parse %s/%s: %v", DirectoryEtcSeaweedFS, FilerConfName, err)
+	}
+	if !fc.ClearReadOnly(bucketsPath + "/" + bucketName + "/") {
+		return false, nil
+	}
+	var buf bytes.Buffer
+	if err = fc.ToText(&buf); err != nil {
+		return false, err
+	}
+	return true, SaveInsideFiler(ctx, client, DirectoryEtcSeaweedFS, FilerConfName, buf.Bytes())
+}
+
 func (fc *FilerConf) GetCollectionTtls(collection string) (ttls map[string]string) {
 	ttls = make(map[string]string)
 	fc.rules.Walk(func(key []byte, value *filer_pb.FilerConf_PathConf) bool {

--- a/weed/filer/filer_conf.go
+++ b/weed/filer/filer_conf.go
@@ -290,6 +290,8 @@ func ClearBucketReadOnly(ctx context.Context, client filer_pb.SeaweedFilerClient
 	if err = fc.LoadFromBytes(data); err != nil {
 		return false, fmt.Errorf("parse %s/%s: %v", DirectoryEtcSeaweedFS, FilerConfName, err)
 	}
+	// join the rule key exactly as s3.bucket.quota.enforce writes it, so the
+	// exact-match lookup finds the rule even for a non-canonical bucketsPath
 	if !fc.ClearReadOnly(bucketsPath + "/" + bucketName + "/") {
 		return false, nil
 	}
@@ -297,7 +299,10 @@ func ClearBucketReadOnly(ctx context.Context, client filer_pb.SeaweedFilerClient
 	if err = fc.ToText(&buf); err != nil {
 		return false, err
 	}
-	return true, SaveInsideFiler(ctx, client, DirectoryEtcSeaweedFS, FilerConfName, buf.Bytes())
+	if err = SaveInsideFiler(ctx, client, DirectoryEtcSeaweedFS, FilerConfName, buf.Bytes()); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (fc *FilerConf) GetCollectionTtls(collection string) (ttls map[string]string) {

--- a/weed/filer/filer_conf_test.go
+++ b/weed/filer/filer_conf_test.go
@@ -161,3 +161,24 @@ func TestApplyBucketQuotaReadOnly(t *testing.T) {
 	_, changed = fc.ApplyBucketQuotaReadOnly(prefix, 50, 100)
 	assert.False(t, changed)
 }
+
+func TestClearReadOnly(t *testing.T) {
+	const prefix = "/buckets/b/"
+
+	fc := NewFilerConf()
+	assert.False(t, fc.ClearReadOnly(prefix), "no rule to clear")
+
+	// locked by quota enforcement, then quota removed: still clearable
+	fc.ApplyBucketQuotaReadOnly(prefix, 150, 100)
+	assert.True(t, fc.ClearReadOnly(prefix))
+	assert.False(t, fc.MatchStorageRule(prefix).ReadOnly)
+	assert.False(t, fc.ClearReadOnly(prefix), "already writable")
+
+	// clearing the flag keeps the rule's other settings
+	fc = NewFilerConf()
+	fc.SetLocationConf(&filer_pb.FilerConf_PathConf{LocationPrefix: prefix, Ttl: "7d", ReadOnly: true})
+	assert.True(t, fc.ClearReadOnly(prefix))
+	rule := fc.MatchStorageRule(prefix)
+	assert.False(t, rule.ReadOnly)
+	assert.Equal(t, "7d", rule.Ttl)
+}

--- a/weed/shell/command_fs_configure.go
+++ b/weed/shell/command_fs_configure.go
@@ -41,6 +41,9 @@ func (c *commandFsConfigure) Help() string {
 	# apply the changes
 	fs.configure -locationPrefix=/my/folder -collection=abc -apply
 
+	# example: unlock a bucket that quota enforcement made read-only
+	fs.configure -locationPrefix=/buckets/my_bucket/ -readOnly=false -apply
+
 	# delete the changes
 	fs.configure -locationPrefix=/my/folder -delete -apply
 
@@ -131,6 +134,21 @@ func (c *commandFsConfigure) Do(args []string, commandEnv *CommandEnv, writer io
 			fc.DeleteLocationConf(*locationPrefix)
 		} else {
 			fc.AddLocationConf(locConf)
+			// AddLocationConf merges boolean fields with OR, which can never turn
+			// a flag off; let an explicitly passed false win, e.g. -readOnly=false
+			// to reopen a bucket that quota enforcement locked
+			if mergedConf, found := fc.GetLocationConf(*locationPrefix); found {
+				fsConfigureCommand.Visit(func(f *flag.Flag) {
+					switch f.Name {
+					case "readOnly":
+						mergedConf.ReadOnly = *isReadOnly
+					case "fsync":
+						mergedConf.Fsync = *fsync
+					case "worm":
+						mergedConf.Worm = *worm
+					}
+				})
+			}
 		}
 	}
 

--- a/weed/shell/command_s3_bucket_quota.go
+++ b/weed/shell/command_s3_bucket_quota.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 )
 
@@ -25,6 +26,9 @@ func (c *commandS3BucketQuota) Help() string {
 
 	Example:
 		s3.bucket.quota -name=<bucket_name> -op=set -sizeMB=1024
+
+	Removing or disabling the quota also clears the read-only flag that
+	s3.bucket.quota.enforce may have set on the bucket.
 `
 }
 
@@ -65,6 +69,7 @@ func (c *commandS3BucketQuota) Do(args []string, commandEnv *CommandEnv, writer 
 		}
 		bucketEntry := lookupResp.Entry
 
+		clearReadOnly := false
 		switch *operationName {
 		case "set":
 			bucketEntry.Quota = *sizeMB * 1024 * 1024
@@ -73,6 +78,7 @@ func (c *commandS3BucketQuota) Do(args []string, commandEnv *CommandEnv, writer 
 			return nil
 		case "remove":
 			bucketEntry.Quota = 0
+			clearReadOnly = true
 		case "enable":
 			if bucketEntry.Quota < 0 {
 				bucketEntry.Quota = -bucketEntry.Quota
@@ -81,6 +87,7 @@ func (c *commandS3BucketQuota) Do(args []string, commandEnv *CommandEnv, writer 
 			if bucketEntry.Quota > 0 {
 				bucketEntry.Quota = -bucketEntry.Quota
 			}
+			clearReadOnly = true
 		}
 
 		if err := filer_pb.UpdateEntry(context.Background(), client, &filer_pb.UpdateEntryRequest{
@@ -91,6 +98,18 @@ func (c *commandS3BucketQuota) Do(args []string, commandEnv *CommandEnv, writer 
 		}
 
 		println("updated quota for bucket", *bucketName)
+
+		if clearReadOnly {
+			// with the quota removed or disabled, s3.bucket.quota.enforce can no
+			// longer clear a read-only flag it turned on, so lift it here
+			cleared, err := filer.ClearBucketReadOnly(ctx, client, filerBucketsPath, *bucketName)
+			if err != nil {
+				return err
+			}
+			if cleared {
+				fmt.Fprintf(writer, "cleared read-only for bucket %s\n", *bucketName)
+			}
+		}
 
 		return nil
 


### PR DESCRIPTION
## What

A bucket marked read-only by `s3.bucket.quota.enforce` stays read-only forever once its quota is removed or disabled, with no supported way to unlock it short of deleting the whole path rule:

- `ApplyBucketQuotaReadOnly` deliberately skips buckets with a non-positive quota (so enforcement never reopens a manually locked bucket), which means it also never clears the flag it set itself once the quota is gone. The bucket then shows **No quota** + **Read-only** indefinitely.
- `fs.configure -readOnly=false` couldn't clear it either: `AddLocationConf` merges boolean fields with OR (`a.ReadOnly = b.ReadOnly || a.ReadOnly`), so once true, always true.

## Changes

- `filer.ClearBucketReadOnly` / `FilerConf.ClearReadOnly`: lift the read-only flag on the bucket's exact path rule and save the conf.
- `s3.bucket.quota -op=remove` and `-op=disable` now clear the flag — explicitly ending or suspending quota enforcement is the operator's intent to make the bucket writable again. Prints `cleared read-only for bucket <name>` when it does.
- Admin server `SetBucketQuota` does the same when the resulting quota is non-positive (the admin UI quota dialog is the other place quotas get removed).
- `fs.configure` now honors explicitly passed false boolean flags (`-readOnly=false`, `-fsync=false`, `-worm=false`) as an override after the merge, using `flag.Visit` to distinguish an explicit false from an unset flag. Flags not passed keep their existing values, and a parent-prefix read-only still wins at match time as before.

Enforcement semantics are unchanged: a bucket with an active quota still locks/unlocks on usage, and a manual `fs.configure -readOnly` lock still survives enforcement runs.

## Verified on a live cluster

```
> s3.bucket.quota -name=testbkt -op=set -sizeMB=1
> s3.bucket.quota.enforce -apply
    changing bucket testbkt to read only!
# filer rejects writes: {"error":"read only: /buckets/testbkt/ (e.g. bucket over quota)"}
> s3.bucket.quota -name=testbkt -op=remove
updated quota for bucket testbkt
cleared read-only for bucket testbkt
# writes succeed again; fs.configure shows readOnly: false
```

Also exercised: `-op=disable` clears the flag; `fs.configure -locationPrefix=/buckets/testbkt/ -readOnly=false -apply` unlocks while keeping the rule's other settings (ttl survived); an unrelated `fs.configure -ttl=3d` on a locked rule leaves `readOnly: true` untouched; explicit `-readOnly` still locks and rejects writes.

## Note

A deleted bucket's path rule (and any read-only flag on it) still survives bucket deletion, so a recreated bucket of the same name inherits it — separate issue, not addressed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Removing or disabling an S3 bucket quota now automatically restores write access when quota enforcement had made the bucket read-only.
  * Added guidance in `fs.configure` to show how to unlock a quota-restricted bucket (`-readOnly=false -apply`).
* **Bug Fixes**
  * Fixed `fs.configure` so explicitly provided boolean settings (ReadOnly, Fsync, WORM) can be turned off, even when updating an existing location.
* **Tests**
  * Added coverage for clearing bucket read-only behavior without affecting other settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->