### PR TITLE
chore(weed/s3api): prune dead code

### DIFF
--- a/weed/s3api/auth_credentials.go
+++ b/weed/s3api/auth_credentials.go
@@ -57,7 +57,6 @@ type IdentityAccessManagement struct {
 	hashes            map[string]*sync.Pool
 	hashCounters      map[string]*int32
 	identityAnonymous *Identity
-	hashMu            sync.RWMutex
 	domain            string
 	externalHost      string // pre-computed host for S3 signature verification (from ExternalUrl)
 	isAuthEnabled     bool

--- a/weed/s3api/custom_types.go
+++ b/weed/s3api/custom_types.go
@@ -5,8 +5,6 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
 )
 
-const s3TimeFormat = "2006-01-02T15:04:05.999Z07:00"
-
 // ConditionalHeaderResult holds the result of conditional header checking
 type ConditionalHeaderResult struct {
 	ErrorCode s3err.ErrorCode

--- a/weed/s3api/s3_iam_middleware.go
+++ b/weed/s3api/s3_iam_middleware.go
@@ -516,12 +516,6 @@ func (s3a *S3ApiServer) SetIAMIntegration(iamManager *integration.IAMManager) {
 	}
 }
 
-// EnhancedS3ApiServer extends S3ApiServer with IAM integration
-type EnhancedS3ApiServer struct {
-	*S3ApiServer
-	iamIntegration IAMIntegration
-}
-
 // OIDCIdentity represents an identity validated through OIDC
 type OIDCIdentity struct {
 	UserID      string

--- a/weed/s3api/s3_sse_kms.go
+++ b/weed/s3api/s3_sse_kms.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -22,12 +21,6 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
-)
-
-// Compiled regex patterns for KMS key validation
-var (
-	uuidRegex = regexp.MustCompile(`^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$`)
-	arnRegex  = regexp.MustCompile(`^arn:aws:kms:[a-z0-9-]+:\d{12}:(key|alias)/.+$`)
 )
 
 // SSEKMSKey contains the metadata for an SSE-KMS encrypted object

--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -33,17 +33,6 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// corsHeaders defines the CORS headers that need to be preserved
-// Package-level constant to avoid repeated allocations
-var corsHeaders = []string{
-	"Access-Control-Allow-Origin",
-	"Access-Control-Allow-Methods",
-	"Access-Control-Allow-Headers",
-	"Access-Control-Expose-Headers",
-	"Access-Control-Max-Age",
-	"Access-Control-Allow-Credentials",
-}
-
 // zeroBuf is a reusable buffer of zero bytes for padding operations
 // Package-level to avoid per-call allocations in writeZeroBytes
 var zeroBuf = make([]byte, 32*1024)
@@ -2998,15 +2987,6 @@ type MultipartSSEReader struct {
 	readers     []io.Reader
 }
 
-// SSERangeReader applies range logic to an underlying reader
-type SSERangeReader struct {
-	reader    io.Reader
-	offset    int64  // bytes to skip from the beginning
-	remaining int64  // bytes remaining to read (-1 for unlimited)
-	skipped   int64  // bytes already skipped
-	skipBuf   []byte // reusable buffer for skipping bytes (avoids per-call allocation)
-}
-
 // NewMultipartSSEReader creates a new multipart reader that can properly close all underlying readers
 func NewMultipartSSEReader(readers []io.Reader) *MultipartSSEReader {
 	return &MultipartSSEReader{
@@ -3117,7 +3097,7 @@ func (s3a *S3ApiServer) buildRemoteObjectPath(bucket, object string) (dir, name 
 }
 
 // doCacheRemoteObject calls the filer's CacheRemoteObjectToLocalCluster gRPC endpoint.
-// This is the core caching function used by both cacheRemoteObjectWithDedup and cacheRemoteObjectForStreaming.
+// This is the core caching function used by cacheRemoteObjectForStreaming.
 func (s3a *S3ApiServer) doCacheRemoteObject(ctx context.Context, dir, name string) (*filer_pb.Entry, error) {
 	var cachedEntry *filer_pb.Entry
 	err := s3a.WithFilerClient(false, func(client filer_pb.SeaweedFilerClient) error {
@@ -3134,36 +3114,6 @@ func (s3a *S3ApiServer) doCacheRemoteObject(ctx context.Context, dir, name strin
 		return nil
 	})
 	return cachedEntry, err
-}
-
-// cacheRemoteObjectWithDedup caches a remote-only object to the local cluster.
-// The filer server handles singleflight deduplication, so all clients (S3, HTTP, Hadoop) benefit.
-// On cache error, returns the original entry (will retry in streamFromVolumeServers).
-// Uses a bounded timeout to avoid blocking requests indefinitely.
-func (s3a *S3ApiServer) cacheRemoteObjectWithDedup(ctx context.Context, bucket, object string, entry *filer_pb.Entry) *filer_pb.Entry {
-	const cacheTimeout = 30 * time.Second
-	cacheCtx, cancel := context.WithTimeout(ctx, cacheTimeout)
-	defer cancel()
-
-	dir, name := s3a.buildRemoteObjectPath(bucket, object)
-	glog.V(2).Infof("cacheRemoteObjectWithDedup: caching %s/%s (remote size: %d)", bucket, object, entry.RemoteEntry.RemoteSize)
-
-	cachedEntry, err := s3a.doCacheRemoteObject(cacheCtx, dir, name)
-	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
-			glog.V(1).Infof("cacheRemoteObjectWithDedup: timeout caching %s/%s after %v (will retry in streaming)", bucket, object, cacheTimeout)
-		} else {
-			glog.Warningf("cacheRemoteObjectWithDedup: failed to cache %s/%s: %v (will retry in streaming)", bucket, object, err)
-		}
-		return entry
-	}
-
-	if cachedEntry != nil && len(cachedEntry.GetChunks()) > 0 {
-		glog.V(1).Infof("cacheRemoteObjectWithDedup: successfully cached %s/%s (%d chunks)", bucket, object, len(cachedEntry.GetChunks()))
-		entry.Chunks = cachedEntry.Chunks
-	}
-
-	return entry
 }
 
 func (s3a *S3ApiServer) buildVersionedRemoteObjectPath(bucket, object, versionId string) (dir, name string) {

--- a/weed/s3api/s3api_sosapi.go
+++ b/weed/s3api/s3api_sosapi.go
@@ -36,9 +36,6 @@ const (
 	// sosAPICapacityXML is the path to the capacity information XML file.
 	sosAPICapacityXML = sosAPISystemFolder + "/capacity.xml"
 
-	// sosAPIClientUserAgent is a substring to detect SOSAPI-compatible backup clients.
-	sosAPIClientUserAgent = "APN/1.0 Veeam/1.0"
-
 	// sosAPIProtocolVersion is the SOSAPI protocol version supported.
 	sosAPIProtocolVersion = `"1.0"`
 


### PR DESCRIPTION
This prunes dead functions and variables from `weed/s3api.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved multipart server-side encrypted object streaming by introducing a unified reader abstraction that streams across multiple inputs and properly closes all underlying streams.
  * Simplified the remote-object caching flow used by streaming to reduce duplicated handling paths.
* **Refactor**
  * Streamlined S3 IAM and SOSAPI compatibility components by removing no-longer-needed wrappers and internal constants.
  * Further simplified related request-side handling for clearer, more maintainable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->