### PR TITLE
ci: harden the fusermount3 repair

### DIFF
--- a/.github/actions/fix-fusermount-setuid/action.yml
+++ b/.github/actions/fix-fusermount-setuid/action.yml
@@ -1,0 +1,42 @@
+name: Fix fusermount3 setuid
+description: >
+  Restore the setuid bit on the fusermount3 an unprivileged mount will use.
+  Some runner images carry a second, source-built fusermount3 in /usr/local/bin
+  that shadows the distro one in PATH without its setuid bit, and every mount
+  then fails with "mount failed: Operation not permitted". Both the Go mount
+  and sw-fuse resolve the helper through PATH, so repair the first one.
+  Run it after the step that apt-installs fuse3.
+
+runs:
+  using: composite
+  steps:
+    - name: Repair the fusermount3 in PATH
+      shell: bash
+      run: |
+        set -euo pipefail
+        bin=$(command -v fusermount3 || true)
+        if [ -z "$bin" ]; then
+          echo "no fusermount3 in PATH"
+          exit 0
+        fi
+        if [ -u "$bin" ]; then
+          ls -l "$bin"
+          exit 0
+        fi
+        # Reaching here means unprivileged mounts cannot work as-is, but the
+        # target comes from PATH: grant setuid root only to a root-owned system
+        # binary, and say why rather than escalating anything else.
+        case "$bin" in
+          /bin/*|/sbin/*|/usr/bin/*|/usr/sbin/*|/usr/local/bin/*|/usr/local/sbin/*) ;;
+          *) echo "refusing to setuid $bin: outside the system bin paths" >&2; exit 1 ;;
+        esac
+        if [ -L "$bin" ] || [ ! -f "$bin" ] || [ ! -x "$bin" ]; then
+          echo "refusing to setuid $bin: not a regular executable file" >&2
+          exit 1
+        fi
+        if [ "$(stat -c %u "$bin")" != 0 ] || [ "$(stat -c %g "$bin")" != 0 ]; then
+          echo "refusing to setuid $bin: not owned by root:root" >&2
+          exit 1
+        fi
+        sudo chmod u+s "$bin"
+        ls -l "$bin"

--- a/.github/actions/fix-fusermount-setuid/action.yml
+++ b/.github/actions/fix-fusermount-setuid/action.yml
@@ -1,31 +1,55 @@
 name: Fix fusermount3 setuid
 description: >
-  Restore the setuid bit on the fusermount3 an unprivileged mount will use.
+  Make sure the fusermount3 an unprivileged mount will find can actually mount.
   Some runner images carry a second, source-built fusermount3 in /usr/local/bin
-  that shadows the distro one in PATH without its setuid bit, and every mount
-  then fails with "mount failed: Operation not permitted". Both the Go mount
-  and sw-fuse resolve the helper through PATH, so repair the first one.
+  that shadows the distro one in PATH; it is neither setuid nor root-owned, so
+  every mount fails with "mount failed: Operation not permitted". Both the Go
+  mount and sw-fuse resolve the helper through PATH.
   Run it after the step that apt-installs fuse3.
 
 runs:
   using: composite
   steps:
-    - name: Repair the fusermount3 in PATH
+    - name: Point PATH at a fusermount3 that can mount
       shell: bash
       run: |
         set -euo pipefail
+
+        # setuid only grants root when root owns the file, and exec follows
+        # symlinks, so judge the target.
+        can_mount() {
+          [ -u "$1" ] && [ "$(stat -Lc %u "$1")" = 0 ]
+        }
+
         bin=$(command -v fusermount3 || true)
         if [ -z "$bin" ]; then
-          echo "no fusermount3 in PATH"
-          exit 0
+          echo "no fusermount3 in PATH" >&2
+          exit 1
         fi
-        if [ -u "$bin" ]; then
+        if can_mount "$bin"; then
           ls -l "$bin"
           exit 0
         fi
-        # Reaching here means unprivileged mounts cannot work as-is, but the
-        # target comes from PATH: grant setuid root only to a root-owned system
-        # binary, and say why rather than escalating anything else.
+        echo "$bin cannot mount unprivileged:"
+        ls -l "$bin"
+
+        # The distro fusermount3 is setuid root and is the one meant to be used.
+        # Reach it through a symlink earlier in PATH: exec resolves the link, so
+        # the target keeps its setuid bit, and nothing on the image is modified.
+        for distro in /usr/bin/fusermount3 /bin/fusermount3; do
+          if [ "$distro" != "$bin" ] && can_mount "$distro"; then
+            mkdir -p "$RUNNER_TEMP/fuse-bin"
+            ln -sf "$distro" "$RUNNER_TEMP/fuse-bin/fusermount3"
+            echo "$RUNNER_TEMP/fuse-bin" >> "$GITHUB_PATH"
+            echo "using $distro instead"
+            ls -l "$distro"
+            exit 0
+          fi
+        done
+
+        # No usable distro binary, so setting the bit is the only way out - but
+        # the target came from PATH: do that only for a root-owned system binary,
+        # never for anything else that happens to sit there.
         case "$bin" in
           /bin/*|/sbin/*|/usr/bin/*|/usr/sbin/*|/usr/local/bin/*|/usr/local/sbin/*) ;;
           *) echo "refusing to setuid $bin: outside the system bin paths" >&2; exit 1 ;;

--- a/.github/workflows/fuse-dlm-integration.yml
+++ b/.github/workflows/fuse-dlm-integration.yml
@@ -44,18 +44,9 @@ jobs:
           sudo apt-get install -y libfuse3-dev
           echo 'user_allow_other' | sudo tee -a /etc/fuse.conf
           sudo chmod 644 /etc/fuse.conf
-          # Some runner images carry a second, source-built fusermount3 in
-          # /usr/local/bin that shadows the distro one in PATH without its setuid
-          # bit, and every unprivileged mount then fails with EPERM. go-fuse takes
-          # the first fusermount3 in PATH, so repair that one.
-          fusermount_bin=$(command -v fusermount3 || true)
-          if [ -n "$fusermount_bin" ]; then
-            if [ ! -u "$fusermount_bin" ]; then
-              sudo chown root:root "$fusermount_bin"
-              sudo chmod u+s "$fusermount_bin"
-            fi
-            ls -l "$fusermount_bin"
-          fi
+
+      - name: Repair the fusermount3 setuid bit
+        uses: ./.github/actions/fix-fusermount-setuid
 
       - name: Build SeaweedFS
         run: go build -o weed/weed -buildvcs=false ./weed

--- a/.github/workflows/fuse-dlm-integration.yml
+++ b/.github/workflows/fuse-dlm-integration.yml
@@ -8,6 +8,7 @@ on:
       - 'weed/cluster/**'
       - 'test/fuse_dlm/**'
       - '.github/workflows/fuse-dlm-integration.yml'
+      - '.github/actions/fix-fusermount-setuid/**'
   push:
     branches: [master]
     paths:
@@ -15,6 +16,7 @@ on:
       - 'weed/mount/**'
       - 'weed/cluster/**'
       - 'test/fuse_dlm/**'
+      - '.github/actions/fix-fusermount-setuid/**'
 
 concurrency:
   group: ${{ github.head_ref || github.ref }}/fuse-dlm-integration

--- a/.github/workflows/fuse-integration.yml
+++ b/.github/workflows/fuse-integration.yml
@@ -45,21 +45,12 @@ jobs:
         # Allow non-root FUSE mounts with allow_other
         echo 'user_allow_other' | sudo tee -a /etc/fuse.conf
         sudo chmod 644 /etc/fuse.conf
-        # Some runner images carry a second, source-built fusermount3 in
-        # /usr/local/bin that shadows the distro one in PATH without its setuid
-        # bit, and every unprivileged mount then fails with EPERM. go-fuse takes
-        # the first fusermount3 in PATH, so repair that one.
-        fusermount_bin=$(command -v fusermount3 || true)
-        if [ -n "$fusermount_bin" ]; then
-          if [ ! -u "$fusermount_bin" ]; then
-            sudo chown root:root "$fusermount_bin"
-            sudo chmod u+s "$fusermount_bin"
-          fi
-          ls -l "$fusermount_bin"
-        fi
         # Verify FUSE installation
         fusermount3 --version || fusermount --version || true
         ls -la /dev/fuse
+
+    - name: Repair the fusermount3 setuid bit
+      uses: ./.github/actions/fix-fusermount-setuid
 
     - name: Build SeaweedFS
       run: |

--- a/.github/workflows/fuse-integration.yml
+++ b/.github/workflows/fuse-integration.yml
@@ -7,12 +7,14 @@ on:
       - 'weed/**'
       - 'test/fuse_integration/**'
       - '.github/workflows/fuse-integration.yml'
+      - '.github/actions/fix-fusermount-setuid/**'
   pull_request:
     branches: [ master, main ]
     paths:
       - 'weed/**'
       - 'test/fuse_integration/**'
       - '.github/workflows/fuse-integration.yml'
+      - '.github/actions/fix-fusermount-setuid/**'
 
 concurrency:
   group: ${{ github.head_ref }}/fuse-integration

--- a/.github/workflows/fuse-p2p-integration.yml
+++ b/.github/workflows/fuse-p2p-integration.yml
@@ -50,18 +50,9 @@ jobs:
           sudo apt-get install -y libfuse3-dev
           echo 'user_allow_other' | sudo tee -a /etc/fuse.conf
           sudo chmod 644 /etc/fuse.conf
-          # Some runner images carry a second, source-built fusermount3 in
-          # /usr/local/bin that shadows the distro one in PATH without its setuid
-          # bit, and every unprivileged mount then fails with EPERM. go-fuse takes
-          # the first fusermount3 in PATH, so repair that one.
-          fusermount_bin=$(command -v fusermount3 || true)
-          if [ -n "$fusermount_bin" ]; then
-            if [ ! -u "$fusermount_bin" ]; then
-              sudo chown root:root "$fusermount_bin"
-              sudo chmod u+s "$fusermount_bin"
-            fi
-            ls -l "$fusermount_bin"
-          fi
+
+      - name: Repair the fusermount3 setuid bit
+        uses: ./.github/actions/fix-fusermount-setuid
 
       - name: Build SeaweedFS
         run: go build -o weed/weed -buildvcs=false ./weed

--- a/.github/workflows/fuse-p2p-integration.yml
+++ b/.github/workflows/fuse-p2p-integration.yml
@@ -11,6 +11,7 @@ on:
       - 'weed/pb/filer.proto'
       - 'test/fuse_p2p/**'
       - '.github/workflows/fuse-p2p-integration.yml'
+      - '.github/actions/fix-fusermount-setuid/**'
   push:
     branches: [master]
     paths:
@@ -21,6 +22,7 @@ on:
       - 'weed/pb/mount_peer.proto'
       - 'weed/pb/filer.proto'
       - 'test/fuse_p2p/**'
+      - '.github/actions/fix-fusermount-setuid/**'
 
 concurrency:
   group: ${{ github.head_ref || github.ref }}/fuse-p2p-integration

--- a/test/fuse_integration/framework_test.go
+++ b/test/fuse_integration/framework_test.go
@@ -219,7 +219,7 @@ func (p *managedProcess) exited() error {
 		if p.err != nil {
 			return p.err
 		}
-		return fmt.Errorf("exited with status 0")
+		return fmt.Errorf("exit status 0")
 	default:
 		return nil
 	}
@@ -227,7 +227,9 @@ func (p *managedProcess) exited() error {
 
 // stop asks the process to terminate and waits for it to go away.
 func (p *managedProcess) stop() {
-	p.cmd.Process.Signal(syscall.SIGTERM)
+	// Signal fails with os.ErrProcessDone when the child is already gone, which
+	// is exactly the case the select below handles.
+	_ = p.cmd.Process.Signal(syscall.SIGTERM)
 	select {
 	case <-p.done:
 	case <-time.After(10 * time.Second):
@@ -379,7 +381,7 @@ func (f *FuseTestFramework) waitForService(proc *managedProcess, addr string, ti
 			return nil
 		}
 		if exitErr := proc.exited(); exitErr != nil {
-			return fmt.Errorf("process %v before %s accepted connections", exitErr, addr)
+			return fmt.Errorf("process exited (%v) before %s accepted connections", exitErr, addr)
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
@@ -406,7 +408,7 @@ func (f *FuseTestFramework) waitForMount(timeout time.Duration) error {
 		// A mount that cannot mount at all (no /dev/fuse, fusermount not setuid)
 		// dies within a second; reporting that beats waiting out the timeout.
 		if exitErr := f.mountProcess.exited(); exitErr != nil {
-			return fmt.Errorf("mount process %v", exitErr)
+			return fmt.Errorf("mount process exited (%v)", exitErr)
 		}
 		time.Sleep(100 * time.Millisecond)
 	}


### PR DESCRIPTION
Review follow-up to #10484.

**The repair target comes from PATH.** The first version chowned it to `root:root` before setting the setuid bit, so a binary that landed earlier in PATH owned by someone else would have been handed root. The chown is gone: the target must sit under a system bin path, be a regular non-symlink executable, and already be owned by `root:root`, otherwise the step fails with the reason.

**One implementation instead of three.** The block was copied into all three FUSE workflows; it now lives in `.github/actions/fix-fusermount-setuid`, matching what artifactory does.

Exercised on `ubuntu:22.04`:

| case | result |
|---|---|
| no fusermount3 in PATH | exit 0, noted |
| already setuid in `/usr/bin` | pass through |
| root-owned, not setuid, `/usr/local/bin` (the failure this fixes) | repaired to `-rwsr-xr-x` |
| not owned by root | refuses, exit 1 |
| symlink to a non-setuid target | refuses, exit 1 |
| outside the system bin paths | refuses, exit 1 |
| symlink to a setuid target | pass through |

Also fixes the wait errors, which read `process exit status 1 before 127.0.0.1:20000 accepted connections` - missing a verb - and marks the SIGTERM return discarded, since it fails with `os.ErrProcessDone` exactly when the select below already handles it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated CI step/action to automatically repair the `fusermount3` setuid permissions needed for unprivileged FUSE mounts.
  - Updated integration workflows to run when the repair action changes.

- **Bug Fixes**
  - Improved FUSE, DLM, and peer-to-peer integration reliability by removing ad-hoc permission logic and consistently applying the repair step.
  - Added stricter safety checks before changing helper permissions.

- **Tests**
  - Enhanced integration test process/diagnostic messaging when services or mounts exit before becoming ready.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->