### PR TITLE
helm: label the hook Job pods so selectors can reach them

### DIFF
--- a/.github/workflows/helm_ci.yml
+++ b/.github/workflows/helm_ci.yml
@@ -697,6 +697,92 @@ jobs:
           echo "$BOOL_FALSE" | grep -q -- '-status Suspended' || { echo "FAIL: bool false versioning did not Suspend the bucket"; exit 1; }
           echo "Bucket versioning: YAML bool false suspends consistently with string \"false\""
 
+          echo ""
+          echo "=== Testing hook Job labels ==="
+          # The hook Jobs were the only pods in the chart without the standard
+          # app.kubernetes.io label set, so nothing label-based could target
+          # them - NetworkPolicy podSelectors, monitoring, kubectl -l. Assert
+          # both the Job and its pod template carry the same name/instance/
+          # component triple the other components use, and that the triple is
+          # the hook's own so a per-component selector cannot match it too.
+          #
+          # Only the bucket hook is covered: the volume resize hook is gated on
+          # lookup finding a StatefulSet with a smaller PVC than requested, and
+          # lookup returns nothing under helm template, so it never renders here.
+          python3 - "$CHART_DIR" <<'PYEOF'
+          import subprocess, sys, yaml
+
+          chart = sys.argv[1]
+          TRIPLE = ("app.kubernetes.io/name", "app.kubernetes.io/instance",
+                    "app.kubernetes.io/component")
+
+          def render(values):
+              args = ["helm", "template", "test", chart]
+              for k, v in values.items():
+                  args += ["--set", f"{k}={v}"]
+              return subprocess.check_output(args, text=True)
+
+          def docs(manifest):
+              return [d for d in yaml.safe_load_all(manifest) if d]
+
+          def hook_job(manifest):
+              for d in docs(manifest):
+                  if d.get("kind") == "Job" and d["metadata"]["name"].endswith("-bucket-hook"):
+                      return d
+              return None
+
+          def triple(labels):
+              return {k: labels.get(k) for k in TRIPLE}
+
+          modes = {
+              "s3": {"s3.enabled": "true",
+                     "s3.createBuckets[0].name": "b"},
+              "filer.s3": {"filer.s3.enabled": "true",
+                           "filer.s3.createBuckets[0].name": "b"},
+              "allInOne": {"allInOne.enabled": "true",
+                           "allInOne.s3.enabled": "true",
+                           "allInOne.s3.createBuckets[0].name": "b"},
+          }
+
+          failed = []
+          for mode, values in modes.items():
+              before = len(failed)
+              out = render(values)
+              job = hook_job(out)
+              if job is None:
+                  failed.append(f"{mode}: bucket hook Job not rendered")
+                  continue
+              pod_labels = job["spec"]["template"]["metadata"].get("labels", {})
+              for where, labels in (("Job", job["metadata"].get("labels", {})),
+                                    ("pod", pod_labels)):
+                  missing = [k for k in TRIPLE if not labels.get(k)]
+                  if missing:
+                      failed.append(f"{mode}: bucket hook {where} has no {missing}, "
+                                    "nothing can select it")
+              component = pod_labels.get("app.kubernetes.io/component")
+              if component != "bucket-hook":
+                  failed.append(f"{mode}: bucket hook pod component is {component!r}, "
+                                "expected 'bucket-hook'")
+              # The triple must not also match another component's pods, or a
+              # selector meant for that component would pull the hook pod in.
+              for d in docs(out):
+                  if d.get("kind") not in ("Deployment", "StatefulSet"):
+                      continue
+                  other = d["spec"]["template"]["metadata"].get("labels", {})
+                  if triple(other) == triple(pod_labels):
+                      failed.append(f"{mode}: bucket hook pod shares its label triple "
+                                    f"with {d['metadata']['name']}")
+              if len(failed) == before:
+                  print(f"{mode}: bucket hook Job and pod carry a distinct label triple")
+
+          if failed:
+              print("\nFAIL:", file=sys.stderr)
+              for f in failed:
+                  print(f"  - {f}", file=sys.stderr)
+              sys.exit(1)
+          PYEOF
+          echo "Hook Job label tests passed"
+
           echo "All template rendering tests passed!"
 
       - name: Create kind cluster

--- a/.github/workflows/helm_ci.yml
+++ b/.github/workflows/helm_ci.yml
@@ -713,8 +713,13 @@ jobs:
           import subprocess, sys, yaml
 
           chart = sys.argv[1]
+          # The three a selector keys on, and the full set the other workloads
+          # carry - a missing chart or managed-by label is not a selector
+          # problem, but it does leave the hook Jobs looking unlike everything
+          # else the release owns.
           TRIPLE = ("app.kubernetes.io/name", "app.kubernetes.io/instance",
                     "app.kubernetes.io/component")
+          STANDARD = TRIPLE + ("helm.sh/chart", "app.kubernetes.io/managed-by")
 
           def render(values):
               args = ["helm", "template", "test", chart]
@@ -752,17 +757,21 @@ jobs:
               if job is None:
                   failed.append(f"{mode}: bucket hook Job not rendered")
                   continue
+              job_labels = job["metadata"].get("labels", {})
               pod_labels = job["spec"]["template"]["metadata"].get("labels", {})
-              for where, labels in (("Job", job["metadata"].get("labels", {})),
-                                    ("pod", pod_labels)):
-                  missing = [k for k in TRIPLE if not labels.get(k)]
+              for where, labels in (("Job", job_labels), ("pod", pod_labels)):
+                  missing = [k for k in STANDARD if not labels.get(k)]
                   if missing:
                       failed.append(f"{mode}: bucket hook {where} has no {missing}, "
                                     "nothing can select it")
-              component = pod_labels.get("app.kubernetes.io/component")
-              if component != "bucket-hook":
-                  failed.append(f"{mode}: bucket hook pod component is {component!r}, "
-                                "expected 'bucket-hook'")
+                  component = labels.get("app.kubernetes.io/component")
+                  if component != "bucket-hook":
+                      failed.append(f"{mode}: bucket hook {where} component is "
+                                    f"{component!r}, expected 'bucket-hook'")
+              # A selector written against the Job has to find its pods.
+              if triple(job_labels) != triple(pod_labels):
+                  failed.append(f"{mode}: bucket hook Job and pod disagree: "
+                                f"{triple(job_labels)} vs {triple(pod_labels)}")
               # The triple must not also match another component's pods, or a
               # selector meant for that component would pull the hook pod in.
               for d in docs(out):

--- a/.github/workflows/helm_ci.yml
+++ b/.github/workflows/helm_ci.yml
@@ -719,6 +719,15 @@ jobs:
           # else the release owns.
           TRIPLE = ("app.kubernetes.io/name", "app.kubernetes.io/instance",
                     "app.kubernetes.io/component")
+          # The labels that identify the release rather than the workload, and
+          # so have to hold the same values everywhere. They are compared
+          # against a workload that already renders them instead of being
+          # spelled out here, which keeps the chart version out of the test.
+          # managed-by is not among them on purpose: the chart puts it on
+          # workload metadata but not on pod templates, so it cannot be part of
+          # a cross-workload comparison. Its presence is still checked below.
+          RELEASE = ("app.kubernetes.io/name", "app.kubernetes.io/instance",
+                     "helm.sh/chart")
           STANDARD = TRIPLE + ("helm.sh/chart", "app.kubernetes.io/managed-by")
 
           def render(values):
@@ -738,6 +747,16 @@ jobs:
 
           def triple(labels):
               return {k: labels.get(k) for k in TRIPLE}
+
+          def release(labels):
+              return {k: labels.get(k) for k in RELEASE}
+
+          def reference(manifest):
+              """Any long-running workload; they all carry the release labels."""
+              for d in docs(manifest):
+                  if d.get("kind") in ("Deployment", "StatefulSet"):
+                      return d
+              return None
 
           modes = {
               "s3": {"s3.enabled": "true",
@@ -759,6 +778,11 @@ jobs:
                   continue
               job_labels = job["metadata"].get("labels", {})
               pod_labels = job["spec"]["template"]["metadata"].get("labels", {})
+              ref = reference(out)
+              if ref is None:
+                  failed.append(f"{mode}: no workload to compare the release labels against")
+                  continue
+              ref_labels = release(ref["spec"]["template"]["metadata"].get("labels", {}))
               for where, labels in (("Job", job_labels), ("pod", pod_labels)):
                   missing = [k for k in STANDARD if not labels.get(k)]
                   if missing:
@@ -768,6 +792,12 @@ jobs:
                   if component != "bucket-hook":
                       failed.append(f"{mode}: bucket hook {where} component is "
                                     f"{component!r}, expected 'bucket-hook'")
+                  # Present is not enough: the values have to be the release's
+                  # own, or a selector written for this release misses the hook.
+                  if release(labels) != ref_labels:
+                      failed.append(f"{mode}: bucket hook {where} release labels "
+                                    f"{release(labels)} differ from "
+                                    f"{ref['metadata']['name']}'s {ref_labels}")
               # A selector written against the Job has to find its pods.
               if triple(job_labels) != triple(pod_labels):
                   failed.append(f"{mode}: bucket hook Job and pod disagree: "

--- a/k8s/charts/seaweedfs/templates/shared/post-install-bucket-hook.yaml
+++ b/k8s/charts/seaweedfs/templates/shared/post-install-bucket-hook.yaml
@@ -47,8 +47,11 @@ kind: Job
 metadata:
   name: "{{ $.Release.Name }}-bucket-hook"
   labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/component: bucket-hook
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-5"
@@ -58,8 +61,11 @@ spec:
     metadata:
       name: "{{ .Release.Name }}"
       labels:
+        app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        app.kubernetes.io/component: bucket-hook
     spec:
       restartPolicy: Never
       {{- if .Values.filer.podSecurityContext.enabled }}

--- a/k8s/charts/seaweedfs/templates/volume/volume-resize-hook.yaml
+++ b/k8s/charts/seaweedfs/templates/volume/volume-resize-hook.yaml
@@ -56,8 +56,8 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/component: volume-resize-hook
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
@@ -70,8 +70,8 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
         helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
         app.kubernetes.io/component: volume-resize-hook
     spec:
       serviceAccountName: {{ $seaweedfsName }}-volume-resize-hook

--- a/k8s/charts/seaweedfs/templates/volume/volume-resize-hook.yaml
+++ b/k8s/charts/seaweedfs/templates/volume/volume-resize-hook.yaml
@@ -53,6 +53,12 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: "{{ $seaweedfsName }}-volume-resize-hook"
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: volume-resize-hook
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "0"
@@ -60,6 +66,13 @@ metadata:
 spec:
   backoffLimit: 1
   template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: volume-resize-hook
     spec:
       serviceAccountName: {{ $seaweedfsName }}-volume-resize-hook
       restartPolicy: Never


### PR DESCRIPTION
# What problem are we solving?

Every workload in the chart carries the standard `app.kubernetes.io` labels, except the two hook Jobs:

* the bucket hook pod has only `managed-by` and `instance`
* the volume resize hook pod has none at all — its pod template has no `metadata:` block

So there is nothing to select either of them by. Anything keyed on the label set the rest of the chart uses — a `NetworkPolicy` podSelector, a monitoring scrape config, a plain `kubectl get pod -l app.kubernetes.io/component=...` — silently skips both pods, and `instance` on its own matches every pod in the release, which isn't a useful selector for either hook.

This came up in #10421 while working out how to key per-component NetworkPolicies; @chrislusf asked for the label gap as its own PR.

# How are we solving the problem?

Add the label block the other workloads already use, on the Job and on the pod template of both hooks:

```yaml
app.kubernetes.io/name: seaweedfs
helm.sh/chart: seaweedfs-4.40.0
app.kubernetes.io/managed-by: Helm
app.kubernetes.io/instance: <release>
app.kubernetes.io/component: bucket-hook        # volume-resize-hook for the other
```

The two component values are new, so neither hook shares a `name`/`instance`/`component` triple with an existing component — a selector meant for the filer or the volume servers won't pick up a hook pod by accident.

Nothing else changes. Both Jobs are recreated on every install/upgrade (`before-hook-creation` delete policy), so there is no immutable-selector problem on an existing release; the Job's own `spec.selector` stays controller-generated as before.

Two things I left out on purpose, happy to add either if you'd rather have them:

* `podLabels`/`podAnnotations` on the hooks. The values exist chart-wide since #4959, but no hook honours them today, and wiring them up is a bigger change than giving the pods a selector.
* labels on the resize hook's ServiceAccount/Role/RoleBinding. They aren't selector targets.

# How is the PR tested?

Added to the chart CI workflow (`=== Testing hook Job labels ===`): renders the bucket hook in all three modes that produce it (`s3`, `filer.s3`, `allInOne`) and asserts that the Job and its pod both carry `name`/`instance`/`component`, that the component is `bucket-hook`, and that the triple doesn't match any Deployment or StatefulSet pod template in the same render. Against master it fails with `bucket hook Job has no ['app.kubernetes.io/name', 'app.kubernetes.io/component'], nothing can select it` for each of the three modes.

The resize hook isn't covered there and can't be: it only renders when `lookup` finds a StatefulSet whose `volumeClaimTemplates` are smaller than the requested size, and `lookup` returns nothing under `helm template`. I checked it by temporarily replacing that guard with `if true` and rendering the default values:

```
test-seaweedfs-volume-resize-hook
job labels: {'app.kubernetes.io/name': 'seaweedfs', ..., 'app.kubernetes.io/component': 'volume-resize-hook'}
pod labels: {'app.kubernetes.io/name': 'seaweedfs', ..., 'app.kubernetes.io/component': 'volume-resize-hook'}
```

`helm lint` is clean, and `helm template` still renders for both `ci/` value files and for `allInOne`, `sftp`, `admin`, `cosi` and `enableSecurity`+`s3`.

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
  Left unchecked deliberately rather than as an open item: the wiki is not writable for non-maintainers (a push to `seaweedfs.wiki.git` returns 403), and chart configuration is not documented there by design - the Helm section of `Deployment-to-Kubernetes-and-Minikube.md` points at the chart README for it. Nothing user-facing changes here either: the labels are internal, and no value is added or renamed.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes labeling for the bucket-creation and volume-resize hook Jobs by adding consistent standard labels to both the Job and its pod template.
  * Ensured hook Jobs/pods carry matching label metadata for more reliable identification and selection.
* **Tests**
  * Added a CI regression check that renders the Helm chart in S3-related configurations and validates bucket-hook labels match expected release labeling and don’t conflict with other workloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
