### PR TITLE
filer.replicate: acknowledge notifications after the sink write, not on receipt

### DIFF
--- a/weed/replication/sub/notification_aws_sqs.go
+++ b/weed/replication/sub/notification_aws_sqs.go
@@ -103,14 +103,21 @@ func (k *AwsSqsInput) ReceiveMessage() (key string, message *filer_pb.EventNotif
 		err = fmt.Errorf("unmarshal message from sqs %s: %w", k.queueUrl, err)
 		return
 	}
-	// delete the message
-	_, err = k.svc.DeleteMessage(&sqs.DeleteMessageInput{
-		QueueUrl:      &k.queueUrl,
-		ReceiptHandle: result.Messages[0].ReceiptHandle,
-	})
 
-	if err != nil {
-		glog.V(1).Infof("delete message from sqs %s: %v", k.queueUrl, err)
+	// Delete only once the message has been replicated. Deleting on receipt
+	// drops the message for good when the sink write fails; leaving it in the
+	// queue lets the visibility timeout redeliver it.
+	receiptHandle := result.Messages[0].ReceiptHandle
+	onSuccessFn = func() {
+		if _, deleteErr := k.svc.DeleteMessage(&sqs.DeleteMessageInput{
+			QueueUrl:      &k.queueUrl,
+			ReceiptHandle: receiptHandle,
+		}); deleteErr != nil {
+			glog.V(1).Infof("delete message from sqs %s: %v", k.queueUrl, deleteErr)
+		}
+	}
+	onFailureFn = func() {
+		glog.V(1).Infof("keeping message %s in sqs %s for redelivery", key, k.queueUrl)
 	}
 
 	return

--- a/weed/replication/sub/notification_kafka.go
+++ b/weed/replication/sub/notification_kafka.go
@@ -23,6 +23,7 @@ type KafkaInput struct {
 	topic       string
 	consumer    sarama.Consumer
 	messageChan chan *sarama.ConsumerMessage
+	progress    *KafkaProgress
 }
 
 func (k *KafkaInput) GetName() string {
@@ -81,6 +82,8 @@ func (k *KafkaInput) initialize(hosts []string, topic string, offsetFile string,
 	progress.lastSaveTime = time.Now()
 	progress.offsetFile = offsetFile
 	progress.offsetSaveIntervalSeconds = offsetSaveIntervalSeconds
+	progress.failedOffsets = make(map[int32]int64)
+	k.progress = progress
 
 	for _, partition := range partitions {
 		offset, found := progress.PartitionOffsets[partition]
@@ -100,9 +103,6 @@ func (k *KafkaInput) initialize(hosts []string, topic string, offsetFile string,
 					fmt.Println(err)
 				case msg := <-partitionConsumer.Messages():
 					k.messageChan <- msg
-					if err := progress.setOffset(msg.Partition, msg.Offset); err != nil {
-						glog.Warningf("set kafka offset: %v", err)
-					}
 				}
 			}
 		}()
@@ -114,6 +114,17 @@ func (k *KafkaInput) initialize(hosts []string, topic string, offsetFile string,
 func (k *KafkaInput) ReceiveMessage() (key string, message *filer_pb.EventNotification, onSuccessFn func(), onFailureFn func(), err error) {
 
 	msg := <-k.messageChan
+
+	// Commit only once the message has been replicated. Committing on receipt
+	// leaves nothing to redeliver when the sink write fails.
+	onSuccessFn = func() {
+		if err := k.progress.setOffset(msg.Partition, msg.Offset); err != nil {
+			glog.Warningf("set kafka offset: %v", err)
+		}
+	}
+	onFailureFn = func() {
+		k.progress.markFailed(msg.Partition, msg.Offset)
+	}
 
 	key = string(msg.Key)
 	message = &filer_pb.EventNotification{}
@@ -128,6 +139,10 @@ type KafkaProgress struct {
 	offsetFile                string
 	lastSaveTime              time.Time
 	offsetSaveIntervalSeconds int
+	// failedOffsets is the oldest offset that failed to replicate in each
+	// partition. Nothing at or past it is ever committed, so a restart
+	// redelivers from the failure instead of resuming after it.
+	failedOffsets map[int32]int64
 	sync.Mutex
 }
 
@@ -164,9 +179,25 @@ func (progress *KafkaProgress) setOffset(partition int32, offset int64) error {
 	progress.Lock()
 	defer progress.Unlock()
 
+	if failedOffset, found := progress.failedOffsets[partition]; found && offset >= failedOffset {
+		return nil
+	}
+
 	progress.PartitionOffsets[partition] = offset
 	if int(time.Now().Sub(progress.lastSaveTime).Seconds()) > progress.offsetSaveIntervalSeconds {
 		return progress.saveProgress()
 	}
 	return nil
+}
+
+// markFailed records an offset that could not be replicated, holding the
+// committed offset for that partition behind it.
+func (progress *KafkaProgress) markFailed(partition int32, offset int64) {
+	progress.Lock()
+	defer progress.Unlock()
+
+	if failedOffset, found := progress.failedOffsets[partition]; !found || offset < failedOffset {
+		progress.failedOffsets[partition] = offset
+		glog.Errorf("replicate kafka %s partition %d offset %d failed; holding the committed offset before it", progress.Topic, partition, offset)
+	}
 }

--- a/weed/replication/sub/notification_kafka_test.go
+++ b/weed/replication/sub/notification_kafka_test.go
@@ -1,0 +1,69 @@
+package sub
+
+import (
+	"testing"
+	"time"
+)
+
+func newTestProgress() *KafkaProgress {
+	return &KafkaProgress{
+		Topic:            "test",
+		PartitionOffsets: make(map[int32]int64),
+		failedOffsets:    make(map[int32]int64),
+		lastSaveTime:     time.Now(),
+		// large enough that no test call reaches saveProgress and touches disk
+		offsetSaveIntervalSeconds: 3600,
+	}
+}
+
+// TestKafkaProgressHoldsOffsetAtFailure verifies that a message that failed to
+// replicate keeps the committed offset behind it, so a restart redelivers it
+// rather than resuming after it.
+func TestKafkaProgressHoldsOffsetAtFailure(t *testing.T) {
+	progress := newTestProgress()
+
+	if err := progress.setOffset(0, 10); err != nil {
+		t.Fatalf("setOffset: %v", err)
+	}
+	if got := progress.PartitionOffsets[0]; got != 10 {
+		t.Fatalf("offset = %d after a replicated message, want 10", got)
+	}
+
+	progress.markFailed(0, 11)
+
+	if err := progress.setOffset(0, 12); err != nil {
+		t.Fatalf("setOffset: %v", err)
+	}
+	if got := progress.PartitionOffsets[0]; got != 10 {
+		t.Fatalf("offset = %d after a later success, want it held at 10", got)
+	}
+
+	// a failure in one partition must not stall the others
+	if err := progress.setOffset(1, 5); err != nil {
+		t.Fatalf("setOffset: %v", err)
+	}
+	if got := progress.PartitionOffsets[1]; got != 5 {
+		t.Fatalf("offset = %d in an unaffected partition, want 5", got)
+	}
+}
+
+// TestKafkaProgressKeepsOldestFailure verifies that the hold point is the
+// oldest failed offset, not the most recent one.
+func TestKafkaProgressKeepsOldestFailure(t *testing.T) {
+	progress := newTestProgress()
+
+	progress.markFailed(0, 20)
+	progress.markFailed(0, 11)
+	progress.markFailed(0, 30)
+
+	if got := progress.failedOffsets[0]; got != 11 {
+		t.Fatalf("held at offset %d, want the oldest failure 11", got)
+	}
+
+	if err := progress.setOffset(0, 10); err != nil {
+		t.Fatalf("setOffset: %v", err)
+	}
+	if got := progress.PartitionOffsets[0]; got != 10 {
+		t.Fatalf("offset = %d, want an offset before the failure to still commit", got)
+	}
+}


### PR DESCRIPTION
Follow-up to #10424. Same defect shape, different command: `weed filer.replicate` acknowledged notifications before the sink write was attempted, so a failed replication was logged and the message was already gone.

The `NotificationInput` interface has had the right contract all along (`onSuccessFn`/`onFailureFn`, `weed/replication/sub/notifications.go:13`) and `filer_replication.go:106-115` calls `onFailureFn()` correctly. Two of the four inputs never supplied one and acked at receive time instead. `GoCDKPubSubInput` and `GooglePubSubInput` already do it right.

**Kafka.** The partition consumer did `k.messageChan <- msg` and then `progress.setOffset(...)`, committing before the replicator had even seen the message. Commit moves into `onSuccessFn`. `onFailureFn` records the offset in `failedOffsets`, and `setOffset` refuses to commit at or past the oldest failure in that partition -- otherwise the next successful message would commit straight over the failed one, which is the bug from #10424 in a different guise. Other partitions keep progressing.

**SQS.** `ReceiveMessage` called `DeleteMessage` inline, before the replicator ran. The delete moves into `onSuccessFn`; on failure the message is simply left in the queue and the existing 20s visibility timeout redelivers it. Note this means a sink write slower than the visibility timeout can see the message redelivered while still being processed -- at-least-once, as intended. The unmarshal-error path is untouched: it still returns before the callbacks are set, so a malformed message behaves exactly as it does today.

Both inputs now stall the committed offset on a persistent failure rather than skipping the message, matching #10424. `markFailed` logs the topic, partition, and offset so the stall is attributable.

Tests: `KafkaProgress` offset-hold unit tests (a failure holds the commit point, other partitions unaffected, oldest failure wins). The SQS change has no test -- the package has no AWS fake and the change is a code move into a callback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Replication messages from Amazon SQS are now removed only after successful processing, allowing failed messages to be retried.
  * Kafka replication now commits offsets only after successful processing.
  * Kafka failures hold processing at the earliest failed message to prevent messages from being skipped after restart.

* **Tests**
  * Added coverage for Kafka offset handling across failed messages and partitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->