### PR TITLE
fix(s3): fall back to remote on local chunk 404 for remote-mounted objects

### DIFF
--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -1154,6 +1154,18 @@ func (s3a *S3ApiServer) streamFromVolumeServers(w http.ResponseWriter, r *http.R
 		BucketTrafficSent(cw.written, r)
 	}
 	if err != nil {
+		// A remote-mounted entry can still reference local chunks whose backing
+		// needle has been reclaimed (vacuum-compaction / deletion), so the
+		// volume-server read returns 404 even though the object is intact in the
+		// remote store. Because the entry still has chunks, IsInRemoteOnly() is
+		// false and the normal remote re-pull above never runs. When nothing has
+		// been written yet, drop the dead chunks and re-pull from the remote
+		// rather than failing the GET.
+		if cw.written == 0 && errors.Is(err, util_http.ErrNotFound) &&
+			s3a.recoverFromStaleRemoteChunks(w, r, entry, bucket, object, versionId, offset, size, totalSize) {
+			glog.V(1).Infof("streamFromVolumeServers: recovered %s/%s from remote after stale-chunk 404", bucket, object)
+			return nil
+		}
 		switch {
 		case isCanceledStreamingError(err):
 			// Client disconnected mid-stream (e.g. Nginx upstream timeout, browser cancel) - expected
@@ -3211,6 +3223,105 @@ func (s3a *S3ApiServer) cacheRemoteObjectForStreamingWithShortTimeout(r *http.Re
 	}
 
 	return nil, nil
+}
+
+// recoverFromStaleRemoteChunks self-heals a remote-mounted entry whose local
+// chunks point at a reclaimed needle (vacuum-compaction / deletion), which makes
+// the volume-server read return 404 even though the object is intact in the
+// remote store. Because the entry still has chunks, IsInRemoteOnly() is false
+// and the normal remote re-pull path never runs.
+//
+// It drops the dead chunks — turning the entry back into a remote-only entry so
+// future reads self-heal via the existing remote-only path — re-pulls the object
+// from the remote store, and streams the requested range from the fresh chunks
+// to satisfy the current request.
+//
+// It only acts on entries with a remote backing, so non-remote buckets are
+// unaffected. Returns true only when it fully served the response body, so the
+// caller (which must not have written any bytes yet) can return success.
+func (s3a *S3ApiServer) recoverFromStaleRemoteChunks(w http.ResponseWriter, r *http.Request, entry *filer_pb.Entry, bucket, object, versionId string, offset, size, totalSize int64) bool {
+	if entry == nil || entry.RemoteEntry == nil || entry.RemoteEntry.RemoteSize == 0 {
+		return false
+	}
+	if r.Context().Err() != nil {
+		return false
+	}
+
+	cacheVersionId := resolvedSourceVersionId(versionId, entry)
+	dir, name := s3a.buildVersionedRemoteObjectPath(bucket, object, cacheVersionId)
+	glog.Warningf("recoverFromStaleRemoteChunks: %s/%s references a reclaimed needle; dropping stale chunks and re-pulling from remote", dir, name)
+
+	if err := s3a.dropLocalChunks(dir, name); err != nil {
+		glog.Errorf("recoverFromStaleRemoteChunks: failed to drop stale chunks for %s/%s: %v", dir, name, err)
+		return false
+	}
+
+	cachedEntry, err := s3a.cacheRemoteObjectForStreamingWithShortTimeout(r, entry, bucket, object, cacheVersionId)
+	if err != nil || cachedEntry == nil || len(cachedEntry.GetChunks()) == 0 {
+		// The entry is now remote-only, so a client retry self-heals via the
+		// existing remote-only path even if this in-line re-pull did not finish.
+		glog.Errorf("recoverFromStaleRemoteChunks: re-pull from remote did not produce chunks for %s/%s: %v", dir, name, err)
+		return false
+	}
+
+	if streamErr := s3a.streamEntryRangeToResponse(r, w, cachedEntry, offset, size, totalSize); streamErr != nil {
+		glog.Errorf("recoverFromStaleRemoteChunks: streaming re-pulled chunks failed for %s/%s: %v", dir, name, streamErr)
+		return false
+	}
+
+	glog.V(1).Infof("recoverFromStaleRemoteChunks: served %s/%s from re-pulled remote chunks (%d chunks)", dir, name, len(cachedEntry.GetChunks()))
+	return true
+}
+
+// dropLocalChunks clears a remote-backed entry's local chunk references so a
+// subsequent CacheRemoteObjectToLocalCluster re-downloads from the remote
+// instead of short-circuiting as "already cached". A no-op when the entry has no
+// chunks; errors when the entry is not remote-backed.
+func (s3a *S3ApiServer) dropLocalChunks(dir, name string) error {
+	entry, err := s3a.getEntry(dir, name)
+	if err != nil {
+		return err
+	}
+	if entry.RemoteEntry == nil || entry.RemoteEntry.RemoteSize == 0 {
+		return fmt.Errorf("%s/%s is not remote-backed", dir, name)
+	}
+	if len(entry.GetChunks()) == 0 {
+		return nil
+	}
+	entry.Chunks = nil
+	return s3a.updateEntry(dir, entry)
+}
+
+// streamEntryRangeToResponse streams the [offset, offset+size) range of entry's
+// chunks to w, mirroring the reader setup used by streamFromVolumeServers.
+func (s3a *S3ApiServer) streamEntryRangeToResponse(r *http.Request, w io.Writer, entry *filer_pb.Entry, offset, size, totalSize int64) error {
+	chunks := entry.GetChunks()
+	if len(chunks) == 0 {
+		return fmt.Errorf("entry has no chunks to stream")
+	}
+
+	ctx := r.Context()
+	lookupFileIdFn := s3a.createLookupFileIdFunction()
+	visibleIntervals, err := filer.NonOverlappingVisibleIntervals(ctx, lookupFileIdFn, chunks, offset, offset+size)
+	if err != nil {
+		return fmt.Errorf("resolve chunks: %w", err)
+	}
+
+	chunkViews := filer.ViewFromVisibleIntervals(visibleIntervals, offset, size)
+	reader := filer.NewChunkReaderAtFromClient(ctx, s3a.readerCache, chunkViews, totalSize, filer.DefaultPrefetchCount)
+
+	cw := &countingWriter{w: w}
+	const maxCopyBuf = 256 * 1024
+	copyBufSize := int64(maxCopyBuf)
+	if size > 0 && size < copyBufSize {
+		copyBufSize = size
+	}
+	copyBuf := make([]byte, copyBufSize)
+	_, err = io.CopyBuffer(cw, io.NewSectionReader(reader, offset, size), copyBuf)
+	if cw.written > 0 {
+		BucketTrafficSent(cw.written, r)
+	}
+	return err
 }
 
 // cacheRemoteObjectForStreaming caches a remote-only object to the local cluster for streaming.

--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -941,13 +941,12 @@ func (s3a *S3ApiServer) streamFromVolumeServers(w http.ResponseWriter, r *http.R
 		rangeParseTime   time.Duration
 		headerSetTime    time.Duration
 		chunkResolveTime time.Duration
-		streamPrepTime   time.Duration
 		streamExecTime   time.Duration
 	)
 	defer func() {
 		totalTime := time.Since(t0)
-		glog.V(2).Infof("  └─ streamFromVolumeServers: total=%v, rangeParse=%v, headerSet=%v, chunkResolve=%v, streamPrep=%v, streamExec=%v",
-			totalTime, rangeParseTime, headerSetTime, chunkResolveTime, streamPrepTime, streamExecTime)
+		glog.V(2).Infof("  └─ streamFromVolumeServers: total=%v, rangeParse=%v, headerSet=%v, chunkResolve=%v, streamExec=%v",
+			totalTime, rangeParseTime, headerSetTime, chunkResolveTime, streamExecTime)
 	}()
 
 	if entry == nil {
@@ -1091,24 +1090,6 @@ func (s3a *S3ApiServer) streamFromVolumeServers(w http.ResponseWriter, r *http.R
 		return newStreamErrorWithResponse(fmt.Errorf("failed to resolve chunks: %v", err))
 	}
 
-	// Build a ChunkReadAt backed by the server-wide ReaderCache. This mirrors
-	// the WebDAV read path (server/webdav_server.go) and outperforms the
-	// io.Pipe-based streamChunksPrefetched path: ReaderCache prefetches whole
-	// chunks into memory buffers that the consumer can memcpy out of, so
-	// prefetchCount translates into actual in-flight bytes rather than just
-	// parallel TCP handshakes.
-	//
-	// We do NOT call reader.Close() here — ChunkReadAt.Close() would destroy
-	// the ReaderCache's downloaders map, which is shared across concurrent
-	// requests. Eviction is handled by the ReaderCache's own downloader
-	// limit. JWT for volume-server requests is generated internally by
-	// util_http.RetriedFetchChunkData from jwtSigningReadKey, matching the
-	// WebDAV and mount read paths.
-	tStreamPrep := time.Now()
-	chunkViews := filer.ViewFromVisibleIntervals(visibleIntervals, offset, size)
-	reader := filer.NewChunkReaderAtFromClient(ctx, s3a.readerCache, chunkViews, totalSize, filer.DefaultPrefetchCount)
-	streamPrepTime = time.Since(tStreamPrep)
-
 	// All validation and preparation successful - NOW set headers and write status
 	tHeaderSet := time.Now()
 	s3a.setResponseHeaders(w, r, entry, totalSize)
@@ -1132,27 +1113,10 @@ func (s3a *S3ApiServer) streamFromVolumeServers(w http.ResponseWriter, r *http.R
 	// Track time to first byte metric
 	TimeToFirstByte(r.Method, t0, r)
 
-	// Stream directly to response with counting wrapper.
-	// ChunkReadAt's ReadAt is backed by in-memory prefetched chunk buffers, so
-	// io.CopyBuffer drains them as fast memcpys.
 	tStreamExec := time.Now()
 	glog.V(4).Infof("streamFromVolumeServers: starting chunk reader, offset=%d, size=%d", offset, size)
-	cw := &countingWriter{w: w}
-	// Cap the copy buffer to the response size so small-object GETs (common
-	// for thumbnails, config files, etc.) don't allocate a 256 KiB scratch
-	// buffer per request.
-	const maxCopyBuf = 256 * 1024
-	copyBufSize := int64(maxCopyBuf)
-	if size > 0 && size < copyBufSize {
-		copyBufSize = size
-	}
-	copyBuf := make([]byte, copyBufSize)
-	_, err = io.CopyBuffer(cw, io.NewSectionReader(reader, offset, size), copyBuf)
+	written, err := s3a.streamResolvedRangeToResponse(ctx, r, w, visibleIntervals, offset, size, totalSize)
 	streamExecTime = time.Since(tStreamExec)
-	// Track traffic even on partial writes for accurate egress accounting
-	if cw.written > 0 {
-		BucketTrafficSent(cw.written, r)
-	}
 	if err != nil {
 		// A remote-mounted entry can still reference local chunks whose backing
 		// needle has been reclaimed (vacuum-compaction / deletion), so the
@@ -1161,7 +1125,7 @@ func (s3a *S3ApiServer) streamFromVolumeServers(w http.ResponseWriter, r *http.R
 		// false and the normal remote re-pull above never runs. When nothing has
 		// been written yet, drop the dead chunks and re-pull from the remote
 		// rather than failing the GET.
-		if cw.written == 0 && errors.Is(err, util_http.ErrNotFound) &&
+		if written == 0 && errors.Is(err, util_http.ErrNotFound) &&
 			s3a.recoverFromStaleRemoteChunks(w, r, entry, bucket, object, versionId, offset, size, totalSize) {
 			glog.V(1).Infof("streamFromVolumeServers: recovered %s/%s from remote after stale-chunk 404", bucket, object)
 			return nil
@@ -1169,17 +1133,17 @@ func (s3a *S3ApiServer) streamFromVolumeServers(w http.ResponseWriter, r *http.R
 		switch {
 		case isCanceledStreamingError(err):
 			// Client disconnected mid-stream (e.g. Nginx upstream timeout, browser cancel) - expected
-			glog.V(3).Infof("streamFromVolumeServers: client disconnected after writing %d bytes: %v", cw.written, err)
+			glog.V(3).Infof("streamFromVolumeServers: client disconnected after writing %d bytes: %v", written, err)
 		case errors.Is(err, context.DeadlineExceeded):
 			// Server-side deadline exceeded - unexpected, warrants operator attention
-			glog.Warningf("streamFromVolumeServers: server-side deadline exceeded after writing %d bytes: %v", cw.written, err)
+			glog.Warningf("streamFromVolumeServers: server-side deadline exceeded after writing %d bytes: %v", written, err)
 		default:
-			glog.Errorf("streamFromVolumeServers: streamFn failed after writing %d bytes: %v", cw.written, err)
+			glog.Errorf("streamFromVolumeServers: streamFn failed after writing %d bytes: %v", written, err)
 		}
 		// Streaming error after WriteHeader was called - response already partially written
 		return newStreamErrorWithResponse(err)
 	}
-	glog.V(4).Infof("streamFromVolumeServers: streamFn completed successfully, wrote %d bytes", cw.written)
+	glog.V(4).Infof("streamFromVolumeServers: streamFn completed successfully, wrote %d bytes", written)
 	return nil
 }
 
@@ -3297,8 +3261,8 @@ func (s3a *S3ApiServer) dropLocalChunks(dir, name string) error {
 	return s3a.updateEntry(dir, entry)
 }
 
-// streamEntryRangeToResponse streams the [offset, offset+size) range of entry's
-// chunks to w, mirroring the reader setup used by streamFromVolumeServers.
+// streamEntryRangeToResponse resolves entry's chunks and streams the
+// [offset, offset+size) range to w.
 func (s3a *S3ApiServer) streamEntryRangeToResponse(r *http.Request, w io.Writer, entry *filer_pb.Entry, offset, size, totalSize int64) error {
 	chunks := entry.GetChunks()
 	if len(chunks) == 0 {
@@ -3312,21 +3276,37 @@ func (s3a *S3ApiServer) streamEntryRangeToResponse(r *http.Request, w io.Writer,
 		return fmt.Errorf("resolve chunks: %w", err)
 	}
 
+	_, err = s3a.streamResolvedRangeToResponse(ctx, r, w, visibleIntervals, offset, size, totalSize)
+	return err
+}
+
+// streamResolvedRangeToResponse builds a ReaderCache-backed reader over the
+// resolved [offset, offset+size) intervals and copies it to w, returning the
+// number of bytes written (also accounted as bucket egress). Shared by the
+// primary GET path and the stale-remote-chunk recovery path.
+//
+// We do NOT call reader.Close() here — ChunkReadAt.Close() would destroy the
+// ReaderCache's downloaders map, which is shared across concurrent requests;
+// eviction is handled by the ReaderCache's own downloader limit. JWT for
+// volume-server requests is generated internally by util_http.RetriedFetchChunkData.
+func (s3a *S3ApiServer) streamResolvedRangeToResponse(ctx context.Context, r *http.Request, w io.Writer, visibleIntervals *filer.IntervalList[*filer.VisibleInterval], offset, size, totalSize int64) (int64, error) {
 	chunkViews := filer.ViewFromVisibleIntervals(visibleIntervals, offset, size)
 	reader := filer.NewChunkReaderAtFromClient(ctx, s3a.readerCache, chunkViews, totalSize, filer.DefaultPrefetchCount)
 
 	cw := &countingWriter{w: w}
+	// Cap the copy buffer to the response size so small-object GETs don't
+	// allocate a 256 KiB scratch buffer per request.
 	const maxCopyBuf = 256 * 1024
 	copyBufSize := int64(maxCopyBuf)
 	if size > 0 && size < copyBufSize {
 		copyBufSize = size
 	}
 	copyBuf := make([]byte, copyBufSize)
-	_, err = io.CopyBuffer(cw, io.NewSectionReader(reader, offset, size), copyBuf)
+	_, err := io.CopyBuffer(cw, io.NewSectionReader(reader, offset, size), copyBuf)
 	if cw.written > 0 {
 		BucketTrafficSent(cw.written, r)
 	}
-	return err
+	return cw.written, err
 }
 
 // cacheRemoteObjectForStreaming caches a remote-only object to the local cluster for streaming.

--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -3247,6 +3247,10 @@ func (s3a *S3ApiServer) recoverFromStaleRemoteChunks(w http.ResponseWriter, r *h
 		return false
 	}
 
+	// Count only real recovery attempts (past the not-applicable guards above).
+	recovered := false
+	defer func() { stats.RecordRemoteStaleChunkRecovery(stats.RemoteCacheSourceS3, bucket, recovered) }()
+
 	cacheVersionId := resolvedSourceVersionId(versionId, entry)
 	dir, name := s3a.buildVersionedRemoteObjectPath(bucket, object, cacheVersionId)
 	glog.Warningf("recoverFromStaleRemoteChunks: %s/%s references a reclaimed needle; dropping stale chunks and re-pulling from remote", dir, name)
@@ -3270,6 +3274,7 @@ func (s3a *S3ApiServer) recoverFromStaleRemoteChunks(w http.ResponseWriter, r *h
 	}
 
 	glog.V(1).Infof("recoverFromStaleRemoteChunks: served %s/%s from re-pulled remote chunks (%d chunks)", dir, name, len(cachedEntry.GetChunks()))
+	recovered = true
 	return true
 }
 

--- a/weed/s3api/s3api_remote_storage_test.go
+++ b/weed/s3api/s3api_remote_storage_test.go
@@ -585,3 +585,42 @@ func TestCacheRemoteObjectForStreamingCached(t *testing.T) {
 	require.NotNil(t, got)
 	assert.Len(t, got.GetChunks(), 1)
 }
+
+// TestRecoverFromStaleRemoteChunksGuards pins the guards that keep the
+// stale-chunk recovery from touching the filer for cases it must not act on:
+// entries with no remote backing (i.e. normal, non-remote buckets) and requests
+// whose client already disconnected. In both cases it must return false without
+// dialing the filer, so behavior for non-remote buckets is unchanged.
+func TestRecoverFromStaleRemoteChunksGuards(t *testing.T) {
+	// A filer that fails the test if any recovery step ever dials it.
+	filerAddr := startFakeCacheFiler(t, &fakeCacheFiler{
+		cache: func(ctx context.Context, req *filer_pb.CacheRemoteObjectToLocalClusterRequest) (*filer_pb.CacheRemoteObjectToLocalClusterResponse, error) {
+			t.Fatalf("recovery must not reach the filer for guarded cases")
+			return nil, nil
+		},
+	})
+	s3a := newRemoteCacheTestServer(filerAddr)
+
+	t.Run("non-remote entry", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/mybucket/obj.bin", nil)
+		localEntry := &filer_pb.Entry{
+			Name:   "obj.bin",
+			Chunks: []*filer_pb.FileChunk{{FileId: "1,dead", Size: 100}},
+		}
+		assert.False(t, s3a.recoverFromStaleRemoteChunks(w, r, localEntry, "mybucket", "obj.bin", "", 0, 100, 100))
+	})
+
+	t.Run("canceled request", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		r := httptest.NewRequest(http.MethodGet, "/mybucket/obj.bin", nil).WithContext(ctx)
+		remoteEntry := &filer_pb.Entry{
+			Name:        "obj.bin",
+			RemoteEntry: &filer_pb.RemoteEntry{RemoteSize: 100},
+			Chunks:      []*filer_pb.FileChunk{{FileId: "1,dead", Size: 100}},
+		}
+		assert.False(t, s3a.recoverFromStaleRemoteChunks(w, r, remoteEntry, "mybucket", "obj.bin", "", 0, 100, 100))
+	})
+}

--- a/weed/stats/metrics.go
+++ b/weed/stats/metrics.go
@@ -669,6 +669,14 @@ var (
 			Help:      "Remote-mount object read attempts by source, bucket and cache result. A cold object retried before caching completes records a miss per attempt; paths outside the buckets folder use bucket \"_other\".",
 		}, []string{"source", "bucket", "result"})
 
+	RemoteStaleChunkRecoveryCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: subsystemRemote,
+			Name:      "stale_chunk_recovery_total",
+			Help:      "Remote-mount reads that found a local chunk pointing at a reclaimed needle and fell back to re-pulling from the remote, by source, bucket and result (recovered, failed). A nonzero rate means local cache/volume state is diverging from the remote and is worth alerting on.",
+		}, []string{"source", "bucket", "result"})
+
 	UploadErrorCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: Namespace,
@@ -937,6 +945,7 @@ func init() {
 	Gather.MustRegister(S3BucketReadOnlyGauge)
 
 	Gather.MustRegister(RemoteCacheReadCounter)
+	Gather.MustRegister(RemoteStaleChunkRecoveryCounter)
 
 	Gather.MustRegister(S3LifecycleDispatchCounter)
 	Gather.MustRegister(S3LifecycleScheduleDepthGauge)
@@ -1026,6 +1035,17 @@ func RecordRemoteCacheRead(source, bucket string, hit bool) {
 	RemoteCacheReadCounter.WithLabelValues(source, bucket, result).Inc()
 }
 
+func RecordRemoteStaleChunkRecovery(source, bucket string, recovered bool) {
+	if bucket == "" {
+		bucket = "_other"
+	}
+	result := "failed"
+	if recovered {
+		result = "recovered"
+	}
+	RemoteStaleChunkRecoveryCounter.WithLabelValues(source, bucket, result).Inc()
+}
+
 func DeleteBucketMetrics(bucket string) {
 	bucketLastActiveLock.Lock()
 	delete(bucketLastActiveTsNs, bucket)
@@ -1048,6 +1068,7 @@ func DeleteBucketMetrics(bucket string) {
 	c += S3LifecycleBootstrapDispatchCounter.DeletePartialMatch(labels)
 	c += S3LifecycleMetadataOnlyCounter.DeletePartialMatch(labels)
 	c += RemoteCacheReadCounter.DeletePartialMatch(labels)
+	c += RemoteStaleChunkRecoveryCounter.DeletePartialMatch(labels)
 
 	glog.V(0).Infof("delete bucket metrics, %s: %d", bucket, c)
 }


### PR DESCRIPTION
## Motivation

Fixes #10366.

When a remote-storage mount is used as a read-through cache over an object store, an S3 `GetObject` can fail with `404 Not Found` even though the object is intact in the remote store.

Objects are dual-populated (app writes to both the object store and SeaweedFS), and a local eviction process later clears local chunks and stamps a remote-only `RemoteEntry` so reads re-pull. That remote-only re-pull path works. The bug is the case where a filer entry **still has local chunks** (so `IsInRemoteOnly()` is false) but the referenced volume needle has been reclaimed by vacuum-compaction/deletion — the chunk read 404s and there is no fallback to the remote copy.

Production log evidence (generalized):

```
stream.go: read chunk <VID>,<NEEDLE> failed, invalidating cache and retrying: ...?readDeleted=true: 404 Not Found
reader_at.go: fetching chunk {FileId:<VID>,<NEEDLE> ...}: 404
s3api_object_handlers.go: streamFromVolumeServers: streamFn failed after writing 0 bytes: ...404
s3api_object_handlers.go: GetObjectHandler: failed to stream <bucket>/<key> from volume servers: ...404
```

## Overview

`streamFromVolumeServers` now detects a not-found chunk read (via `errors.Is(err, util_http.ErrNotFound)`), and — only when no response bytes have been written yet and the entry is remote-backed — recovers instead of failing:

1. **Drop the stale chunks** (`dropLocalChunks`) so the filer entry becomes remote-only again. This is required because `CacheRemoteObjectToLocalCluster` short-circuits as "already cached" while chunks are present, and it also makes future reads self-heal through the existing, well-tested remote-only path.
2. **Re-pull from the remote** via the existing `cacheRemoteObjectForStreamingWithShortTimeout` → `CacheRemoteObjectToLocalCluster` mechanism.
3. **Stream** the requested range from the freshly cached chunks (`streamEntryRangeToResponse`, mirroring the existing reader setup).

The recovery is guarded on `entry.RemoteEntry` being present, so non-remote buckets are completely unaffected. Since `Content-Length` has already been sent and no bytes were written, streaming exactly the requested range still yields a valid response.

All new code lives in `weed/s3api/s3api_object_handlers.go`.

## Status: Draft / WIP

- The SSE-encrypted read path (`streamFromVolumeServersWithSSE`) is not yet covered — only the plain `streamFromVolumeServers` path (where the production 404 occurred).
- Only a guard-level unit test is included (`TestRecoverFromStaleRemoteChunksGuards`), asserting the recovery is skipped for non-remote entries and canceled requests without touching the filer. **TODO:** a full integration test with fake volume servers exercising the drop-chunks → re-pull → stream flow end to end.

## Testing

- `go build ./...` passes.
- `go vet ./weed/s3api/` reports only pre-existing warnings in unrelated test files.
- `go test ./weed/s3api/ -run 'TestRecoverFromStaleRemoteChunksGuards|TestCacheRemoteObjectForStreaming'` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved S3 object downloads by automatically recovering when remote-mounted reads detect stale local chunk references.
  - Recovery re-reruns the originally requested byte range and avoids returning not-found when zero bytes were written initially.
  - Added safeguards to skip recovery for local objects and for canceled requests, and ensured egress traffic accounting continues during recovery.
- **New Features**
  - Added a new Prometheus metric to track stale remote-chunk recovery outcomes (recovered vs. failed) and included it in bucket metric cleanup.
- **Tests**
  - Added coverage for guard behavior to ensure recovery doesn’t dial or cache when it must be skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->