### PR TITLE
shell: cluster.ps lists s3 servers

### DIFF
--- a/weed/shell/command_cluster_ps.go
+++ b/weed/shell/command_cluster_ps.go
@@ -47,39 +47,30 @@ func (c *commandClusterPs) Do(args []string, commandEnv *CommandEnv, writer io.W
 		return nil
 	}
 
-	var filerNodes []*master_pb.ListClusterNodesResponse_ClusterNode
-	var mqBrokerNodes []*master_pb.ListClusterNodesResponse_ClusterNode
-
-	// get the list of filers
-	err = commandEnv.MasterClient.WithClient(false, func(client master_pb.SeaweedClient) error {
-		resp, err := client.ListClusterNodes(context.Background(), &master_pb.ListClusterNodesRequest{
-			ClientType: cluster.FilerType,
-			FilerGroup: *commandEnv.option.FilerGroup,
+	listClusterNodes := func(clientType string) (nodes []*master_pb.ListClusterNodesResponse_ClusterNode, err error) {
+		err = commandEnv.MasterClient.WithClient(false, func(client master_pb.SeaweedClient) error {
+			resp, err := client.ListClusterNodes(context.Background(), &master_pb.ListClusterNodesRequest{
+				ClientType: clientType,
+				FilerGroup: *commandEnv.option.FilerGroup,
+			})
+			if err != nil {
+				return err
+			}
+			nodes = resp.ClusterNodes
+			return nil
 		})
-		if err != nil {
-			return err
-		}
-
-		filerNodes = resp.ClusterNodes
-		return err
-	})
-	if err != nil {
 		return
 	}
 
-	// get the list of message queue brokers
-	err = commandEnv.MasterClient.WithClient(false, func(client master_pb.SeaweedClient) error {
-		resp, err := client.ListClusterNodes(context.Background(), &master_pb.ListClusterNodesRequest{
-			ClientType: cluster.BrokerType,
-			FilerGroup: *commandEnv.option.FilerGroup,
-		})
-		if err != nil {
-			return err
-		}
-
-		mqBrokerNodes = resp.ClusterNodes
-		return err
-	})
+	filerNodes, err := listClusterNodes(cluster.FilerType)
+	if err != nil {
+		return
+	}
+	mqBrokerNodes, err := listClusterNodes(cluster.BrokerType)
+	if err != nil {
+		return
+	}
+	s3Nodes, err := listClusterNodes(cluster.S3Type)
 	if err != nil {
 		return
 	}
@@ -87,6 +78,19 @@ func (c *commandClusterPs) Do(args []string, commandEnv *CommandEnv, writer io.W
 	if len(mqBrokerNodes) > 0 {
 		fmt.Fprintf(writer, "* message queue brokers %d\n", len(mqBrokerNodes))
 		for _, node := range mqBrokerNodes {
+			fmt.Fprintf(writer, "  * %s (%v)\n", node.Address, node.Version)
+			if node.DataCenter != "" {
+				fmt.Fprintf(writer, "    DataCenter: %v\n", node.DataCenter)
+			}
+			if node.Rack != "" {
+				fmt.Fprintf(writer, "    Rack: %v\n", node.Rack)
+			}
+		}
+	}
+
+	if len(s3Nodes) > 0 {
+		fmt.Fprintf(writer, "* s3 servers %d\n", len(s3Nodes))
+		for _, node := range s3Nodes {
 			fmt.Fprintf(writer, "  * %s (%v)\n", node.Address, node.Version)
 			if node.DataCenter != "" {
 				fmt.Fprintf(writer, "    DataCenter: %v\n", node.DataCenter)

--- a/weed/shell/command_cluster_ps.go
+++ b/weed/shell/command_cluster_ps.go
@@ -47,8 +47,9 @@ func (c *commandClusterPs) Do(args []string, commandEnv *CommandEnv, writer io.W
 		return nil
 	}
 
-	listClusterNodes := func(clientType string) (nodes []*master_pb.ListClusterNodesResponse_ClusterNode, err error) {
-		err = commandEnv.MasterClient.WithClient(false, func(client master_pb.SeaweedClient) error {
+	listClusterNodes := func(clientType string) ([]*master_pb.ListClusterNodesResponse_ClusterNode, error) {
+		var nodes []*master_pb.ListClusterNodesResponse_ClusterNode
+		err := commandEnv.MasterClient.WithClient(false, func(client master_pb.SeaweedClient) error {
 			resp, err := client.ListClusterNodes(context.Background(), &master_pb.ListClusterNodesRequest{
 				ClientType: clientType,
 				FilerGroup: *commandEnv.option.FilerGroup,
@@ -59,7 +60,7 @@ func (c *commandClusterPs) Do(args []string, commandEnv *CommandEnv, writer io.W
 			nodes = resp.ClusterNodes
 			return nil
 		})
-		return
+		return nodes, err
 	}
 
 	filerNodes, err := listClusterNodes(cluster.FilerType)


### PR DESCRIPTION
S3 gateways already register with the master, so cluster.ps just needed to ask for them. Prints address, version, and data center/rack like the broker section; hidden when none are registered.

```
* s3 servers 1
  * 127.0.0.1:28333 (30GB 4.39 )
* filers 1
  * 127.0.0.1:18888.28888 (30GB 4.39 ) 2026-07-18 00:13:41 +0000 UTC
```

Folded the three identical ListClusterNodes calls into one helper while there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cluster status output now includes an **S3 servers** section when S3 nodes are present.
  * S3 server entries show each node’s address and version, plus any available data center and rack details.

* **Improvements**
  * Cluster node listing now handles retrieval failures consistently across **filers**, **message queue brokers**, and **S3 servers**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->