### PR TITLE
fuse test: keep derived filer gRPC port below the ephemeral floor

### DIFF
--- a/test/fuse_integration/framework_test.go
+++ b/test/fuse_integration/framework_test.go
@@ -86,33 +86,45 @@ func NewFuseTestFramework(t *testing.T, config *TestConfig) *FuseTestFramework {
 	}
 }
 
-// freePort asks the OS for a free TCP port in a range where the gRPC
-// offset (port + 10000) won't collide with well-known ports.
-// Stay below the Linux ephemeral floor (32768) so the kernel does not
-// reuse the chosen port for an outbound connection between close() here
-// and re-bind in the child "weed mini" process.
+// grpcPortOffset mirrors weed's HTTP->gRPC port convention (gRPC = HTTP + offset);
+// "weed mount" derives the filer gRPC port from the filer HTTP address the same way.
+const grpcPortOffset = 10000
+
+// freePort returns a free filer HTTP port whose gRPC sibling (port+grpcPortOffset)
+// is also free. Both must stay below the Linux ephemeral floor (32768): a gRPC port
+// above it can be transiently grabbed by an outbound connection, forcing mini to
+// relocate its filer gRPC port while "weed mount" keeps dialing HTTP+10000 — the
+// mount then never connects and the test times out. Capping HTTP at 22000 keeps the
+// gRPC port at or below 32000.
 func freePort(t *testing.T) int {
 	t.Helper()
 	const (
 		minServicePort = 20000
-		maxServicePort = 32000
+		maxServicePort = 22000
 	)
 
 	portCount := maxServicePort - minServicePort + 1
 	start := minServicePort + int(time.Now().UnixNano()%int64(portCount))
 
-	for attempt := 0; attempt < 512; attempt++ {
+	for attempt := 0; attempt < portCount; attempt++ {
 		port := minServicePort + (start-minServicePort+attempt)%portCount
-		l, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
-		if err != nil {
-			continue
+		if portIsFree(port) && portIsFree(port+grpcPortOffset) {
+			return port
 		}
-		l.Close()
-		return port
 	}
 
-	t.Fatalf("failed to allocate port <= %d after repeated attempts", maxServicePort)
+	t.Fatalf("failed to allocate a free HTTP/gRPC port pair in [%d,%d]", minServicePort, maxServicePort)
 	return 0
+}
+
+// portIsFree reports whether a TCP port can currently be bound on 127.0.0.1.
+func portIsFree(port int) bool {
+	l, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+	if err != nil {
+		return false
+	}
+	l.Close()
+	return true
 }
 
 // Setup starts "weed mini" and mounts the FUSE filesystem.


### PR DESCRIPTION
The FUSE integration harness picks the filer HTTP port and lets `weed mount` derive the filer gRPC port as HTTP+10000. `freePort` kept the HTTP port under the Linux ephemeral floor (32768) but not the derived gRPC port, which ranged up to 42000.

When the gRPC port lands above the floor, an outbound connection on the runner can transiently hold it. Mini then cannot bind it:

```
mini.go:1001 gRPC port 38832 for Filer is not available, finding alternative...
```

Mini relocates its filer gRPC port, but `weed mount` keeps dialing HTTP+10000 (`connection refused`), so the mount never becomes ready and the test times out:

```
FUSE mount not ready: mount point not ready within timeout
--- FAIL: TestWritebackCacheDataIntegrity (32.71s)
```

Fix: cap the HTTP port at 22000 so the gRPC sibling stays at or below 32000, below the ephemeral floor, and verify both ports are bindable before returning so a stale listener on either is skipped. The new HTTP range `[20000, 22000]` (gRPC `[30000, 32000]`) does not collide with mini's fixed defaults (Master 9333/19333, Volume 9340/19340, Admin 23646/33646).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test setup to select available HTTP ports along with their corresponding gRPC ports.
  * Reduced the risk of port conflicts and flaky integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->