### PR TITLE
fix(redis2/redis3): support separate sentinel auth credentials

### DIFF
--- a/weed/command/scaffold/filer.toml
+++ b/weed/command/scaffold/filer.toml
@@ -237,6 +237,9 @@ addresses = ["172.22.12.7:26379","172.22.12.8:26379","172.22.12.9:26379"]
 masterName = "master"
 username = ""
 password = ""
+# credentials used to authenticate against the sentinel nodes themselves (if they require auth)
+sentinel_username = ""
+sentinel_password = ""
 database = 0
 # prefix for filer redis keys
 keyPrefix = ""

--- a/weed/filer/redis2/redis_sentinel_store.go
+++ b/weed/filer/redis2/redis_sentinel_store.go
@@ -26,22 +26,26 @@ func (store *Redis2SentinelStore) Initialize(configuration util.Configuration, p
 		configuration.GetString(prefix+"masterName"),
 		configuration.GetString(prefix+"username"),
 		configuration.GetString(prefix+"password"),
+		configuration.GetString(prefix+"sentinel_username"),
+		configuration.GetString(prefix+"sentinel_password"),
 		configuration.GetInt(prefix+"database"),
 		configuration.GetString(prefix+"keyPrefix"),
 	)
 }
 
-func (store *Redis2SentinelStore) initialize(addresses []string, masterName string, username string, password string, database int, keyPrefix string) (err error) {
+func (store *Redis2SentinelStore) initialize(addresses []string, masterName string, username string, password string, sentinelUsername string, sentinelPassword string, database int, keyPrefix string) (err error) {
 	store.Client = redis.NewFailoverClient(&redis.FailoverOptions{
-		MasterName:      masterName,
-		SentinelAddrs:   addresses,
-		Username:        username,
-		Password:        password,
-		DB:              database,
-		MinRetryBackoff: time.Millisecond * 100,
-		MaxRetryBackoff: time.Minute * 1,
-		ReadTimeout:     time.Second * 30,
-		WriteTimeout:    time.Second * 5,
+		MasterName:       masterName,
+		SentinelAddrs:    addresses,
+		Username:         username,
+		Password:         password,
+		SentinelUsername: sentinelUsername,
+		SentinelPassword: sentinelPassword,
+		DB:               database,
+		MinRetryBackoff:  time.Millisecond * 100,
+		MaxRetryBackoff:  time.Minute * 1,
+		ReadTimeout:      time.Second * 30,
+		WriteTimeout:     time.Second * 5,
 	})
 	store.keyPrefix = keyPrefix
 	return

--- a/weed/filer/redis3/redis_sentinel_store.go
+++ b/weed/filer/redis3/redis_sentinel_store.go
@@ -28,21 +28,25 @@ func (store *Redis3SentinelStore) Initialize(configuration util.Configuration, p
 		configuration.GetString(prefix+"masterName"),
 		configuration.GetString(prefix+"username"),
 		configuration.GetString(prefix+"password"),
+		configuration.GetString(prefix+"sentinel_username"),
+		configuration.GetString(prefix+"sentinel_password"),
 		configuration.GetInt(prefix+"database"),
 	)
 }
 
-func (store *Redis3SentinelStore) initialize(addresses []string, masterName string, username string, password string, database int) (err error) {
+func (store *Redis3SentinelStore) initialize(addresses []string, masterName string, username string, password string, sentinelUsername string, sentinelPassword string, database int) (err error) {
 	store.Client = redis.NewFailoverClient(&redis.FailoverOptions{
-		MasterName:      masterName,
-		SentinelAddrs:   addresses,
-		Username:        username,
-		Password:        password,
-		DB:              database,
-		MinRetryBackoff: time.Millisecond * 100,
-		MaxRetryBackoff: time.Minute * 1,
-		ReadTimeout:     time.Second * 30,
-		WriteTimeout:    time.Second * 5,
+		MasterName:       masterName,
+		SentinelAddrs:    addresses,
+		Username:         username,
+		Password:         password,
+		SentinelUsername: sentinelUsername,
+		SentinelPassword: sentinelPassword,
+		DB:               database,
+		MinRetryBackoff:  time.Millisecond * 100,
+		MaxRetryBackoff:  time.Minute * 1,
+		ReadTimeout:      time.Second * 30,
+		WriteTimeout:     time.Second * 5,
 	})
 	store.redsync = redsync.New(goredis.NewPool(store.Client))
 	return


### PR DESCRIPTION
## Summary
- `redis2_sentinel` and `redis3_sentinel` stores only pass `Username`/`Password` into `redis.FailoverOptions`. Those fields authenticate against the Redis master/replica servers, not against Sentinel itself.
- When Sentinel is configured with `requirepass` (common in production HA setups), go-redis has no credentials to send to it, and the connection fails with `NOAUTH Authentication required` before it even reaches the master.
- go-redis's `FailoverOptions` already exposes `SentinelUsername`/`SentinelPassword` for exactly this case, but the toml config loader never read or wired them through.

This adds `sentinel_username`/`sentinel_password` config keys (separate from the existing `username`/`password`) to both `redis2_sentinel` and `redis3_sentinel`, and documents the new keys in the `[redis2_sentinel]` section of the scaffold `filer.toml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional username and password settings for authenticating with Redis Sentinel nodes.
  * Redis Sentinel connections now support the configured sentinel credentials for both supported Redis integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->