### PR TITLE
plugin: fix flaky scheduler lock test

### DIFF
--- a/weed/admin/plugin/plugin_scheduler_test.go
+++ b/weed/admin/plugin/plugin_scheduler_test.go
@@ -633,16 +633,19 @@ func TestRunLaneSchedulerIterationLockBehavior(t *testing.T) {
 			t.Parallel()
 
 			lm := &trackingLockManager{}
-			pluginSvc, err := New(Options{
-				LockManager: lm,
-				ClusterContextProvider: func(context.Context) (*plugin_pb.ClusterContext, error) {
-					return &plugin_pb.ClusterContext{}, nil
-				},
-			})
+			// Construct without a cluster-context provider so the background
+			// lane loops do not start: they call runLaneSchedulerIteration on
+			// the same lane and would race this test's own manual call,
+			// consuming the due job before it observes the lock. The provider
+			// is set afterward so the manual iteration can still detect.
+			pluginSvc, err := New(Options{LockManager: lm})
 			if err != nil {
 				t.Fatalf("New: %v", err)
 			}
 			defer pluginSvc.Shutdown()
+			pluginSvc.clusterContextProvider = func(context.Context) (*plugin_pb.ClusterContext, error) {
+				return &plugin_pb.ClusterContext{}, nil
+			}
 
 			// Register a detectable worker for the job type.
 			pluginSvc.registry.UpsertFromHello(&plugin_pb.WorkerHello{


### PR DESCRIPTION
`TestRunLaneSchedulerIterationLockBehavior` fails intermittently:

```
--- FAIL: TestRunLaneSchedulerIterationLockBehavior/Default
    plugin_scheduler_test.go: lock acquired 0 times, wantLock=true
```

### Cause

The test constructs the plugin with a `ClusterContextProvider`. `New` starts a background scheduler loop per lane **only when a provider is set**, and those loops call `runLaneSchedulerIteration` on the same lane in a tight loop. The test then makes a job due and calls `runLaneSchedulerIteration` itself, expecting the lock to be taken around the due work.

The background loop races that: it can pick up the due job first, run detection, and push `nextDetectionAt` into the future before the manual call observes anything — so the manual call sees the job not-due and takes no lock, and the assertion sees zero. It reproduces under `-race -count=100 -p 4`.

### Fix

Construct without the provider so no loops start, then set `clusterContextProvider` directly afterward so the manual iteration can still detect. `scheduler_status_test.go` already does exactly this ("Set the provider after construction so runJobTypeIteration can use it"). The test is white-box (`package plugin`), so it can set the field.

Green under `-race -count=100 -p 4`; the full `weed/admin/plugin` package passes with `-race`. Test-only change.

https://claude.ai/code/session_01Ks16jnt4S7gdDk8cheQ3xu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated scheduler lock-behavior test setup to ensure lane scheduling starts under the intended cluster context.
  * Improved test reliability when validating lock acquisition during scheduler iterations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->