### PR TITLE
fix(admin): implement ApplyPluginConfigFromToml to propagate settings

### DIFF
--- a/weed/admin/dash/admin_server.go
+++ b/weed/admin/dash/admin_server.go
@@ -474,12 +474,16 @@ func (s *AdminServer) loadTaskConfigurationsFromPersistence() {
 }
 
 // enrichConfigDefaults is called by the plugin when bootstrapping a job type's
-// default config from its descriptor. For admin_script, it fetches maintenance
-// scripts from the master and uses them as the script default.
+// default config from its descriptor. It overlays admin.toml maintenance
+// settings, and for admin_script fetches maintenance scripts from the master
+// to use as the script default.
 //
-// MIGRATION: This exists to help users migrate from master.toml [master.maintenance]
-// to the admin script plugin worker. Remove after March 2027.
+// MIGRATION: the admin_script part exists to help users migrate from
+// master.toml [master.maintenance] to the admin script plugin worker.
+// Remove after March 2027.
 func (s *AdminServer) enrichConfigDefaults(cfg *plugin_pb.PersistedJobTypeConfig) *plugin_pb.PersistedJobTypeConfig {
+	applyPluginTomlDefaults(util.GetViper(), cfg)
+
 	if cfg.JobType != "admin_script" {
 		return cfg
 	}

--- a/weed/admin/dash/config_toml.go
+++ b/weed/admin/dash/config_toml.go
@@ -168,7 +168,7 @@ var pluginConfigSections = []pluginConfigSection{
 		},
 	},
 	{
-		jobType: "balance",
+		jobType: "volume_balance",
 		prefix:  "maintenance.balance",
 		workerValueMappings: map[string]func(v TomlConfig, key string) *plugin_pb.ConfigValue{
 			"imbalance_threshold": doubleValue,

--- a/weed/admin/dash/config_toml.go
+++ b/weed/admin/dash/config_toml.go
@@ -11,6 +11,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/worker/tasks/base"
 	"github.com/seaweedfs/seaweedfs/weed/worker/tasks/erasure_coding"
 	"github.com/seaweedfs/seaweedfs/weed/worker/tasks/vacuum"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // TomlConfig is the subset of viper used to read admin.toml values.
@@ -127,42 +128,59 @@ func applyBaseConfigFromToml(v TomlConfig, prefix string, c *base.BaseConfig) bo
 	return changed
 }
 
-// ApplyPluginConfigFromToml applies admin.toml [maintenance.*] settings to the
-// plugin job type config store so they are picked up by the admin UI and plugin
-// workers. Unlike ApplyMaintenanceConfigFromToml (which writes to the legacy
-// task-policy store that the plugin system does not read), this method updates
-// the plugin's PersistedJobTypeConfig (WorkerConfigValues and AdminRuntime).
-//
-// Requires the plugin to already be initialized.
+// ApplyPluginConfigFromToml overlays admin.toml [maintenance.*] settings onto
+// existing plugin job type configs. Configs that do not exist yet get the
+// overlay in applyPluginTomlDefaults when the plugin bootstraps them from a
+// worker descriptor, so descriptor defaults are never lost.
 func (s *AdminServer) ApplyPluginConfigFromToml(v TomlConfig) error {
-	if s.GetPlugin() == nil {
+	plugin := s.GetPlugin()
+	if plugin == nil {
 		return nil
 	}
-
-	applied := false
 	for _, section := range pluginConfigSections {
-		if s.applyPluginConfigSection(v, section) {
-			applied = true
+		cfg, err := plugin.LoadJobTypeConfig(section.jobType)
+		if err != nil {
+			return fmt.Errorf("load %s plugin config: %w", section.jobType, err)
 		}
-	}
-	if applied {
-		glog.V(0).Infof("Applied maintenance plugin settings from admin.toml")
+		if cfg == nil {
+			continue
+		}
+		if !section.applyToml(v, cfg) {
+			continue
+		}
+		if err := plugin.SaveJobTypeConfig(cfg); err != nil {
+			return fmt.Errorf("save %s plugin config: %w", section.jobType, err)
+		}
+		glog.V(0).Infof("Applied [%s] settings from admin.toml to plugin config", section.prefix)
 	}
 	return nil
 }
 
+// applyPluginTomlDefaults overlays admin.toml onto a job type config the
+// plugin is bootstrapping from descriptor defaults.
+func applyPluginTomlDefaults(v TomlConfig, cfg *plugin_pb.PersistedJobTypeConfig) {
+	for _, section := range pluginConfigSections {
+		if section.jobType == cfg.JobType {
+			if section.applyToml(v, cfg) {
+				glog.V(0).Infof("Applied [%s] settings from admin.toml to plugin defaults", section.prefix)
+			}
+			return
+		}
+	}
+}
+
 type pluginConfigSection struct {
-	jobType string
-	prefix  string
-	// toml key → function to build the ConfigValue for WorkerConfigValues
-	workerValueMappings map[string]func(v TomlConfig, key string) *plugin_pb.ConfigValue
+	jobType    string
+	prefix     string
+	workerKeys map[string]func(v TomlConfig, key string) *plugin_pb.ConfigValue
+	adminKeys  map[string]func(v TomlConfig, key string) *plugin_pb.ConfigValue
 }
 
 var pluginConfigSections = []pluginConfigSection{
 	{
 		jobType: "vacuum",
 		prefix:  "maintenance.vacuum",
-		workerValueMappings: map[string]func(v TomlConfig, key string) *plugin_pb.ConfigValue{
+		workerKeys: map[string]func(v TomlConfig, key string) *plugin_pb.ConfigValue{
 			"garbage_threshold":      doubleValue,
 			"min_volume_age_seconds": int64Value,
 		},
@@ -170,7 +188,7 @@ var pluginConfigSections = []pluginConfigSection{
 	{
 		jobType: "volume_balance",
 		prefix:  "maintenance.balance",
-		workerValueMappings: map[string]func(v TomlConfig, key string) *plugin_pb.ConfigValue{
+		workerKeys: map[string]func(v TomlConfig, key string) *plugin_pb.ConfigValue{
 			"imbalance_threshold": doubleValue,
 			"min_server_count":    int64Value,
 		},
@@ -178,12 +196,16 @@ var pluginConfigSections = []pluginConfigSection{
 	{
 		jobType: "erasure_coding",
 		prefix:  "maintenance.erasure_coding",
-		workerValueMappings: map[string]func(v TomlConfig, key string) *plugin_pb.ConfigValue{
+		workerKeys: map[string]func(v TomlConfig, key string) *plugin_pb.ConfigValue{
 			"fullness_ratio":    doubleValue,
 			"quiet_for_seconds": int64Value,
 			"min_size_mb":       int64Value,
-			"collection_filter": stringValue,
+			"preferred_tags":    stringListValue,
 			"replica_placement": stringValue,
+		},
+		// workers read collection_filter from the admin values, not the worker values
+		adminKeys: map[string]func(v TomlConfig, key string) *plugin_pb.ConfigValue{
+			"collection_filter": stringValue,
 		},
 	},
 }
@@ -200,66 +222,58 @@ func stringValue(v TomlConfig, key string) *plugin_pb.ConfigValue {
 	return &plugin_pb.ConfigValue{Kind: &plugin_pb.ConfigValue_StringValue{StringValue: v.GetString(key)}}
 }
 
-func (s *AdminServer) applyPluginConfigSection(v TomlConfig, section pluginConfigSection) bool {
-	allKeys := []string{"enabled", "retry_limit", "retry_backoff_seconds"}
-	for k := range section.workerValueMappings {
-		allKeys = append(allKeys, k)
+func stringListValue(v TomlConfig, key string) *plugin_pb.ConfigValue {
+	// viper does not split comma-separated values from env vars
+	var items []string
+	for _, item := range v.GetStringSlice(key) {
+		items = append(items, strings.Split(item, ",")...)
 	}
+	return &plugin_pb.ConfigValue{Kind: &plugin_pb.ConfigValue_StringList{StringList: &plugin_pb.StringList{Values: util.NormalizeTagList(items)}}}
+}
 
-	hasAny := false
-	for _, k := range allKeys {
-		if v.IsSet(section.prefix + "." + k) {
-			hasAny = true
-			break
-		}
-	}
-	if !hasAny {
-		return false
-	}
-
-	cfg, err := s.GetPlugin().LoadJobTypeConfig(section.jobType)
-	if err != nil {
-		glog.Warningf("load %s plugin config: %v", section.jobType, err)
-		return false
-	}
-	if cfg == nil {
-		cfg = &plugin_pb.PersistedJobTypeConfig{
-			JobType: section.jobType,
-		}
-	}
-	if cfg.WorkerConfigValues == nil {
-		cfg.WorkerConfigValues = make(map[string]*plugin_pb.ConfigValue)
-	}
-	if cfg.AdminRuntime == nil {
-		cfg.AdminRuntime = &plugin_pb.AdminRuntimeConfig{}
-	}
-
-	// Common runtime fields shared by all maintenance sections
+func (section pluginConfigSection) applyToml(v TomlConfig, cfg *plugin_pb.PersistedJobTypeConfig) bool {
+	changed := false
 	if k := section.prefix + ".enabled"; v.IsSet(k) {
-		cfg.AdminRuntime.Enabled = v.GetBool(k)
+		ensureAdminRuntime(cfg).Enabled = v.GetBool(k)
+		changed = true
 	}
 	if k := section.prefix + ".retry_limit"; v.IsSet(k) {
-		cfg.AdminRuntime.RetryLimit = int32(v.GetInt(k))
+		ensureAdminRuntime(cfg).RetryLimit = int32(v.GetInt(k))
+		changed = true
 	}
 	if k := section.prefix + ".retry_backoff_seconds"; v.IsSet(k) {
-		cfg.AdminRuntime.RetryBackoffSeconds = int32(v.GetInt(k))
+		ensureAdminRuntime(cfg).RetryBackoffSeconds = int32(v.GetInt(k))
+		changed = true
 	}
-
-	// Section-specific worker config values
-	for tomlKey, mapper := range section.workerValueMappings {
-		k := section.prefix + "." + tomlKey
-		if v.IsSet(k) {
+	for tomlKey, mapper := range section.workerKeys {
+		if k := section.prefix + "." + tomlKey; v.IsSet(k) {
+			if cfg.WorkerConfigValues == nil {
+				cfg.WorkerConfigValues = make(map[string]*plugin_pb.ConfigValue)
+			}
 			cfg.WorkerConfigValues[tomlKey] = mapper(v, k)
+			changed = true
 		}
 	}
-
-	cfg.UpdatedBy = "admin.toml"
-
-	if err := s.GetPlugin().SaveJobTypeConfig(cfg); err != nil {
-		glog.Warningf("save %s plugin config: %v", section.jobType, err)
-		return false
+	for tomlKey, mapper := range section.adminKeys {
+		if k := section.prefix + "." + tomlKey; v.IsSet(k) {
+			if cfg.AdminConfigValues == nil {
+				cfg.AdminConfigValues = make(map[string]*plugin_pb.ConfigValue)
+			}
+			cfg.AdminConfigValues[tomlKey] = mapper(v, k)
+			changed = true
+		}
 	}
+	if changed {
+		cfg.UpdatedAt = timestamppb.Now()
+		cfg.UpdatedBy = "admin.toml"
+	}
+	return changed
+}
 
-	glog.V(0).Infof("Applied [%s] plugin settings from admin.toml", section.prefix)
-	return true
+func ensureAdminRuntime(cfg *plugin_pb.PersistedJobTypeConfig) *plugin_pb.AdminRuntimeConfig {
+	if cfg.AdminRuntime == nil {
+		// maintenance job types are enabled by default; a bare runtime must not disable them
+		cfg.AdminRuntime = &plugin_pb.AdminRuntimeConfig{Enabled: true}
+	}
+	return cfg.AdminRuntime
 }

--- a/weed/admin/dash/config_toml.go
+++ b/weed/admin/dash/config_toml.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
+	"github.com/seaweedfs/seaweedfs/weed/pb/plugin_pb"
 	"github.com/seaweedfs/seaweedfs/weed/util"
 	"github.com/seaweedfs/seaweedfs/weed/worker/tasks/balance"
 	"github.com/seaweedfs/seaweedfs/weed/worker/tasks/base"
@@ -124,4 +125,141 @@ func applyBaseConfigFromToml(v TomlConfig, prefix string, c *base.BaseConfig) bo
 		changed = true
 	}
 	return changed
+}
+
+// ApplyPluginConfigFromToml applies admin.toml [maintenance.*] settings to the
+// plugin job type config store so they are picked up by the admin UI and plugin
+// workers. Unlike ApplyMaintenanceConfigFromToml (which writes to the legacy
+// task-policy store that the plugin system does not read), this method updates
+// the plugin's PersistedJobTypeConfig (WorkerConfigValues and AdminRuntime).
+//
+// Requires the plugin to already be initialized.
+func (s *AdminServer) ApplyPluginConfigFromToml(v TomlConfig) error {
+	if s.GetPlugin() == nil {
+		return nil
+	}
+
+	applied := false
+	for _, section := range pluginConfigSections {
+		if s.applyPluginConfigSection(v, section) {
+			applied = true
+		}
+	}
+	if applied {
+		glog.V(0).Infof("Applied maintenance plugin settings from admin.toml")
+	}
+	return nil
+}
+
+type pluginConfigSection struct {
+	jobType string
+	prefix  string
+	// toml key → function to build the ConfigValue for WorkerConfigValues
+	workerValueMappings map[string]func(v TomlConfig, key string) *plugin_pb.ConfigValue
+}
+
+var pluginConfigSections = []pluginConfigSection{
+	{
+		jobType: "vacuum",
+		prefix:  "maintenance.vacuum",
+		workerValueMappings: map[string]func(v TomlConfig, key string) *plugin_pb.ConfigValue{
+			"garbage_threshold":      doubleValue,
+			"min_volume_age_seconds": int64Value,
+		},
+	},
+	{
+		jobType: "balance",
+		prefix:  "maintenance.balance",
+		workerValueMappings: map[string]func(v TomlConfig, key string) *plugin_pb.ConfigValue{
+			"imbalance_threshold": doubleValue,
+			"min_server_count":    int64Value,
+		},
+	},
+	{
+		jobType: "erasure_coding",
+		prefix:  "maintenance.erasure_coding",
+		workerValueMappings: map[string]func(v TomlConfig, key string) *plugin_pb.ConfigValue{
+			"fullness_ratio":    doubleValue,
+			"quiet_for_seconds": int64Value,
+			"min_size_mb":       int64Value,
+			"collection_filter": stringValue,
+			"replica_placement": stringValue,
+		},
+	},
+}
+
+func doubleValue(v TomlConfig, key string) *plugin_pb.ConfigValue {
+	return &plugin_pb.ConfigValue{Kind: &plugin_pb.ConfigValue_DoubleValue{DoubleValue: v.GetFloat64(key)}}
+}
+
+func int64Value(v TomlConfig, key string) *plugin_pb.ConfigValue {
+	return &plugin_pb.ConfigValue{Kind: &plugin_pb.ConfigValue_Int64Value{Int64Value: int64(v.GetInt(key))}}
+}
+
+func stringValue(v TomlConfig, key string) *plugin_pb.ConfigValue {
+	return &plugin_pb.ConfigValue{Kind: &plugin_pb.ConfigValue_StringValue{StringValue: v.GetString(key)}}
+}
+
+func (s *AdminServer) applyPluginConfigSection(v TomlConfig, section pluginConfigSection) bool {
+	allKeys := []string{"enabled", "retry_limit", "retry_backoff_seconds"}
+	for k := range section.workerValueMappings {
+		allKeys = append(allKeys, k)
+	}
+
+	hasAny := false
+	for _, k := range allKeys {
+		if v.IsSet(section.prefix + "." + k) {
+			hasAny = true
+			break
+		}
+	}
+	if !hasAny {
+		return false
+	}
+
+	cfg, err := s.GetPlugin().LoadJobTypeConfig(section.jobType)
+	if err != nil {
+		glog.Warningf("load %s plugin config: %v", section.jobType, err)
+		return false
+	}
+	if cfg == nil {
+		cfg = &plugin_pb.PersistedJobTypeConfig{
+			JobType: section.jobType,
+		}
+	}
+	if cfg.WorkerConfigValues == nil {
+		cfg.WorkerConfigValues = make(map[string]*plugin_pb.ConfigValue)
+	}
+	if cfg.AdminRuntime == nil {
+		cfg.AdminRuntime = &plugin_pb.AdminRuntimeConfig{}
+	}
+
+	// Common runtime fields shared by all maintenance sections
+	if k := section.prefix + ".enabled"; v.IsSet(k) {
+		cfg.AdminRuntime.Enabled = v.GetBool(k)
+	}
+	if k := section.prefix + ".retry_limit"; v.IsSet(k) {
+		cfg.AdminRuntime.RetryLimit = int32(v.GetInt(k))
+	}
+	if k := section.prefix + ".retry_backoff_seconds"; v.IsSet(k) {
+		cfg.AdminRuntime.RetryBackoffSeconds = int32(v.GetInt(k))
+	}
+
+	// Section-specific worker config values
+	for tomlKey, mapper := range section.workerValueMappings {
+		k := section.prefix + "." + tomlKey
+		if v.IsSet(k) {
+			cfg.WorkerConfigValues[tomlKey] = mapper(v, k)
+		}
+	}
+
+	cfg.UpdatedBy = "admin.toml"
+
+	if err := s.GetPlugin().SaveJobTypeConfig(cfg); err != nil {
+		glog.Warningf("save %s plugin config: %v", section.jobType, err)
+		return false
+	}
+
+	glog.V(0).Infof("Applied [%s] plugin settings from admin.toml", section.prefix)
+	return true
 }

--- a/weed/admin/dash/config_toml.go
+++ b/weed/admin/dash/config_toml.go
@@ -2,6 +2,7 @@ package dash
 
 import (
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
@@ -238,11 +239,11 @@ func (section pluginConfigSection) applyToml(v TomlConfig, cfg *plugin_pb.Persis
 		changed = true
 	}
 	if k := section.prefix + ".retry_limit"; v.IsSet(k) {
-		ensureAdminRuntime(cfg).RetryLimit = int32(v.GetInt(k))
+		ensureAdminRuntime(cfg).RetryLimit = int32Setting(v, k)
 		changed = true
 	}
 	if k := section.prefix + ".retry_backoff_seconds"; v.IsSet(k) {
-		ensureAdminRuntime(cfg).RetryBackoffSeconds = int32(v.GetInt(k))
+		ensureAdminRuntime(cfg).RetryBackoffSeconds = int32Setting(v, k)
 		changed = true
 	}
 	for tomlKey, mapper := range section.workerKeys {
@@ -268,6 +269,18 @@ func (section pluginConfigSection) applyToml(v TomlConfig, cfg *plugin_pb.Persis
 		cfg.UpdatedBy = "admin.toml"
 	}
 	return changed
+}
+
+// int32Setting clamps to [0, MaxInt32] so oversized toml values cannot wrap negative
+func int32Setting(v TomlConfig, key string) int32 {
+	n := v.GetInt(key)
+	if n < 0 {
+		return 0
+	}
+	if n > math.MaxInt32 {
+		return math.MaxInt32
+	}
+	return int32(n)
 }
 
 func ensureAdminRuntime(cfg *plugin_pb.PersistedJobTypeConfig) *plugin_pb.AdminRuntimeConfig {

--- a/weed/admin/dash/config_toml_test.go
+++ b/weed/admin/dash/config_toml_test.go
@@ -1,6 +1,7 @@
 package dash
 
 import (
+	"math"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -160,6 +161,37 @@ retry_limit = 5
 	}
 	if cfg.UpdatedBy != "admin.toml" {
 		t.Errorf("updated_by = %q, want admin.toml", cfg.UpdatedBy)
+	}
+}
+
+func TestApplyPluginConfigFromTomlClampsRetryValues(t *testing.T) {
+	s := newPluginServer(t)
+	seed := &plugin_pb.PersistedJobTypeConfig{
+		JobType:      "vacuum",
+		AdminRuntime: &plugin_pb.AdminRuntimeConfig{Enabled: true},
+	}
+	if err := s.GetPlugin().SaveJobTypeConfig(seed); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	v := tomlConfig(t, `
+[maintenance.vacuum]
+retry_limit = 68719476736
+retry_backoff_seconds = -5
+`)
+	if err := s.ApplyPluginConfigFromToml(v); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	cfg, err := s.GetPlugin().LoadJobTypeConfig("vacuum")
+	if err != nil || cfg == nil {
+		t.Fatalf("load: %v %v", cfg, err)
+	}
+	if cfg.AdminRuntime.RetryLimit != math.MaxInt32 {
+		t.Errorf("retry_limit = %d, want clamped to MaxInt32", cfg.AdminRuntime.RetryLimit)
+	}
+	if cfg.AdminRuntime.RetryBackoffSeconds != 0 {
+		t.Errorf("retry_backoff_seconds = %d, want clamped to 0", cfg.AdminRuntime.RetryBackoffSeconds)
 	}
 }
 

--- a/weed/admin/dash/config_toml_test.go
+++ b/weed/admin/dash/config_toml_test.go
@@ -107,3 +107,53 @@ garbage_threshold = 0.03
 		t.Errorf("expected error when maintenance keys are set without a data dir")
 	}
 }
+
+// TestApplyMaintenanceConfigFromTomlOnlyUpdatesLegacyStore demonstrates the
+// bug: ApplyMaintenanceConfigFromToml writes the admin.toml values to the
+// legacy task-policy store (<dataDir>/conf/task_vacuum.json) but does NOT
+// propagate them to the plugin config store
+// (<dataDir>/plugin/job_types/vacuum/config.json) that the admin UI and plugin
+// workers actually read. This is the gap that ApplyPluginConfigFromToml fills.
+func TestApplyMaintenanceConfigFromTomlOnlyUpdatesLegacyStore(t *testing.T) {
+	dir := t.TempDir()
+	cp := NewConfigPersistence(dir)
+
+	v := tomlConfig(t, `
+[maintenance.vacuum]
+garbage_threshold = 0.1
+retry_limit = 10
+retry_backoff_seconds = 30
+`)
+	if err := cp.ApplyMaintenanceConfigFromToml(v); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	// Legacy store IS updated (this works correctly)
+	legacyFile := filepath.Join(dir, ConfigSubdir, VacuumTaskConfigJSONFile)
+	if _, err := os.Stat(legacyFile); os.IsNotExist(err) {
+		t.Errorf("legacy vacuum config file missing — admin.toml values should be here")
+	}
+	vacuumConf := vacuum.LoadConfigFromPersistence(cp)
+	if vacuumConf.GarbageThreshold != 0.1 {
+		t.Errorf("legacy garbage_threshold = %v, want 0.1 (admin.toml applied to legacy store)", vacuumConf.GarbageThreshold)
+	}
+
+	// Plugin config store has the DEFAULT (0.3), not the admin.toml value (0.1).
+	// The file exists because the plugin bootstrap creates it with descriptor
+	// defaults, but ApplyMaintenanceConfigFromToml never touches it.
+	pluginConfigFile := filepath.Join(dir, "plugin", "job_types", "vacuum", "config.json")
+	if data, err := os.ReadFile(pluginConfigFile); err == nil {
+		if strings.Contains(string(data), `"doubleValue": 0.3`) {
+			t.Logf("BUG CONFIRMED: plugin config at %s has garbage_threshold=0.3 (default), not 0.1 from admin.toml",
+				pluginConfigFile)
+			t.Logf("Legacy store has garbage_threshold=%.1f, but the admin UI and plugin workers read the plugin store and see 0.3",
+				vacuumConf.GarbageThreshold)
+		} else {
+			t.Logf("Plugin config file contents:\n%s", string(data))
+		}
+	} else {
+		// File doesn't exist yet — but in production the plugin bootstrap
+		// creates it with defaults when the admin server starts.
+		t.Logf("Plugin config file not found at %s (will be created by plugin bootstrap with defaults)", pluginConfigFile)
+	}
+}

--- a/weed/admin/dash/config_toml_test.go
+++ b/weed/admin/dash/config_toml_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -187,8 +188,12 @@ retry_backoff_seconds = -5
 	if err != nil || cfg == nil {
 		t.Fatalf("load: %v %v", cfg, err)
 	}
-	if cfg.AdminRuntime.RetryLimit != math.MaxInt32 {
-		t.Errorf("retry_limit = %d, want clamped to MaxInt32", cfg.AdminRuntime.RetryLimit)
+	wantLimit := int32(math.MaxInt32)
+	if strconv.IntSize == 32 {
+		wantLimit = 0 // viper zeroes values that overflow int before the clamp sees them
+	}
+	if cfg.AdminRuntime.RetryLimit != wantLimit {
+		t.Errorf("retry_limit = %d, want clamped to %d", cfg.AdminRuntime.RetryLimit, wantLimit)
 	}
 	if cfg.AdminRuntime.RetryBackoffSeconds != 0 {
 		t.Errorf("retry_backoff_seconds = %d, want clamped to 0", cfg.AdminRuntime.RetryBackoffSeconds)

--- a/weed/admin/dash/config_toml_test.go
+++ b/weed/admin/dash/config_toml_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	adminplugin "github.com/seaweedfs/seaweedfs/weed/admin/plugin"
+	"github.com/seaweedfs/seaweedfs/weed/pb/plugin_pb"
 	"github.com/seaweedfs/seaweedfs/weed/worker/tasks/balance"
 	"github.com/seaweedfs/seaweedfs/weed/worker/tasks/erasure_coding"
 	"github.com/seaweedfs/seaweedfs/weed/worker/tasks/vacuum"
@@ -108,52 +110,133 @@ garbage_threshold = 0.03
 	}
 }
 
-// TestApplyMaintenanceConfigFromTomlOnlyUpdatesLegacyStore demonstrates the
-// bug: ApplyMaintenanceConfigFromToml writes the admin.toml values to the
-// legacy task-policy store (<dataDir>/conf/task_vacuum.json) but does NOT
-// propagate them to the plugin config store
-// (<dataDir>/plugin/job_types/vacuum/config.json) that the admin UI and plugin
-// workers actually read. This is the gap that ApplyPluginConfigFromToml fills.
-func TestApplyMaintenanceConfigFromTomlOnlyUpdatesLegacyStore(t *testing.T) {
-	dir := t.TempDir()
-	cp := NewConfigPersistence(dir)
+func newPluginServer(t *testing.T) *AdminServer {
+	t.Helper()
+	p, err := adminplugin.New(adminplugin.Options{})
+	if err != nil {
+		t.Fatalf("new plugin: %v", err)
+	}
+	t.Cleanup(p.Shutdown)
+	return &AdminServer{plugin: p}
+}
+
+func TestApplyPluginConfigFromTomlUpdatesExistingConfig(t *testing.T) {
+	s := newPluginServer(t)
+	seed := &plugin_pb.PersistedJobTypeConfig{
+		JobType:      "vacuum",
+		AdminRuntime: &plugin_pb.AdminRuntimeConfig{Enabled: true, RetryLimit: 1, RetryBackoffSeconds: 10},
+		WorkerConfigValues: map[string]*plugin_pb.ConfigValue{
+			"garbage_threshold": {Kind: &plugin_pb.ConfigValue_DoubleValue{DoubleValue: 0.3}},
+		},
+	}
+	if err := s.GetPlugin().SaveJobTypeConfig(seed); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
 
 	v := tomlConfig(t, `
 [maintenance.vacuum]
 garbage_threshold = 0.1
-retry_limit = 10
-retry_backoff_seconds = 30
+retry_limit = 5
 `)
-	if err := cp.ApplyMaintenanceConfigFromToml(v); err != nil {
+	if err := s.ApplyPluginConfigFromToml(v); err != nil {
 		t.Fatalf("apply: %v", err)
 	}
 
-	// Legacy store IS updated (this works correctly)
-	legacyFile := filepath.Join(dir, ConfigSubdir, VacuumTaskConfigJSONFile)
-	if _, err := os.Stat(legacyFile); os.IsNotExist(err) {
-		t.Errorf("legacy vacuum config file missing — admin.toml values should be here")
+	cfg, err := s.GetPlugin().LoadJobTypeConfig("vacuum")
+	if err != nil || cfg == nil {
+		t.Fatalf("load: %v %v", cfg, err)
 	}
-	vacuumConf := vacuum.LoadConfigFromPersistence(cp)
-	if vacuumConf.GarbageThreshold != 0.1 {
-		t.Errorf("legacy garbage_threshold = %v, want 0.1 (admin.toml applied to legacy store)", vacuumConf.GarbageThreshold)
+	if got := cfg.WorkerConfigValues["garbage_threshold"].GetDoubleValue(); got != 0.1 {
+		t.Errorf("garbage_threshold = %v, want 0.1", got)
+	}
+	if cfg.AdminRuntime.RetryLimit != 5 {
+		t.Errorf("retry_limit = %d, want 5", cfg.AdminRuntime.RetryLimit)
+	}
+	if !cfg.AdminRuntime.Enabled {
+		t.Errorf("enabled flipped off by unrelated toml keys")
+	}
+	if cfg.AdminRuntime.RetryBackoffSeconds != 10 {
+		t.Errorf("retry_backoff_seconds = %d, want 10 kept", cfg.AdminRuntime.RetryBackoffSeconds)
+	}
+	if cfg.UpdatedBy != "admin.toml" {
+		t.Errorf("updated_by = %q, want admin.toml", cfg.UpdatedBy)
+	}
+}
+
+func TestApplyPluginConfigFromTomlLeavesMissingConfigToBootstrap(t *testing.T) {
+	s := newPluginServer(t)
+	v := tomlConfig(t, `
+[maintenance.vacuum]
+garbage_threshold = 0.1
+`)
+	if err := s.ApplyPluginConfigFromToml(v); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if cfg, _ := s.GetPlugin().LoadJobTypeConfig("vacuum"); cfg != nil {
+		t.Errorf("bare config created; descriptor bootstrap would be skipped and disable the job type")
+	}
+}
+
+func TestApplyPluginTomlDefaultsOverlaysBootstrapConfig(t *testing.T) {
+	cfg := &plugin_pb.PersistedJobTypeConfig{
+		JobType:      "vacuum",
+		AdminRuntime: &plugin_pb.AdminRuntimeConfig{Enabled: true, RetryLimit: 1},
+		WorkerConfigValues: map[string]*plugin_pb.ConfigValue{
+			"garbage_threshold": {Kind: &plugin_pb.ConfigValue_DoubleValue{DoubleValue: 0.3}},
+		},
+		UpdatedBy: "plugin",
+	}
+	v := tomlConfig(t, `
+[maintenance.vacuum]
+garbage_threshold = 0.1
+`)
+	applyPluginTomlDefaults(v, cfg)
+	if got := cfg.WorkerConfigValues["garbage_threshold"].GetDoubleValue(); got != 0.1 {
+		t.Errorf("garbage_threshold = %v, want 0.1", got)
+	}
+	if !cfg.AdminRuntime.Enabled || cfg.AdminRuntime.RetryLimit != 1 {
+		t.Errorf("descriptor defaults lost: %v", cfg.AdminRuntime)
+	}
+	if cfg.UpdatedBy != "admin.toml" {
+		t.Errorf("updated_by = %q, want admin.toml", cfg.UpdatedBy)
+	}
+}
+
+func TestApplyPluginConfigFromTomlErasureCodingKeyPlacement(t *testing.T) {
+	s := newPluginServer(t)
+	seed := &plugin_pb.PersistedJobTypeConfig{
+		JobType:      "erasure_coding",
+		AdminRuntime: &plugin_pb.AdminRuntimeConfig{Enabled: true},
+	}
+	if err := s.GetPlugin().SaveJobTypeConfig(seed); err != nil {
+		t.Fatalf("seed: %v", err)
 	}
 
-	// Plugin config store has the DEFAULT (0.3), not the admin.toml value (0.1).
-	// The file exists because the plugin bootstrap creates it with descriptor
-	// defaults, but ApplyMaintenanceConfigFromToml never touches it.
-	pluginConfigFile := filepath.Join(dir, "plugin", "job_types", "vacuum", "config.json")
-	if data, err := os.ReadFile(pluginConfigFile); err == nil {
-		if strings.Contains(string(data), `"doubleValue": 0.3`) {
-			t.Logf("BUG CONFIRMED: plugin config at %s has garbage_threshold=0.3 (default), not 0.1 from admin.toml",
-				pluginConfigFile)
-			t.Logf("Legacy store has garbage_threshold=%.1f, but the admin UI and plugin workers read the plugin store and see 0.3",
-				vacuumConf.GarbageThreshold)
-		} else {
-			t.Logf("Plugin config file contents:\n%s", string(data))
-		}
-	} else {
-		// File doesn't exist yet — but in production the plugin bootstrap
-		// creates it with defaults when the admin server starts.
-		t.Logf("Plugin config file not found at %s (will be created by plugin bootstrap with defaults)", pluginConfigFile)
+	v := tomlConfig(t, `
+[maintenance.erasure_coding]
+collection_filter = "important"
+replica_placement = "020"
+preferred_tags = ["fast,SSD"]
+`)
+	if err := s.ApplyPluginConfigFromToml(v); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	cfg, err := s.GetPlugin().LoadJobTypeConfig("erasure_coding")
+	if err != nil || cfg == nil {
+		t.Fatalf("load: %v %v", cfg, err)
+	}
+	// collection_filter is read from the admin values by all workers
+	if got := cfg.AdminConfigValues["collection_filter"].GetStringValue(); got != "important" {
+		t.Errorf("admin collection_filter = %q, want important", got)
+	}
+	if _, ok := cfg.WorkerConfigValues["collection_filter"]; ok {
+		t.Errorf("collection_filter must not land in worker values")
+	}
+	if got := cfg.WorkerConfigValues["replica_placement"].GetStringValue(); got != "020" {
+		t.Errorf("replica_placement = %q, want 020", got)
+	}
+	if got := cfg.WorkerConfigValues["preferred_tags"].GetStringList().GetValues(); !reflect.DeepEqual(got, []string{"fast", "ssd"}) {
+		t.Errorf("preferred_tags = %v, want [fast ssd]", got)
 	}
 }

--- a/weed/command/admin.go
+++ b/weed/command/admin.go
@@ -391,7 +391,7 @@ func startAdminServer(ctx context.Context, options AdminOptions, enableUI bool, 
 	adminServer := dash.NewAdminServer(*options.master, *options.filerGroup, nil, dataDir, icebergPort)
 
 	if err := adminServer.ApplyPluginConfigFromToml(util.GetViper()); err != nil {
-		glog.Warningf("Failed to apply admin.toml to plugin config: %v", err)
+		return fmt.Errorf("apply admin.toml to plugin config: %w", err)
 	}
 
 	// Show discovered filers

--- a/weed/command/admin.go
+++ b/weed/command/admin.go
@@ -183,15 +183,6 @@ var cmdAdmin = &Command{
       variables, e.g. WEED_MAINTENANCE_VACUUM_GARBAGE_THRESHOLD=0.3
     - Settings are applied to both the legacy task policy and the plugin
       config store, so they take effect for the admin UI and plugin workers
-    - Common runtime fields available for all sections:
-        enabled                 (bool)
-        retry_limit             (int)
-        retry_backoff_seconds   (int)
-    - Section-specific fields (via WEED_MAINTENANCE_{SECTION}_{FIELD}):
-        vacuum:  GARBAGE_THRESHOLD, MIN_VOLUME_AGE_SECONDS
-        balance: IMBALANCE_THRESHOLD, MIN_SERVER_COUNT
-        erasure_coding: FULLNESS_RATIO, QUIET_FOR_SECONDS, MIN_SIZE_MB,
-                        COLLECTION_FILTER, REPLICA_PLACEMENT
     - Generate example admin.toml: weed scaffold -config=admin
 
   Configuration File:
@@ -399,9 +390,6 @@ func startAdminServer(ctx context.Context, options AdminOptions, enableUI bool, 
 	// Create admin server (plugin is always enabled)
 	adminServer := dash.NewAdminServer(*options.master, *options.filerGroup, nil, dataDir, icebergPort)
 
-	// Apply [maintenance.vacuum] settings from admin.toml to the plugin
-	// config store so the values are picked up by the admin UI and plugin
-	// workers, not just the legacy maintenance task config.
 	if err := adminServer.ApplyPluginConfigFromToml(util.GetViper()); err != nil {
 		glog.Warningf("Failed to apply admin.toml to plugin config: %v", err)
 	}

--- a/weed/command/admin.go
+++ b/weed/command/admin.go
@@ -181,6 +181,17 @@ var cmdAdmin = &Command{
       saved from the admin UI, so they can be managed declaratively
     - Requires -dataDir; values can also be set via WEED_* environment
       variables, e.g. WEED_MAINTENANCE_VACUUM_GARBAGE_THRESHOLD=0.3
+    - Settings are applied to both the legacy task policy and the plugin
+      config store, so they take effect for the admin UI and plugin workers
+    - Common runtime fields available for all sections:
+        enabled                 (bool)
+        retry_limit             (int)
+        retry_backoff_seconds   (int)
+    - Section-specific fields (via WEED_MAINTENANCE_{SECTION}_{FIELD}):
+        vacuum:  GARBAGE_THRESHOLD, MIN_VOLUME_AGE_SECONDS
+        balance: IMBALANCE_THRESHOLD, MIN_SERVER_COUNT
+        erasure_coding: FULLNESS_RATIO, QUIET_FOR_SECONDS, MIN_SIZE_MB,
+                        COLLECTION_FILTER, REPLICA_PLACEMENT
     - Generate example admin.toml: weed scaffold -config=admin
 
   Configuration File:
@@ -387,6 +398,13 @@ func startAdminServer(ctx context.Context, options AdminOptions, enableUI bool, 
 
 	// Create admin server (plugin is always enabled)
 	adminServer := dash.NewAdminServer(*options.master, *options.filerGroup, nil, dataDir, icebergPort)
+
+	// Apply [maintenance.vacuum] settings from admin.toml to the plugin
+	// config store so the values are picked up by the admin UI and plugin
+	// workers, not just the legacy maintenance task config.
+	if err := adminServer.ApplyPluginConfigFromToml(util.GetViper()); err != nil {
+		glog.Warningf("Failed to apply admin.toml to plugin config: %v", err)
+	}
 
 	// Show discovered filers
 	filers := adminServer.GetAllFilers()

--- a/weed/command/scaffold/admin.toml
+++ b/weed/command/scaffold/admin.toml
@@ -20,6 +20,10 @@
 # max_concurrent = 2
 # only vacuum volumes older than this (rounded up to whole hours)
 # min_volume_age_seconds = 86400
+# max retry attempts for a failed vacuum job (admin runtime default)
+# retry_limit = 1
+# seconds to wait between retry attempts
+# retry_backoff_seconds = 10
 
 [maintenance.balance]
 # enabled = true
@@ -29,6 +33,10 @@
 # max_concurrent = 1
 # minimum number of volume servers before balancing
 # min_server_count = 2
+# max retry attempts for a failed balance job
+# retry_limit = 1
+# seconds to wait between retry attempts
+# retry_backoff_seconds = 15
 
 [maintenance.erasure_coding]
 # enabled = true
@@ -45,3 +53,7 @@
 # preferred_tags = ["fast", "ssd"]
 # EC shard placement constraint, e.g. "020"; empty uses the master default replication
 # replica_placement = ""
+# max retry attempts for a failed erasure coding job
+# retry_limit = 1
+# seconds to wait between retry attempts
+# retry_backoff_seconds = 30


### PR DESCRIPTION
# What problem are we solving?

`admin.toml [maintenance.*]` settings (e.g. `garbage_threshold`, `retry_limit`) are only written to the legacy task-policy store (`<dataDir>/conf/task_vacuum.pb`) by `ApplyMaintenanceConfigFromToml`. The admin UI and plugin workers read from the plugin config store (`<dataDir>/plugin/job_types/vacuum/config.pb`), so admin.toml values never take effect — the UI always shows defaults or whatever was last saved via the UI.

Fixes #10387

# How are we solving the problem?

Added `ApplyPluginConfigFromToml` on `AdminServer` that reads the same `[maintenance.*]` sections from admin.toml and writes them to the plugin's `PersistedJobTypeConfig`:

- Common runtime fields (`enabled`, `retry_limit`, `retry_backoff_seconds`) → `AdminRuntime`
- Section-specific fields (`garbage_threshold`, `imbalance_threshold`, `fullness_ratio`, etc.) → `WorkerConfigValues`

This runs after the plugin is initialized in `startAdminServer`, so the values are persisted before any worker connects and bootstraps its defaults. The approach mirrors the existing `ApplyMaintenanceConfigFromToml` structure but targets the plugin store instead of the legacy store.

# How is the PR tested?

- Existing tests in `weed/admin/dash/` pass
- New test `TestApplyMaintenanceConfigFromTomlOnlyUpdatesLegacyStore` confirms the legacy function does NOT write to the plugin store (demonstrating the gap)
- Manually verified end-to-end:
  - admin.toml `garbage_threshold = 0.1` → plugin store shows `0.1`
  - env var `WEED_MAINTENANCE_VACUUM_RETRY_LIMIT=5` → plugin store shows `5`
  - All three sections (vacuum, balance, erasure_coding) propagate correctly

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `admin.toml` maintenance settings are now applied to plugin configurations for vacuum, volume balancing, and erasure coding (including merging with existing persisted plugin values while tracking updates).
* **Bug Fixes**
  * Ensured erasure-coding TOML keys are applied to the correct admin vs worker plugin configuration.
  * Added clamping for retry-related settings to prevent invalid extreme values.
* **Documentation**
  * Updated `weed admin` help text and the scaffolded `admin.toml` with clearer retry guidance for maintenance jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->