### PR TITLE
rust volume: mark-readonly notifies the live leader, not the static seed

### DIFF
--- a/seaweed-volume/src/server/grpc_server.rs
+++ b/seaweed-volume/src/server/grpc_server.rs
@@ -182,7 +182,19 @@ impl VolumeGrpcService {
         info: &MasterVolumeInfo,
         is_readonly: bool,
     ) -> Result<(), Status> {
-        let master_url = self.state.master_url.clone();
+        // VolumeMarkReadonly mutates raft-replicated master topology, so it must
+        // reach the leader. Prefer the live leader the heartbeat is talking to
+        // (current_master_url), falling back to the static seed before the first
+        // heartbeat — mirrors store_ec.rs and Go's vs.GetMaster(). Sending it to
+        // the static seed fails "not current leader" after any master failover.
+        let master_url = {
+            let live = self.state.current_master_url.read().await.clone();
+            if !live.is_empty() {
+                live
+            } else {
+                self.state.master_url.clone()
+            }
+        };
         if master_url.is_empty() {
             return Ok(());
         }


### PR DESCRIPTION
## Summary

The Rust volume server sends its `VolumeMarkReadonly` notification to the **static seed master** (`config.masters.first()`) instead of the **live Raft leader**. `VolumeMarkReadonly` mutates raft-replicated master topology, so it must reach the leader — after any master failover (or a rolling master restart) it hits a follower and fails:

```
set volume <id> readonly=true on master <seed>:9333: "raft.Server: Not current leader"
```

Marking the source volume read-only is the first step of EC encoding, so on a multi-master cluster this aborts the operation after a leadership change until the seed happens to be the leader again.

## Root cause

`notify_master_volume_readonly` (`seaweed-volume/src/server/grpc_server.rs`) used:

```rust
let master_url = self.state.master_url.clone();   // static seed, set once at startup
```

`VolumeServerState` already tracks the live leader in `current_master_url`, which the heartbeat loop updates on every leader redirect. This function just never consulted it. Both the mark-readonly and mark-writable paths funnel through it, so both were affected. The Go volume server does this correctly (`vs.GetMaster()` = the leader-following current master).

## Fix

Prefer the live leader, fall back to the seed before the first heartbeat — the exact pattern already used by the EC-shard lookup path in `store_ec.rs`:

```rust
let master_url = {
    let live = self.state.current_master_url.read().await.clone();
    if !live.is_empty() { live } else { self.state.master_url.clone() }
};
```

Before the first heartbeat `current_master_url` is empty and this falls back to the seed — identical to the previous behavior, so no startup regression. The `.read().await` guard is scoped and dropped before any gRPC `await`.

## Validation

`cargo check` (default features) clean.

https://claude.ai/code/session_01Ks16jnt4S7gdDk8cheQ3xu


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved volume read-only notifications during master failover by directing requests to the current master leader.
  * Added fallback behavior to maintain compatibility when the live leader address is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->