### PR TITLE
telemetry: fix empty over-time charts on the built-in dashboard

### DIFF
--- a/telemetry/server/storage/prometheus.go
+++ b/telemetry/server/storage/prometheus.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"sort"
 	"sync"
 	"time"
 
@@ -147,29 +148,39 @@ func (s *PrometheusStorage) GetMetrics(days int) (map[string]interface{}, error)
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	// Return current metrics from in-memory storage
-	// Historical data should be queried from Prometheus directly
+	// Return current metrics from in-memory storage, aggregated per day
+	// in the parallel-array shape the dashboard charts expect.
+	// Historical data should be queried from Prometheus directly.
 	cutoff := time.Now().AddDate(0, 0, -days)
 
-	var volumeServers []map[string]interface{}
-	var diskUsage []map[string]interface{}
+	serverCountByDate := make(map[string]int64)
+	diskUsageByDate := make(map[string]uint64)
 
 	for _, instance := range s.instances {
 		if instance.ReceivedAt.After(cutoff) {
-			volumeServers = append(volumeServers, map[string]interface{}{
-				"date":  instance.ReceivedAt.Format("2006-01-02"),
-				"value": instance.TelemetryData.VolumeServerCount,
-			})
-			diskUsage = append(diskUsage, map[string]interface{}{
-				"date":  instance.ReceivedAt.Format("2006-01-02"),
-				"value": instance.TelemetryData.TotalDiskBytes,
-			})
+			date := instance.ReceivedAt.Format("2006-01-02")
+			serverCountByDate[date] += int64(instance.TelemetryData.VolumeServerCount)
+			diskUsageByDate[date] += instance.TelemetryData.TotalDiskBytes
 		}
 	}
 
+	dates := make([]string, 0, len(serverCountByDate))
+	for date := range serverCountByDate {
+		dates = append(dates, date)
+	}
+	sort.Strings(dates)
+
+	serverCounts := make([]int64, 0, len(dates))
+	diskUsage := make([]uint64, 0, len(dates))
+	for _, date := range dates {
+		serverCounts = append(serverCounts, serverCountByDate[date])
+		diskUsage = append(diskUsage, diskUsageByDate[date])
+	}
+
 	return map[string]interface{}{
-		"volume_servers": volumeServers,
-		"disk_usage":     diskUsage,
+		"dates":         dates,
+		"server_counts": serverCounts,
+		"disk_usage":    diskUsage,
 	}, nil
 }
 


### PR DESCRIPTION
The built-in dashboard's "Volume Servers Over Time" and "Total Disk Usage Over Time" charts never render: the JS guards on `metrics.dates && metrics.server_counts`, but `/api/metrics` returned per-instance `{date,value}` lists under `volume_servers`/`disk_usage` — different keys and a different shape — so both charts silently no-op.

Fix `PrometheusStorage.GetMetrics` to aggregate per day (summing volume-server counts and disk bytes across instances) and return the `{dates, server_counts, disk_usage}` parallel arrays the dashboard expects, with dates sorted ascending.

Nothing else consumes `/api/metrics` (Grafana reads the Prometheus gauges), so the shape change is safe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved telemetry reporting by aggregating server counts and disk usage by day.
  * Ensured dashboard metrics are returned in a consistent, chronological order.
  * Updated metric data to use aligned date, server count, and disk usage series for more reliable visualization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->