### PR TITLE
ci: fix Deploy Telemetry Server build (nested telemetry/server module)

### DIFF
--- a/.github/workflows/deploy_telemetry.yml
+++ b/.github/workflows/deploy_telemetry.yml
@@ -26,14 +26,17 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version-file: 'go.mod'
+          go-version-file: 'telemetry/server/go.mod'
 
       - name: Build Telemetry Server
         if: github.event_name == 'workflow_dispatch' && inputs.deploy
         run: |
+          # telemetry/server is its own Go module; build from within it
+          cd telemetry/server
           go mod tidy
           echo "Building telemetry server..."
-          GOOS=linux GOARCH=amd64 go build -o telemetry-server ./telemetry/server/main.go
+          GOOS=linux GOARCH=amd64 go build -o ../../telemetry-server .
+          cd ../..
           ls -la telemetry-server
           echo "Build completed successfully"
 


### PR DESCRIPTION
The "Deploy Telemetry Server" workflow fails at the build step (e.g. run 29964332352):

```
telemetry/server/main.go:12:2: no required module provides package github.com/seaweedfs/seaweedfs/telemetry/server/api
```

`telemetry/server` has been its own Go module since #9924, so `go build ./telemetry/server/main.go` from the repo root resolves imports against the root module, which doesn't contain the nested module's packages.

Fix: `cd telemetry/server` and build the module there (`go build -o ../../telemetry-server .`), and point setup-go's `go-version-file` at `telemetry/server/go.mod`. Verified locally: the exact commands produce a 15 MB linux/amd64 binary from current master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved telemetry server deployment builds by correctly using the server’s Go module configuration.
  * Ensured the Linux AMD64 telemetry server binary is built and packaged from the appropriate project directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->