### PR TITLE
fix Rust build with protoc versions lacking native proto3 optional

### DIFF
--- a/seaweed-volume/build.rs
+++ b/seaweed-volume/build.rs
@@ -3,6 +3,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
         .build_server(true)
         .build_client(true)
+        // filer.proto uses proto3 optional; older protoc (e.g. 3.12 from ubuntu-22.04 apt)
+        // rejects it without this flag, and newer protoc still accepts the flag
+        .protoc_arg("--experimental_allow_proto3_optional")
         .file_descriptor_set_path(out_dir.join("seaweed_descriptor.bin"))
         .compile_protos(
             &[


### PR DESCRIPTION
The docker dev-container build and the other Rust volume-server workflows run on ubuntu-22.04, whose apt protoc is 3.12. Since filer.proto now carries a proto3 optional field, that protoc aborts with "This file contains proto3 optional fields, but --experimental_allow_proto3_optional was not set."

Pass the flag from build.rs so all workflows and local builds work regardless of protoc version — new protoc (verified through 35.0) still accepts it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when building the application with older Protocol Buffers compiler versions.
  * Ensured optional fields in filer-related data compile successfully across supported environments.

* **Documentation**
  * Added build configuration comments clarifying compiler compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->