### PR TITLE
trigger dev container builds on seaweed-volume changes

### DIFF
--- a/.github/workflows/container_dev.yml
+++ b/.github/workflows/container_dev.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
     paths:
       - 'weed/**'
+      - 'seaweed-volume/**'
       - 'docker/**'
       - 'go.mod'
       - 'go.sum'


### PR DESCRIPTION
The dev container workflow prebuilds the Rust volume server from seaweed-volume/ but its paths filter did not watch that directory, so Rust build fixes could land without this workflow validating them. The other Rust-building workflows already watch seaweed-volume/ or run on tags/dispatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated container workflow triggers to run when files under the volume service path change.
  * Existing build and publishing steps remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->