### PR TITLE
helm: support fixed nodePort numbers on all-in-one, s3, sftp, and admin services

### DIFF
--- a/k8s/charts/seaweedfs/templates/admin/admin-service.yaml
+++ b/k8s/charts/seaweedfs/templates/admin/admin-service.yaml
@@ -15,15 +15,26 @@ metadata:
     {{- toYaml .Values.admin.service.annotations | nindent 4 }}
 {{- end }}
 spec:
-  type: {{ .Values.admin.service.type }}
+  {{- $serviceType := .Values.admin.service.type }}
+  {{- $nodePorts := dict }}
+  {{- if or (eq $serviceType "NodePort") (eq $serviceType "LoadBalancer") }}
+  {{- $nodePorts = .Values.admin.service.nodePorts | default dict }}
+  {{- end }}
+  type: {{ $serviceType }}
   ports:
   - name: "http"
     port: {{ .Values.admin.port }}
     targetPort: {{ .Values.admin.port }}
+    {{- if $nodePorts.http }}
+    nodePort: {{ $nodePorts.http }}
+    {{- end }}
     protocol: TCP
   - name: "grpc"
     port: {{ .Values.admin.grpcPort }}
     targetPort: {{ .Values.admin.grpcPort }}
+    {{- if $nodePorts.grpc }}
+    nodePort: {{ $nodePorts.grpc }}
+    {{- end }}
     protocol: TCP
   selector:
     app.kubernetes.io/name: {{ template "seaweedfs.name" . }}

--- a/k8s/charts/seaweedfs/templates/all-in-one/all-in-one-service.yml
+++ b/k8s/charts/seaweedfs/templates/all-in-one/all-in-one-service.yml
@@ -15,7 +15,12 @@ metadata:
     {{- toYaml .Values.allInOne.service.annotations | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.allInOne.service.type | default "ClusterIP" }}
+  {{- $serviceType := .Values.allInOne.service.type | default "ClusterIP" }}
+  {{- $nodePorts := dict }}
+  {{- if or (eq $serviceType "NodePort") (eq $serviceType "LoadBalancer") }}
+  {{- $nodePorts = .Values.allInOne.service.nodePorts | default dict }}
+  {{- end }}
+  type: {{ $serviceType }}
   internalTrafficPolicy: {{ .Values.allInOne.service.internalTrafficPolicy | default "Cluster" }}
   {{- if and (semverCompare ">=1.31-0" .Capabilities.KubeVersion.GitVersion) .Values.allInOne.s3.trafficDistribution }}
   trafficDistribution: {{ include "seaweedfs.trafficDistribution" (dict "value" .Values.allInOne.s3.trafficDistribution "Capabilities" .Capabilities) }}
@@ -25,30 +30,48 @@ spec:
   - name: "swfs-master"
     port: {{ .Values.master.port }}
     targetPort: {{ .Values.master.port }}
+    {{- if $nodePorts.master }}
+    nodePort: {{ $nodePorts.master }}
+    {{- end }}
     protocol: TCP
   - name: "swfs-master-grpc"
     port: {{ .Values.master.grpcPort }}
     targetPort: {{ .Values.master.grpcPort }}
+    {{- if $nodePorts.masterGrpc }}
+    nodePort: {{ $nodePorts.masterGrpc }}
+    {{- end }}
     protocol: TCP
-  
+
   # Volume ports
   - name: "swfs-volume"
     port: {{ .Values.volume.port }}
     targetPort: {{ .Values.volume.port }}
+    {{- if $nodePorts.volume }}
+    nodePort: {{ $nodePorts.volume }}
+    {{- end }}
     protocol: TCP
   - name: "swfs-volume-grpc"
     port: {{ .Values.volume.grpcPort }}
     targetPort: {{ .Values.volume.grpcPort }}
+    {{- if $nodePorts.volumeGrpc }}
+    nodePort: {{ $nodePorts.volumeGrpc }}
+    {{- end }}
     protocol: TCP
-  
+
   # Filer ports
   - name: "swfs-filer"
     port: {{ .Values.filer.port }}
     targetPort: {{ .Values.filer.port }}
+    {{- if $nodePorts.filer }}
+    nodePort: {{ $nodePorts.filer }}
+    {{- end }}
     protocol: TCP
   - name: "swfs-filer-grpc"
     port: {{ .Values.filer.grpcPort }}
     targetPort: {{ .Values.filer.grpcPort }}
+    {{- if $nodePorts.filerGrpc }}
+    nodePort: {{ $nodePorts.filerGrpc }}
+    {{- end }}
     protocol: TCP
   
   # S3 ports (if enabled)
@@ -56,21 +79,30 @@ spec:
   - name: "swfs-s3"
     port: {{ .Values.allInOne.s3.port | default .Values.s3.port }}
     targetPort: {{ .Values.allInOne.s3.port | default .Values.s3.port }}
+    {{- if $nodePorts.s3 }}
+    nodePort: {{ $nodePorts.s3 }}
+    {{- end }}
     protocol: TCP
   {{- $httpsPort := .Values.allInOne.s3.httpsPort | default .Values.s3.httpsPort }}
   {{- if $httpsPort }}
   - name: "swfs-s3-tls"
     port: {{ $httpsPort }}
     targetPort: {{ $httpsPort }}
+    {{- if $nodePorts.s3Https }}
+    nodePort: {{ $nodePorts.s3Https }}
+    {{- end }}
     protocol: TCP
   {{- end }}
   {{- end }}
-  
+
   # SFTP ports (if enabled)
   {{- if .Values.allInOne.sftp.enabled }}
   - name: "swfs-sftp"
     port: {{ .Values.allInOne.sftp.port | default .Values.sftp.port }}
     targetPort: {{ .Values.allInOne.sftp.port | default .Values.sftp.port }}
+    {{- if $nodePorts.sftp }}
+    nodePort: {{ $nodePorts.sftp }}
+    {{- end }}
     protocol: TCP
   {{- end }}
 
@@ -79,6 +111,9 @@ spec:
   - name: "server-metrics"
     port: {{ .Values.allInOne.metricsPort }}
     targetPort: {{ .Values.allInOne.metricsPort }}
+    {{- if $nodePorts.metrics }}
+    nodePort: {{ $nodePorts.metrics }}
+    {{- end }}
     protocol: TCP
   {{- end }}
   

--- a/k8s/charts/seaweedfs/templates/s3/s3-service.yaml
+++ b/k8s/charts/seaweedfs/templates/s3/s3-service.yaml
@@ -15,7 +15,12 @@ metadata:
     {{- toYaml .Values.s3.annotations | nindent 4 }}
 {{- end }}
 spec:
-  type: {{ .Values.s3.service.type }}
+  {{- $serviceType := .Values.s3.service.type }}
+  {{- $nodePorts := dict }}
+  {{- if or (eq $serviceType "NodePort") (eq $serviceType "LoadBalancer") }}
+  {{- $nodePorts = .Values.s3.service.nodePorts | default dict }}
+  {{- end }}
+  type: {{ $serviceType }}
   internalTrafficPolicy: {{ .Values.s3.internalTrafficPolicy | default "Cluster" }}
   {{- $td := .Values.s3.trafficDistribution | default .Values.filer.s3.trafficDistribution }}
   {{- if and (semverCompare ">=1.31-0" .Capabilities.KubeVersion.GitVersion) $td }}
@@ -25,23 +30,35 @@ spec:
   - name: "swfs-s3"
     port: {{ if .Values.s3.enabled }}{{ .Values.s3.port }}{{ else }}{{ .Values.filer.s3.port }}{{ end }}
     targetPort: {{ if .Values.s3.enabled }}{{ .Values.s3.port }}{{ else }}{{ .Values.filer.s3.port }}{{ end }}
+{{- if $nodePorts.http }}
+    nodePort: {{ $nodePorts.http }}
+{{- end }}
     protocol: TCP
 {{- if and .Values.s3.enabled .Values.s3.icebergPort }}
   - name: "swfs-iceberg"
     port: {{ .Values.s3.icebergPort }}
     targetPort: {{ .Values.s3.icebergPort }}
+{{- if $nodePorts.iceberg }}
+    nodePort: {{ $nodePorts.iceberg }}
+{{- end }}
     protocol: TCP
 {{- end }}
 {{- if and .Values.s3.enabled .Values.s3.httpsPort }}
   - name: "swfs-s3-tls"
     port: {{ .Values.s3.httpsPort }}
     targetPort: {{ .Values.s3.httpsPort }}
+{{- if $nodePorts.https }}
+    nodePort: {{ $nodePorts.https }}
+{{- end }}
     protocol: TCP
 {{- end }}
 {{- if and .Values.s3.enabled .Values.s3.metricsPort }}
   - name: "metrics"
     port: {{ .Values.s3.metricsPort }}
     targetPort: {{ .Values.s3.metricsPort }}
+{{- if $nodePorts.metrics }}
+    nodePort: {{ $nodePorts.metrics }}
+{{- end }}
     protocol: TCP
 {{- end }}
   selector:

--- a/k8s/charts/seaweedfs/templates/sftp/sftp-service.yaml
+++ b/k8s/charts/seaweedfs/templates/sftp/sftp-service.yaml
@@ -15,17 +15,28 @@ metadata:
     {{- toYaml .Values.sftp.annotations | nindent 4 }}
 {{- end }}
 spec:
-  type: {{ .Values.sftp.service.type }}
+  {{- $serviceType := .Values.sftp.service.type }}
+  {{- $nodePorts := dict }}
+  {{- if or (eq $serviceType "NodePort") (eq $serviceType "LoadBalancer") }}
+  {{- $nodePorts = .Values.sftp.service.nodePorts | default dict }}
+  {{- end }}
+  type: {{ $serviceType }}
   internalTrafficPolicy: {{ .Values.sftp.internalTrafficPolicy | default "Cluster" }}
   ports:
   - name: "swfs-sftp"
     port: {{ .Values.sftp.port }}
     targetPort: {{ .Values.sftp.port }}
+{{- if $nodePorts.sftp }}
+    nodePort: {{ $nodePorts.sftp }}
+{{- end }}
     protocol: TCP
 {{- if .Values.sftp.metricsPort }}
   - name: "metrics"
     port: {{ .Values.sftp.metricsPort }}
     targetPort: {{ .Values.sftp.metricsPort }}
+{{- if $nodePorts.metrics }}
+    nodePort: {{ $nodePorts.metrics }}
+{{- end }}
     protocol: TCP
 {{- end }}
   selector:

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -1142,8 +1142,7 @@ s3:
   # Service settings
   service:
     type: ClusterIP
-    # Fixed nodePort numbers, applied only when type is NodePort or LoadBalancer.
-    # Leave null to let Kubernetes allocate them.
+    # fixed nodePorts, used only when type is NodePort or LoadBalancer
     nodePorts:
       http: null
       https: null
@@ -1246,7 +1245,7 @@ sftp:
   # Service settings
   service:
     type: ClusterIP
-    # Fixed nodePort numbers, applied only when type is NodePort or LoadBalancer.
+    # fixed nodePorts, used only when type is NodePort or LoadBalancer
     nodePorts:
       sftp: null
       metrics: null
@@ -1387,7 +1386,7 @@ admin:
   service:
     type: ClusterIP
     annotations: {}
-    # Fixed nodePort numbers, applied only when type is NodePort or LoadBalancer.
+    # fixed nodePorts, used only when type is NodePort or LoadBalancer
     nodePorts:
       http: null
       grpc: null
@@ -1610,8 +1609,7 @@ allInOne:
     annotations: {}  # Annotations for the service
     type: ClusterIP  # Service type (ClusterIP, NodePort, LoadBalancer)
     internalTrafficPolicy: Cluster  # Internal traffic policy
-    # Fixed nodePort numbers, applied only when type is NodePort or LoadBalancer.
-    # Leave null to let Kubernetes allocate them.
+    # fixed nodePorts, used only when type is NodePort or LoadBalancer
     nodePorts:
       master: null
       masterGrpc: null

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -1142,6 +1142,13 @@ s3:
   # Service settings
   service:
     type: ClusterIP
+    # Fixed nodePort numbers, applied only when type is NodePort or LoadBalancer.
+    # Leave null to let Kubernetes allocate them.
+    nodePorts:
+      http: null
+      https: null
+      iceberg: null
+      metrics: null
 
   icebergIngress:
     enabled: false
@@ -1239,6 +1246,10 @@ sftp:
   # Service settings
   service:
     type: ClusterIP
+    # Fixed nodePort numbers, applied only when type is NodePort or LoadBalancer.
+    nodePorts:
+      sftp: null
+      metrics: null
 
 admin:
   enabled: false
@@ -1376,6 +1387,10 @@ admin:
   service:
     type: ClusterIP
     annotations: {}
+    # Fixed nodePort numbers, applied only when type is NodePort or LoadBalancer.
+    nodePorts:
+      http: null
+      grpc: null
 
   # ServiceMonitor annotations (separate from pod/deployment annotations)
   serviceMonitor:
@@ -1595,6 +1610,19 @@ allInOne:
     annotations: {}  # Annotations for the service
     type: ClusterIP  # Service type (ClusterIP, NodePort, LoadBalancer)
     internalTrafficPolicy: Cluster  # Internal traffic policy
+    # Fixed nodePort numbers, applied only when type is NodePort or LoadBalancer.
+    # Leave null to let Kubernetes allocate them.
+    nodePorts:
+      master: null
+      masterGrpc: null
+      volume: null
+      volumeGrpc: null
+      filer: null
+      filerGrpc: null
+      s3: null
+      s3Https: null
+      sftp: null
+      metrics: null
 
   # Note: For ingress in all-in-one mode, use the standard s3.ingress and
   # filer.ingress settings. The templates automatically detect all-in-one mode


### PR DESCRIPTION
The services that accept `type: NodePort` or `LoadBalancer` now also take fixed nodePort numbers, useful for edge or appliance deployments where clients expect stable node ports:

```yaml
allInOne:
  service:
    type: NodePort
    nodePorts:
      s3: 30833
      filer: 30888
```

One key per exposed port on the all-in-one, s3, sftp, and admin services. Unset ports keep Kubernetes-allocated numbers, and the values are ignored while the type stays ClusterIP, so existing values files render unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fixed `nodePort` support for Kubernetes Services for S3, SFTP, Admin, and all-in-one components.
  * You can now set per-endpoint NodePorts for HTTP/HTTPS, gRPC, metrics, and additional ports (including optional ones like Iceberg/SFTP), when the Service type is `NodePort` or `LoadBalancer`.
* **Configuration**
  * Introduced `service.nodePorts` options in chart configuration while keeping existing `ClusterIP` behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->