### PR TITLE
test(s3): aim collection force-delete at the master the suite actually runs

### DIFF
--- a/.github/workflows/s3tests.yml
+++ b/.github/workflows/s3tests.yml
@@ -765,7 +765,7 @@ jobs:
             sleep 2
           done
           
-          go test -v
+          MASTER_ENDPOINT="http://127.0.0.1:9336" go test -v
           kill -9 $pid || true
           # Clean up data directory
           rm -rf "$WEED_DATA_DIR" || true

--- a/test/s3/copying/Makefile
+++ b/test/s3/copying/Makefile
@@ -13,6 +13,9 @@ ACCESS_KEY ?= some_access_key1
 SECRET_KEY ?= some_secret_key1
 VOLUME_MAX_SIZE_MB ?= 50
 
+# Let the tests force-drop collections at the master they actually run against
+export MASTER_ENDPOINT ?= http://127.0.0.1:$(MASTER_PORT)
+
 # Test directory
 TEST_DIR := $(shell pwd)
 SEAWEEDFS_ROOT := $(shell cd ../../../ && pwd)

--- a/test/s3/tagging/Makefile
+++ b/test/s3/tagging/Makefile
@@ -12,6 +12,9 @@ FILER_PORT := 8893
 TEST_TIMEOUT := 10m
 TEST_PATTERN := TestObjectTaggingOnUpload|TestPutObjectTaggingAPI|TestDeleteObjectTagging|TestTag
 
+# Let the tests force-drop collections at the master they actually run against
+export MASTER_ENDPOINT ?= http://127.0.0.1:$(MASTER_PORT)
+
 # Default target
 help:
 	@echo "S3 Object Tagging Tests Makefile"


### PR DESCRIPTION
The copying and tagging suites force-drop each bucket's collection at the master so volume slots are freed deterministically between tests. But the copy-tests CI job runs its master on 9336 and the tagging Makefile on 9338, while the tests default to 9333 — the cleanup dialed a dead port and quietly no-oped (`Note: force-delete collection ... connection refused` on every call).

Each test bucket then grows 7 volumes against `-volume.max=100`, and whenever async collection deletion lagged, the data node ran out of slots and the next PutObject 500ed with "No writable volumes and no free volumes left" — the intermittent copy-tests failure.

Set `MASTER_ENDPOINT` where the master port is non-default: the copy-tests workflow step, and the copying/tagging Makefiles (derived from `MASTER_PORT`, so local overrides stay consistent).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved S3 copy and tagging test reliability by ensuring tests connect to the correct local master endpoint.
  * Standardized endpoint configuration across local test runs and automated test workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->