### PR TITLE
volume: skip a shard-holding disk when staging a decoded volume (Go+Rust)

### DIFF
--- a/seaweed-volume/src/server/grpc_server.rs
+++ b/seaweed-volume/src/server/grpc_server.rs
@@ -1768,7 +1768,14 @@ impl VolumeServer for VolumeGrpcService {
                                 // .idx.copying/.vif.copying are not valid volume names,
                                 // so the scanner never half-loads a partial push.
                                 let want = DiskType::from_string(&info.disk_type);
-                                match store.find_free_location_predicate(|l| l.disk_type == want) {
+                                let staged_vid = VolumeId(info.volume_id);
+                                // Skip a disk already holding this vid's EC shards, so the
+                                // decoded .dat never lands in the same directory as a shard —
+                                // lets the caller target a shard host that has a spare disk.
+                                match store.find_free_location_predicate(|l| {
+                                    l.disk_type == want
+                                        && !l.ec_volumes().any(|(v, _)| *v == staged_vid)
+                                }) {
                                     Some(i) => {
                                         let dir = store.locations[i].directory.clone();
                                         drop(store);

--- a/weed/server/volume_grpc_copy.go
+++ b/weed/server/volume_grpc_copy.go
@@ -700,7 +700,14 @@ func (vs *VolumeServer) ReceiveFile(stream volume_server_pb.VolumeServer_Receive
 					// VolumeEcShardsToVolume(from_staged). .idx.copying/.vif.copying
 					// are not valid volume names, so the scanner never half-loads.
 					want := types.ToDiskType(fileInfo.DiskType)
+					stagedVid := needle.VolumeId(fileInfo.VolumeId)
 					loc := vs.store.FindFreeLocation(func(l *storage.DiskLocation) bool {
+						// Skip a disk that already holds this vid's EC shards, so the
+						// decoded .dat never lands in the same directory as a shard —
+						// lets the caller target a shard host that has a spare disk.
+						if _, holds := l.FindEcVolume(stagedVid); holds {
+							return false
+						}
 						return l.DiskType == want
 					})
 					if loc == nil {


### PR DESCRIPTION
Hardens the `ReceiveFile` staged-new-volume mode added in #10463.

That mode picks a free disk of the requested medium (`FindFreeLocation(disk_type == want)`) to stage a decoded `<vid>.dat` as `<base><ext>.copying`. It picked **any** free disk — including one that already holds the vid's EC shards, which would put the decoded `.dat` in the same directory as `<vid>.ec*` (the exact EC/normal coexistence the staged mode exists to avoid).

Skip a disk that already holds the vid's EC shards:
- **Go**: `DiskLocation.FindEcVolume(vid)`
- **Rust**: `l.ec_volumes()`

So the caller can safely target a host that holds a shard of the vid on one disk as long as it has a spare disk — the receiver won't stage onto the shard's disk. Defense-in-depth regardless of caller.

`go build` + `cargo check` (default features): clean.

https://claude.ai/code/session_01Ks16jnt4S7gdDk8cheQ3xu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved staged volume file placement to avoid disks already containing erasure-coded shards for the same volume.
  - Reduced the risk of data overlap during volume transfers and decoding.
  - Preserved existing disk-type matching and staged-file handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->