### PR TITLE
exclusive_locks: clear renew-running flag before dropping isLocked

### DIFF
--- a/weed/wdclient/exclusive_locks/exclusive_locker.go
+++ b/weed/wdclient/exclusive_locks/exclusive_locker.go
@@ -93,13 +93,15 @@ func (l *ExclusiveLocker) RequestLock(clientName string) {
 	if l.renewGoroutineRunning.CompareAndSwap(false, true) {
 		// start a goroutine to renew the lease
 		go func() {
-			defer l.renewGoroutineRunning.Store(false)
 			ctx2, cancel2 := context.WithCancel(context.Background())
 			defer cancel2()
 
 			for {
 				if err := l.renewLease(ctx2); err != nil {
 					glog.Warningf("Failed to renew lock %s: %v", l.lockName, err)
+					// clear the running flag before isLocked, so a RequestLock that
+					// reacquires (once isLocked is false) starts a replacement renewer
+					l.renewGoroutineRunning.Store(false)
 					l.isLocked.Store(false)
 					return
 				}


### PR DESCRIPTION
## Bug
In `ExclusiveLocker`, on renewal failure the renew goroutine stores `isLocked=false` **before** its deferred `renewGoroutineRunning.Store(false)` runs. A concurrent `RequestLock` interleaving in that window reacquires the lease (it sees `isLocked=false`), sets `isLocked=true`, then its `CompareAndSwap(false, true)` on `renewGoroutineRunning` **fails** because the old goroutine's flag is still set — so no replacement renewer starts.

The result: the lock is held locally (`isLocked==true`) with nothing renewing it. After the lease TTL it silently expires on the master, and a second client can acquire the same admin lock — a two-holder window for `weed shell` volume operations / admin leadership.

## Fix
Clear `renewGoroutineRunning` **before** `isLocked` on the failure path (dropping the defer, since the loop has a single exit). A concurrent `RequestLock` only reacquires once `isLocked` is false, and by then the running flag is already clear, so its `CompareAndSwap` succeeds and a fresh renewer starts. Closes the two-holder window.

Builds and `go vet` clean; no behavior change on the success path.

https://claude.ai/code/session_01Ks16jnt4S7gdDk8cheQ3xu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lock lease recovery after a renewal failure.
  * Prevented lock reacquisition from being blocked while a replacement lease-renewal process starts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->