### PR TITLE
fix(filer): opt-in chunk-list optimistic concurrency in UpdateEntry (RFC)

### DIFF
--- a/other/java/client/src/main/proto/filer.proto
+++ b/other/java/client/src/main/proto/filer.proto
@@ -447,6 +447,13 @@ message UpdateEntryRequest {
     bool is_from_other_cluster = 3;
     repeated int32 signatures = 4;
     map<string, bytes> expected_extended = 5;
+    // Optimistic concurrency on the chunk list. When non-empty, the filer
+    // rejects the update with FAILED_PRECONDITION unless the stored entry's
+    // current chunk set (by fid string) exactly matches this set. Empty/nil
+    // disables the check (backward compatible). Prevents a stale
+    // chunk-preserving read-modify-write from resurrecting a needle that a
+    // concurrent update already queued for deletion.
+    repeated string expected_chunks = 6;
 }
 message UpdateEntryResponse {
     SubscribeMetadataResponse metadata_event = 1;

--- a/weed/pb/filer.proto
+++ b/weed/pb/filer.proto
@@ -447,6 +447,13 @@ message UpdateEntryRequest {
     bool is_from_other_cluster = 3;
     repeated int32 signatures = 4;
     map<string, bytes> expected_extended = 5;
+    // Optimistic concurrency on the chunk list. When non-empty, the filer
+    // rejects the update with FAILED_PRECONDITION unless the stored entry's
+    // current chunk set (by fid string) exactly matches this set. Empty/nil
+    // disables the check (backward compatible). Prevents a stale
+    // chunk-preserving read-modify-write from resurrecting a needle that a
+    // concurrent update already queued for deletion.
+    repeated string expected_chunks = 6;
 }
 message UpdateEntryResponse {
     SubscribeMetadataResponse metadata_event = 1;

--- a/weed/pb/filer_pb/filer.pb.go
+++ b/weed/pb/filer_pb/filer.pb.go
@@ -2310,8 +2310,15 @@ type UpdateEntryRequest struct {
 	IsFromOtherCluster bool                   `protobuf:"varint,3,opt,name=is_from_other_cluster,json=isFromOtherCluster,proto3" json:"is_from_other_cluster,omitempty"`
 	Signatures         []int32                `protobuf:"varint,4,rep,packed,name=signatures,proto3" json:"signatures,omitempty"`
 	ExpectedExtended   map[string][]byte      `protobuf:"bytes,5,rep,name=expected_extended,json=expectedExtended,proto3" json:"expected_extended,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// Optimistic concurrency on the chunk list. When non-empty, the filer
+	// rejects the update with FAILED_PRECONDITION unless the stored entry's
+	// current chunk set (by fid string) exactly matches this set. Empty/nil
+	// disables the check (backward compatible). Prevents a stale
+	// chunk-preserving read-modify-write from resurrecting a needle that a
+	// concurrent update already queued for deletion.
+	ExpectedChunks []string `protobuf:"bytes,6,rep,name=expected_chunks,json=expectedChunks,proto3" json:"expected_chunks,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *UpdateEntryRequest) Reset() {
@@ -2375,6 +2382,13 @@ func (x *UpdateEntryRequest) GetSignatures() []int32 {
 func (x *UpdateEntryRequest) GetExpectedExtended() map[string][]byte {
 	if x != nil {
 		return x.ExpectedExtended
+	}
+	return nil
+}
+
+func (x *UpdateEntryRequest) GetExpectedChunks() []string {
+	if x != nil {
+		return x.ExpectedChunks
 	}
 	return nil
 }
@@ -7034,7 +7048,7 @@ const file_filer_proto_rawDesc = "" +
 	"\x05error\x18\x01 \x01(\tR\x05error\x12J\n" +
 	"\x0emetadata_event\x18\x02 \x01(\v2#.filer_pb.SubscribeMetadataResponseR\rmetadataEvent\x123\n" +
 	"\n" +
-	"error_code\x18\x03 \x01(\x0e2\x14.filer_pb.FilerErrorR\terrorCode\"\xd2\x02\n" +
+	"error_code\x18\x03 \x01(\x0e2\x14.filer_pb.FilerErrorR\terrorCode\"\xfb\x02\n" +
 	"\x12UpdateEntryRequest\x12\x1c\n" +
 	"\tdirectory\x18\x01 \x01(\tR\tdirectory\x12%\n" +
 	"\x05entry\x18\x02 \x01(\v2\x0f.filer_pb.EntryR\x05entry\x121\n" +
@@ -7042,7 +7056,8 @@ const file_filer_proto_rawDesc = "" +
 	"\n" +
 	"signatures\x18\x04 \x03(\x05R\n" +
 	"signatures\x12_\n" +
-	"\x11expected_extended\x18\x05 \x03(\v22.filer_pb.UpdateEntryRequest.ExpectedExtendedEntryR\x10expectedExtended\x1aC\n" +
+	"\x11expected_extended\x18\x05 \x03(\v22.filer_pb.UpdateEntryRequest.ExpectedExtendedEntryR\x10expectedExtended\x12'\n" +
+	"\x0fexpected_chunks\x18\x06 \x03(\tR\x0eexpectedChunks\x1aC\n" +
 	"\x15ExpectedExtendedEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\fR\x05value:\x028\x01\"a\n" +

--- a/weed/pb/filer_pb/filer_vtproto.pb.go
+++ b/weed/pb/filer_pb/filer_vtproto.pb.go
@@ -2038,6 +2038,15 @@ func (m *UpdateEntryRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.ExpectedChunks) > 0 {
+		for iNdEx := len(m.ExpectedChunks) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.ExpectedChunks[iNdEx])
+			copy(dAtA[i:], m.ExpectedChunks[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ExpectedChunks[iNdEx])))
+			i--
+			dAtA[i] = 0x32
+		}
+	}
 	if len(m.ExpectedExtended) > 0 {
 		for k := range m.ExpectedExtended {
 			v := m.ExpectedExtended[k]
@@ -6977,6 +6986,12 @@ func (m *UpdateEntryRequest) SizeVT() (n int) {
 			l = 1 + len(v) + protohelpers.SizeOfVarint(uint64(len(v)))
 			mapEntrySize := 1 + len(k) + protohelpers.SizeOfVarint(uint64(len(k))) + l
 			n += mapEntrySize + 1 + protohelpers.SizeOfVarint(uint64(mapEntrySize))
+		}
+	}
+	if len(m.ExpectedChunks) > 0 {
+		for _, s := range m.ExpectedChunks {
+			l = len(s)
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 		}
 	}
 	n += len(m.unknownFields)
@@ -14419,6 +14434,38 @@ func (m *UpdateEntryRequest) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			m.ExpectedExtended[mapkey] = mapvalue
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ExpectedChunks", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ExpectedChunks = append(m.ExpectedChunks, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/weed/server/filer_grpc_server.go
+++ b/weed/server/filer_grpc_server.go
@@ -598,7 +598,7 @@ func (fs *FilerServer) UpdateEntry(ctx context.Context, req *filer_pb.UpdateEntr
 	if err != nil {
 		return &filer_pb.UpdateEntryResponse{}, fmt.Errorf("not found %s: %v", fullpath, err)
 	}
-	if err := validateUpdateEntryPreconditions(entry, req.ExpectedExtended); err != nil {
+	if err := validateUpdateEntryPreconditions(entry, req.ExpectedExtended, req.ExpectedChunks); err != nil {
 		return &filer_pb.UpdateEntryResponse{}, err
 	}
 
@@ -634,10 +634,7 @@ func (fs *FilerServer) UpdateEntry(ctx context.Context, req *filer_pb.UpdateEntr
 	return resp, err
 }
 
-func validateUpdateEntryPreconditions(entry *filer.Entry, expectedExtended map[string][]byte) error {
-	if len(expectedExtended) == 0 {
-		return nil
-	}
+func validateUpdateEntryPreconditions(entry *filer.Entry, expectedExtended map[string][]byte, expectedChunks []string) error {
 
 	for key, expectedValue := range expectedExtended {
 		var actualValue []byte
@@ -653,6 +650,42 @@ func validateUpdateEntryPreconditions(entry *filer.Entry, expectedExtended map[s
 		}
 		if len(expectedValue) > 0 {
 			return status.Errorf(codes.FailedPrecondition, "extended attribute %q changed", key)
+		}
+	}
+
+	return validateExpectedChunks(entry, expectedChunks)
+}
+
+// validateExpectedChunks enforces optimistic concurrency on the chunk list.
+// When expectedChunks is non-empty, the stored entry's current set of chunk
+// fids must match it exactly; otherwise the update is rejected as retryable so
+// a stale chunk-preserving read-modify-write cannot resurrect a needle that a
+// concurrent update already diffed away and queued for deletion. The comparison
+// is order-independent because chunk ordering is not semantically meaningful for
+// needle liveness. Empty/nil disables the check (backward compatible).
+func validateExpectedChunks(entry *filer.Entry, expectedChunks []string) error {
+	if len(expectedChunks) == 0 {
+		return nil
+	}
+
+	actual := make(map[string]int)
+	if entry != nil {
+		for _, chunk := range entry.GetChunks() {
+			actual[chunk.GetFileIdString()]++
+		}
+	}
+
+	expected := make(map[string]int, len(expectedChunks))
+	for _, fid := range expectedChunks {
+		expected[fid]++
+	}
+
+	if len(actual) != len(expected) {
+		return status.Errorf(codes.FailedPrecondition, "chunk set changed")
+	}
+	for fid, count := range expected {
+		if actual[fid] != count {
+			return status.Errorf(codes.FailedPrecondition, "chunk set changed")
 		}
 	}
 

--- a/weed/server/filer_grpc_server.go
+++ b/weed/server/filer_grpc_server.go
@@ -668,23 +668,37 @@ func validateExpectedChunks(entry *filer.Entry, expectedChunks []string) error {
 		return nil
 	}
 
-	actual := make(map[string]int)
+	var actual []*filer_pb.FileChunk
 	if entry != nil {
-		for _, chunk := range entry.GetChunks() {
-			actual[chunk.GetFileIdString()]++
+		actual = entry.GetChunks()
+	}
+
+	// Fast path: the common successful-OCC case is an identical, in-order list,
+	// which we can confirm without allocating comparison maps.
+	if len(actual) == len(expectedChunks) {
+		ordered := true
+		for i, chunk := range actual {
+			if chunk.GetFileIdString() != expectedChunks[i] {
+				ordered = false
+				break
+			}
+		}
+		if ordered {
+			return nil
 		}
 	}
 
-	expected := make(map[string]int, len(expectedChunks))
+	// Fall back to an order-independent multiset compare: expected fids increment
+	// and stored fids decrement a single counter map; equal multisets net to zero.
+	counts := make(map[string]int, len(expectedChunks))
 	for _, fid := range expectedChunks {
-		expected[fid]++
+		counts[fid]++
 	}
-
-	if len(actual) != len(expected) {
-		return status.Errorf(codes.FailedPrecondition, "chunk set changed")
+	for _, chunk := range actual {
+		counts[chunk.GetFileIdString()]--
 	}
-	for fid, count := range expected {
-		if actual[fid] != count {
+	for _, c := range counts {
+		if c != 0 {
 			return status.Errorf(codes.FailedPrecondition, "chunk set changed")
 		}
 	}

--- a/weed/server/filer_grpc_server_chunk_cas_test.go
+++ b/weed/server/filer_grpc_server_chunk_cas_test.go
@@ -33,8 +33,12 @@ func TestValidateExpectedChunks(t *testing.T) {
 	}{
 		{"nil-disables", withChunks("3,01"), nil, false},
 		{"empty-disables", withChunks("3,01"), []string{}, false},
+		{"nil-entry-disables", nil, nil, false},
+		{"nil-entry-with-expected", nil, []string{"3,01"}, true},
 		{"exact-match", withChunks("3,01", "3,02"), []string{"3,01", "3,02"}, false},
 		{"order-independent", withChunks("3,01", "3,02"), []string{"3,02", "3,01"}, false},
+		{"matching-duplicates", withChunks("3,01", "3,01", "3,02"), []string{"3,01", "3,01", "3,02"}, false},
+		{"matching-duplicates-reordered", withChunks("3,02", "3,01", "3,01"), []string{"3,01", "3,02", "3,01"}, false},
 		// The strand: stored was diffed down to empty by a concurrent update,
 		// but the stale writer still expects the old chunk present -> reject.
 		{"stored-emptied", withChunks(), []string{"3,01"}, true},

--- a/weed/server/filer_grpc_server_chunk_cas_test.go
+++ b/weed/server/filer_grpc_server_chunk_cas_test.go
@@ -1,0 +1,144 @@
+package weed_server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/filer"
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func chunkFid(fid string, size uint64) *filer_pb.FileChunk {
+	return &filer_pb.FileChunk{FileId: fid, Offset: 0, Size: size}
+}
+
+func TestValidateExpectedChunks(t *testing.T) {
+	withChunks := func(fids ...string) *filer.Entry {
+		e := &filer.Entry{FullPath: "/test/obj"}
+		for _, fid := range fids {
+			e.Chunks = append(e.Chunks, chunkFid(fid, 100))
+		}
+		return e
+	}
+
+	cases := []struct {
+		name     string
+		entry    *filer.Entry
+		expected []string
+		wantErr  bool
+	}{
+		{"nil-disables", withChunks("3,01"), nil, false},
+		{"empty-disables", withChunks("3,01"), []string{}, false},
+		{"exact-match", withChunks("3,01", "3,02"), []string{"3,01", "3,02"}, false},
+		{"order-independent", withChunks("3,01", "3,02"), []string{"3,02", "3,01"}, false},
+		// The strand: stored was diffed down to empty by a concurrent update,
+		// but the stale writer still expects the old chunk present -> reject.
+		{"stored-emptied", withChunks(), []string{"3,01"}, true},
+		{"chunk-added", withChunks("3,01", "3,02"), []string{"3,01"}, true},
+		{"chunk-removed", withChunks("3,01"), []string{"3,01", "3,02"}, true},
+		{"chunk-replaced", withChunks("3,09"), []string{"3,01"}, true},
+		{"duplicate-count-mismatch", withChunks("3,01"), []string{"3,01", "3,01"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateExpectedChunks(tc.entry, tc.expected)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want FailedPrecondition, got nil")
+				}
+				if status.Code(err) != codes.FailedPrecondition {
+					t.Fatalf("want FailedPrecondition, got %v", status.Code(err))
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("want nil, got %v", err)
+			}
+		})
+	}
+}
+
+// TestUpdateEntryChunkCASPreventsStrand drives the real UpdateEntry handler
+// through the stranding interleaving from issue #10366:
+//
+//  1. entry has chunks=[F]; needle F is live.
+//  2. R (a chunk-preserving read-modify-write) snapshots expected chunks=[F].
+//  3. D (eviction) commits chunks=[] first; F is diffed away and queued for
+//     deletion. We model D's commit by leaving the stored entry at chunks=[].
+//  4. R commits its stale snapshot last.
+//
+// Without the precondition, R's stale write resurrects the reference to F
+// (last-write-wins) even though F is already queued for deletion, stranding the
+// entry on a dead needle. With expected_chunks set, R's write is rejected with a
+// retryable FAILED_PRECONDITION and the stored entry stays chunks=[].
+func TestUpdateEntryChunkCASPreventsStrand(t *testing.T) {
+	const fidF = "3,01637037d6"
+
+	newFiler := func(storedChunks []*filer_pb.FileChunk) (*FilerServer, *renameTestStore) {
+		store := newRenameTestStore()
+		store.entries["/test/obj"] = &filer.Entry{
+			FullPath: "/test/obj",
+			Attr:     filer.Attr{Inode: 1, Mtime: time.Unix(1700000000, 0), Mode: 0644},
+			Chunks:   storedChunks,
+		}
+		f := newRenameTestFiler(store)
+		fs := &FilerServer{filer: f, option: &FilerOption{}, entryLockTable: util.NewLockTable[util.FullPath]()}
+		return fs, store
+	}
+
+	// R's stale request: it read chunks=[F] and re-asserts chunks=[F].
+	staleReq := func(withCAS bool) *filer_pb.UpdateEntryRequest {
+		req := &filer_pb.UpdateEntryRequest{
+			Directory: "/test",
+			Entry: &filer_pb.Entry{
+				Name:       "obj",
+				Attributes: &filer_pb.FuseAttributes{Mtime: 1700000005, FileMode: 0644, Inode: 1},
+				Chunks:     []*filer_pb.FileChunk{chunkFid(fidF, 100)},
+			},
+		}
+		if withCAS {
+			req.ExpectedChunks = []string{fidF}
+		}
+		return req
+	}
+
+	// D already committed chunks=[]; R commits last WITHOUT the precondition.
+	t.Run("without-cas-resurrects", func(t *testing.T) {
+		fs, store := newFiler(nil)
+		if _, err := fs.UpdateEntry(context.Background(), staleReq(false)); err != nil {
+			t.Fatalf("UpdateEntry: %v", err)
+		}
+		if got := len(store.entries["/test/obj"].GetChunks()); got != 1 {
+			t.Fatalf("expected the buggy resurrection (chunks=[F]); got %d chunks", got)
+		}
+	})
+
+	// D already committed chunks=[]; R commits last WITH the precondition.
+	t.Run("with-cas-rejected", func(t *testing.T) {
+		fs, store := newFiler(nil)
+		_, err := fs.UpdateEntry(context.Background(), staleReq(true))
+		if status.Code(err) != codes.FailedPrecondition {
+			t.Fatalf("stale chunk-preserving write must be rejected with FailedPrecondition, got %v", err)
+		}
+		if got := len(store.entries["/test/obj"].GetChunks()); got != 0 {
+			t.Fatalf("entry must stay chunks=[] (no resurrected reference); got %d chunks", got)
+		}
+	})
+
+	// Fresh RMW: the precondition still matches the stored chunk set, so the
+	// metadata-only update is applied and chunks=[F] is preserved.
+	t.Run("with-cas-fresh-passes", func(t *testing.T) {
+		fs, store := newFiler([]*filer_pb.FileChunk{chunkFid(fidF, 100)})
+		if _, err := fs.UpdateEntry(context.Background(), staleReq(true)); err != nil {
+			t.Fatalf("fresh RMW must succeed, got %v", err)
+		}
+		chunks := store.entries["/test/obj"].GetChunks()
+		if len(chunks) != 1 || chunks[0].GetFileIdString() != fidF {
+			t.Fatalf("fresh RMW must preserve chunks=[F]; got %v", chunks)
+		}
+	})
+}


### PR DESCRIPTION
> **RFC / DRAFT** — opening this for design feedback before hardening. The proto field shape, error/retry semantics, and which call sites should populate the precondition are open questions (see below). Companion to the read-side defense-in-depth in #10367; both address #10366.

## Motivation

A filer entry can end up referencing a volume needle that has been deleted and vacuumed, so reads 404 even though the object is intact in a remote-storage mount. The root cause is a last-write-wins race in the filer's `UpdateEntry`.

`UpdateEntry` (`weed/server/filer_grpc_server.go`) is a read-modify-write:

1. `FindEntry` reads the current stored entry.
2. `validateUpdateEntryPreconditions(entry, req.ExpectedExtended)` — guards **only** the `Extended` map, **not** the chunk list.
3. `cleanupChunks(entry, req.Entry)` diffs stored-vs-incoming chunks to compute garbage needles.
4. the incoming entry is written, then `DeleteChunksNotRecursive(garbage)` fire-and-forget queues the garbage for deletion.

Because the precondition ignores the chunk list, two concurrent RMWs on one entry are last-write-wins on chunks. The stranding interleaving:

1. entry `chunks=[F]`, needle F live.
2. **R** (a chunk-preserving RMW — S3 tag/attr/copy, FUSE setattr, another controller) reads the entry and prepares a metadata-only change that keeps `chunks=[F]`.
3. **D** (eviction/uncache) commits `UpdateEntry chunks=[]`: garbage = `[F]`, F is enqueued for deletion.
4. **R** commits its stale snapshot last: stored is now `[]`, so its garbage diff is empty, and it writes `chunks=[F]` — **resurrecting the reference to F**, which is already queued for deletion.
5. the deletion queue tombstones F; vacuum reclaims it → the entry references a dead needle. `IsInRemoteOnly()` is false (the entry still has chunks) so there is no remote re-pull → **404**.

This has been reproduced deterministically and via a real eviction/uncache path in a testcontainers harness against a released build.

## Overview

Add **opt-in optimistic concurrency on the chunk list** to `UpdateEntry`, mirroring the existing `ExpectedExtended` mechanism:

- **Proto** (`weed/pb/filer.proto`): a new optional `repeated string expected_chunks = 6` on `UpdateEntryRequest`. It carries the client's expected current chunk set as fid strings (`FileChunk.GetFileIdString()`). A fid-string list was chosen as the lightest faithful representation: needle liveness — the thing this bug is about — is keyed exactly by fid `(volume, key, cookie)`, and fid strings are already the identity used throughout chunk diffing (`DoMinusChunks`, `SeparateGarbageChunks`). Regenerated with `make gen` in `weed/pb` (protoc + go + go-grpc + vtproto).
- **Handler**: `validateUpdateEntryPreconditions` now also takes `expectedChunks` and delegates to a new `validateExpectedChunks`. When `expected_chunks` is non-empty, the stored entry's current chunk set is compared (order-independent, multiset by fid) against it, and a mismatch returns a retryable `codes.FailedPrecondition`. This makes R's stale chunk-preserving write fail cleanly so the caller can re-read the emptied state instead of resurrecting F.
- **Backward compatible / opt-in**: empty or nil `expected_chunks` ⇒ no check ⇒ current behavior is preserved exactly. No existing call site changes behavior until it starts populating the field.

### Related: `CreateEntry`

`CreateEntry` shares the same `cleanupChunks` → `DeleteChunksNotRecursive` pattern and the same class of race on overwrite. It is intentionally **not** changed here to keep this PR focused; covering it is a candidate follow-up (see open questions).

## Test

`weed/server/filer_grpc_server_chunk_cas_test.go`:

- `TestValidateExpectedChunks` — unit coverage of the precondition: nil/empty disables, exact match and reordering pass, and every mutation (stored emptied, chunk added/removed/replaced, duplicate-count mismatch) is rejected with `FailedPrecondition`.
- `TestUpdateEntryChunkCASPreventsStrand` — drives the real `UpdateEntry` gRPC handler through the #10366 interleaving:
  - **without** the precondition, R's stale write resurrects `chunks=[F]` (demonstrates the current buggy behavior);
  - **with** `expected_chunks=[F]` against the concurrently-emptied entry, R's write is rejected and the stored entry correctly stays `chunks=[]` (no resurrected reference — the strand does not occur);
  - a fresh RMW whose precondition still matches is applied normally.

`go build ./...`, `go vet`, and `go test ./weed/server/ ./weed/pb/filer_pb/` all pass.

## Open questions for maintainers

1. **Field shape / name.** Is `repeated string expected_chunks` (fid strings) the representation you'd want, or would you prefer a compact fingerprint (e.g. a hash of the sorted fid set) or a structured `repeated FileId`? Fid strings are simple and debuggable but grow with chunk count for large/manifest objects.
2. **Should `CreateEntry` get the same precondition?** It has the same overwrite race. Happy to extend it here if the shape is agreed, or split it into a follow-up.
3. **Which upstream RMW call sites should populate the precondition?** Candidates: the S3 API metadata/tagging/copy paths, FUSE `setattr`, and other filer-client read-modify-write callers. This PR only adds the mechanism; wiring the producers is deliberately deferred pending direction.
4. **Error type / retry semantics.** `FAILED_PRECONDITION` mirrors the existing `ExpectedExtended` behavior and signals "re-read and retry". Is that the contract you want, or should this be a distinct/typed error (or `ABORTED`, which gRPC conventionally marks retryable) so callers can auto-retry without conflating it with object-lock / If-Match precondition failures?

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional optimistic concurrency guard for file chunk updates via a new “expected chunk set” parameter.
  * When provided, updates are rejected unless the stored chunk set matches the expected list exactly.
  * If not provided, behavior remains backward compatible.
* **Bug Fixes**
  * Prevents concurrent chunk changes from being reverted by stale read-modify-write updates.
* **Tests**
  * Added coverage for chunk-set validation and end-to-end update behavior, including CAS enabled vs disabled scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->