### PR TITLE
volume server: fill in ModifiedAtSecond on the /status volume list

### DIFF
--- a/weed/storage/store.go
+++ b/weed/storage/store.go
@@ -389,6 +389,11 @@ func collectStatForOneVolume(vid needle.VolumeId, v *Volume) (s *VolumeInfo) {
 	s.DeleteCount = v.nm.DeletedCount()
 	s.DeletedByteCount = v.nm.DeletedSize()
 	s.Size = v.nm.ContentSize()
+	if v.DataBackend != nil {
+		if _, modTime, e := v.DataBackend.GetStat(); e == nil {
+			s.ModifiedAtSecond = modTime.Unix()
+		}
+	}
 	return
 }
 

--- a/weed/storage/store_status_test.go
+++ b/weed/storage/store_status_test.go
@@ -1,0 +1,31 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
+	"github.com/seaweedfs/seaweedfs/weed/storage/super_block"
+	"github.com/seaweedfs/seaweedfs/weed/storage/types"
+)
+
+// The /status handler builds VolumeInfo via collectStatForOneVolume, which
+// used to leave ModifiedAtSecond at 0; only the heartbeat path filled it in.
+func TestCollectStatForOneVolumeModifiedAtSecond(t *testing.T) {
+	dir := t.TempDir()
+
+	v, err := NewVolume(dir, dir, "", 1, NeedleMapInMemory, &super_block.ReplicaPlacement{}, &needle.TTL{}, 0, needle.GetCurrentVersion(), 0, 0)
+	if err != nil {
+		t.Fatalf("create volume: %v", err)
+	}
+	defer v.Close()
+	v.location = &DiskLocation{Directory: dir, DiskType: types.HardDriveType}
+
+	if _, _, _, err := v.writeNeedle2(newRandomNeedle(1), true, false); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	s := collectStatForOneVolume(v.Id, v)
+	if s.ModifiedAtSecond <= 0 {
+		t.Fatalf("ModifiedAtSecond = %d, want > 0", s.ModifiedAtSecond)
+	}
+}


### PR DESCRIPTION
The /status volume list built by collectStatForOneVolume always reported ModifiedAtSecond as 0; only the heartbeat path read the .dat mtime. Read it from DataBackend.GetStat() the same way, so /status consumers can tell how long a volume has been idle. The Rust volume server already reports this field.

Fixes #10347

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Volume status information now includes the latest modification timestamp when available.
  * Prevents modification time data from remaining blank during volume statistics collection.

* **Tests**
  * Added coverage to verify that volume modification timestamps are populated correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->