### PR TITLE
mount: surface ENOSPC instead of endless waiting when the cluster is full

### DIFF
--- a/weed/mount/dirty_pages_chunked.go
+++ b/weed/mount/dirty_pages_chunked.go
@@ -13,6 +13,7 @@ import (
 type ChunkedDirtyPages struct {
 	fh             *FileHandle
 	writeWaitGroup sync.WaitGroup
+	lastErrLock    sync.Mutex
 	lastErr        error
 	collection     string
 	replication    string
@@ -40,6 +41,12 @@ func newMemoryChunkPages(fh *FileHandle, chunkSize int64) *ChunkedDirtyPages {
 }
 
 func (pages *ChunkedDirtyPages) AddPage(offset int64, data []byte, isSequential bool, tsNs int64) error {
+	// A failed chunk upload already dropped its data, so this handle can never
+	// flush cleanly. Reject further writes so the writer fails fast instead of
+	// pushing the rest of the file through a pipeline that cannot persist it.
+	if err := pages.LastError(); err != nil {
+		return err
+	}
 	pages.hasWrites = true
 
 	glog.V(4).Infof("%v memory AddPage [%d, %d)", pages.fh.fh, offset, offset+int64(len(data)))
@@ -53,10 +60,26 @@ func (pages *ChunkedDirtyPages) FlushData() error {
 		return nil
 	}
 	pages.uploadPipeline.FlushAll()
-	if pages.lastErr != nil {
-		return fmt.Errorf("flush data: %v", pages.lastErr)
+	if err := pages.LastError(); err != nil {
+		return fmt.Errorf("flush data: %w", err)
 	}
 	return nil
+}
+
+// LastError returns the first chunk upload failure on this handle. It is
+// sticky: the failed chunk's data is gone, so the handle stays poisoned.
+func (pages *ChunkedDirtyPages) LastError() error {
+	pages.lastErrLock.Lock()
+	defer pages.lastErrLock.Unlock()
+	return pages.lastErr
+}
+
+func (pages *ChunkedDirtyPages) setLastError(err error) {
+	pages.lastErrLock.Lock()
+	defer pages.lastErrLock.Unlock()
+	if pages.lastErr == nil {
+		pages.lastErr = err
+	}
 }
 
 func (pages *ChunkedDirtyPages) ReadDirtyDataAt(data []byte, startOffset int64, tsNs int64) (maxStop int64) {
@@ -75,7 +98,7 @@ func (pages *ChunkedDirtyPages) saveChunkedFileIntervalToStorage(reader io.Reade
 	chunk, err := pages.fh.wfs.saveDataAsChunk(fileFullPath)(reader, fileName, offset, modifiedTsNs, uint64(size))
 	if err != nil {
 		glog.V(0).Infof("%v saveToStorage [%d,%d): %v", fileFullPath, offset, offset+size, err)
-		pages.lastErr = err
+		pages.setLastError(err)
 		return
 	}
 	pages.fh.AddChunks([]*filer_pb.FileChunk{chunk})

--- a/weed/mount/dirty_pages_chunked_test.go
+++ b/weed/mount/dirty_pages_chunked_test.go
@@ -1,0 +1,31 @@
+package mount
+
+import (
+	"errors"
+	"testing"
+)
+
+// Once a chunk upload fails its data is gone, so the handle must reject
+// further writes instead of buffering the rest of the file — against a full
+// cluster that turned cp into an hours-long crawl that only errored at close.
+func TestChunkedDirtyPagesFailWritesAfterUploadError(t *testing.T) {
+	fh := &FileHandle{wfs: &WFS{option: &Option{}}}
+	pages := newMemoryChunkPages(fh, 1024)
+	defer pages.Destroy()
+	pages.hasWrites = true
+
+	uploadErr := errors.New("assign volume failure: no writable volumes")
+	pages.setLastError(uploadErr)
+
+	if err := pages.AddPage(0, []byte("x"), true, 1); !errors.Is(err, uploadErr) {
+		t.Fatalf("AddPage after upload failure = %v, want sticky %v", err, uploadErr)
+	}
+	if err := pages.FlushData(); !errors.Is(err, uploadErr) {
+		t.Fatalf("FlushData after upload failure = %v, want wrapped %v", err, uploadErr)
+	}
+	// First failure wins; later errors must not mask the root cause.
+	pages.setLastError(errors.New("later error"))
+	if err := pages.LastError(); !errors.Is(err, uploadErr) {
+		t.Fatalf("LastError = %v, want first error %v", err, uploadErr)
+	}
+}

--- a/weed/mount/error_classifier.go
+++ b/weed/mount/error_classifier.go
@@ -48,6 +48,28 @@ func grpcErrorToFuseStatus(err error) fuse.Status {
 	return fuse.EIO
 }
 
+// isStorageFullError reports whether a chunk upload failed because the cluster
+// has no writable volume left (disks full and volume growth failed). The
+// master's message reaches the mount as plain text inside
+// AssignVolumeResponse.Error, so match on text rather than a status code.
+func isStorageFullError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := strings.ToLower(err.Error())
+	return strings.Contains(errStr, "no writable volumes") ||
+		strings.Contains(errStr, "no free volumes")
+}
+
+// writeErrorToFuseStatus maps a dirty-page write/flush failure to the status
+// returned to the kernel: ENOSPC when the cluster is out of space, EIO otherwise.
+func writeErrorToFuseStatus(err error) fuse.Status {
+	if isStorageFullError(err) {
+		return fuse.Status(syscall.ENOSPC)
+	}
+	return fuse.EIO
+}
+
 // isRetryableFilerError reports whether a filer RPC error looks transient
 // enough to retry. It takes a conservative whitelist approach: only errors
 // that clearly describe a permanent application-level failure

--- a/weed/mount/error_classifier_test.go
+++ b/weed/mount/error_classifier_test.go
@@ -44,6 +44,41 @@ func TestGrpcErrorToFuseStatusDropsCanceledThroughPercentV(t *testing.T) {
 	}
 }
 
+// A full cluster must surface as ENOSPC so cp/rsync abort with "No space left
+// on device" instead of a generic I/O error. The master's message reaches the
+// mount stringified inside AssignVolumeResponse.Error, in one of two shapes:
+// the load-shedding gRPC status text or the topology's plain error text.
+func TestWriteErrorToFuseStatus(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want fuse.Status
+	}{
+		{
+			"assign shed during growth",
+			errors.New("upload data: filerGrpcAddress assign volume: assign volume failure count:1: assign volume: rpc error: code = ResourceExhausted desc = no writable volumes for replication:000 collection:, volume growth in progress"),
+			fuse.Status(syscall.ENOSPC),
+		},
+		{
+			"no free volumes left",
+			errors.New("flush data: upload data: assign volume: No writable volumes available for collection: replication:000 ttl: and no free volumes left for {replication:000}"),
+			fuse.Status(syscall.ENOSPC),
+		},
+		{
+			"unrelated upload failure",
+			errors.New("upload data: put http://volume:8080/3,0144: connection reset by peer"),
+			fuse.EIO,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := writeErrorToFuseStatus(tc.err); got != tc.want {
+				t.Fatalf("writeErrorToFuseStatus(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestIsRetryableFilerError(t *testing.T) {
 	cases := []struct {
 		name string

--- a/weed/mount/weedfs_file_copy_range.go
+++ b/weed/mount/weedfs_file_copy_range.go
@@ -186,7 +186,7 @@ func (wfs *WFS) CopyFileRange(cancel <-chan struct{}, in *fuse.CopyFileRangeIn) 
 			fhOut.dirtyPages.writerPattern.IsSequentialMode(),
 			nowUnixNano); err != nil {
 			glog.Errorf("AddPage error: %v", err)
-			return 0, fuse.EIO
+			return 0, writeErrorToFuseStatus(err)
 		}
 
 		// Accumulate for the next loop iteration

--- a/weed/mount/weedfs_file_sync.go
+++ b/weed/mount/weedfs_file_sync.go
@@ -161,7 +161,7 @@ func (wfs *WFS) doFlush(ctx context.Context, fh *FileHandle, uid, gid uint32, al
 	if !isOverQuota {
 		if err := fh.dirtyPages.FlushData(); err != nil {
 			glog.Errorf("%v doFlush: %v", fileFullPath, err)
-			return fuse.EIO
+			return writeErrorToFuseStatus(err)
 		}
 	}
 

--- a/weed/mount/weedfs_file_write.go
+++ b/weed/mount/weedfs_file_write.go
@@ -85,7 +85,7 @@ func (wfs *WFS) Write(cancel <-chan struct{}, in *fuse.WriteIn, data []byte) (wr
 
 	if err := fh.dirtyPages.AddPage(offset, data, fh.dirtyPages.writerPattern.IsSequentialMode(), tsNs); err != nil {
 		glog.Errorf("AddPage error: %v", err)
-		return 0, fuse.EIO
+		return 0, writeErrorToFuseStatus(err)
 	}
 
 	written = uint32(len(data))


### PR DESCRIPTION
When every volume is full, a mount write only fails after the assign retry budget expires, the failed chunk's data is dropped, and the mount keeps accepting new writes anyway. A plain cp into the mount looks like a permanent hang: each sealed chunk burns ~30s of assign retries, the write buffer keeps draining into failures, and only close() finally reports an error - a generic EIO.

Now the first failed chunk upload poisons the file handle, so the next write() fails immediately instead of buffering the rest of the file. Errors that mean the cluster is out of space ("no writable volumes", "no free volumes") map to ENOSPC, so the writing process aborts with "No space left on device" within one chunk-upload attempt. Other upload failures keep returning EIO.

The sticky error is also what FlushData already reported, so close()/fsync() return ENOSPC for small files that never sealed a chunk before flush. While here, guard lastErr with a mutex - it was written concurrently by uploader goroutines - and keep the first error so later failures do not mask the root cause.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Write and flush failures now preserve the original upload error, preventing subsequent writes from masking the root cause.
  * Storage-full conditions are reported as “No space left on device” instead of generic I/O errors.
  * File writes, synchronization, and copy operations now return more accurate error statuses.
* **Tests**
  * Added coverage for persistent upload failures and storage-full error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->