### PR TITLE
Do not fail immediately when running the post bucket hook

### DIFF
--- a/k8s/charts/seaweedfs/templates/shared/post-install-bucket-hook.yaml
+++ b/k8s/charts/seaweedfs/templates/shared/post-install-bucket-hook.yaml
@@ -103,7 +103,7 @@ spec:
               
               echo "Waiting for service at $url..."
               while [ $attempt -le $max_attempts ]; do
-                if wget -q --spider "$url" >/dev/null 2>&1; then
+                if curl -sS -o /dev/null --max-time 5 "$url" >/dev/null 2>&1; then
                   echo "Service at $url is up!"
                   return 0
                 fi


### PR DESCRIPTION
curl exits 0 as soon as it gets any HTTP response, even 401/403 - required if the filer rejects unauthenticated requests when JWT auth is enabled

# What problem are we solving?

When JWT authentication is enabled, the post bucket hook fails

# How are we solving the problem?

By using curl with --max-time instead of wget. curl does fail if it gets a non 2xx code.

# How is the PR tested?

By deploying with

```
  s3:
    enabled: true
    ingress:
      enabled: true
      className: "traefik"
      host: "k3s.local"
    createBuckets:
      - name: b0
      - name: b1
      - name: b2
```

# Checks
- [ ] I have added unit tests _if possible_.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service readiness checks during bucket setup after installation or upgrades.
  * Added a timeout to prevent readiness checks from hanging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->