### PR TITLE
batch delete: align the shard test and Rust server with continue-past-mismatch

### DIFF
--- a/seaweed-volume/src/server/grpc_server.rs
+++ b/seaweed-volume/src/server/grpc_server.rs
@@ -380,7 +380,7 @@ impl VolumeServer for VolumeGrpcService {
                         size: 0,
                         version: 0,
                     });
-                    break;
+                    continue;
                 }
             }
 

--- a/test/volume_server/grpc/batch_delete_test.go
+++ b/test/volume_server/grpc/batch_delete_test.go
@@ -119,7 +119,7 @@ func TestBatchDeleteCookieMismatchAndSkipCheck(t *testing.T) {
 	}
 }
 
-func TestBatchDeleteMixedStatusesAndMismatchStopsProcessing(t *testing.T) {
+func TestBatchDeleteMixedStatusesAndMismatchContinuesProcessing(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
@@ -188,29 +188,32 @@ func TestBatchDeleteMixedStatusesAndMismatchStopsProcessing(t *testing.T) {
 	}
 
 	wrongCookieB := framework.NewFileID(volumeID, needleB, cookieB+1)
-	stopResp, err := client.BatchDelete(ctx, &volume_server_pb.BatchDeleteRequest{
+	mismatchContinueResp, err := client.BatchDelete(ctx, &volume_server_pb.BatchDeleteRequest{
 		FileIds: []string{wrongCookieB, fidC},
 	})
 	if err != nil {
-		t.Fatalf("BatchDelete mismatch-stop request failed: %v", err)
+		t.Fatalf("BatchDelete mismatch-continue request failed: %v", err)
 	}
-	if len(stopResp.GetResults()) != 1 {
-		t.Fatalf("BatchDelete mismatch-stop expected 1 result due early break, got %d", len(stopResp.GetResults()))
+	if len(mismatchContinueResp.GetResults()) != 2 {
+		t.Fatalf("BatchDelete mismatch-continue expected 2 results, got %d", len(mismatchContinueResp.GetResults()))
 	}
-	if stopResp.GetResults()[0].GetStatus() != http.StatusBadRequest {
-		t.Fatalf("BatchDelete mismatch-stop expected 400, got %d", stopResp.GetResults()[0].GetStatus())
+	if mismatchContinueResp.GetResults()[0].GetStatus() != http.StatusBadRequest {
+		t.Fatalf("BatchDelete mismatch-continue result[0] expected 400, got %d", mismatchContinueResp.GetResults()[0].GetStatus())
+	}
+	if mismatchContinueResp.GetResults()[1].GetStatus() != http.StatusAccepted {
+		t.Fatalf("BatchDelete mismatch-continue result[1] expected 202, got %d", mismatchContinueResp.GetResults()[1].GetStatus())
 	}
 
 	readB := framework.ReadBytes(t, httpClient, cluster.VolumeAdminURL(), fidB)
 	_ = framework.ReadAllAndClose(t, readB)
 	if readB.StatusCode != http.StatusOK {
-		t.Fatalf("fidB should remain after cookie mismatch path, got %d", readB.StatusCode)
+		t.Fatalf("fidB should remain after cookie mismatch, got %d", readB.StatusCode)
 	}
 
 	readC := framework.ReadBytes(t, httpClient, cluster.VolumeAdminURL(), fidC)
 	_ = framework.ReadAllAndClose(t, readC)
-	if readC.StatusCode != http.StatusOK {
-		t.Fatalf("fidC should remain when batch processing stops on mismatch, got %d", readC.StatusCode)
+	if readC.StatusCode != http.StatusNotFound {
+		t.Fatalf("fidC should be deleted when processing continues past a mismatch, got %d", readC.StatusCode)
 	}
 }
 


### PR DESCRIPTION
Fixes the `Volume Server Integration Tests (grpc - Shard 1)` failure on master (e.g. https://github.com/seaweedfs/seaweedfs/actions/runs/29485837291).

**Root cause**: #10342 (`8bff3b32`) intentionally changed `BatchDelete` to keep processing after a cookie mismatch (`break` → `continue`), but left two things behind:
- the integration test `TestBatchDeleteMixedStatusesAndMismatchStopsProcessing` still asserted the old early-break behavior (1 result, trailing fids untouched), so it fails deterministically on every master run since;
- the Rust volume server's `batch_delete` still `break`s on mismatch, so the shared `test/volume_server/grpc` suite (run against Rust via `VOLUME_SERVER_IMPL=rust` in `rust-volume-server-tests.yml`) would fail the updated test the same way.

**Change**: the test is renamed to `...MismatchContinuesProcessing` and now asserts 2 results (400 for the mismatched fid, 202 for the next one), with the mismatched needle preserved and the following needle deleted; the Rust server gets the matching `break` → `continue`.

**Validation**: all five `TestBatchDelete*` integration tests pass locally against both servers — the Go binary (`WEED_BINARY`) and the Rust binary (`VOLUME_SERVER_IMPL=rust` + `RUST_VOLUME_BINARY`); `cargo check` is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Batch delete operations now continue processing remaining files after encountering a cookie mismatch.
  * Later files in the same request are correctly deleted instead of being left unprocessed.
  * Batch responses now accurately report individual success and failure results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->