### PR TITLE
helm: pass extraEnvironmentVars and security.toml to the bucket-creation hook

### DIFF
--- a/.github/workflows/helm_ci.yml
+++ b/.github/workflows/helm_ci.yml
@@ -255,7 +255,7 @@ jobs:
           # The key reaches the hook either through security.toml or through
           # an environment override in extraEnvironmentVars.
           python3 - "$CHART_DIR" <<'PYEOF'
-          import subprocess, sys, yaml
+          import re, subprocess, sys, yaml
 
           chart = sys.argv[1]
 
@@ -281,8 +281,8 @@ jobs:
           failed = []
 
           # The script in the hook addresses master and filer through
-          # WEED_CLUSTER_*, which now comes from extraEnvironmentVars instead
-          # of being hardcoded. Duplicate names would be a rendering bug.
+          # WEED_CLUSTER_*, now rendered next to extraEnvironmentVars.
+          # Duplicate names would be a rendering bug.
           pod = hook_pod(render(buckets))
           if pod is None:
               failed.append("createBuckets: bucket hook Job missing")
@@ -319,6 +319,33 @@ jobs:
                   failed.append(f"filerWrite=true: bucket hook mounts security-config as {mount}")
               else:
                   print("filerWrite=true: bucket hook mounts security-config at /etc/seaweedfs/security.toml")
+
+          # The readiness waits dereference the cluster env names, so renaming
+          # the cluster alias has to rename them too: an undefined name leaves
+          # the hook polling "http://" for five minutes and then failing the
+          # release. The endpoints stay chart-computed, so an address kept in
+          # extraEnvironmentVars is replaced, not rendered twice.
+          pod = hook_pod(render(dict(buckets, **{
+              "global.seaweedfs.extraEnvironmentVars.WEED_CLUSTER_DEFAULT": "prod",
+              "global.seaweedfs.extraEnvironmentVars.WEED_CLUSTER_PROD_MASTER": "stale:9333",
+              "global.seaweedfs.extraEnvironmentVars.WEED_CLUSTER_SW_MASTER": "null",
+              "global.seaweedfs.extraEnvironmentVars.WEED_CLUSTER_SW_FILER": "null",
+          })))
+          if pod is None:
+              failed.append("cluster alias: bucket hook Job missing")
+          else:
+              container = pod["containers"][0]
+              env = {e["name"]: e.get("value") for e in container["env"]}
+              waited = re.findall(r'wait_for_service "http://\$(\w+)', container["command"][2])
+              undefined = sorted(n for n in set(waited) if not env.get(n))
+              if not waited:
+                  failed.append("cluster alias: hook script has no readiness waits")
+              elif undefined:
+                  failed.append(f"cluster alias: hook waits on undefined env {undefined}")
+              elif env.get("WEED_CLUSTER_PROD_MASTER") == "stale:9333":
+                  failed.append("cluster alias: hook kept the values address instead of the chart's")
+              else:
+                  print("cluster alias: hook waits on the renamed cluster env names")
 
           # Keys kept in a Secret are referenced, not inlined, so the hook
           # must render valueFrom for non-string extraEnvironmentVars.

--- a/.github/workflows/helm_ci.yml
+++ b/.github/workflows/helm_ci.yml
@@ -246,6 +246,98 @@ jobs:
           PYEOF
           echo "IAM gRPC decoupling tests passed"
 
+          echo ""
+          echo "=== Testing bucket hook credentials ==="
+          # The bucket hook pipes s3.configure into `weed shell`, which needs
+          # the filer JWT signing key once jwtSigning.filerWrite is on: the
+          # filer rejects unsigned IAM gRPC calls, and `weed shell` still
+          # exits 0, so the Job goes green while anonymousRead is dropped.
+          # The key reaches the hook either through security.toml or through
+          # an environment override in extraEnvironmentVars.
+          python3 - "$CHART_DIR" <<'PYEOF'
+          import subprocess, sys, yaml
+
+          chart = sys.argv[1]
+
+          def render(values):
+              args = ["helm", "template", "test", chart]
+              for k, v in values.items():
+                  args += ["--set", f"{k}={v}"]
+              return subprocess.check_output(args, text=True)
+
+          def hook_pod(manifest):
+              for d in yaml.safe_load_all(manifest):
+                  if d and d.get("kind") == "Job" and d["metadata"]["name"].endswith("-bucket-hook"):
+                      return d["spec"]["template"]["spec"]
+              return None
+
+          buckets = {
+              "s3.enabled": "true",
+              "s3.createBuckets[0].name": "data",
+              "s3.createBuckets[0].anonymousRead": "true",
+          }
+          jwt = dict(buckets, **{"global.seaweedfs.securityConfig.jwtSigning.filerWrite": "true"})
+
+          failed = []
+
+          # The script in the hook addresses master and filer through
+          # WEED_CLUSTER_*, which now comes from extraEnvironmentVars instead
+          # of being hardcoded. Duplicate names would be a rendering bug.
+          pod = hook_pod(render(buckets))
+          if pod is None:
+              failed.append("createBuckets: bucket hook Job missing")
+          else:
+              env = pod["containers"][0]["env"]
+              names = [e["name"] for e in env]
+              dupes = sorted({n for n in names if names.count(n) > 1})
+              if dupes:
+                  failed.append(f"createBuckets: duplicate env entries {dupes}")
+              values = {e["name"]: e.get("value") for e in env}
+              for name in ("WEED_CLUSTER_DEFAULT", "WEED_CLUSTER_SW_MASTER", "WEED_CLUSTER_SW_FILER"):
+                  if not values.get(name):
+                      failed.append(f"createBuckets: hook env {name} is empty")
+              if not dupes and all(values.get(n) for n in ("WEED_CLUSTER_SW_MASTER", "WEED_CLUSTER_SW_FILER")):
+                  print("createBuckets: hook env resolves the cluster addresses once")
+              if any(v["name"] == "security-config" for v in pod.get("volumes", [])):
+                  failed.append("createBuckets: hook mounts security-config without JWT signing")
+
+          # filerWrite=true: the hook needs the same security.toml the filer
+          # gets, otherwise s3.configure fails with "missing authorization
+          # metadata".
+          pod = hook_pod(render(jwt))
+          if pod is None:
+              failed.append("filerWrite=true: bucket hook Job missing")
+          else:
+              vols = {v["name"] for v in pod.get("volumes", [])}
+              mounts = {m["name"] for m in pod["containers"][0].get("volumeMounts", [])}
+              if "security-config" not in vols or "security-config" not in mounts:
+                  failed.append("filerWrite=true: bucket hook does not mount security-config (s3.configure would fail)")
+              else:
+                  print("filerWrite=true: bucket hook mounts security-config")
+
+          # Keys kept in a Secret are referenced, not inlined, so the hook
+          # must render valueFrom for non-string extraEnvironmentVars.
+          out = render(dict(jwt, **{
+              "global.seaweedfs.extraEnvironmentVars.WEED_JWT_FILER_SIGNING_KEY.secretKeyRef.name": "signing-keys",
+              "global.seaweedfs.extraEnvironmentVars.WEED_JWT_FILER_SIGNING_KEY.secretKeyRef.key": "filerWrite",
+          }))
+          pod = hook_pod(out)
+          entry = next((e for e in pod["containers"][0]["env"] if e["name"] == "WEED_JWT_FILER_SIGNING_KEY"), None)
+          if entry is None:
+              failed.append("secretKeyRef: hook env WEED_JWT_FILER_SIGNING_KEY missing")
+          elif entry.get("valueFrom", {}).get("secretKeyRef") != {"name": "signing-keys", "key": "filerWrite"}:
+              failed.append(f"secretKeyRef: hook env rendered as {entry}")
+          else:
+              print("secretKeyRef: hook env keeps the secret reference")
+
+          if failed:
+              print("\nFAIL:", file=sys.stderr)
+              for f in failed:
+                  print(f"  - {f}", file=sys.stderr)
+              sys.exit(1)
+          PYEOF
+          echo "Bucket hook credential tests passed"
+
           echo "=== Testing with monitoring enabled ==="
           helm template test $CHART_DIR \
             --set global.seaweedfs.monitoring.enabled=true \

--- a/.github/workflows/helm_ci.yml
+++ b/.github/workflows/helm_ci.yml
@@ -271,6 +271,26 @@ jobs:
                       return d["spec"]["template"]["spec"]
               return None
 
+          def cluster_endpoints(manifest):
+              """Where the chart's own Services put master and filer.
+
+              The hook's WEED_CLUSTER_* values have to match these: a defined
+              name pointing anywhere else fails the readiness wait exactly as
+              an undefined one does.
+              """
+              wanted = {"-master": "swfs-master", "-filer-client": "swfs-filer"}
+              found = {}
+              for d in yaml.safe_load_all(manifest):
+                  if not d or d.get("kind") != "Service":
+                      continue
+                  for suffix, portName in wanted.items():
+                      if not d["metadata"]["name"].endswith(suffix):
+                          continue
+                      port = next((p["port"] for p in d["spec"]["ports"] if p.get("name") == portName), None)
+                      if port:
+                          found[suffix] = f"{d['metadata']['name']}.{d['metadata']['namespace']}:{port}"
+              return found.get("-master"), found.get("-filer-client")
+
           buckets = {
               "s3.enabled": "true",
               "s3.createBuckets[0].name": "data",
@@ -283,7 +303,8 @@ jobs:
           # The script in the hook addresses master and filer through
           # WEED_CLUSTER_*, now rendered next to extraEnvironmentVars.
           # Duplicate names would be a rendering bug.
-          pod = hook_pod(render(buckets))
+          out = render(buckets)
+          pod = hook_pod(out)
           if pod is None:
               failed.append("createBuckets: bucket hook Job missing")
           else:
@@ -293,10 +314,15 @@ jobs:
               if dupes:
                   failed.append(f"createBuckets: duplicate env entries {dupes}")
               values = {e["name"]: e.get("value") for e in env}
-              for name in ("WEED_CLUSTER_DEFAULT", "WEED_CLUSTER_SW_MASTER", "WEED_CLUSTER_SW_FILER"):
-                  if not values.get(name):
-                      failed.append(f"createBuckets: hook env {name} is empty")
-              if not dupes and all(values.get(n) for n in ("WEED_CLUSTER_SW_MASTER", "WEED_CLUSTER_SW_FILER")):
+              if not values.get("WEED_CLUSTER_DEFAULT"):
+                  failed.append("createBuckets: hook env WEED_CLUSTER_DEFAULT is empty")
+              rendered = (values.get("WEED_CLUSTER_SW_MASTER"), values.get("WEED_CLUSTER_SW_FILER"))
+              expected = cluster_endpoints(out)
+              if not all(expected):
+                  failed.append(f"createBuckets: no master/filer-client Service to compare against, found {expected}")
+              elif rendered != expected:
+                  failed.append(f"createBuckets: hook env holds {rendered}, the services are at {expected}")
+              elif not dupes:
                   print("createBuckets: hook env resolves the cluster addresses once")
               if any(v["name"] == "security-config" for v in pod.get("volumes", [])):
                   failed.append("createBuckets: hook mounts security-config without JWT signing")
@@ -308,15 +334,20 @@ jobs:
           if pod is None:
               failed.append("filerWrite=true: bucket hook Job missing")
           else:
-              vols = {v["name"] for v in pod.get("volumes", [])}
+              vol = next((v for v in pod.get("volumes", []) if v["name"] == "security-config"), None)
               mount = next((m for m in pod["containers"][0].get("volumeMounts", []) if m["name"] == "security-config"), None)
-              # The file has to land on one of weed's config search paths,
-              # so the target matters as much as the volume itself.
+              # The file has to land on one of weed's config search paths, so
+              # the target matters as much as the volume itself - and a volume
+              # of that name backed by anything but the chart's ConfigMap
+              # leaves `weed shell` without the signing key just the same.
               target = ("/etc/seaweedfs/security.toml", "security.toml")
-              if "security-config" not in vols or mount is None:
+              configmap = "test-seaweedfs-security-config"
+              if vol is None or mount is None:
                   failed.append("filerWrite=true: bucket hook does not mount security-config (s3.configure would fail)")
               elif (mount.get("mountPath"), mount.get("subPath")) != target:
                   failed.append(f"filerWrite=true: bucket hook mounts security-config as {mount}")
+              elif vol.get("configMap", {}).get("name") != configmap:
+                  failed.append(f"filerWrite=true: security-config is not backed by the {configmap} ConfigMap: {vol}")
               else:
                   print("filerWrite=true: bucket hook mounts security-config at /etc/seaweedfs/security.toml")
 
@@ -325,12 +356,13 @@ jobs:
           # the hook polling "http://" for five minutes and then failing the
           # release. The endpoints stay chart-computed, so an address kept in
           # extraEnvironmentVars is replaced, not rendered twice.
-          pod = hook_pod(render(dict(buckets, **{
+          out = render(dict(buckets, **{
               "global.seaweedfs.extraEnvironmentVars.WEED_CLUSTER_DEFAULT": "prod",
               "global.seaweedfs.extraEnvironmentVars.WEED_CLUSTER_PROD_MASTER": "stale:9333",
               "global.seaweedfs.extraEnvironmentVars.WEED_CLUSTER_SW_MASTER": "null",
               "global.seaweedfs.extraEnvironmentVars.WEED_CLUSTER_SW_FILER": "null",
-          })))
+          }))
+          pod = hook_pod(out)
           if pod is None:
               failed.append("cluster alias: bucket hook Job missing")
           else:
@@ -338,14 +370,21 @@ jobs:
               env = {e["name"]: e.get("value") for e in container["env"]}
               waited = re.findall(r'wait_for_service "http://\$(\w+)', container["command"][2])
               undefined = sorted(n for n in set(waited) if not env.get(n))
+              renamed = (env.get("WEED_CLUSTER_PROD_MASTER"), env.get("WEED_CLUSTER_PROD_FILER"))
+              expected = cluster_endpoints(out)
               if not waited:
                   failed.append("cluster alias: hook script has no readiness waits")
               elif undefined:
                   failed.append(f"cluster alias: hook waits on undefined env {undefined}")
-              elif env.get("WEED_CLUSTER_PROD_MASTER") == "stale:9333":
-                  failed.append("cluster alias: hook kept the values address instead of the chart's")
+              elif not all(expected):
+                  failed.append(f"cluster alias: no master/filer-client Service to compare against, found {expected}")
+              elif renamed != expected:
+                  # Both addresses under the renamed alias, not just the one
+                  # the values tried to keep: the stale one would fail the
+                  # release, and a missing filer address just as much.
+                  failed.append(f"cluster alias: hook waits on {renamed}, the services are at {expected}")
               else:
-                  print("cluster alias: hook waits on the renamed cluster env names")
+                  print("cluster alias: hook waits on the renamed names and the chart's addresses")
 
           # Keys kept in a Secret are referenced, not inlined, so the hook
           # must render valueFrom for non-string extraEnvironmentVars.

--- a/.github/workflows/helm_ci.yml
+++ b/.github/workflows/helm_ci.yml
@@ -309,11 +309,16 @@ jobs:
               failed.append("filerWrite=true: bucket hook Job missing")
           else:
               vols = {v["name"] for v in pod.get("volumes", [])}
-              mounts = {m["name"] for m in pod["containers"][0].get("volumeMounts", [])}
-              if "security-config" not in vols or "security-config" not in mounts:
+              mount = next((m for m in pod["containers"][0].get("volumeMounts", []) if m["name"] == "security-config"), None)
+              # The file has to land on one of weed's config search paths,
+              # so the target matters as much as the volume itself.
+              target = ("/etc/seaweedfs/security.toml", "security.toml")
+              if "security-config" not in vols or mount is None:
                   failed.append("filerWrite=true: bucket hook does not mount security-config (s3.configure would fail)")
+              elif (mount.get("mountPath"), mount.get("subPath")) != target:
+                  failed.append(f"filerWrite=true: bucket hook mounts security-config as {mount}")
               else:
-                  print("filerWrite=true: bucket hook mounts security-config")
+                  print("filerWrite=true: bucket hook mounts security-config at /etc/seaweedfs/security.toml")
 
           # Keys kept in a Secret are referenced, not inlined, so the hook
           # must render valueFrom for non-string extraEnvironmentVars.

--- a/.github/workflows/helm_ci.yml
+++ b/.github/workflows/helm_ci.yml
@@ -322,13 +322,16 @@ jobs:
               "global.seaweedfs.extraEnvironmentVars.WEED_JWT_FILER_SIGNING_KEY.secretKeyRef.key": "filerWrite",
           }))
           pod = hook_pod(out)
-          entry = next((e for e in pod["containers"][0]["env"] if e["name"] == "WEED_JWT_FILER_SIGNING_KEY"), None)
-          if entry is None:
-              failed.append("secretKeyRef: hook env WEED_JWT_FILER_SIGNING_KEY missing")
-          elif entry.get("valueFrom", {}).get("secretKeyRef") != {"name": "signing-keys", "key": "filerWrite"}:
-              failed.append(f"secretKeyRef: hook env rendered as {entry}")
+          if pod is None:
+              failed.append("secretKeyRef: bucket hook Job missing")
           else:
-              print("secretKeyRef: hook env keeps the secret reference")
+              entry = next((e for e in pod["containers"][0]["env"] if e["name"] == "WEED_JWT_FILER_SIGNING_KEY"), None)
+              if entry is None:
+                  failed.append("secretKeyRef: hook env WEED_JWT_FILER_SIGNING_KEY missing")
+              elif entry.get("valueFrom", {}).get("secretKeyRef") != {"name": "signing-keys", "key": "filerWrite"}:
+                  failed.append(f"secretKeyRef: hook env rendered as {entry}")
+              else:
+                  print("secretKeyRef: hook env keeps the secret reference")
 
           if failed:
               print("\nFAIL:", file=sys.stderr)

--- a/k8s/charts/seaweedfs/templates/shared/post-install-bucket-hook.yaml
+++ b/k8s/charts/seaweedfs/templates/shared/post-install-bucket-hook.yaml
@@ -71,12 +71,6 @@ spec:
         image: {{ template "seaweedfs.master.image" . }}
         imagePullPolicy: {{ $.Values.global.seaweedfs.imagePullPolicy | default "IfNotPresent" }}
         env:
-          - name: WEED_CLUSTER_DEFAULT
-            value: "sw"
-          - name: WEED_CLUSTER_SW_MASTER
-            value: {{ include "seaweedfs.cluster.masterAddress" . | quote }}
-          - name: WEED_CLUSTER_SW_FILER
-            value: {{ include "seaweedfs.cluster.filerAddress" . | quote }}
           - name: POD_IP
             valueFrom:
               fieldRef:
@@ -91,6 +85,19 @@ spec:
                 fieldPath: metadata.namespace
           - name: SEAWEEDFS_FULLNAME
             value: "{{ include "seaweedfs.fullname" . }}"
+          {{- /* Carries the WEED_CLUSTER_* defaults the script below uses, and the
+                 JWT signing keys when they are set as environment overrides
+                 rather than in security.toml. */}}
+          {{- range $key := keys $bucketEnvVars | sortAlpha }}
+          {{- $value := index $bucketEnvVars $key }}
+          - name: {{ $key }}
+          {{- if kindIs "string" $value }}
+            value: {{ tpl $value $ | quote }}
+          {{- else }}
+            valueFrom:
+              {{ toYaml $value | nindent 14 | trim }}
+          {{- end -}}
+          {{- end }}
         command:
           - "/bin/sh"
           - "-ec"
@@ -177,11 +184,19 @@ spec:
                 /usr/bin/weed shell
           {{- end }}  
           {{- end }}
-        {{- if $enableAuth }}
+        {{- if or $enableAuth (include "seaweedfs.securityConfigEnabled" .) }}
         volumeMounts:
+          {{- if $enableAuth }}
           - name: config-users
             mountPath: /etc/sw
             readOnly: true
+          {{- end }}
+          {{- if include "seaweedfs.securityConfigEnabled" . }}
+          - name: security-config
+            readOnly: true
+            mountPath: /etc/seaweedfs/security.toml
+            subPath: security.toml
+          {{- end }}
         {{- end }}
         ports:
           - containerPort: {{ .Values.master.port }}
@@ -199,8 +214,9 @@ spec:
         {{- if .Values.filer.containerSecurityContext.enabled }}
         securityContext: {{- omit .Values.filer.containerSecurityContext "enabled" | toYaml | nindent 12 }}
         {{- end }}
-    {{- if $enableAuth }}
+    {{- if or $enableAuth (include "seaweedfs.securityConfigEnabled" .) }}
       volumes:
+        {{- if $enableAuth }}
         - name: config-users
           secret:
             defaultMode: 420
@@ -209,5 +225,11 @@ spec:
             {{- else }}
             secretName: {{ include "seaweedfs.fullname" . }}-s3-secret
             {{- end }}
+        {{- end }}
+        {{- if include "seaweedfs.securityConfigEnabled" . }}
+        - name: security-config
+          configMap:
+            name: {{ include "seaweedfs.fullname" . }}-security-config
+        {{- end }}
     {{- end }}
 {{- end }}

--- a/k8s/charts/seaweedfs/templates/shared/post-install-bucket-hook.yaml
+++ b/k8s/charts/seaweedfs/templates/shared/post-install-bucket-hook.yaml
@@ -13,6 +13,10 @@
 {{- end }}
 {{- $bucketsFolder = default $bucketsFolder (get $bucketEnvVars "WEED_FILER_BUCKETS_FOLDER") }}
 {{- $bucketsFolder = trimSuffix "/" $bucketsFolder }}
+{{- $clusterAlias := default "sw" (get $bucketEnvVars "WEED_CLUSTER_DEFAULT") }}
+{{- $clusterUpper := upper $clusterAlias }}
+{{- $clusterMasterKey := printf "WEED_CLUSTER_%s_MASTER" $clusterUpper }}
+{{- $clusterFilerKey := printf "WEED_CLUSTER_%s_FILER" $clusterUpper }}
 
 {{- /* Check allInOne mode first */}}
 {{- if .Values.allInOne.enabled }}
@@ -85,19 +89,28 @@ spec:
                 fieldPath: metadata.namespace
           - name: SEAWEEDFS_FULLNAME
             value: "{{ include "seaweedfs.fullname" . }}"
-          {{- /* Carries the WEED_CLUSTER_* defaults the script below uses, and the
-                 JWT signing keys when they are set as environment overrides
-                 rather than in security.toml. */}}
+          {{- /* Carries the JWT signing keys when they are set as environment
+                 overrides rather than in security.toml. */}}
           {{- range $key := keys $bucketEnvVars | sortAlpha }}
           {{- $value := index $bucketEnvVars $key }}
+          {{- if not (has $key (list "WEED_CLUSTER_DEFAULT" $clusterMasterKey $clusterFilerKey)) }}
           - name: {{ $key }}
           {{- if kindIs "string" $value }}
             value: {{ tpl $value $ | quote }}
           {{- else }}
             valueFrom:
               {{ toYaml $value | nindent 14 | trim }}
-          {{- end -}}
           {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- /* Computed, as in all-in-one: the values pick the cluster alias,
+                 the chart still owns the endpoints the script waits on. */}}
+          - name: WEED_CLUSTER_DEFAULT
+            value: {{ $clusterAlias | quote }}
+          - name: {{ $clusterMasterKey }}
+            value: {{ include "seaweedfs.cluster.masterAddress" . | quote }}
+          - name: {{ $clusterFilerKey }}
+            value: {{ include "seaweedfs.cluster.filerAddress" . | quote }}
         command:
           - "/bin/sh"
           - "-ec"
@@ -122,11 +135,11 @@ spec:
               exit 1
             }
             {{- if .Values.allInOne.enabled }}
-            wait_for_service "http://$WEED_CLUSTER_SW_MASTER{{ .Values.allInOne.readinessProbe.httpGet.path }}"
-            wait_for_service "http://$WEED_CLUSTER_SW_FILER{{ .Values.filer.readinessProbe.httpGet.path }}"
+            wait_for_service "http://${{ $clusterMasterKey }}{{ .Values.allInOne.readinessProbe.httpGet.path }}"
+            wait_for_service "http://${{ $clusterFilerKey }}{{ .Values.filer.readinessProbe.httpGet.path }}"
             {{- else }}
-            wait_for_service "http://$WEED_CLUSTER_SW_MASTER{{ .Values.master.readinessProbe.httpGet.path }}"
-            wait_for_service "http://$WEED_CLUSTER_SW_FILER{{ .Values.filer.readinessProbe.httpGet.path }}"
+            wait_for_service "http://${{ $clusterMasterKey }}{{ .Values.master.readinessProbe.httpGet.path }}"
+            wait_for_service "http://${{ $clusterFilerKey }}{{ .Values.filer.readinessProbe.httpGet.path }}"
             {{- end }}
             {{- range $createBuckets }}
             {{- $bucketName := .name }}


### PR DESCRIPTION
# What problem are we solving?

With `global.seaweedfs.securityConfig.jwtSigning.filerWrite=true`, the post-install bucket hook cannot talk to the filer's IAM service:

```
error: failed to get user anonymous: rpc error: code = Unauthenticated desc = missing authorization metadata
```

The hook pipes `s3.configure` into `weed shell`. Since #9442 the filer requires an admin-signed JWT on its IAM gRPC service, and since #9536 `weed shell` mints that token itself — but only if it can find the filer signing key, i.e. from a mounted `security.toml` or a `WEED_*` environment override (#9981). The hook job gets neither:

* its `env:` list is hardcoded, and `global.seaweedfs.extraEnvironmentVars` is never rendered into it. The template does compute the merged map, but only to derive `WEED_FILER_BUCKETS_FOLDER` from it.
* it is the only workload in the chart without a `security.toml` mount — master, volume, filer, s3, sftp, admin, cosi, worker and all-in-one all have one.

The failure is silent: `weed shell` exits 0 even though the command failed, so the Job goes green, `helm install/upgrade` succeeds, and `anonymousRead: true` is quietly never applied. Same visible symptom as #6238 / #7259, different cause. (`weed shell` returning 0 on failure is a separate defect; I'll open an issue for it rather than mix it in here.)

Bucket creation, object lock, versioning, `fs.configure -ttl` and both readiness waits are unaffected — only the `s3.configure` calls behind `anonymousRead` need the key.

Affects master and every released chart version up to 4.40.0.

# How are we solving the problem?

Two changes to `templates/shared/post-install-bucket-hook.yaml`, one per configuration where the key can live:

| the key is set via | where it is | what the hook needs |
| --- | --- | --- |
| `jwtSigning.filerWrite=true` (chart generates it) | `security.toml` ConfigMap only | the `security.toml` mount |
| `extraEnvironmentVars` (string or `secretKeyRef`) | the environment, overrides the toml | the env vars |

* Render the already-merged `$bucketEnvVars` into the container's `env:`, using the same `kindIs "string"` / `valueFrom` pattern as the other workloads, so keys kept in a Secret stay a reference instead of being inlined.
* Mount `security.toml` from the existing `<fullname>-security-config` ConfigMap, gated on the existing `seaweedfs.securityConfigEnabled` helper, next to the `config-users` mount.

This gives the hook the same environment as the filer (or all-in-one) it configures, which is deliberate: `weed shell` reads its configuration the same way the filer does, and an operator overriding a cluster address or a key in `extraEnvironmentVars` expects the hook to follow. In the default values that means the hook also sees the `WEED_MYSQL_*` / `WEED_LEVELDB2_*` placeholders; happy to filter the set down if you'd rather keep the hook's environment narrow.

The three hardcoded `WEED_CLUSTER_*` entries are removed: they are part of the `global.seaweedfs.extraEnvironmentVars` defaults, so keeping them would render duplicate env names. No other workload hardcodes them either. The values are templates and resolve through `tpl`, and the hook script still reads `$WEED_CLUSTER_SW_MASTER` / `$WEED_CLUSTER_SW_FILER`.

Nothing changes for installs without JWT signing: no `securityConfig` means no mount and no volume, and the env list only gains what the values already contain.

# How is the PR tested?

Added to the chart CI workflow (`=== Testing bucket hook credentials ===`): the hook must resolve the cluster addresses exactly once with no duplicate env names, must mount `security-config` under `filerWrite=true` and not without it, and must keep a `secretKeyRef` as `valueFrom`. The assertions fail against the pre-change template.

Verified by hand with `helm template` — default, `s3`, `filer.s3` and `allInOne` modes, with and without `filerWrite`, with `enableSecurity`, with `securityConfig`/`jwtSigning` set to null, and with a `secretKeyRef` value; the rendered-Job diff for an install without JWT signing is env ordering only.

Verified end to end against a filer with the write key active (podman, no cluster), running the hook's own command:

* no key: `missing authorization metadata`, and `exit=0` — the silent failure this PR fixes
* key in `WEED_JWT_FILER_SIGNING_KEY`: `s3.configure` applies the anonymous identity
* key only in a `security.toml` mounted at `/etc/seaweedfs/security.toml`: same, the identity shows up in `s3.configure` output afterwards

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
  Left unchecked deliberately rather than as an open item: the wiki is not writable for non-maintainers (a push to `seaweedfs.wiki.git` returns 403), and chart configuration is not documented there by design - the Helm section of `Deployment-to-Kubernetes-and-Minikube.md` points at the chart README for it. Nothing user-facing changes here either; this is a fix to an existing hook.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.

---

Note: #10471 touched this file for the same JWT reason a day ago, but only the readiness probe (`wget --spider` → `curl`); the missing credentials are untouched by it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Bucket creation hooks now support custom cluster aliases and dynamically target the correct master and filer endpoints.
  - Improved readiness checks prevent stale or incorrect service endpoint references.
  - Security configuration is mounted when required by authentication or JWT signing settings.
  - Preserved references to externally supplied JWT signing keys without embedding their values.

- **Tests**
  - Expanded Helm CI coverage for alias changes, invalid cluster configurations, security mounts, endpoint validation, and secret-based JWT keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
