### PR TITLE
route log buffer flush copies through the shared slab pool

### DIFF
--- a/weed/util/log_buffer/log_buffer.go
+++ b/weed/util/log_buffer/log_buffer.go
@@ -15,6 +15,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/mq_pb"
 	"github.com/seaweedfs/seaweedfs/weed/util"
+	"github.com/seaweedfs/seaweedfs/weed/util/mem"
 )
 
 const BufferSize = 8 * 1024 * 1024
@@ -34,7 +35,7 @@ var (
 type dataToFlush struct {
 	startTime time.Time
 	stopTime  time.Time
-	data      *bytes.Buffer
+	data      []byte // slab from mem.Allocate; returned via mem.Free after flush
 	minOffset int64
 	maxOffset int64
 	done      chan struct{} // Signal when flush completes
@@ -541,7 +542,7 @@ func (logBuffer *LogBuffer) loopFlush() {
 		if d == nil {
 			break // shutdown sentinel
 		}
-		logBuffer.flushFn(logBuffer, d.startTime, d.stopTime, d.data.Bytes(), d.minOffset, d.maxOffset)
+		logBuffer.flushFn(logBuffer, d.startTime, d.stopTime, d.data, d.minOffset, d.maxOffset)
 		d.releaseMemory()
 		// local logbuffer is different from aggregate logbuffer here
 		if d.maxOffset >= 0 {
@@ -711,8 +712,8 @@ func (logBuffer *LogBuffer) SetLastFlushTsNs(ts int64) {
 }
 
 func (d *dataToFlush) releaseMemory() {
-	d.data.Reset()
-	bufferPool.Put(d.data)
+	mem.Free(d.data)
+	d.data = nil
 }
 
 // ReadFromBuffer returns the in-memory log data at lastReadPosition. isPooled
@@ -958,11 +959,14 @@ var bufferPool = sync.Pool{
 	},
 }
 
-func copiedBytes(buf []byte) (copied *bytes.Buffer) {
-	copied = bufferPool.Get().(*bytes.Buffer)
-	copied.Reset()
-	copied.Write(buf)
-	return
+// copiedBytes returns a private copy of buf backed by the shared, size-classed
+// slab pool. The caller owns it until mem.Free (see dataToFlush.releaseMemory),
+// so the live buffer never outlives the flush. Routing through mem reuses slabs
+// across the process instead of reallocating a window-sized array per flush.
+func copiedBytes(buf []byte) []byte {
+	copied := mem.Allocate(len(buf))
+	copy(copied, buf)
+	return copied
 }
 
 // sharedBufferView wraps the sealed window's shared snapshot from pos onward.

--- a/weed/util/log_buffer/log_buffer.go
+++ b/weed/util/log_buffer/log_buffer.go
@@ -712,8 +712,13 @@ func (logBuffer *LogBuffer) SetLastFlushTsNs(ts int64) {
 }
 
 func (d *dataToFlush) releaseMemory() {
-	mem.Free(d.data)
-	d.data = nil
+	// Guard nil: mem.Free(nil) would put a zero-cap slice into the smallest slot
+	// pool, so a later Allocate could hand back nil and panic. Also makes a double
+	// release harmless.
+	if d.data != nil {
+		mem.Free(d.data)
+		d.data = nil
+	}
 }
 
 // ReadFromBuffer returns the in-memory log data at lastReadPosition. isPooled


### PR DESCRIPTION
## Problem

Heap profiles from the many-subscriber filer workload in #10253 (on 4.39, with the earlier subscription-memory fixes in place) show `bytes.growSlice` as the top `inuse_space` node, attributed to the log buffer flush path.

The source is the per-flush window copy. Each flush copies the sealed window into a `bytes.Buffer` drawn from a package-local `sync.Pool`. GC drains that pool, so once collections run frequently — exactly what happens under a `GOMEMLIMIT` (the operator's mitigation in that issue) — most flushes miss the pool and `bytes.Buffer.Write` grows a fresh window-sized backing array. That allocation churn is the `bytes.growSlice` the profile flags.

## Change

Copy the window into a size-classed slab from `weed/util/mem` (the allocator the volume/needle paths already use) instead of a bespoke `bytes.Buffer` pool:

- `dataToFlush.data` becomes a `[]byte` slab; `releaseMemory` returns it with `mem.Free`.
- Slabs are shared process-wide and returned to their exact size class, so the variable-sized flushes produced by many partitions stop churning mismatched buffers.

This does not change the flush-queue backpressure (`flushQueueDepth`) that already bounds in-flight copies; it only changes where each copy is allocated from. The `bytes.growSlice` node leaves the profile and flush copies reuse slabs rather than reallocating.

## Notes

- The read path's `ReleaseMemory` / `bufferPool` are now fully dormant (reads have used shared snapshots since the subscription-memory work). Removing that dead pooling touches `ReadFromBuffer`'s signature and `log_read.go` broadly, so it's left for a separate cleanup.

## Test

`go test ./weed/util/log_buffer/` passes, including under `-race`. Dependent packages (`weed/mq`, `weed/filer`, `weed/server`, `weed/pb`) build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved log-buffer memory handling during flush operations, reducing unnecessary intermediate allocations.
  * Streamlined ownership and cleanup of buffered log data to minimize copying overhead during high-volume logging.
  * Faster, more consistent flush behavior under load with less time spent preparing buffered output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->