### PR TITLE
feat(stats): add remote-mount bucket cache hit/miss metrics

### DIFF
--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
+	"github.com/seaweedfs/seaweedfs/weed/stats"
 	util_http "github.com/seaweedfs/seaweedfs/weed/util/http"
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
@@ -1189,6 +1190,10 @@ func (s3a *S3ApiServer) createLookupFileIdFunction() func(context.Context, strin
 
 // streamFromVolumeServersWithSSE handles streaming with inline SSE decryption
 func (s3a *S3ApiServer) streamFromVolumeServersWithSSE(w http.ResponseWriter, r *http.Request, entry *filer_pb.Entry, sseType string, bucket, object, versionId string) error {
+	if entry != nil && entry.RemoteEntry != nil && entry.RemoteEntry.RemoteSize > 0 {
+		stats.RecordRemoteCacheRead(stats.RemoteCacheSourceS3, bucket, len(entry.GetChunks()) > 0)
+	}
+
 	// If not encrypted, use fast path without decryption
 	if sseType == "" || sseType == "None" {
 		return s3a.streamFromVolumeServers(w, r, entry, sseType, bucket, object, versionId)

--- a/weed/server/filer_server_handlers_read.go
+++ b/weed/server/filer_server_handlers_read.go
@@ -193,6 +193,11 @@ func (fs *FilerServer) GetOrHeadHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	if entry.Remote != nil && entry.Remote.RemoteSize > 0 {
+		bucket := bucketUnderBucketsPath(string(entry.FullPath), fs.filer.DirBucketsPath)
+		stats.RecordRemoteCacheRead(stats.RemoteCacheSourceFiler, bucket, len(entry.GetChunks()) > 0)
+	}
+
 	ProcessRangeRequest(r, w, totalSize, mimeType, func(offset int64, size int64) (filer.DoStreamContent, error) {
 		if offset+size <= int64(len(entry.Content)) {
 			return func(writer io.Writer) error {
@@ -266,4 +271,18 @@ func (fs *FilerServer) maybeGetVolumeReadJwtAuthorizationToken(fileId string) st
 		return ""
 	}
 	return string(security.GenJwtForVolumeServer(key, fs.volumeGuard.ReadExpiresAfterSec(), fileId))
+}
+
+// bucketUnderBucketsPath returns the top-level bucket name for a path under the
+// filer buckets root, or "" if the path is not under that root.
+func bucketUnderBucketsPath(fullPath, bucketsPath string) string {
+	prefix := bucketsPath + "/"
+	if !strings.HasPrefix(fullPath, prefix) {
+		return ""
+	}
+	rest := fullPath[len(prefix):]
+	if i := strings.IndexByte(rest, '/'); i >= 0 {
+		return rest[:i]
+	}
+	return rest
 }

--- a/weed/server/filer_server_handlers_read.go
+++ b/weed/server/filer_server_handlers_read.go
@@ -276,11 +276,10 @@ func (fs *FilerServer) maybeGetVolumeReadJwtAuthorizationToken(fileId string) st
 // bucketUnderBucketsPath returns the top-level bucket name for a path under the
 // filer buckets root, or "" if the path is not under that root.
 func bucketUnderBucketsPath(fullPath, bucketsPath string) string {
-	prefix := bucketsPath + "/"
-	if !strings.HasPrefix(fullPath, prefix) {
+	if len(fullPath) <= len(bucketsPath) || !strings.HasPrefix(fullPath, bucketsPath) || fullPath[len(bucketsPath)] != '/' {
 		return ""
 	}
-	rest := fullPath[len(prefix):]
+	rest := fullPath[len(bucketsPath)+1:]
 	if i := strings.IndexByte(rest, '/'); i >= 0 {
 		return rest[:i]
 	}

--- a/weed/server/filer_server_handlers_read_test.go
+++ b/weed/server/filer_server_handlers_read_test.go
@@ -1,0 +1,26 @@
+package weed_server
+
+import "testing"
+
+func TestBucketUnderBucketsPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		fullPath    string
+		bucketsPath string
+		want        string
+	}{
+		{"object in bucket", "/buckets/mybucket/a/b.txt", "/buckets", "mybucket"},
+		{"bucket root", "/buckets/mybucket", "/buckets", "mybucket"},
+		{"not under buckets path", "/other/path/x", "/buckets", ""},
+		{"buckets path itself", "/buckets", "/buckets", ""},
+		{"custom buckets path", "/data/buckets/mybucket/x", "/data/buckets", "mybucket"},
+		{"nested object", "/buckets/b/deep/nested/key", "/buckets", "b"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := bucketUnderBucketsPath(tt.fullPath, tt.bucketsPath); got != tt.want {
+				t.Errorf("bucketUnderBucketsPath(%q, %q) = %q, want %q", tt.fullPath, tt.bucketsPath, got, tt.want)
+			}
+		})
+	}
+}

--- a/weed/stats/metrics.go
+++ b/weed/stats/metrics.go
@@ -52,6 +52,7 @@ const (
 	subsystemS3           = "s3"
 	subsystemS3Lifecycle  = "s3_lifecycle"
 	subsystemAdmin        = "admin"
+	subsystemRemote       = "remote"
 )
 
 var bucketLastActiveTsNs map[string]int64 = map[string]int64{}
@@ -612,6 +613,14 @@ var (
 			Help:      "Number of objects deleted in each bucket.",
 		}, []string{"bucket"})
 
+	RemoteCacheReadCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: subsystemRemote,
+			Name:      "cache_read_total",
+			Help:      "Remote-mount object reads by source, bucket and cache result.",
+		}, []string{"source", "bucket", "result"})
+
 	S3UploadedObjectsCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: Namespace,
@@ -920,6 +929,7 @@ func init() {
 	Gather.MustRegister(S3BucketTrafficReceivedBytesCounter)
 	Gather.MustRegister(S3BucketTrafficSentBytesCounter)
 	Gather.MustRegister(S3DeletedObjectsCounter)
+	Gather.MustRegister(RemoteCacheReadCounter)
 	Gather.MustRegister(S3UploadedObjectsCounter)
 	Gather.MustRegister(S3BucketSizeBytesGauge)
 	Gather.MustRegister(S3BucketPhysicalSizeBytesGauge)
@@ -1004,6 +1014,17 @@ func RecordBucketActiveTime(bucket string) {
 	bucketLastActiveLock.Unlock()
 }
 
+func RecordRemoteCacheRead(source, bucket string, hit bool) {
+	if bucket == "" {
+		bucket = "_other"
+	}
+	result := RemoteCacheResultMiss
+	if hit {
+		result = RemoteCacheResultHit
+	}
+	RemoteCacheReadCounter.WithLabelValues(source, bucket, result).Inc()
+}
+
 func DeleteBucketMetrics(bucket string) {
 	bucketLastActiveLock.Lock()
 	delete(bucketLastActiveTsNs, bucket)
@@ -1016,6 +1037,7 @@ func DeleteBucketMetrics(bucket string) {
 	c += S3BucketTrafficReceivedBytesCounter.DeletePartialMatch(labels)
 	c += S3BucketTrafficSentBytesCounter.DeletePartialMatch(labels)
 	c += S3DeletedObjectsCounter.DeletePartialMatch(labels)
+	c += RemoteCacheReadCounter.DeletePartialMatch(labels)
 	c += S3UploadedObjectsCounter.DeletePartialMatch(labels)
 	c += S3BucketSizeBytesGauge.DeletePartialMatch(labels)
 	c += S3BucketPhysicalSizeBytesGauge.DeletePartialMatch(labels)

--- a/weed/stats/metrics_names.go
+++ b/weed/stats/metrics_names.go
@@ -81,4 +81,10 @@ const (
 	FailureContextCancelled = "context_cancelled"
 	// FailureServerError is the failure reason label for generic server-side errors.
 	FailureServerError = "server_error"
+
+	// remote-mount cache read labels
+	RemoteCacheSourceFiler = "filer"
+	RemoteCacheSourceS3    = "s3"
+	RemoteCacheResultHit   = "hit"
+	RemoteCacheResultMiss  = "miss"
 )

--- a/weed/stats/metrics_remote_cache_test.go
+++ b/weed/stats/metrics_remote_cache_test.go
@@ -1,0 +1,50 @@
+package stats
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestRecordRemoteCacheRead(t *testing.T) {
+	RemoteCacheReadCounter.Reset()
+	t.Cleanup(RemoteCacheReadCounter.Reset)
+
+	RecordRemoteCacheRead(RemoteCacheSourceS3, "bkt", true)
+	RecordRemoteCacheRead(RemoteCacheSourceS3, "bkt", true)
+	RecordRemoteCacheRead(RemoteCacheSourceS3, "bkt", false)
+	RecordRemoteCacheRead(RemoteCacheSourceFiler, "", true) // empty bucket -> "_other"
+
+	if got := testutil.ToFloat64(RemoteCacheReadCounter.WithLabelValues(RemoteCacheSourceS3, "bkt", RemoteCacheResultHit)); got != 2 {
+		t.Errorf("s3/bkt hit = %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(RemoteCacheReadCounter.WithLabelValues(RemoteCacheSourceS3, "bkt", RemoteCacheResultMiss)); got != 1 {
+		t.Errorf("s3/bkt miss = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(RemoteCacheReadCounter.WithLabelValues(RemoteCacheSourceFiler, "_other", RemoteCacheResultHit)); got != 1 {
+		t.Errorf("filer/_other hit = %v, want 1", got)
+	}
+}
+
+func TestDeleteBucketMetricsRemovesRemoteCacheSeries(t *testing.T) {
+	RemoteCacheReadCounter.Reset()
+	t.Cleanup(RemoteCacheReadCounter.Reset)
+
+	RecordRemoteCacheRead(RemoteCacheSourceS3, "delbkt", true)
+	RecordRemoteCacheRead(RemoteCacheSourceS3, "delbkt", false)
+	RecordRemoteCacheRead(RemoteCacheSourceFiler, "delbkt", true)
+	RecordRemoteCacheRead(RemoteCacheSourceS3, "keepbkt", true)
+
+	if got := testutil.CollectAndCount(RemoteCacheReadCounter); got != 4 {
+		t.Fatalf("before delete: %d series, want 4", got)
+	}
+
+	DeleteBucketMetrics("delbkt")
+
+	if got := testutil.CollectAndCount(RemoteCacheReadCounter); got != 1 {
+		t.Errorf("after delete: %d series, want 1 (only keepbkt)", got)
+	}
+	if got := testutil.ToFloat64(RemoteCacheReadCounter.WithLabelValues(RemoteCacheSourceS3, "keepbkt", RemoteCacheResultHit)); got != 1 {
+		t.Errorf("keepbkt hit should survive deletion, got %v", got)
+	}
+}


### PR DESCRIPTION
## Motivation

Operators running remote-mount buckets (filer/S3 namespaces backed by remote object storage such as S3/GCS/Azure) currently have no visibility into cache effectiveness. When a remote-only object is read it is fetched from the remote store and cached locally as chunks, and subsequent reads are served locally — but the only signal for this today is a `glog.V(1)` line plus an error-only counter (`read.cache.failed`). There is no hit-vs-miss counter, so a cache hit ratio cannot be computed.

This adds a Prometheus counter that records every remote-mount object read as a hit or a miss, labeled by bucket, so a hit ratio can be graphed per bucket.

## Overview

- Add `SeaweedFS_remote_cache_read_total{source, bucket, result}` counter in `weed/stats`, with a `RecordRemoteCacheRead(source, bucket, hit)` helper that maps to the `hit`/`miss` result label and falls back to `_other` for mounts outside the buckets path. The counter is registered on the shared `Gather` registry and cleaned up per bucket in `DeleteBucketMetrics`.
- Instrument the two client read paths at the point a remote-backed entry is served: filer HTTP (`GetOrHeadHandler`) and S3 GET streaming (`streamFromVolumeServersWithSSE`). A read is counted only when the entry is remote-backed (`RemoteEntry != nil && RemoteSize > 0`); it is a hit when local chunks exist and a miss when the object must be fetched from the remote store.
- Derive the bucket label cheaply: the S3 path already has the request bucket in scope; the filer path uses a small `bucketUnderBucketsPath` helper against `DirBucketsPath` (unit-tested).
- Misses from all clients funnel through the filer's `CacheRemoteObjectToLocalCluster`, but client-side hits never reach it, so the counters are recorded per read path rather than at that gRPC to keep the ratio accurate and avoid double-counting.
- The counter is a shared package-level metric, so in a combined `weed server` deployment both roles increment it on the single `/metrics` endpoint, distinguished by the `source` label.

Hit ratio query:

```
rate(SeaweedFS_remote_cache_read_total{result="hit"}[5m]) / rate(SeaweedFS_remote_cache_read_total[5m])
```

FUSE mount reads are intentionally not covered here: the mount process has no metrics endpoint, so that is a separate change.

Verified end-to-end with two local instances and a mounted remote bucket: an object placed in the remote bucket and synced into the mount as a remote-only entry produced `result="miss"` on the first read and `result="hit"` on the second, with the correct `bucket` and `source` labels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new monitoring metrics for remote object cache reads, capturing hit/miss outcomes.
  - Metrics are reported for remote reads served through both filer and S3 paths, including bucket attribution.

- **Bug Fixes**
  - Metric recording is now limited to valid remote entries with a positive remote size to avoid misleading counts.
  - Remote-cache metric series are properly removed when buckets are deleted.

- **Tests**
  - Added test coverage for bucket name extraction from filer paths.
  - Added tests validating remote-cache metric labeling and deletion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->