### PR TITLE
s3: register the advertised ip with the master

### DIFF
--- a/weed/command/filer.go
+++ b/weed/command/filer.go
@@ -257,6 +257,7 @@ func runFiler(cmd *Command, args []string) bool {
 	startDelay := time.Duration(2)
 	if *filerStartS3 {
 		filerS3Options.filer = &filerAddress
+		filerS3Options.ip = f.ip
 		if *filerS3Options.bindIp == "" {
 			filerS3Options.bindIp = f.bindIp
 		}

--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -1223,6 +1223,7 @@ func runMini(cmd *Command, args []string) bool {
 	miniFilerOptions.masters = pb.ServerAddresses(actualPeersForComponents).ToServiceDiscovery()
 	miniFilerOptions.ip = miniIp
 	miniFilerOptions.bindIp = miniBindIp
+	miniS3Options.ip = miniIp
 	miniS3Options.bindIp = miniBindIp
 	miniWebDavOptions.ipBind = miniBindIp
 	miniOptions.v.ip = miniIp

--- a/weed/command/s3.go
+++ b/weed/command/s3.go
@@ -42,6 +42,7 @@ var (
 // When adding a new field, update all four flag registration sites.
 type S3Options struct {
 	filer                     *string
+	ip                        *string
 	bindIp                    *string
 	port                      *int
 	portHttps                 *int
@@ -83,6 +84,7 @@ type S3Options struct {
 func init() {
 	cmdS3.Run = runS3 // break init cycle
 	s3StandaloneOptions.filer = cmdS3.Flag.String("filer", "localhost:8888", "comma-separated filer server addresses for high availability")
+	s3StandaloneOptions.ip = cmdS3.Flag.String("ip", "", "ip address advertised to the cluster. If empty, default to -ip.bind, or the auto-detected address.")
 	s3StandaloneOptions.bindIp = cmdS3.Flag.String("ip.bind", "", "ip address to bind to. If empty, default to 0.0.0.0.")
 	s3StandaloneOptions.port = cmdS3.Flag.Int("port", 8333, "s3 server http listen port")
 	s3StandaloneOptions.portHttps = cmdS3.Flag.Int("port.https", 0, "s3 server https listen port")
@@ -358,6 +360,7 @@ func (s3opt *S3Options) startS3Server() bool {
 		EnableIam:                 *s3opt.enableIam, // Embedded IAM API (enabled by default)
 		IamReadOnly:               *s3opt.iamReadOnly,
 		Cipher:                    *s3opt.cipher, // encrypt data on volume servers
+		Ip:                        *s3opt.ip,
 		BindIp:                    *s3opt.bindIp,
 		GrpcPort:                  *s3opt.portGrpc,
 		ExternalUrl:               s3opt.resolveExternalUrl(),

--- a/weed/command/server.go
+++ b/weed/command/server.go
@@ -289,6 +289,7 @@ func runServer(cmd *Command, args []string) bool {
 	filerOptions.masters = pb.ServerAddresses(actualPeersForComponents).ToServiceDiscovery()
 	filerOptions.ip = serverIp
 	filerOptions.bindIp = serverBindIp
+	s3Options.ip = serverIp
 	if *s3Options.bindIp == "" {
 		s3Options.bindIp = serverBindIp
 	}

--- a/weed/s3api/s3api_server.go
+++ b/weed/s3api/s3api_server.go
@@ -140,13 +140,21 @@ func NewS3ApiServer(router *mux.Router, option *S3ApiServerOption) (s3ApiServer 
 // back here at all (a VPN address, a container-internal IP), and the push then
 // fails silently after a 10s deadline.
 func (option *S3ApiServerOption) advertisedHost() string {
-	if option.Ip != "" {
+	if option.Ip != "" && !isWildcardHost(option.Ip) {
 		return option.Ip
 	}
-	if option.BindIp != "" && option.BindIp != "0.0.0.0" {
+	if option.BindIp != "" && !isWildcardHost(option.BindIp) {
 		return option.BindIp
 	}
 	return util.DetectedHostAddress()
+}
+
+// isWildcardHost reports whether host is an unspecified address (0.0.0.0, ::,
+// [::]) — one that accepts connections but tells a peer nothing about where to
+// reach us. Host names parse as nil and are addresses in their own right.
+func isWildcardHost(host string) bool {
+	ip := net.ParseIP(strings.TrimSuffix(strings.TrimPrefix(host, "["), "]"))
+	return ip != nil && ip.IsUnspecified()
 }
 
 func NewS3ApiServerWithStore(router *mux.Router, option *S3ApiServerOption, explicitStore string) (s3ApiServer *S3ApiServer, err error) {

--- a/weed/s3api/s3api_server.go
+++ b/weed/s3api/s3api_server.go
@@ -58,9 +58,10 @@ type S3ApiServerOption struct {
 	IamConfig                 string // Advanced IAM configuration file path
 	ConcurrentUploadLimit     int64
 	ConcurrentFileUploadLimit int64
-	EnableIam                 bool // Enable embedded IAM API on the same port
-	IamReadOnly               bool // Disable IAM write operations on this server
-	Cipher                    bool // encrypt data on volume servers
+	EnableIam                 bool   // Enable embedded IAM API on the same port
+	IamReadOnly               bool   // Disable IAM write operations on this server
+	Cipher                    bool   // encrypt data on volume servers
+	Ip                        string // address advertised to the cluster; empty falls back to BindIp
 	BindIp                    string
 	GrpcPort                  int
 	ExternalUrl               string // external URL clients use, for signature verification behind a reverse proxy
@@ -132,6 +133,22 @@ func NewS3ApiServer(router *mux.Router, option *S3ApiServerOption) (s3ApiServer 
 	return NewS3ApiServerWithStore(router, option, "")
 }
 
+// advertisedHost is the address this server registers with the master, which is
+// how peers reach it — IAM changes are pushed to it over gRPC. It must be the
+// advertised -ip, not the bind address: binding 0.0.0.0 and registering the
+// auto-detected interface makes those pushes dial a host that may not route
+// back here at all (a VPN address, a container-internal IP), and the push then
+// fails silently after a 10s deadline.
+func (option *S3ApiServerOption) advertisedHost() string {
+	if option.Ip != "" {
+		return option.Ip
+	}
+	if option.BindIp != "" && option.BindIp != "0.0.0.0" {
+		return option.BindIp
+	}
+	return util.DetectedHostAddress()
+}
+
 func NewS3ApiServerWithStore(router *mux.Router, option *S3ApiServerOption, explicitStore string) (s3ApiServer *S3ApiServer, err error) {
 	if len(option.Filers) == 0 {
 		return nil, fmt.Errorf("at least one filer address is required")
@@ -174,10 +191,7 @@ func NewS3ApiServerWithStore(router *mux.Router, option *S3ApiServerOption, expl
 		for i, addr := range option.Masters {
 			masterMap[fmt.Sprintf("master%d", i)] = addr
 		}
-		clientHost := option.BindIp
-		if clientHost == "0.0.0.0" || clientHost == "" {
-			clientHost = util.DetectedHostAddress()
-		}
+		clientHost := option.advertisedHost()
 		masterClient = wdclient.NewMasterClient(option.GrpcDialOption, option.FilerGroup, cluster.S3Type, pb.ServerAddress(util.JoinHostPort(clientHost, option.GrpcPort)), option.DataCenter, "", *pb.NewServiceDiscoveryFromMap(masterMap))
 		// Build the object-write lock client and subscribe to the master's
 		// lock-ring updates BEFORE starting the master loop, so the initial

--- a/weed/s3api/s3api_server_advertise_test.go
+++ b/weed/s3api/s3api_server_advertise_test.go
@@ -18,7 +18,13 @@ func TestAdvertisedHost(t *testing.T) {
 		{"advertised ip wins over wildcard bind", "localhost", "0.0.0.0", "localhost"},
 		{"advertised ip wins over specific bind", "s3.example.com", "10.0.0.5", "s3.example.com"},
 		{"bind ip used when no advertised ip", "", "10.0.0.5", "10.0.0.5"},
+		{"ipv6 bind ip used when no advertised ip", "", "2001:db8::1", "2001:db8::1"},
 		{"wildcard bind falls back to detected", "", "0.0.0.0", detected},
+		{"ipv6 wildcard bind falls back to detected", "", "::", detected},
+		{"bracketed ipv6 wildcard bind falls back to detected", "", "[::]", detected},
+		{"expanded ipv6 wildcard bind falls back to detected", "", "0:0:0:0:0:0:0:0", detected},
+		{"wildcard advertised ip falls back to bind ip", "0.0.0.0", "10.0.0.5", "10.0.0.5"},
+		{"wildcard advertised ip and bind fall back to detected", "::", "0.0.0.0", detected},
 		{"empty falls back to detected", "", "", detected},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/weed/s3api/s3api_server_advertise_test.go
+++ b/weed/s3api/s3api_server_advertise_test.go
@@ -1,0 +1,31 @@
+package s3api
+
+import (
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/util"
+)
+
+func TestAdvertisedHost(t *testing.T) {
+	detected := util.DetectedHostAddress()
+
+	for _, tc := range []struct {
+		name   string
+		ip     string
+		bindIp string
+		want   string
+	}{
+		{"advertised ip wins over wildcard bind", "localhost", "0.0.0.0", "localhost"},
+		{"advertised ip wins over specific bind", "s3.example.com", "10.0.0.5", "s3.example.com"},
+		{"bind ip used when no advertised ip", "", "10.0.0.5", "10.0.0.5"},
+		{"wildcard bind falls back to detected", "", "0.0.0.0", detected},
+		{"empty falls back to detected", "", "", detected},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			option := &S3ApiServerOption{Ip: tc.ip, BindIp: tc.bindIp}
+			if got := option.advertisedHost(); got != tc.want {
+				t.Errorf("advertisedHost() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`weed mini -ip=localhost` still registered its S3 gateway with the master under a completely different address:

```
$ weed shell -master=localhost:9333 <<< cluster.ps
* s3 servers 1
  * 10.21.155.124:18333        <- not on any local interface
* filers 1
  * localhost:8888.18888       <- honored -ip
```

`S3ApiServerOption` had no advertise-ip field. The registration address came from `BindIp`, which mini sets to the wildcard, so it fell through to `util.DetectedHostAddress()` and picked whatever interface sorted first — here a VPN `utun` address that stopped routing once the tunnel dropped.

IAM changes are pushed to every registered S3 server over gRPC, so the consequence shows up on every admin mutation:

```
W propagating_store.go:95 failed to propagate change to s3 server 10.21.155.124:18333:
  rpc error: code = DeadlineExceeded desc = context deadline exceeded
```

Creating a user took 10.014s — the full propagation deadline — before failing the push, and `cluster.ps` and the admin UI both listed a node nothing could reach.

Worth noting what this is *not*: identities still arrive, because the `/etc/iam/identities` metadata subscription delivers them independently of the gRPC push. I confirmed a freshly created key works against a gateway whose push had just timed out. This is a latency and visibility bug, not credential loss.

## Change

Adds `S3ApiServerOption.Ip` and an `advertisedHost()` helper with an explicit precedence chain — advertised ip, then bind address, then auto-detect — and wires the parent `-ip` through `server.go`, `filer.go` and `mini.go`. Standalone `weed s3` gains an `-ip` flag defaulting to empty, so the existing fallback behavior is unchanged for anyone who does not set it.

## Verification

Before, with `-ip=localhost`: s3 registers `192.168.1.98:18633`. After: `localhost:18633`, matching the filer.

Pointing a gateway at a deliberately unreachable advertised address reproduces the 10s stall and the warning above; with the fix, user creation drops to 10ms, no propagate warnings, the new key works immediately on S3, and a wrong key is still rejected.

`TestAdvertisedHost` covers the precedence chain. `go build ./weed/...` clean; `weed/s3api` and `weed/command` suites pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an `-ip` option to control the S3 gateway’s advertised cluster address.

- **Bug Fixes**
  - Improved advertised-host selection and fallback behavior when `Ip`/bind addresses are wildcard or unspecified.
  - Embedded S3 gateways (server, filer, mini) now consistently use the cluster/server identity address for advertisement.

- **Tests**
  - Added unit coverage for advertised-host precedence and fallback logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->