### PR TITLE
fix(helm): add scheduling options to bucket hook

### DIFF
--- a/k8s/charts/seaweedfs/templates/shared/post-install-bucket-hook.yaml
+++ b/k8s/charts/seaweedfs/templates/shared/post-install-bucket-hook.yaml
@@ -66,6 +66,10 @@ spec:
       securityContext: {{- omit .Values.filer.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
       {{- include "seaweedfs.imagePullSecrets" $ | nindent 6 }}
+      {{- with coalesce .Values.allInOne.s3.createBucketsHook.tolerations .Values.s3.createBucketsHook.tolerations .Values.filer.s3.createBucketsHook.tolerations }}
+      tolerations:
+        {{ tpl . $ | nindent 8 }}
+      {{- end }}
       containers:
       - name: post-install-job
         image: {{ template "seaweedfs.master.image" . }}
@@ -209,5 +213,9 @@ spec:
             {{- else }}
             secretName: {{ include "seaweedfs.fullname" . }}-s3-secret
             {{- end }}
+    {{- end }}
+    {{- with coalesce .Values.allInOne.s3.createBucketsHook.nodeSelector .Values.s3.createBucketsHook.nodeSelector .Values.filer.s3.createBucketsHook.nodeSelector }}
+      nodeSelector:
+        {{ tpl . $ | nindent 8 }}
     {{- end }}
 {{- end }}

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -958,6 +958,10 @@ filer:
     #     anonymousRead: false
     createBucketsHook:
       resources: {}
+      # Toleration settings for the bucket creation Job.
+      tolerations: ""
+      # Node selector labels for the bucket creation Job.
+      nodeSelector: ""
 
 s3:
   enabled: false
@@ -1127,6 +1131,10 @@ s3:
 
   createBucketsHook:
     resources: {}
+    # Toleration settings for the bucket creation Job.
+    tolerations: ""
+    # Node selector labels for the bucket creation Job.
+    nodeSelector: ""
 
   ingress:
     enabled: false
@@ -1579,6 +1587,10 @@ allInOne:
     #     anonymousRead: false
     createBucketsHook:
       resources: {}
+      # Toleration settings for the bucket creation Job.
+      tolerations: ""
+      # Node selector labels for the bucket creation Job.
+      nodeSelector: ""
 
   # SFTP server configuration
   # Note: Most parameters below default to null, which means they inherit from


### PR DESCRIPTION
## Summary

Adds optional `nodeSelector` and `tolerations` values for the post-install bucket-creation Job.

The options work for standalone S3, filer S3, and all-in-one S3. They allow the hook to run on tainted node pools, matching the long-running SeaweedFS workloads.

## Validation

- `helm lint k8s/charts/seaweedfs`
- Rendered the bucket hook with selector and toleration values for standalone, filer, and all-in-one S3
- Rendered all three default configurations and confirmed the Job remains unchanged without the new values
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring node selectors and tolerations for bucket-creation jobs.
  * Scheduling settings can be customized for standalone, S3 gateway, and all-in-one deployments.
  * Supports templated configuration values and clear precedence across configuration levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->