### PR TITLE
ec.encode: name the shard ids an aborted deletion found

### DIFF
--- a/weed/shell/command_ec_encode.go
+++ b/weed/shell/command_ec_encode.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -801,6 +802,19 @@ func ecShardsClumpedOnOneNode(topoInfo *master_pb.TopologyInfo, vid needle.Volum
 	return "", false
 }
 
+// ecShardSummaryByNode says where a volume's shards are, one entry per node,
+// sorted so the message is stable. It names the ids and not just the count: a
+// set holding shards 0-9 and one holding 4-13 are both "10 shards", and which
+// ones survived is what says whether the set is recoverable and from where.
+func ecShardSummaryByNode(byNode map[pb.ServerAddress]erasure_coding.ShardBits) []string {
+	summary := make([]string, 0, len(byNode))
+	for node, bits := range byNode {
+		summary = append(summary, fmt.Sprintf("%s=%d shards %v", node, bits.Count(), slices.Collect(bits.All())))
+	}
+	sort.Strings(summary)
+	return summary
+}
+
 func verifyEcShardsBeforeDelete(commandEnv *CommandEnv, volumeIds []needle.VolumeId, diskType types.DiskType, expectSpread bool) error {
 	// Shard relocations from the preceding EC balance reach the master via
 	// volume-server heartbeats, so freshly distributed shards may not all be
@@ -847,12 +861,7 @@ func verifyEcShardsBeforeDelete(commandEnv *CommandEnv, volumeIds []needle.Volum
 			totalShards := erasure_coding.TotalShardsCount
 			degraded, err := erasure_coding.RequireRecoverableShardSet(uint32(vid), union, erasure_coding.DataShardsCount, totalShards)
 			if err != nil {
-				summary := make([]string, 0, len(byNode))
-				for node, bits := range byNode {
-					summary = append(summary, fmt.Sprintf("%s=%d shards", node, bits.Count()))
-				}
-				sort.Strings(summary)
-				lastErr = fmt.Errorf("volume %d: %w (observed: %v)", vid, err, summary)
+				lastErr = fmt.Errorf("volume %d: %w (observed: %v)", vid, err, ecShardSummaryByNode(byNode))
 				break
 			}
 			if expectSpread {

--- a/weed/shell/command_ec_encode_test.go
+++ b/weed/shell/command_ec_encode_test.go
@@ -466,3 +466,19 @@ func TestEcShardCountIgnoresDiskTypeOfTheShards(t *testing.T) {
 	scoped, _ := collectEcNodeShardsInfo(topo, needle.VolumeId(1), types.ToDiskType(""))
 	assert.Empty(t, scoped, "the hdd-scoped view cannot see ssd shards")
 }
+
+// The message an aborted deletion leaves behind is all the operator has to go
+// on, so it has to name which shards were found and not only how many: a set
+// holding 0-9 and one holding 4-13 are both "10 shards", and only the ids say
+// whether what survived can rebuild the volume.
+func TestEcShardSummaryNamesTheShardIds(t *testing.T) {
+	byNode := map[pb.ServerAddress]erasure_coding.ShardBits{
+		"node2:8080": erasure_coding.ShardBits(0).Set(1).Set(2),
+		"node1:8080": erasure_coding.ShardBits(0).Set(0).Set(12),
+	}
+
+	assert.Equal(t, []string{
+		"node1:8080=2 shards [0 12]",
+		"node2:8080=2 shards [1 2]",
+	}, ecShardSummaryByNode(byNode))
+}


### PR DESCRIPTION
Review follow-up on #10483. The correctness fix there is right; this restores the diagnostics it cost.

Switching the pre-delete check from per-node `ShardsInfo` to `collectEcShardBitsByNode` was necessary — that is what makes it see shards on whatever medium they landed on. But `ShardsInfo.String()` printed shard ids and sizes, and the replacement prints `%d shards`. So the message an operator gets when `ec.encode` refuses to delete a source volume now says how many shards each node holds and not which.

That is the less useful half. A set holding shards 0-9 and one holding 4-13 are both "10 shards"; only the ids say whether what survived can rebuild the volume, or which node to go looking at. And this message is all the operator has — the check has already decided to abort.

Sizes are genuinely gone (`collectEcShardBitsByNode` returns bits, not sizes) and are not worth widening the collector for. The ids are free:

```
volume 42: ... (observed: [node1:8080=2 shards [0 12] node2:8080=2 shards [1 2]])
```

The summary building moves into `ecShardSummaryByNode` so it can be tested directly, matching how the other helpers in this file are covered.

`go test ./weed/shell/` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error details when erasure-coded shard recovery requirements are not met.
  * Error messages now identify each node, the number of shards it reports, and the specific shard IDs, making deletion issues easier to diagnose.

* **Tests**
  * Added coverage to verify that shard IDs and node information appear correctly in diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->