### PR TITLE
fix: report short S3 ReaderAt reads

### DIFF
--- a/weed/storage/backend/s3_backend/s3_backend.go
+++ b/weed/storage/backend/s3_backend/s3_backend.go
@@ -129,8 +129,16 @@ type S3BackendStorageFile struct {
 }
 
 func (s3backendStorageFile S3BackendStorageFile) ReadAt(p []byte, off int64) (n int, err error) {
-	datSize, _, _ := s3backendStorageFile.GetStat()
+	if off < 0 {
+		return 0, fmt.Errorf("s3_backend: negative offset %d", off)
+	}
+
 	requested := len(p)
+	if requested == 0 {
+		return 0, nil
+	}
+
+	datSize, _, _ := s3backendStorageFile.GetStat()
 
 	if datSize > 0 && off >= datSize {
 		return 0, io.EOF

--- a/weed/storage/backend/s3_backend/s3_backend.go
+++ b/weed/storage/backend/s3_backend/s3_backend.go
@@ -130,6 +130,7 @@ type S3BackendStorageFile struct {
 
 func (s3backendStorageFile S3BackendStorageFile) ReadAt(p []byte, off int64) (n int, err error) {
 	datSize, _, _ := s3backendStorageFile.GetStat()
+	requested := len(p)
 
 	if datSize > 0 && off >= datSize {
 		return 0, io.EOF
@@ -162,7 +163,7 @@ func (s3backendStorageFile S3BackendStorageFile) ReadAt(p []byte, off int64) (n 
 		}
 	}
 
-	if err == io.EOF {
+	if err == io.EOF && n == requested {
 		err = nil
 	}
 

--- a/weed/storage/backend/s3_backend/s3_backend.go
+++ b/weed/storage/backend/s3_backend/s3_backend.go
@@ -130,7 +130,7 @@ type S3BackendStorageFile struct {
 
 func (s3backendStorageFile S3BackendStorageFile) ReadAt(p []byte, off int64) (n int, err error) {
 	if off < 0 {
-		return 0, fmt.Errorf("s3_backend: negative offset %d", off)
+		return 0, fmt.Errorf("negative offset %d", off)
 	}
 
 	requested := len(p)

--- a/weed/storage/backend/s3_backend/s3_backend.go
+++ b/weed/storage/backend/s3_backend/s3_backend.go
@@ -163,6 +163,9 @@ func (s3backendStorageFile S3BackendStorageFile) ReadAt(p []byte, off int64) (n 
 	var readCount int
 	for {
 		p = p[readCount:]
+		if len(p) == 0 {
+			break
+		}
 		readCount, err = getObjectOutput.Body.Read(p)
 		n += readCount
 

--- a/weed/storage/backend/s3_backend/s3_backend_test.go
+++ b/weed/storage/backend/s3_backend/s3_backend_test.go
@@ -41,3 +41,40 @@ func TestReadAtReturnsEOFForShortRead(t *testing.T) {
 		t.Fatalf("ReadAt() error = %v, want io.EOF", err)
 	}
 }
+
+func TestReadAtRejectsInvalidRequestsLocally(t *testing.T) {
+	tests := []struct {
+		name    string
+		buffer  []byte
+		offset  int64
+		wantErr bool
+	}{
+		{name: "empty buffer", buffer: nil},
+		{name: "negative offset", buffer: make([]byte, 1), offset: -1, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			called := false
+			client := &stubS3Client{getObject: func(*s3.GetObjectInput) (*s3.GetObjectOutput, error) {
+				called = true
+				return nil, errors.New("unexpected GetObject")
+			}}
+			file := S3BackendStorageFile{
+				backendStorage: &S3BackendStorage{conn: client, bucket: "bucket"},
+				key:            "key",
+				tierInfo: &volume_server_pb.VolumeInfo{Files: []*volume_server_pb.RemoteFile{
+					{FileSize: 10},
+				}},
+			}
+
+			n, err := file.ReadAt(tt.buffer, tt.offset)
+			if n != 0 || (err != nil) != tt.wantErr {
+				t.Fatalf("ReadAt() = (%d, %v), want error %t", n, err, tt.wantErr)
+			}
+			if called {
+				t.Fatal("ReadAt() called S3 for an invalid request")
+			}
+		})
+	}
+}

--- a/weed/storage/backend/s3_backend/s3_backend_test.go
+++ b/weed/storage/backend/s3_backend/s3_backend_test.go
@@ -1,0 +1,43 @@
+package s3_backend
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/seaweedfs/seaweedfs/weed/pb/volume_server_pb"
+)
+
+type stubS3Client struct {
+	s3iface.S3API
+	getObject func(*s3.GetObjectInput) (*s3.GetObjectOutput, error)
+}
+
+func (s *stubS3Client) GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
+	return s.getObject(input)
+}
+
+func TestReadAtReturnsEOFForShortRead(t *testing.T) {
+	client := &stubS3Client{getObject: func(*s3.GetObjectInput) (*s3.GetObjectOutput, error) {
+		return &s3.GetObjectOutput{Body: io.NopCloser(strings.NewReader("abc"))}, nil
+	}}
+	file := S3BackendStorageFile{
+		backendStorage: &S3BackendStorage{conn: client, bucket: "bucket"},
+		key:            "key",
+		tierInfo: &volume_server_pb.VolumeInfo{Files: []*volume_server_pb.RemoteFile{
+			{FileSize: 10},
+		}},
+	}
+
+	buffer := make([]byte, 5)
+	n, err := file.ReadAt(buffer, 0)
+	if n != 3 {
+		t.Fatalf("ReadAt() read %d bytes, want 3", n)
+	}
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("ReadAt() error = %v, want io.EOF", err)
+	}
+}

--- a/weed/storage/backend/s3_backend/s3_backend_test.go
+++ b/weed/storage/backend/s3_backend/s3_backend_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"testing/iotest"
 
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
@@ -39,6 +40,28 @@ func TestReadAtReturnsEOFForShortRead(t *testing.T) {
 	}
 	if !errors.Is(err, io.EOF) {
 		t.Fatalf("ReadAt() error = %v, want io.EOF", err)
+	}
+}
+
+func TestReadAtClearsEOFOnFullRead(t *testing.T) {
+	client := &stubS3Client{getObject: func(*s3.GetObjectInput) (*s3.GetObjectOutput, error) {
+		return &s3.GetObjectOutput{Body: io.NopCloser(iotest.DataErrReader(strings.NewReader("abcde")))}, nil
+	}}
+	file := S3BackendStorageFile{
+		backendStorage: &S3BackendStorage{conn: client, bucket: "bucket"},
+		key:            "key",
+		tierInfo: &volume_server_pb.VolumeInfo{Files: []*volume_server_pb.RemoteFile{
+			{FileSize: 10},
+		}},
+	}
+
+	buffer := make([]byte, 5)
+	n, err := file.ReadAt(buffer, 0)
+	if n != 5 || err != nil {
+		t.Fatalf("ReadAt() = (%d, %v), want (5, nil)", n, err)
+	}
+	if string(buffer) != "abcde" {
+		t.Fatalf("ReadAt() buffer = %q, want %q", buffer, "abcde")
 	}
 }
 


### PR DESCRIPTION


# What problem are we solving?

Problem: S3BackendStorageFile.ReadAt returned a short buffer with a nil error, hiding truncated remote data.

Root cause: Every terminal io.EOF was cleared regardless of how many bytes were read.


# How are we solving the problem?

Clear io.EOF only when the requested buffer was completely filled.

# How is the PR tested?

go test ./weed/storage/backend/...

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved S3-backed `ReadAt` handling for negative offsets and zero-length reads.
  * Refined EOF behavior: `io.EOF` is now returned only for short/partial reads, while full reads clear any would-be EOF.
* **Tests**
  * Added coverage for short S3 object reads and correct `io.EOF` handling.
  * Added coverage ensuring invalid `ReadAt` inputs are rejected locally without contacting S3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->