### PR TITLE
sftp: match permission paths on path-component boundaries

### DIFF
--- a/test/sftp/sibling_prefix_test.go
+++ b/test/sftp/sibling_prefix_test.go
@@ -1,0 +1,72 @@
+package sftp
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestScopedUserCannotAccessSiblingPrefix verifies that a permission entry
+// for /tenants/alice does not leak onto sibling paths such as
+// /tenants/alice-archive that merely share the string prefix.
+func TestScopedUserCannotAccessSiblingPrefix(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	config := DefaultTestConfig()
+	config.EnableDebug = testing.Verbose()
+
+	fw := NewSftpTestFramework(t, config)
+	require.NoError(t, fw.Setup(config))
+	defer fw.Cleanup()
+
+	// admin seeds both tenants
+	admin, adminConn, err := fw.ConnectSFTP("admin", "adminpassword")
+	require.NoError(t, err)
+	defer adminConn.Close()
+	defer admin.Close()
+
+	require.NoError(t, admin.MkdirAll("/tenants/alice"))
+	require.NoError(t, admin.MkdirAll("/tenants/alice-archive"))
+	secret, err := admin.Create("/tenants/alice-archive/secret.txt")
+	require.NoError(t, err)
+	_, err = secret.Write([]byte("SIBLING-SECRET"))
+	require.NoError(t, err)
+	require.NoError(t, secret.Close())
+
+	scoped, scopedConn, err := fw.ConnectSFTP("scoped", "scopedpassword")
+	require.NoError(t, err)
+	defer scopedConn.Close()
+	defer scoped.Close()
+
+	// positive control: the scoped user can write within its own prefix
+	own, err := scoped.Create("/tenants/alice/own.txt")
+	require.NoError(t, err)
+	_, err = own.Write([]byte("ok"))
+	require.NoError(t, err)
+	require.NoError(t, own.Close())
+
+	// reading the sibling tenant's file must fail
+	if f, err := scoped.Open("/tenants/alice-archive/secret.txt"); err == nil {
+		data, _ := io.ReadAll(f)
+		f.Close()
+		t.Fatalf("ACL for /tenants/alice read sibling /tenants/alice-archive: %q", data)
+	}
+
+	// overwriting the sibling tenant's file must fail
+	if f, err := scoped.Create("/tenants/alice-archive/secret.txt"); err == nil {
+		f.Write([]byte("OVERWRITTEN-BY-SCOPED-USER"))
+		f.Close()
+		t.Fatal("ACL for /tenants/alice overwrote sibling /tenants/alice-archive")
+	}
+
+	// the sibling file is intact
+	f, err := admin.Open("/tenants/alice-archive/secret.txt")
+	require.NoError(t, err)
+	data, err := io.ReadAll(f)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	require.Equal(t, "SIBLING-SECRET", string(data))
+}

--- a/test/sftp/testdata/userstore.json
+++ b/test/sftp/testdata/userstore.json
@@ -31,6 +31,17 @@
     },
     "Uid": 1002,
     "Gid": 1002
+  },
+  {
+    "Username": "scoped",
+    "Password": "scopedpassword",
+    "PublicKeys": [],
+    "HomeDir": "/",
+    "Permissions": {
+      "/tenants/alice": ["read", "write", "list"]
+    },
+    "Uid": 1003,
+    "Gid": 1003
   }
 ]
 

--- a/weed/sftpd/sftp_permissions.go
+++ b/weed/sftpd/sftp_permissions.go
@@ -197,8 +197,9 @@ func HasExplicitPermission(user *user.User, filepath, requiredPerm string, isDir
 
 	for p, userPerms := range user.Permissions {
 		// The path must be the permission path exactly or under that path
-		if p = stdpath.Clean(p); pathWithin(p, filepath) && len(p) > len(bestMatch) {
-			bestMatch = p
+		cleaned := stdpath.Clean(p)
+		if pathWithin(cleaned, filepath) && len(cleaned) > len(bestMatch) {
+			bestMatch = cleaned
 			perms = userPerms
 		}
 	}

--- a/weed/sftpd/sftp_permissions.go
+++ b/weed/sftpd/sftp_permissions.go
@@ -114,9 +114,23 @@ func (fs *SftpServer) CheckFilePermission(path string, perm string) error {
 	return os.ErrPermission
 }
 
+// pathWithin reports whether candidate is base itself or a descendant of base,
+// on path-component boundaries so /a does not match /a-sibling.
+func pathWithin(base, candidate string) bool {
+	base = stdpath.Clean(base)
+	candidate = stdpath.Clean(candidate)
+	if base == "/" {
+		return strings.HasPrefix(candidate, "/")
+	}
+	return candidate == base || strings.HasPrefix(candidate, base+"/")
+}
+
 // isPathInHomeDirectory checks if a path is in the user's home directory
 func isPathInHomeDirectory(user *user.User, path string) bool {
-	return strings.HasPrefix(path, user.HomeDir)
+	if user.HomeDir == "" {
+		return true
+	}
+	return pathWithin(user.HomeDir, path)
 }
 
 // HasUnixPermission checks if the user has the required Unix permission
@@ -182,8 +196,8 @@ func HasExplicitPermission(user *user.User, filepath, requiredPerm string, isDir
 	var perms []string
 
 	for p, userPerms := range user.Permissions {
-		// Check if the path is either the permission path exactly or is under that path
-		if strings.HasPrefix(filepath, p) && len(p) > len(bestMatch) {
+		// The path must be the permission path exactly or under that path
+		if p = stdpath.Clean(p); pathWithin(p, filepath) && len(p) > len(bestMatch) {
 			bestMatch = p
 			perms = userPerms
 		}

--- a/weed/sftpd/sftp_permissions_test.go
+++ b/weed/sftpd/sftp_permissions_test.go
@@ -1,0 +1,64 @@
+package sftpd
+
+import (
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/sftpd/user"
+)
+
+func TestPathWithin(t *testing.T) {
+	tests := []struct {
+		base      string
+		candidate string
+		want      bool
+	}{
+		{"/tenants/alice", "/tenants/alice", true},
+		{"/tenants/alice", "/tenants/alice/file.txt", true},
+		{"/tenants/alice", "/tenants/alice/sub/dir", true},
+		{"/tenants/alice", "/tenants/alice-archive", false},
+		{"/tenants/alice", "/tenants/alice-archive/secret.txt", false},
+		{"/tenants/alice", "/tenants/alice2", false},
+		{"/tenants/alice", "/tenants", false},
+		{"/tenants/alice/", "/tenants/alice/file.txt", true},
+		{"/tenants/alice", "/tenants/alice/../alice-archive", false},
+		{"/tenants/alice", "/tenants/alice/..", false},
+		{"/", "/", true},
+		{"/", "/anything", true},
+	}
+	for _, tt := range tests {
+		if got := pathWithin(tt.base, tt.candidate); got != tt.want {
+			t.Errorf("pathWithin(%q, %q) = %v, want %v", tt.base, tt.candidate, got, tt.want)
+		}
+	}
+}
+
+func TestHasExplicitPermissionSiblingPrefix(t *testing.T) {
+	u := &user.User{
+		Username: "scoped",
+		HomeDir:  "/",
+		Permissions: map[string][]string{
+			"/tenants/alice": {"read", "write", "list"},
+		},
+	}
+
+	if !HasExplicitPermission(u, "/tenants/alice/file.txt", PermRead, false) {
+		t.Error("expected read permission under /tenants/alice")
+	}
+	if HasExplicitPermission(u, "/tenants/alice-archive/secret.txt", PermRead, false) {
+		t.Error("ACL for /tenants/alice must not grant read on sibling /tenants/alice-archive")
+	}
+	if HasExplicitPermission(u, "/tenants/alice-archive/secret.txt", PermWrite, false) {
+		t.Error("ACL for /tenants/alice must not grant write on sibling /tenants/alice-archive")
+	}
+}
+
+func TestIsPathInHomeDirectorySiblingPrefix(t *testing.T) {
+	u := &user.User{Username: "alice", HomeDir: "/tenants/alice"}
+
+	if !isPathInHomeDirectory(u, "/tenants/alice/file.txt") {
+		t.Error("expected /tenants/alice/file.txt to be within home /tenants/alice")
+	}
+	if isPathInHomeDirectory(u, "/tenants/alice-archive/secret.txt") {
+		t.Error("home /tenants/alice must not match sibling /tenants/alice-archive")
+	}
+}


### PR DESCRIPTION
The SFTP permission checks compared paths with raw string prefixes, so a permission entry for `/tenants/alice` also matched sibling paths such as `/tenants/alice-archive`, letting a scoped user read and overwrite another tenant's files through the authenticated SFTP service. The home directory containment check had the same flaw.

Both checks now go through `pathWithin`, which cleans the paths and requires exact equality or a separator-delimited descendant. A base of `/` still matches everything, so root-homed users are unaffected.

Unit tests cover exact, descendant, sibling-prefix, traversal, trailing-slash, and root cases. A new integration test in test/sftp drives a real cluster with a scoped user and verifies sibling reads and overwrites are denied while access within the granted prefix still works; it reproduces the disclosure on the unpatched binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened SFTP permission path matching to prevent access to similarly named “sibling” directories (e.g., `/alice` vs `/alice-archive`).
  * Improved home-directory scoping, including correct handling when the home directory is unset.
  * Refined explicit-permission selection to use boundary-aware path checks, avoiding incorrect prefix matches.

* **Tests**
  * Added unit tests for path-in-scope logic and permission enforcement for sibling-prefix scenarios.
  * Added an integration test ensuring a scoped user cannot read, create, or overwrite sibling-prefix files and that protected content remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->