### PR TITLE
ci: read branch names from env instead of interpolating them into the shell

### DIFF
--- a/.github/workflows/container_foundationdb_version.yml
+++ b/.github/workflows/container_foundationdb_version.yml
@@ -140,13 +140,17 @@ jobs:
 
       - name: Determine branch to build
         id: branch
+        env:
+          INPUT_REF: ${{ inputs.seaweedfs_ref }}
+          HEAD_REF: ${{ github.head_ref }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          if [ -n "${{ inputs.seaweedfs_ref }}" ]; then
-            echo "branch=${{ inputs.seaweedfs_ref }}" >> "$GITHUB_OUTPUT"
+          if [ -n "$INPUT_REF" ]; then
+            echo "branch=$INPUT_REF" >> "$GITHUB_OUTPUT"
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "branch=${{ github.head_ref }}" >> "$GITHUB_OUTPUT"
+            echo "branch=$HEAD_REF" >> "$GITHUB_OUTPUT"
           else
-            echo "branch=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+            echo "branch=$REF_NAME" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build and push image


### PR DESCRIPTION
Hi, and thanks for SeaweedFS.

In `.github/workflows/container_foundationdb_version.yml`, the "Determine branch to build" step writes branch names into `$GITHUB_OUTPUT` by interpolating them into the shell:

```yaml
run: |
  if [ -n "${{ inputs.seaweedfs_ref }}" ]; then
    echo "branch=${{ inputs.seaweedfs_ref }}" >> "$GITHUB_OUTPUT"
  elif [ "${{ github.event_name }}" = "pull_request" ]; then
    echo "branch=${{ github.head_ref }}" >> "$GITHUB_OUTPUT"
```

Actions expands `${{ ... }}` into the script text before bash runs, so these arrive as script rather than as values. Git allows `$`, `(`, `)` and backticks in branch names, and `$(...)` executes inside double quotes, so a branch named something like `x$(id)` would run that on the runner. The `workflow_dispatch` input has the same shape, since it is free text typed by whoever dispatches.

Worth being clear about the limits: the workflow triggers on `pull_request`, not `pull_request_target`, so a fork PR gets a read-only token and the `DOCKER_USERNAME` / `DOCKER_PASSWORD` secrets used further down are not available to it. I am raising this as hardening on a job that does touch registry credentials on internal branches, not as a live exploit path from a fork.

The change binds the three values to environment variables so the shell sees data:

```yaml
env:
  INPUT_REF: ${{ inputs.seaweedfs_ref }}
  HEAD_REF: ${{ github.head_ref }}
  REF_NAME: ${{ github.ref_name }}
run: |
  if [ -n "$INPUT_REF" ]; then
    echo "branch=$INPUT_REF" >> "$GITHUB_OUTPUT"
  elif [ "${{ github.event_name }}" = "pull_request" ]; then
    echo "branch=$HEAD_REF" >> "$GITHUB_OUTPUT"
```

Behaviour is unchanged. I deliberately left `github.event_name` interpolated — that is a fixed GitHub-controlled string, not free text.

Disclosure: I used AI assistance to help spot this and prepare the change, and I verified the workflow and its triggers myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workflow handling for selecting the appropriate SeaweedFS branch during container builds.
  * Preserved existing behavior across manual runs, pull requests, and other workflow events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->