### PR TITLE
filer: drop a caller's jwt query param on a proxied read

### DIFF
--- a/weed/server/filer_server_handlers_proxy.go
+++ b/weed/server/filer_server_handlers_proxy.go
@@ -128,6 +128,14 @@ func (fs *FilerServer) proxyToVolumeServerURL(w http.ResponseWriter, r *http.Req
 	// (e.g. readDeleted=true from weed mount) but drop the internal proxyChunkId.
 	query := r.URL.Query()
 	query.Del("proxyChunkId")
+	if isProxyReadMethod(r.Method) {
+		// On a read the filer decides the volume credential below, and
+		// security.GetJwt reads the "jwt" query parameter before the
+		// Authorization header -- so leaving a caller-supplied one in place
+		// would silently outrank the token we attach. Writes keep theirs: the
+		// proxy forwards a writer's own credential either way.
+		query.Del("jwt")
+	}
 	if encoded := query.Encode(); encoded != "" {
 		targetURL += "?" + encoded
 	}

--- a/weed/server/filer_server_handlers_proxy_test.go
+++ b/weed/server/filer_server_handlers_proxy_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -27,17 +28,25 @@ const (
 // left the filer are otherwise indistinguishable.
 type proxyTestVolume struct {
 	*httptest.Server
-	hits atomic.Int32
-	auth atomic.Value // string
+	hits         atomic.Int32
+	auth         atomic.Value // string
+	effectiveJwt atomic.Value // string
+	rawQuery     atomic.Value // string
 }
 
 func newProxyTestVolume(t *testing.T) *proxyTestVolume {
 	t.Helper()
 	v := &proxyTestVolume{}
 	v.auth.Store("")
+	v.effectiveJwt.Store("")
+	v.rawQuery.Store("")
 	v.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		v.hits.Add(1)
 		v.auth.Store(r.Header.Get("Authorization"))
+		v.rawQuery.Store(r.URL.RawQuery)
+		// The credential the volume server would actually evaluate, which is not
+		// necessarily the Authorization header.
+		v.effectiveJwt.Store(string(security.GetJwt(r)))
 	}))
 	t.Cleanup(func() {
 		v.Close()
@@ -53,10 +62,70 @@ func newProxyTestVolume(t *testing.T) *proxyTestVolume {
 
 func (v *proxyTestVolume) seenAuth() string { return v.auth.Load().(string) }
 
+// seenEffectiveJwt is the token the volume server would validate, resolved the
+// same way VolumeServer.maybeCheckJwtAuthorization resolves it.
+func (v *proxyTestVolume) seenEffectiveJwt() string { return v.effectiveJwt.Load().(string) }
+
+func (v *proxyTestVolume) seenRawQuery() string { return v.rawQuery.Load().(string) }
+
 func (v *proxyTestVolume) requireReached(t *testing.T) {
 	t.Helper()
 	if v.hits.Load() == 0 {
 		t.Fatal("request never reached the volume server, so the assertion below proves nothing")
+	}
+}
+
+// security.GetJwt reads the "jwt" query parameter before the Authorization
+// header, so a caller-supplied one would outrank the token the filer attaches
+// on a read -- the credential the volume server evaluates has to be the filer's.
+func TestProxyReadDropsCallerJwtQueryParam(t *testing.T) {
+	minted := &FilerServer{volumeGuard: security.NewGuard([]string{}, proxyTestWriteKey, 10, proxyTestReadKey, 10)}
+	want := minted.maybeGetVolumeReadJwtAuthorizationToken(proxyTestFileId)
+	if want == "" {
+		t.Fatal("no read token minted despite a configured read key")
+	}
+
+	for _, method := range []string{http.MethodGet, http.MethodHead} {
+		t.Run(method, func(t *testing.T) {
+			volume := newProxyTestVolume(t)
+			fs := &FilerServer{volumeGuard: security.NewGuard([]string{}, proxyTestWriteKey, 10, proxyTestReadKey, 10)}
+
+			r := httptest.NewRequest(method,
+				"http://filer:8888/?proxyChunkId="+proxyTestFileId+"&jwt=caller-supplied&readDeleted=true", nil)
+			fs.proxyToVolumeServerURL(httptest.NewRecorder(), r, proxyTestFileId, volume.URL+"/"+proxyTestFileId)
+
+			volume.requireReached(t)
+			if got := volume.seenEffectiveJwt(); got == "caller-supplied" {
+				t.Fatal("caller's jwt query param outranked the filer-minted token")
+			}
+			if got := volume.seenEffectiveJwt(); got != want {
+				t.Fatalf("volume server would evaluate %q, want the minted token %q", got, want)
+			}
+			if q := volume.seenRawQuery(); strings.Contains(q, "jwt=") {
+				t.Fatalf("jwt survived in the forwarded query: %q", q)
+			}
+			// Unrelated params must still be forwarded.
+			if q := volume.seenRawQuery(); !strings.Contains(q, "readDeleted=true") {
+				t.Fatalf("readDeleted was dropped from the forwarded query: %q", q)
+			}
+		})
+	}
+}
+
+// A writer's credential is its own either way, so the query parameter is left
+// alone on writes -- stripping it would break a caller that presents its volume
+// JWT that way.
+func TestProxyWriteKeepsCallerJwtQueryParam(t *testing.T) {
+	volume := newProxyTestVolume(t)
+	fs := &FilerServer{volumeGuard: security.NewGuard([]string{}, proxyTestWriteKey, 10, proxyTestReadKey, 10)}
+
+	r := httptest.NewRequest(http.MethodPost,
+		"http://filer:8888/?proxyChunkId="+proxyTestFileId+"&jwt=caller-supplied", nil)
+	fs.proxyToVolumeServerURL(httptest.NewRecorder(), r, proxyTestFileId, volume.URL+"/"+proxyTestFileId)
+
+	volume.requireReached(t)
+	if got := volume.seenEffectiveJwt(); got != "caller-supplied" {
+		t.Fatalf("writer's own jwt query param was altered: got %q", got)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #10434, found while reviewing it. Independent of the residual gap noted there.

`security.GetJwt` resolves a token from the query parameter **before** the Authorization header:

```go
// weed/security/jwt.go:115
tokenStr := r.URL.Query().Get("jwt")
if tokenStr == "" {
    bearer := r.Header.Get("Authorization")
    ...
}
```

`proxyToVolumeServerURL` forwards the caller's entire query apart from `proxyChunkId`. So on a read — where the filer mints a volume read token and `Set`s the Authorization header specifically so it, not the caller, decides the credential — a caller-supplied `?jwt=` silently outranked it. The volume server validated whatever the caller chose and returned 401, and the filer had attached a perfectly good token that was never looked at.

Concretely: `GET /?proxyChunkId=3,01637037d6&jwt=garbage` with `jwt.signing.read.key` configured fails the read, and the credential the volume server actually evaluates is fully caller-controlled.

## Fix

Strip `jwt` from the forwarded query on the read path only.

Reads are where the filer owns the credential — it already overrides the caller by `Set`ting the header, and the query parameter quietly defeated that override. Writes keep theirs: the proxy forwards a writer's own AssignVolume token by design (the contract #10434 established), so their `?jwt=` is the same credential through a second channel, with no escalation either way. Stripping it there would contradict that contract and could break an external caller that presents its token that way.

Nothing in-tree passes a jwt by query — `maybeAddAuth` always sets the header — so this affects neither mount, replication, nor the mq broker.

The `AT` cookie, which `GetJwt` checks third, is not an override vector and is left alone: when the filer mints, the header beats the cookie; when it doesn't mint, the volume server isn't enforcing read JWTs at all.

## Tests

The volume-server stub now records `security.GetJwt(r)` — the credential the volume server would *actually* evaluate — rather than just the Authorization header, since asserting on the header is exactly what would have missed this bug.

- GET and HEAD: the caller's `jwt=` no longer reaches the volume server, and the token it would evaluate is the filer-minted one
- an unrelated `readDeleted=true` still survives the strip, so it isn't over-broad
- POST: a writer's own `jwt=` is left untouched

Removing the strip fails the read test. `go build ./weed/...`, `go vet ./weed/server/`, and `./weed/server/ ./weed/security/` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security for proxied read requests by preventing caller-supplied JWT query parameters from being forwarded.
  * Preserved unrelated query parameters during request forwarding.
  * Ensured read requests use the appropriate filer-issued authentication token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->