### PR TITLE
cassandra: do not mask KvGet backend errors as not-found

### DIFF
--- a/weed/filer/cassandra/cassandra_store_kv.go
+++ b/weed/filer/cassandra/cassandra_store_kv.go
@@ -27,9 +27,10 @@ func (store *CassandraStore) KvGet(ctx context.Context, key []byte) (data []byte
 	if err := store.session.Query(
 		"SELECT meta FROM filemeta WHERE directory=? AND name=?",
 		dir, name).Scan(&data); err != nil {
-		if err != gocql.ErrNotFound {
+		if err == gocql.ErrNotFound {
 			return nil, filer.ErrKvNotFound
 		}
+		return nil, fmt.Errorf("kv get: %w", err)
 	}
 
 	if len(data) == 0 {

--- a/weed/filer/cassandra/cassandra_store_kv.go
+++ b/weed/filer/cassandra/cassandra_store_kv.go
@@ -3,6 +3,7 @@ package cassandra
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 
 	gocql "github.com/apache/cassandra-gocql-driver/v2"
@@ -27,7 +28,7 @@ func (store *CassandraStore) KvGet(ctx context.Context, key []byte) (data []byte
 	if err := store.session.Query(
 		"SELECT meta FROM filemeta WHERE directory=? AND name=?",
 		dir, name).Scan(&data); err != nil {
-		if err == gocql.ErrNotFound {
+		if errors.Is(err, gocql.ErrNotFound) {
 			return nil, filer.ErrKvNotFound
 		}
 		return nil, fmt.Errorf("kv get: %w", err)

--- a/weed/filer/cassandra2/cassandra_store_kv.go
+++ b/weed/filer/cassandra2/cassandra_store_kv.go
@@ -3,6 +3,7 @@ package cassandra2
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 
 	gocql "github.com/apache/cassandra-gocql-driver/v2"
@@ -28,7 +29,7 @@ func (store *Cassandra2Store) KvGet(ctx context.Context, key []byte) (data []byt
 	if err := store.session.Query(
 		"SELECT meta FROM filemeta WHERE dirhash=? AND directory=? AND name=?",
 		util.HashStringToLong(dir), dir, name).Scan(&data); err != nil {
-		if err == gocql.ErrNotFound {
+		if errors.Is(err, gocql.ErrNotFound) {
 			return nil, filer.ErrKvNotFound
 		}
 		return nil, fmt.Errorf("kv get: %w", err)

--- a/weed/filer/cassandra2/cassandra_store_kv.go
+++ b/weed/filer/cassandra2/cassandra_store_kv.go
@@ -28,9 +28,10 @@ func (store *Cassandra2Store) KvGet(ctx context.Context, key []byte) (data []byt
 	if err := store.session.Query(
 		"SELECT meta FROM filemeta WHERE dirhash=? AND directory=? AND name=?",
 		util.HashStringToLong(dir), dir, name).Scan(&data); err != nil {
-		if err != gocql.ErrNotFound {
+		if err == gocql.ErrNotFound {
 			return nil, filer.ErrKvNotFound
 		}
+		return nil, fmt.Errorf("kv get: %w", err)
 	}
 
 	if len(data) == 0 {


### PR DESCRIPTION
The cassandra and cassandra2 KvGet had the not-found check reversed: gocql.ErrNotFound fell through to the empty-data check, while every other query error — timeouts, lost quorum, connection failures — was converted to filer.ErrKvNotFound.

On filer startup that made a transient Cassandra read failure look like a missing filer.store.id, so the filer would generate a new store signature and either die trying to write it or, if Cassandra recovered in between, overwrite the existing identity and treat the store as fresh, potentially bootstrapping metadata from a peer.

Now only gocql.ErrNotFound maps to ErrKvNotFound; everything else is returned as a kv get error, matching the other filer stores, and startup aborts without touching the store identity.

Fixes #10356

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved key-value lookup error handling for Cassandra-backed storage.
  - Missing entries now reliably return “not found.”
  - Other database/scan failures are no longer reported as missing data and are surfaced as actual errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->