### PR TITLE
Introduce weed shell command `ec.health`.

### DIFF
--- a/weed/shell/command_ec_health.go
+++ b/weed/shell/command_ec_health.go
@@ -1,0 +1,218 @@
+package shell
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
+	"github.com/seaweedfs/seaweedfs/weed/storage/erasure_coding"
+)
+
+func init() {
+	Commands = append(Commands, &commandEcVolumeHealth{})
+}
+
+type commandEcVolumeHealth struct {
+	writer      io.Writer
+	dataNodes   []*master_pb.DataNodeInfo
+	volumeIDMap map[uint32]bool
+}
+
+func (c *commandEcVolumeHealth) Name() string {
+	return "ec.health"
+}
+
+func (c *commandEcVolumeHealth) Help() string {
+	return `Verifies the overall shard health of EC volumes.
+`
+}
+
+func (c *commandEcVolumeHealth) HasTag(CommandTag) bool {
+	return false
+}
+
+func (c *commandEcVolumeHealth) Do(args []string, commandEnv *CommandEnv, writer io.Writer) (err error) {
+	volHealthCommand := flag.NewFlagSet(c.Name(), flag.ContinueOnError)
+	volumeIDsStr := volHealthCommand.String("volumeIds", "", "comma-separated EC volume IDs to process (optional)")
+	showDetails := volHealthCommand.Bool("details", false, "display result details, if available")
+
+	if err = volHealthCommand.Parse(args); err != nil {
+		return err
+	}
+	if err = commandEnv.confirmIsLocked(args); err != nil {
+		return
+	}
+
+	c.writer = writer
+
+	c.volumeIDMap = map[uint32]bool{}
+	if *volumeIDsStr != "" {
+		for _, vids := range strings.Split(*volumeIDsStr, ",") {
+			vids = strings.TrimSpace(vids)
+			if vids == "" {
+				continue
+			}
+			if vid, err := strconv.ParseUint(vids, 10, 32); err == nil {
+				c.volumeIDMap[uint32(vid)] = true
+			} else {
+				return fmt.Errorf("invalid volume ID %q", vids)
+			}
+		}
+	}
+
+	c.dataNodes, err = collectDataNodes(commandEnv, 0)
+	if err != nil {
+		return err
+	}
+
+	return c.checkEcVolumes(*showDetails)
+}
+
+func (c *commandEcVolumeHealth) write(format string, a ...any) {
+	fmt.Fprintf(c.writer, format, a...)
+}
+
+func (c *commandEcVolumeHealth) isVolumeIDValid(vid uint32) bool {
+	if len(c.volumeIDMap) == 0 {
+		return true
+	}
+	if _, ok := c.volumeIDMap[vid]; ok {
+		return true
+	}
+
+	return false
+}
+
+// TODO: check shard sizes?
+func (c *commandEcVolumeHealth) checkEcVolumes(showDetails bool) error {
+	shardAddressMap := map[uint32]map[erasure_coding.ShardId][]string{}
+
+	// collect EC shard details
+	volumesFound := false
+	for _, dni := range c.dataNodes {
+		nodeAddress := dni.GetAddress()
+		for _, di := range dni.GetDiskInfos() {
+			for _, eci := range di.GetEcShardInfos() {
+				vid := eci.GetId()
+				if !c.isVolumeIDValid(vid) {
+					continue
+				}
+				volumesFound = true
+
+				if _, ok := shardAddressMap[vid]; !ok {
+					shardAddressMap[vid] = map[erasure_coding.ShardId][]string{}
+				}
+
+				sinfo := erasure_coding.ShardsInfoFromVolumeEcShardInformationMessage(eci)
+				for _, sid := range sinfo.Ids() {
+					if _, ok := shardAddressMap[vid][sid]; !ok {
+						shardAddressMap[vid][sid] = []string{}
+					}
+					shardAddressMap[vid][sid] = append(shardAddressMap[vid][sid], nodeAddress)
+				}
+			}
+		}
+	}
+
+	if !volumesFound {
+		return fmt.Errorf("no EC volumes found")
+	}
+
+	// keep the shard address map nicely sorted, for the sake of readability.
+	for _, sm := range shardAddressMap {
+		for _, addrs := range sm {
+			slices.Sort(addrs)
+		}
+	}
+
+	// check each volume, and compute shard counts
+	underreplicatedVolumeIDs := []uint32{}
+	overreplicatedVolumeIDs := []uint32{}
+	shardCountMap := map[uint32]int{}
+
+	for vid, sm := range shardAddressMap {
+		for _, addrs := range sm {
+			shardCountMap[vid] += len(addrs)
+		}
+		under := false
+		over := false
+
+		for sid := range erasure_coding.TotalShardsCount {
+			sid := erasure_coding.ShardId(sid)
+			if len(sm[sid]) == 0 {
+				under = true
+			}
+			if len(sm[sid]) > 1 {
+				over = true
+			}
+		}
+
+		if under {
+			underreplicatedVolumeIDs = append(underreplicatedVolumeIDs, vid)
+		}
+		if !under && over {
+			// don't flag EC volumes as over-replicated if some shards are missing, regardless
+			// of others being repeated.
+			overreplicatedVolumeIDs = append(overreplicatedVolumeIDs, vid)
+		}
+	}
+
+	slices.Sort(underreplicatedVolumeIDs)
+	slices.Sort(overreplicatedVolumeIDs)
+
+	// ...and display results
+	if len(underreplicatedVolumeIDs) == 0 && len(overreplicatedVolumeIDs) == 0 {
+		c.write("EC volumes are healthy.\n")
+		return nil
+	}
+
+	if len(underreplicatedVolumeIDs) != 0 {
+		c.write("Found %d/%d under-replicated EC volumes: %v\n", len(underreplicatedVolumeIDs), len(shardAddressMap), underreplicatedVolumeIDs)
+	}
+	if len(overreplicatedVolumeIDs) != 0 {
+		c.write("Found %d/%d over-replicated EC volumes: %v\n", len(overreplicatedVolumeIDs), len(shardAddressMap), overreplicatedVolumeIDs)
+	}
+
+	if showDetails {
+		shardTypeDesc := func(sid int) string {
+			if sid < erasure_coding.DataShardsCount {
+				return ""
+			}
+			return " (parity)"
+		}
+
+		if len(underreplicatedVolumeIDs) != 0 {
+			c.write("\n")
+			for _, vid := range underreplicatedVolumeIDs {
+				c.write("Shards map for under-replicated EC volume %v (%d/%d shards):\n", vid, shardCountMap[vid], erasure_coding.TotalShardsCount)
+				for sid := range erasure_coding.TotalShardsCount {
+					if addrs, ok := shardAddressMap[vid][erasure_coding.ShardId(sid)]; ok {
+						c.write("\t%02d%s => %v\n", sid, shardTypeDesc(sid), addrs)
+					} else {
+						c.write("\t%02d%s is missing\n", sid, shardTypeDesc(sid))
+					}
+				}
+			}
+		}
+
+		if len(overreplicatedVolumeIDs) != 0 {
+			c.write("\n")
+			for _, vid := range overreplicatedVolumeIDs {
+				c.write("Shards map for over-replicated EC volume %v (%d/%d shards):\n", vid, shardCountMap[vid], erasure_coding.TotalShardsCount)
+				for sid := range erasure_coding.TotalShardsCount {
+					if addrs, ok := shardAddressMap[vid][erasure_coding.ShardId(sid)]; ok {
+						c.write("\t%02d%s => %v\n", sid, shardTypeDesc(sid), addrs)
+					} else {
+						c.write("\t%02d%s is missing\n", sid, shardTypeDesc(sid))
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/weed/shell/command_ec_health_test.go
+++ b/weed/shell/command_ec_health_test.go
@@ -1,0 +1,154 @@
+package shell
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
+)
+
+// TestEcShardMapRegister tests that EC shards are properly registered
+func TestEcShardHealth(t *testing.T) {
+	// Fake topology. EC volume 1 is fully replicated, EC volume 2 is under-replicated, and EC volume 3 is over-replicated.
+	nodes := []*master_pb.DataNodeInfo{
+		&master_pb.DataNodeInfo{
+			Address: "localhost:1111",
+			DiskInfos: map[string]*master_pb.DiskInfo{
+				"d1": &master_pb.DiskInfo{
+					EcShardInfos: []*master_pb.VolumeEcShardInformationMessage{
+						&master_pb.VolumeEcShardInformationMessage{
+							Id:          1,
+							EcIndexBits: 0b0000000011111,
+						},
+						&master_pb.VolumeEcShardInformationMessage{
+							Id:          2,
+							EcIndexBits: 0b0000000011111,
+						},
+						&master_pb.VolumeEcShardInformationMessage{
+							Id:          3,
+							EcIndexBits: 0b11111111111111,
+						},
+					},
+				},
+			},
+		},
+		&master_pb.DataNodeInfo{
+			Address: "localhost:2222",
+			DiskInfos: map[string]*master_pb.DiskInfo{
+				"d2": &master_pb.DiskInfo{
+					EcShardInfos: []*master_pb.VolumeEcShardInformationMessage{
+						&master_pb.VolumeEcShardInformationMessage{
+							Id:          1,
+							EcIndexBits: 0b11111111100000,
+						},
+						&master_pb.VolumeEcShardInformationMessage{
+							Id:          2,
+							EcIndexBits: 0b11111000000000,
+						},
+						&master_pb.VolumeEcShardInformationMessage{
+							Id:          3,
+							EcIndexBits: 0b00000000001111,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name        string
+		showDetails bool
+		volumeIDMap map[uint32]bool
+		want        string
+		wantErr     error
+	}{
+		{
+			name:        "default",
+			showDetails: false,
+			want: `Found 1/3 under-replicated EC volumes: [2]
+Found 1/3 over-replicated EC volumes: [3]
+`,
+		},
+		{
+			name:        "single healthy volume",
+			showDetails: false,
+			volumeIDMap: map[uint32]bool{1: true},
+			want: `EC volumes are healthy.
+`,
+		},
+		{
+			name:        "filtered by volume ID",
+			showDetails: false,
+			volumeIDMap: map[uint32]bool{1: true, 2: true, 5: true},
+			want: `Found 1/2 under-replicated EC volumes: [2]
+`,
+		},
+		{
+			name:        "no valid volume IDs",
+			showDetails: false,
+			volumeIDMap: map[uint32]bool{5: true, 6: true},
+			want:        "",
+			wantErr:     fmt.Errorf("no EC volumes found"),
+		},
+		{
+			name:        "with details",
+			showDetails: true,
+			want: `Found 1/3 under-replicated EC volumes: [2]
+Found 1/3 over-replicated EC volumes: [3]
+
+Shards map for under-replicated EC volume 2 (10/14 shards):
+	00 => [localhost:1111]
+	01 => [localhost:1111]
+	02 => [localhost:1111]
+	03 => [localhost:1111]
+	04 => [localhost:1111]
+	05 is missing
+	06 is missing
+	07 is missing
+	08 is missing
+	09 => [localhost:2222]
+	10 (parity) => [localhost:2222]
+	11 (parity) => [localhost:2222]
+	12 (parity) => [localhost:2222]
+	13 (parity) => [localhost:2222]
+
+Shards map for over-replicated EC volume 3 (18/14 shards):
+	00 => [localhost:1111 localhost:2222]
+	01 => [localhost:1111 localhost:2222]
+	02 => [localhost:1111 localhost:2222]
+	03 => [localhost:1111 localhost:2222]
+	04 => [localhost:1111]
+	05 => [localhost:1111]
+	06 => [localhost:1111]
+	07 => [localhost:1111]
+	08 => [localhost:1111]
+	09 => [localhost:1111]
+	10 (parity) => [localhost:1111]
+	11 (parity) => [localhost:1111]
+	12 (parity) => [localhost:1111]
+	13 (parity) => [localhost:1111]
+`,
+		},
+	}
+
+	for _, tc := range testCases {
+		var buf bytes.Buffer
+
+		cmd := &commandEcVolumeHealth{
+			writer:      &buf,
+			dataNodes:   nodes,
+			volumeIDMap: tc.volumeIDMap,
+		}
+		gotErr := cmd.checkEcVolumes(tc.showDetails)
+		got := buf.String()
+
+		if got != tc.want {
+			t.Errorf("%s: got %v, want %v", tc.name, got, tc.want)
+		}
+		if !reflect.DeepEqual(gotErr, tc.wantErr) {
+			t.Errorf("%s: got error %v, want %v", tc.name, gotErr, tc.wantErr)
+		}
+	}
+}


### PR DESCRIPTION
This command performs a quick health check on EC volumes, by verifying whether their shards are over- or under-replicated.

# What problem are we solving?

Provide visibility on EC volume health through the weed shell.

# How are we solving the problem?

This command performs a quick health check on EC volumes, by verifying whether their shards are over- or under-replicated.

# How is the PR tested?

Unit tests.

# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `ec.health` shell command to verify erasure-coded volume shard replication health.
  * Supports optional filtering by comma-separated volume IDs.
  * Provides summary counts for under-replicated and over-replicated volumes.
  * Includes an optional details mode that prints per-shard node presence (showing “missing” where applicable).
* **Tests**
  * Added automated coverage validating default output, filtered volume selection, no-match behavior, and details output scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->