### PR TITLE
master: assign re-picks once after its growth concludes instead of shedding

### DIFF
--- a/weed/server/master_grpc_server_assign.go
+++ b/weed/server/master_grpc_server_assign.go
@@ -106,10 +106,11 @@ func (ms *MasterServer) Assign(ctx context.Context, req *master_pb.AssignRequest
 	vl.SetLastGrowCount(req.WritableVolumeCount)
 
 	var (
-		lastErr       error
-		maxTimeout    = time.Second * 10
-		startTime     = time.Now()
-		initiatedGrow bool
+		lastErr           error
+		maxTimeout        = time.Second * 10
+		startTime         = time.Now()
+		initiatedGrow     bool
+		repickedAfterGrow bool
 	)
 
 	for time.Now().Sub(startTime) < maxTimeout {
@@ -145,6 +146,14 @@ func (ms *MasterServer) Assign(ctx context.Context, req *master_pb.AssignRequest
 				// Unavailable: clients retry it (assign_file_id.go) without
 				// invalidating the shared master connection.
 				if initiatedGrow != vl.HasGrowRequest() {
+					// The failed pick above may predate the growth concluding, so
+					// re-pick once before shedding: growth registers its volumes
+					// before clearing the flag, and shedding here would bounce the
+					// client off a volume that just landed.
+					if initiatedGrow && !repickedAfterGrow {
+						repickedAfterGrow = true
+						continue
+					}
 					return nil, status.Errorf(codes.ResourceExhausted, "no writable volumes for %s, volume growth in progress", option.String())
 				}
 			}

--- a/weed/server/master_server_handlers.go
+++ b/weed/server/master_server_handlers.go
@@ -158,10 +158,11 @@ func (ms *MasterServer) dirAssignHandler(w http.ResponseWriter, r *http.Request)
 	vl := ms.Topo.GetVolumeLayout(option.Collection, option.ReplicaPlacement, option.Ttl, option.DiskType)
 
 	var (
-		lastErr       error
-		maxTimeout    = time.Second * 10
-		startTime     = time.Now()
-		initiatedGrow bool
+		lastErr           error
+		maxTimeout        = time.Second * 10
+		startTime         = time.Now()
+		initiatedGrow     bool
+		repickedAfterGrow bool
 	)
 
 	if !ms.Topo.DataCenterExists(option.DataCenter) {
@@ -195,6 +196,12 @@ func (ms *MasterServer) dirAssignHandler(w http.ResponseWriter, r *http.Request)
 				// See Assign: only the initiator waits, and only while the
 				// growth it triggered is still pending.
 				if initiatedGrow != vl.HasGrowRequest() {
+					// See Assign: re-pick once after the growth concludes before
+					// shedding — the failed pick may predate the conclusion.
+					if initiatedGrow && !repickedAfterGrow {
+						repickedAfterGrow = true
+						continue
+					}
 					w.Header().Set("Retry-After", "1")
 					writeJsonQuiet(w, r, http.StatusServiceUnavailable, operation.AssignResult{
 						Error: fmt.Sprintf("no writable volumes for %s, volume growth in progress", option.String()),


### PR DESCRIPTION
**Race**: the initiator's shed check `initiatedGrow != vl.HasGrowRequest()` runs against an `err` from a `PickForWrite` that can predate the growth concluding. The grower registers its new volumes *before* calling `DoneGrowRequest` (`master_grpc_server_volume.go`), so when growth completes in the window between the failed pick and the check — a few instructions wide, but real — the assign sheds `ResourceExhausted` even though a writable volume is already registered. The client gets bounced off the very volume its own growth just landed. This also surfaces as a rare CI flake in `TestAssignInitiatorWaitsForItsOwnGrowth`, whose fake grower concludes growth almost instantly.

**Fix**: when the initiator observes its growth has concluded, re-pick once before shedding. If the layout still has nothing writable (growth failed or was discarded), it sheds as before. Follower shedding, the out-of-space fast-fail, and the timeout path are unchanged. Applies to both call sites that share the shed logic: gRPC `Assign` and HTTP `dirAssign` (`master_server_handlers.go`).

**Validation**: the window is too narrow to hit natively, so I widened it with a temporary 5ms sleep after the grow-request enqueue: unpatched code fails `TestAssignInitiatorWaitsForItsOwnGrowth` 20/20 with the exact flake error; with the fix, 20/20 pass. Without the sleep: `go vet`, 30x `-run TestAssign` stress, and the full `weed/server` package all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved write request handling while storage volume growth is in progress.
  * Requests now perform exactly one extra re-placement attempt after growth begins, reducing premature shedding when writable capacity is not yet available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->