### PR TITLE
s3api/iceberg: report the reason a table schema was rejected

### DIFF
--- a/weed/s3api/iceberg/handlers_commit.go
+++ b/weed/s3api/iceberg/handlers_commit.go
@@ -160,7 +160,7 @@ func (s *Server) handleUpdateTable(w http.ResponseWriter, r *http.Request) {
 				}
 
 				if baseMetadata == nil {
-					baseMetadata = newTableMetadata(tableUUID, location, nil, nil, nil, nil)
+					baseMetadata = newEmptyTableMetadata(tableUUID, location, tableName)
 					if baseMetadata == nil {
 						writeError(w, http.StatusInternalServerError, "InternalServerError", "Failed to build current metadata")
 						return
@@ -216,7 +216,7 @@ func (s *Server) handleUpdateTable(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		} else {
-			currentMetadata = newTableMetadata(tableUUID, location, nil, nil, nil, nil)
+			currentMetadata = newEmptyTableMetadata(tableUUID, location, tableName)
 		}
 		if currentMetadata == nil {
 			writeError(w, http.StatusInternalServerError, "InternalServerError", "Failed to build current metadata")

--- a/weed/s3api/iceberg/handlers_commit.go
+++ b/weed/s3api/iceberg/handlers_commit.go
@@ -160,8 +160,9 @@ func (s *Server) handleUpdateTable(w http.ResponseWriter, r *http.Request) {
 				}
 
 				if baseMetadata == nil {
-					baseMetadata = newEmptyTableMetadata(tableUUID, location, tableName)
-					if baseMetadata == nil {
+					var buildErr error
+					if baseMetadata, buildErr = newEmptyTableMetadata(tableUUID, location); buildErr != nil {
+						glog.Errorf("Iceberg: CommitTable placeholder metadata for %s: %v", tableName, buildErr)
 						writeError(w, http.StatusInternalServerError, "InternalServerError", "Failed to build current metadata")
 						return
 					}
@@ -216,11 +217,12 @@ func (s *Server) handleUpdateTable(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		} else {
-			currentMetadata = newEmptyTableMetadata(tableUUID, location, tableName)
-		}
-		if currentMetadata == nil {
-			writeError(w, http.StatusInternalServerError, "InternalServerError", "Failed to build current metadata")
-			return
+			currentMetadata, err = newEmptyTableMetadata(tableUUID, location)
+			if err != nil {
+				glog.Errorf("Iceberg: CommitTable placeholder metadata for %s: %v", tableName, err)
+				writeError(w, http.StatusInternalServerError, "InternalServerError", "Failed to build current metadata")
+				return
+			}
 		}
 
 		for _, requirement := range req.Requirements {

--- a/weed/s3api/iceberg/handlers_commit.go
+++ b/weed/s3api/iceberg/handlers_commit.go
@@ -161,7 +161,7 @@ func (s *Server) handleUpdateTable(w http.ResponseWriter, r *http.Request) {
 
 				if baseMetadata == nil {
 					var buildErr error
-					if baseMetadata, buildErr = newEmptyTableMetadata(tableUUID, location); buildErr != nil {
+					if baseMetadata, buildErr = newTableMetadata(tableUUID, location, nil, nil, nil, nil); buildErr != nil {
 						glog.Errorf("Iceberg: CommitTable placeholder metadata for %s: %v", tableName, buildErr)
 						writeError(w, http.StatusInternalServerError, "InternalServerError", "Failed to build current metadata")
 						return
@@ -217,7 +217,7 @@ func (s *Server) handleUpdateTable(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		} else {
-			currentMetadata, err = newEmptyTableMetadata(tableUUID, location)
+			currentMetadata, err = newTableMetadata(tableUUID, location, nil, nil, nil, nil)
 			if err != nil {
 				glog.Errorf("Iceberg: CommitTable placeholder metadata for %s: %v", tableName, err)
 				writeError(w, http.StatusInternalServerError, "InternalServerError", "Failed to build current metadata")

--- a/weed/s3api/iceberg/handlers_table.go
+++ b/weed/s3api/iceberg/handlers_table.go
@@ -188,9 +188,11 @@ func (s *Server) handleCreateTable(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Build proper Iceberg table metadata using iceberg-go types
-	metadata := newTableMetadata(tableUUID, location, req.Schema, req.PartitionSpec, req.WriteOrder, req.Properties)
-	if metadata == nil {
-		writeError(w, http.StatusInternalServerError, "InternalServerError", "Failed to build table metadata")
+	metadata, err := newTableMetadata(tableUUID, location, req.Schema, req.PartitionSpec, req.WriteOrder, req.Properties)
+	if err != nil {
+		glog.V(1).Infof("Iceberg: CreateTable %s metadata error: %v", req.Name, err)
+		status, errType, message := metadataBuildError(err)
+		writeError(w, status, errType, message)
 		return
 	}
 
@@ -520,12 +522,12 @@ func (s *Server) buildLoadTableResult(getResp s3tables.GetTableResponse, bucketN
 			// Attempt to reconstruct from IcebergMetadata if available, otherwise synthetic
 			// TODO: Extract schema/spec from getResp.Metadata.Iceberg if FullMetadata fails but partial info exists?
 			// For now, fallback to empty metadata
-			metadata = newTableMetadata(tableUUID, location, nil, nil, nil, nil)
+			metadata = newEmptyTableMetadata(tableUUID, location, tableName)
 		}
 	} else {
 		// No full metadata, create synthetic
 		// TODO: If we had stored schema in IcebergMetadata, we would pass it here
-		metadata = newTableMetadata(tableUUID, location, nil, nil, nil, nil)
+		metadata = newEmptyTableMetadata(tableUUID, location, tableName)
 	}
 
 	return LoadTableResult{
@@ -780,7 +782,7 @@ func newTableMetadata(
 	partitionSpec *iceberg.PartitionSpec,
 	sortOrder *table.SortOrder,
 	props iceberg.Properties,
-) table.Metadata {
+) (table.Metadata, error) {
 	// Add schema - use provided or create empty schema
 	var s *iceberg.Schema
 	if schema != nil {
@@ -812,11 +814,34 @@ func newTableMetadata(
 	}
 
 	// Create metadata directly using the constructor which ensures spec compliance for V2
-	metadata, err := table.NewMetadataWithUUID(s, pSpec, so, location, props, tableUUID)
+	return table.NewMetadataWithUUID(s, pSpec, so, location, props, tableUUID)
+}
+
+// newEmptyTableMetadata builds the schema-less placeholder used when a table's
+// persisted metadata is missing or unparseable. Nothing here is client-supplied,
+// so a failure is ours: log it and let the caller report a 500.
+func newEmptyTableMetadata(tableUUID uuid.UUID, location, tableName string) table.Metadata {
+	metadata, err := newTableMetadata(tableUUID, location, nil, nil, nil, nil)
 	if err != nil {
-		glog.Errorf("Failed to create metadata: %v", err)
+		glog.Errorf("Iceberg: failed to build placeholder metadata for %s: %v", tableName, err)
 		return nil
 	}
-
 	return metadata
+}
+
+// metadataBuildError maps a newTableMetadata failure to a REST response. Schema
+// and spec errors come from the request body, so they are the caller's mistake
+// and must carry the reason: a variant field without format-version 3 otherwise
+// reads as a bare 500 with "variant is not supported until v3" only in the log.
+func metadataBuildError(err error) (int, string, string) {
+	switch {
+	case errors.Is(err, iceberg.ErrInvalidSchema),
+		errors.Is(err, iceberg.ErrInvalidPartitionSpec),
+		errors.Is(err, iceberg.ErrInvalidTypeString),
+		errors.Is(err, iceberg.ErrInvalidTransform),
+		errors.Is(err, iceberg.ErrInvalidArgument):
+		return http.StatusBadRequest, "BadRequestException", err.Error()
+	default:
+		return http.StatusInternalServerError, "InternalServerError", "Failed to build table metadata: " + err.Error()
+	}
 }

--- a/weed/s3api/iceberg/handlers_table.go
+++ b/weed/s3api/iceberg/handlers_table.go
@@ -247,7 +247,12 @@ func (s *Server) handleCreateTable(w http.ResponseWriter, r *http.Request) {
 	if existsErr == nil {
 		// Table already registered. Return the existing definition so CTAS/IF NOT
 		// EXISTS flows see a stable response instead of a 409.
-		result := s.buildLoadTableResult(existsResp, bucketName, namespace, tableName)
+		result, buildErr := s.buildLoadTableResult(existsResp, bucketName, namespace, tableName)
+		if buildErr != nil {
+			glog.Errorf("Iceberg: CreateTable load existing %s: %v", tableName, buildErr)
+			writeError(w, http.StatusInternalServerError, "InternalServerError", "Failed to build table metadata")
+			return
+		}
 		writeJSON(w, http.StatusOK, result)
 		return
 	}
@@ -320,7 +325,12 @@ func (s *Server) handleCreateTable(w http.ResponseWriter, r *http.Request) {
 				writeError(w, http.StatusConflict, "AlreadyExistsException", err.Error())
 				return
 			}
-			result := s.buildLoadTableResult(getResp, bucketName, namespace, tableName)
+			result, buildErr := s.buildLoadTableResult(getResp, bucketName, namespace, tableName)
+			if buildErr != nil {
+				glog.Errorf("Iceberg: CreateTable load existing %s: %v", tableName, buildErr)
+				writeError(w, http.StatusInternalServerError, "InternalServerError", "Failed to build table metadata")
+				return
+			}
 			writeJSON(w, http.StatusOK, result)
 			return
 		}
@@ -339,7 +349,12 @@ func (s *Server) handleCreateTable(w http.ResponseWriter, r *http.Request) {
 				writeError(w, http.StatusConflict, "AlreadyExistsException", err.Error())
 				return
 			}
-			result := s.buildLoadTableResult(getResp, bucketName, namespace, tableName)
+			result, buildErr := s.buildLoadTableResult(getResp, bucketName, namespace, tableName)
+			if buildErr != nil {
+				glog.Errorf("Iceberg: CreateTable load existing %s: %v", tableName, buildErr)
+				writeError(w, http.StatusInternalServerError, "InternalServerError", "Failed to build table metadata")
+				return
+			}
 			writeJSON(w, http.StatusOK, result)
 			return
 		}
@@ -451,7 +466,12 @@ func (s *Server) handleRegisterTable(w http.ResponseWriter, r *http.Request) {
 		MetadataLocation: req.MetadataLocation,
 		Metadata:         &s3tables.TableMetadata{FullMetadata: json.RawMessage(metadataBytes)},
 	}
-	result := s.buildLoadTableResult(getResp, bucketName, namespace, req.Name)
+	result, buildErr := s.buildLoadTableResult(getResp, bucketName, namespace, req.Name)
+	if buildErr != nil {
+		glog.Errorf("Iceberg: RegisterTable %s: %v", req.Name, buildErr)
+		writeError(w, http.StatusInternalServerError, "InternalServerError", "Failed to build table metadata")
+		return
+	}
 	writeJSON(w, http.StatusOK, result)
 }
 
@@ -495,11 +515,16 @@ func (s *Server) handleLoadTable(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result := s.buildLoadTableResult(getResp, bucketName, namespace, tableName)
+	result, buildErr := s.buildLoadTableResult(getResp, bucketName, namespace, tableName)
+	if buildErr != nil {
+		glog.Errorf("Iceberg: LoadTable %s: %v", tableName, buildErr)
+		writeError(w, http.StatusInternalServerError, "InternalServerError", "Failed to build table metadata")
+		return
+	}
 	writeJSON(w, http.StatusOK, result)
 }
 
-func (s *Server) buildLoadTableResult(getResp s3tables.GetTableResponse, bucketName string, namespace []string, tableName string) LoadTableResult {
+func (s *Server) buildLoadTableResult(getResp s3tables.GetTableResponse, bucketName string, namespace []string, tableName string) (LoadTableResult, error) {
 	location := tableLocationFromMetadataLocation(getResp.MetadataLocation)
 	if location == "" {
 		location = fmt.Sprintf("s3://%s/%s", bucketName, path.Join(flattenNamespacePath(namespace), tableName))
@@ -514,27 +539,32 @@ func (s *Server) buildLoadTableResult(getResp s3tables.GetTableResponse, bucketN
 	// Stability is guaranteed by not generating random UUIDs on read
 
 	var metadata table.Metadata
+	var err error
 	if getResp.Metadata != nil && len(getResp.Metadata.FullMetadata) > 0 {
-		var err error
 		metadata, err = table.ParseMetadataBytes(getResp.Metadata.FullMetadata)
 		if err != nil {
 			glog.Warningf("Iceberg: Failed to parse persisted metadata for %s: %v", tableName, err)
 			// Attempt to reconstruct from IcebergMetadata if available, otherwise synthetic
 			// TODO: Extract schema/spec from getResp.Metadata.Iceberg if FullMetadata fails but partial info exists?
 			// For now, fallback to empty metadata
-			metadata = newEmptyTableMetadata(tableUUID, location, tableName)
+			metadata, err = newEmptyTableMetadata(tableUUID, location)
 		}
 	} else {
 		// No full metadata, create synthetic
 		// TODO: If we had stored schema in IcebergMetadata, we would pass it here
-		metadata = newEmptyTableMetadata(tableUUID, location, tableName)
+		metadata, err = newEmptyTableMetadata(tableUUID, location)
+	}
+	// A nil metadata would serialize as "metadata":null under HTTP 200, which no
+	// Iceberg client can parse. Fail the request instead.
+	if err != nil {
+		return LoadTableResult{}, fmt.Errorf("build metadata for %s: %w", tableName, err)
 	}
 
 	return LoadTableResult{
 		MetadataLocation: getResp.MetadataLocation,
 		Metadata:         metadata,
 		Config:           s.buildFileIOConfig(),
-	}
+	}, nil
 }
 
 // buildFileIOConfig returns the FileIO properties to advertise to catalog
@@ -818,15 +848,9 @@ func newTableMetadata(
 }
 
 // newEmptyTableMetadata builds the schema-less placeholder used when a table's
-// persisted metadata is missing or unparseable. Nothing here is client-supplied,
-// so a failure is ours: log it and let the caller report a 500.
-func newEmptyTableMetadata(tableUUID uuid.UUID, location, tableName string) table.Metadata {
-	metadata, err := newTableMetadata(tableUUID, location, nil, nil, nil, nil)
-	if err != nil {
-		glog.Errorf("Iceberg: failed to build placeholder metadata for %s: %v", tableName, err)
-		return nil
-	}
-	return metadata
+// persisted metadata is missing or unparseable.
+func newEmptyTableMetadata(tableUUID uuid.UUID, location string) (table.Metadata, error) {
+	return newTableMetadata(tableUUID, location, nil, nil, nil, nil)
 }
 
 // metadataBuildError maps a newTableMetadata failure to a REST response. Schema

--- a/weed/s3api/iceberg/handlers_table.go
+++ b/weed/s3api/iceberg/handlers_table.go
@@ -191,8 +191,7 @@ func (s *Server) handleCreateTable(w http.ResponseWriter, r *http.Request) {
 	metadata, err := newTableMetadata(tableUUID, location, req.Schema, req.PartitionSpec, req.WriteOrder, req.Properties)
 	if err != nil {
 		glog.V(1).Infof("Iceberg: CreateTable %s metadata error: %v", req.Name, err)
-		status, errType, message := metadataBuildError(err)
-		writeError(w, status, errType, message)
+		writeManagerError(w, err)
 		return
 	}
 
@@ -547,12 +546,12 @@ func (s *Server) buildLoadTableResult(getResp s3tables.GetTableResponse, bucketN
 			// Attempt to reconstruct from IcebergMetadata if available, otherwise synthetic
 			// TODO: Extract schema/spec from getResp.Metadata.Iceberg if FullMetadata fails but partial info exists?
 			// For now, fallback to empty metadata
-			metadata, err = newEmptyTableMetadata(tableUUID, location)
+			metadata, err = newTableMetadata(tableUUID, location, nil, nil, nil, nil)
 		}
 	} else {
 		// No full metadata, create synthetic
 		// TODO: If we had stored schema in IcebergMetadata, we would pass it here
-		metadata, err = newEmptyTableMetadata(tableUUID, location)
+		metadata, err = newTableMetadata(tableUUID, location, nil, nil, nil, nil)
 	}
 	// A nil metadata would serialize as "metadata":null under HTTP 200, which no
 	// Iceberg client can parse. Fail the request instead.
@@ -845,27 +844,4 @@ func newTableMetadata(
 
 	// Create metadata directly using the constructor which ensures spec compliance for V2
 	return table.NewMetadataWithUUID(s, pSpec, so, location, props, tableUUID)
-}
-
-// newEmptyTableMetadata builds the schema-less placeholder used when a table's
-// persisted metadata is missing or unparseable.
-func newEmptyTableMetadata(tableUUID uuid.UUID, location string) (table.Metadata, error) {
-	return newTableMetadata(tableUUID, location, nil, nil, nil, nil)
-}
-
-// metadataBuildError maps a newTableMetadata failure to a REST response. Schema
-// and spec errors come from the request body, so they are the caller's mistake
-// and must carry the reason: a variant field without format-version 3 otherwise
-// reads as a bare 500 with "variant is not supported until v3" only in the log.
-func metadataBuildError(err error) (int, string, string) {
-	switch {
-	case errors.Is(err, iceberg.ErrInvalidSchema),
-		errors.Is(err, iceberg.ErrInvalidPartitionSpec),
-		errors.Is(err, iceberg.ErrInvalidTypeString),
-		errors.Is(err, iceberg.ErrInvalidTransform),
-		errors.Is(err, iceberg.ErrInvalidArgument):
-		return http.StatusBadRequest, "BadRequestException", err.Error()
-	default:
-		return http.StatusInternalServerError, "InternalServerError", "Failed to build table metadata: " + err.Error()
-	}
 }

--- a/weed/s3api/iceberg/handlers_transaction.go
+++ b/weed/s3api/iceberg/handlers_transaction.go
@@ -155,10 +155,11 @@ func (s *Server) prepareTableCommit(ctx context.Context, bucketName, bucketARN, 
 			return nil, &icebergRequestError{http.StatusInternalServerError, "InternalServerError", "Failed to parse current metadata"}
 		}
 	} else {
-		currentMetadata = newEmptyTableMetadata(tableUUID, location, tableName)
-	}
-	if currentMetadata == nil {
-		return nil, &icebergRequestError{http.StatusInternalServerError, "InternalServerError", "Failed to build current metadata"}
+		currentMetadata, err = newEmptyTableMetadata(tableUUID, location)
+		if err != nil {
+			glog.Errorf("Iceberg: CommitTransaction placeholder metadata for %s: %v", tableName, err)
+			return nil, &icebergRequestError{http.StatusInternalServerError, "InternalServerError", "Failed to build current metadata"}
+		}
 	}
 
 	for _, requirement := range requirements {

--- a/weed/s3api/iceberg/handlers_transaction.go
+++ b/weed/s3api/iceberg/handlers_transaction.go
@@ -155,7 +155,7 @@ func (s *Server) prepareTableCommit(ctx context.Context, bucketName, bucketARN, 
 			return nil, &icebergRequestError{http.StatusInternalServerError, "InternalServerError", "Failed to parse current metadata"}
 		}
 	} else {
-		currentMetadata = newTableMetadata(tableUUID, location, nil, nil, nil, nil)
+		currentMetadata = newEmptyTableMetadata(tableUUID, location, tableName)
 	}
 	if currentMetadata == nil {
 		return nil, &icebergRequestError{http.StatusInternalServerError, "InternalServerError", "Failed to build current metadata"}

--- a/weed/s3api/iceberg/handlers_transaction.go
+++ b/weed/s3api/iceberg/handlers_transaction.go
@@ -155,7 +155,7 @@ func (s *Server) prepareTableCommit(ctx context.Context, bucketName, bucketARN, 
 			return nil, &icebergRequestError{http.StatusInternalServerError, "InternalServerError", "Failed to parse current metadata"}
 		}
 	} else {
-		currentMetadata, err = newEmptyTableMetadata(tableUUID, location)
+		currentMetadata, err = newTableMetadata(tableUUID, location, nil, nil, nil, nil)
 		if err != nil {
 			glog.Errorf("Iceberg: CommitTransaction placeholder metadata for %s: %v", tableName, err)
 			return nil, &icebergRequestError{http.StatusInternalServerError, "InternalServerError", "Failed to build current metadata"}

--- a/weed/s3api/iceberg/iceberg_create_table_test.go
+++ b/weed/s3api/iceberg/iceberg_create_table_test.go
@@ -3,7 +3,6 @@ package iceberg
 import (
 	"encoding/json"
 	"errors"
-	"net/http"
 	"strings"
 	"testing"
 
@@ -67,15 +66,9 @@ func TestNewTableMetadataRejectsV3TypeBelowV3(t *testing.T) {
 		t.Fatalf("newTableMetadata() error = %v, want ErrInvalidSchema", err)
 	}
 
-	status, errType, message := metadataBuildError(err)
-	if status != http.StatusBadRequest {
-		t.Errorf("status = %d, want %d", status, http.StatusBadRequest)
-	}
-	if errType != "BadRequestException" {
-		t.Errorf("errType = %q, want BadRequestException", errType)
-	}
-	if !strings.Contains(message, "variant is not supported until v3") {
-		t.Errorf("message = %q, want the underlying reason", message)
+	// writeManagerError turns this into a 400; see TestWriteManagerError.
+	if !strings.Contains(err.Error(), "variant is not supported until v3") {
+		t.Errorf("error = %q, want the underlying reason", err.Error())
 	}
 }
 
@@ -111,19 +104,5 @@ func TestBuildLoadTableResultNeverReturnsNilMetadata(t *testing.T) {
 				t.Fatal("buildLoadTableResult() returned nil metadata with no error")
 			}
 		})
-	}
-}
-
-// Failures with no client input to blame stay 500 and keep their detail.
-func TestMetadataBuildErrorDefaultsToServerError(t *testing.T) {
-	status, errType, message := metadataBuildError(errors.New("filer unreachable"))
-	if status != http.StatusInternalServerError {
-		t.Errorf("status = %d, want %d", status, http.StatusInternalServerError)
-	}
-	if errType != "InternalServerError" {
-		t.Errorf("errType = %q, want InternalServerError", errType)
-	}
-	if !strings.Contains(message, "filer unreachable") {
-		t.Errorf("message = %q, want the underlying reason", message)
 	}
 }

--- a/weed/s3api/iceberg/iceberg_create_table_test.go
+++ b/weed/s3api/iceberg/iceberg_create_table_test.go
@@ -1,8 +1,14 @@
 package iceberg
 
 import (
+	"encoding/json"
 	"errors"
+	"net/http"
+	"strings"
 	"testing"
+
+	"github.com/apache/iceberg-go"
+	"github.com/google/uuid"
 )
 
 func TestValidateCreateTableRequestRequiresName(t *testing.T) {
@@ -33,5 +39,69 @@ func TestIsStageCreateEnabledFalseValues(t *testing.T) {
 		if isStageCreateEnabled() {
 			t.Fatalf("isStageCreateEnabled() = true for value %q, want false", value)
 		}
+	}
+}
+
+func mustParseSchema(t *testing.T, raw string) *iceberg.Schema {
+	t.Helper()
+	var schema iceberg.Schema
+	if err := json.Unmarshal([]byte(raw), &schema); err != nil {
+		t.Fatalf("parse schema: %v", err)
+	}
+	return &schema
+}
+
+const variantSchema = `{"type":"struct","schema-id":0,"fields":[
+	{"id":1,"name":"id","required":true,"type":"long"},
+	{"id":2,"name":"payload","required":false,"type":"variant"}]}`
+
+// A v3-only column type without format-version 3 is the client's mistake, and
+// the reason has to travel back to them rather than only into the server log.
+func TestNewTableMetadataRejectsV3TypeBelowV3(t *testing.T) {
+	_, err := newTableMetadata(uuid.New(), "s3://bkt/ns/t", mustParseSchema(t, variantSchema), nil, nil, nil)
+	if err == nil {
+		t.Fatal("newTableMetadata() error = nil, want invalid schema")
+	}
+	if !errors.Is(err, iceberg.ErrInvalidSchema) {
+		t.Fatalf("newTableMetadata() error = %v, want ErrInvalidSchema", err)
+	}
+
+	status, errType, message := metadataBuildError(err)
+	if status != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", status, http.StatusBadRequest)
+	}
+	if errType != "BadRequestException" {
+		t.Errorf("errType = %q, want BadRequestException", errType)
+	}
+	if !strings.Contains(message, "variant is not supported until v3") {
+		t.Errorf("message = %q, want the underlying reason", message)
+	}
+}
+
+func TestNewTableMetadataAcceptsV3TypeAtV3(t *testing.T) {
+	metadata, err := newTableMetadata(uuid.New(), "s3://bkt/ns/t", mustParseSchema(t, variantSchema), nil, nil,
+		iceberg.Properties{"format-version": "3"})
+	if err != nil {
+		t.Fatalf("newTableMetadata() error = %v, want nil", err)
+	}
+	if got := metadata.Version(); got != 3 {
+		t.Fatalf("metadata.Version() = %d, want 3", got)
+	}
+	if _, found := metadata.CurrentSchema().FindFieldByName("payload"); !found {
+		t.Error("variant field missing from stored schema")
+	}
+}
+
+// Failures with no client input to blame stay 500 and keep their detail.
+func TestMetadataBuildErrorDefaultsToServerError(t *testing.T) {
+	status, errType, message := metadataBuildError(errors.New("filer unreachable"))
+	if status != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", status, http.StatusInternalServerError)
+	}
+	if errType != "InternalServerError" {
+		t.Errorf("errType = %q, want InternalServerError", errType)
+	}
+	if !strings.Contains(message, "filer unreachable") {
+		t.Errorf("message = %q, want the underlying reason", message)
 	}
 }

--- a/weed/s3api/iceberg/iceberg_create_table_test.go
+++ b/weed/s3api/iceberg/iceberg_create_table_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/apache/iceberg-go"
 	"github.com/google/uuid"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3tables"
 )
 
 func TestValidateCreateTableRequestRequiresName(t *testing.T) {
@@ -89,6 +90,27 @@ func TestNewTableMetadataAcceptsV3TypeAtV3(t *testing.T) {
 	}
 	if _, found := metadata.CurrentSchema().FindFieldByName("payload"); !found {
 		t.Error("variant field missing from stored schema")
+	}
+}
+
+// A LoadTable response must never carry nil metadata: it serializes as
+// "metadata":null under HTTP 200, which no Iceberg client can parse.
+func TestBuildLoadTableResultNeverReturnsNilMetadata(t *testing.T) {
+	cases := map[string]s3tables.GetTableResponse{
+		"no stored metadata":   {MetadataLocation: "s3://bkt/ns/t/metadata/v1.metadata.json"},
+		"empty full metadata":  {Metadata: &s3tables.TableMetadata{}},
+		"unparseable metadata": {Metadata: &s3tables.TableMetadata{FullMetadata: json.RawMessage(`{"nope":`)}},
+	}
+	for name, getResp := range cases {
+		t.Run(name, func(t *testing.T) {
+			result, err := (&Server{}).buildLoadTableResult(getResp, "bkt", []string{"ns"}, "t")
+			if err != nil {
+				t.Fatalf("buildLoadTableResult() error = %v, want nil", err)
+			}
+			if result.Metadata == nil {
+				t.Fatal("buildLoadTableResult() returned nil metadata with no error")
+			}
+		})
 	}
 }
 

--- a/weed/s3api/iceberg/iceberg_invalid_name_test.go
+++ b/weed/s3api/iceberg/iceberg_invalid_name_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/apache/iceberg-go"
 )
 
 func TestNameValidationError(t *testing.T) {
@@ -41,6 +43,8 @@ func TestWriteManagerError(t *testing.T) {
 		wantType string
 	}{
 		{"invalid name is a client error", fmt.Errorf("invalid namespace name: only 'a-z', '0-9', and '_' are allowed"), http.StatusBadRequest, "BadRequestException"},
+		{"rejected schema is a client error", fmt.Errorf("%w: for v2: variant is not supported until v3", iceberg.ErrInvalidSchema), http.StatusBadRequest, "BadRequestException"},
+		{"bad format version is a client error", fmt.Errorf("%w: 4", iceberg.ErrInvalidFormatVersion), http.StatusBadRequest, "BadRequestException"},
 		{"everything else is a server fault", fmt.Errorf("all filers failed, last error: connection refused"), http.StatusInternalServerError, "InternalServerError"},
 	}
 	for _, c := range cases {

--- a/weed/s3api/iceberg/utils.go
+++ b/weed/s3api/iceberg/utils.go
@@ -2,12 +2,14 @@ package iceberg
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
 	"strconv"
 	"strings"
 
+	"github.com/apache/iceberg-go"
 	"github.com/gorilla/mux"
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
@@ -123,11 +125,19 @@ func nameValidationError(err error) bool {
 	return false
 }
 
-// writeManagerError maps a residual s3tables manager error to a response:
-// name validation failures are client errors (400); anything else is a server
-// fault (500).
+// writeManagerError maps a residual error to a response: name validation
+// failures and rejected schemas come from the request body, so they are client
+// errors (400) and must carry the reason -- a variant field without
+// format-version 3 otherwise reads as a bare 500 with "variant is not supported
+// until v3" only in the log. Anything else is a server fault (500).
 func writeManagerError(w http.ResponseWriter, err error) {
-	if nameValidationError(err) {
+	switch {
+	case nameValidationError(err),
+		errors.Is(err, iceberg.ErrInvalidSchema),
+		errors.Is(err, iceberg.ErrInvalidPartitionSpec),
+		errors.Is(err, iceberg.ErrInvalidTypeString),
+		errors.Is(err, iceberg.ErrInvalidTransform),
+		errors.Is(err, iceberg.ErrInvalidArgument):
 		writeError(w, http.StatusBadRequest, "BadRequestException", err.Error())
 		return
 	}


### PR DESCRIPTION
`newTableMetadata` swallowed the iceberg-go error and returned nil, so every schema the metadata builder refused surfaced as a bare `500 Failed to build table metadata`.

The common case is a v3-only column type. Creating a table with a `variant` field but no `format-version: 3` in the request properties gives the client nothing to act on, while the actual reason sits in the server log:

```
Failed to create metadata: invalid schema: for v2:
- invalid type for payload: variant is not supported until v3
```

That is a client-side mistake reported as a server fault, and it is only diagnosable by someone with access to the `weed s3` log.

## Change

`newTableMetadata` now returns `(table.Metadata, error)`, and `handleCreateTable` classifies it:

- `ErrInvalidSchema`, `ErrInvalidPartitionSpec`, `ErrInvalidTypeString`, `ErrInvalidTransform`, `ErrInvalidArgument` (which `ErrInvalidFormatVersion` wraps) come from the request body, so they answer `400 BadRequestException` carrying the underlying message.
- Anything else stays `500`, now with the reason appended.

The other four call sites build placeholder metadata with no schema, where nothing is client-supplied. They keep their existing `500` behaviour through `newEmptyTableMetadata`, which logs and returns nil as before.

No behaviour change for schemas the builder accepts. Verified that a `variant` field with `format-version: 3` creates, persists and reloads correctly — that path was already working and stays working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Iceberg create, load, and commit behavior when stored metadata is missing or invalid, ensuring table metadata is generated or requests fail safely.
  * Strengthened handling of `variant` columns: invalid schemas are rejected with proper 400-level validation when format version is less than 3.
  * Updated error classification so Iceberg validation issues return the correct client-facing error type instead of generic server errors.
* **Tests**
  * Added tests for `variant` format-version enforcement and for ensuring metadata building never succeeds with nil results.
  * Expanded coverage for error-to-HTTP status mapping on metadata reconstruction failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->