### PR TITLE
s3: invalid tagging on CopyObject returns InvalidTag, not InvalidCopySource

### DIFF
--- a/weed/s3api/s3api_object_handlers_copy.go
+++ b/weed/s3api/s3api_object_handlers_copy.go
@@ -367,7 +367,8 @@ func (s3a *S3ApiServer) CopyObjectHandler(w http.ResponseWriter, r *http.Request
 	// to preserve the encryption header filtering. Fixes GitHub #7562.
 	processedMetadata, tagErr := processMetadataBytes(r.Header, dstEntry.Extended, replaceMeta, replaceTagging)
 	if tagErr != nil {
-		s3err.WriteErrorResponse(w, r, s3err.ErrInvalidCopySource)
+		glog.Errorf("CopyObjectHandler ValidateTags error %s: %v", r.URL, tagErr)
+		s3err.WriteErrorResponse(w, r, s3err.ErrInvalidTag)
 		return
 	}
 


### PR DESCRIPTION
A malformed or invalid x-amz-tagging header on CopyObject was answered with InvalidCopySource, blaming a copy-source header that is perfectly fine. The metadata-only self-copy path already returns InvalidTag for the same failure; the general copy path now does too, and logs the validation error the way the self-copy path does.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Copy operations with invalid tags or metadata now return the correct invalid-tag error.
  * Added clearer validation logging for these failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->