### PR TITLE
telemetry: report anonymous cluster stats by default

### DIFF
--- a/telemetry/README.md
+++ b/telemetry/README.md
@@ -8,7 +8,7 @@ A privacy-respecting telemetry system for SeaweedFS that collects cluster-level 
 - **Prometheus Integration**: Native Prometheus metrics for monitoring and alerting
 - **Grafana Dashboards**: Pre-built dashboards for data visualization
 - **Protocol Buffers**: Efficient binary data transmission for optimal performance
-- **Opt-in Only**: Disabled by default, requires explicit configuration
+- **Opt-out**: On by default, turned off with a single flag
 - **Docker Compose**: Complete monitoring stack deployment
 - **Automatic Cleanup**: Configurable data retention policies
 
@@ -51,7 +51,7 @@ message TelemetryData {
 - **No Personal Data**: No hostnames, IP addresses, or user information
 - **In-Memory IDs**: Cluster IDs are generated in-memory and change on restart
 - **Aggregated Data**: Only cluster-level statistics, no individual file/user data
-- **Opt-in Only**: Telemetry is disabled by default
+- **Opt-out Anytime**: `-telemetry=false` on the master stops all reporting
 - **Transparent**: Open source implementation, clear data collection policy
 
 ## Collected Data
@@ -86,14 +86,15 @@ go run . -port=8080 -dashboard=true
 ### 2. Configure SeaweedFS
 
 ```bash
-# Enable telemetry in SeaweedFS master (uses default telemetry.seaweedfs.com)
-weed master -telemetry=true
+# Reporting to telemetry.seaweedfs.com is on by default
+weed master
 
-# Or in server mode
-weed server -telemetry=true
+# Send to your own telemetry server instead
+weed master -telemetry.url=http://localhost:8080/api/collect
 
-# Or specify custom telemetry server
-weed master -telemetry=true -telemetry.url=http://localhost:8080/api/collect
+# Turn reporting off
+weed master -telemetry=false
+weed server -master.telemetry=false
 ```
 
 ### 3. Access Dashboards
@@ -107,12 +108,14 @@ weed master -telemetry=true -telemetry.url=http://localhost:8080/api/collect
 ### SeaweedFS Master/Server
 
 ```bash
-# Enable telemetry
--telemetry=true
+# Disable telemetry (enabled by default)
+-telemetry=false
 
 # Set custom telemetry server URL (optional, defaults to telemetry.seaweedfs.com)
 -telemetry.url=http://your-telemetry-server:8080/api/collect
 ```
+
+In `weed server` and `weed mini` the flags are prefixed: `-master.telemetry=false` and `-master.telemetry.url=...`.
 
 ### Telemetry Server
 

--- a/weed/command/master.go
+++ b/weed/command/master.go
@@ -106,7 +106,7 @@ func init() {
 	m.raftHashicorp = cmdMaster.Flag.Bool("raftHashicorp", false, "use hashicorp raft")
 	m.raftBootstrap = cmdMaster.Flag.Bool("raftBootstrap", false, "Whether to bootstrap the Raft cluster")
 	m.telemetryUrl = cmdMaster.Flag.String("telemetry.url", "https://telemetry.seaweedfs.com/api/collect", "telemetry server URL to send usage statistics")
-	m.telemetryEnabled = cmdMaster.Flag.Bool("telemetry", false, "enable telemetry reporting")
+	m.telemetryEnabled = cmdMaster.Flag.Bool("telemetry", true, "report anonymous cluster statistics to telemetry.url, use -telemetry=false to opt out")
 	m.debug = cmdMaster.Flag.Bool("debug", false, "serves runtime profiling data via pprof on the port specified by -debug.port")
 	m.debugPort = cmdMaster.Flag.Int("debug.port", 6060, "http port for debugging")
 }

--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -433,7 +433,7 @@ func initMiniMasterFlags() {
 	miniMasterOptions.raftHashicorp = cmdMini.Flag.Bool("master.raftHashicorp", false, "use hashicorp raft")
 	miniMasterOptions.raftBootstrap = cmdMini.Flag.Bool("master.raftBootstrap", false, "whether to bootstrap the Raft cluster")
 	miniMasterOptions.telemetryUrl = cmdMini.Flag.String("master.telemetry.url", "https://telemetry.seaweedfs.com/api/collect", "telemetry server URL")
-	miniMasterOptions.telemetryEnabled = cmdMini.Flag.Bool("master.telemetry", false, "enable telemetry reporting")
+	miniMasterOptions.telemetryEnabled = cmdMini.Flag.Bool("master.telemetry", true, "report anonymous cluster statistics to master.telemetry.url, use -master.telemetry=false to opt out")
 }
 
 // initMiniFilerFlags initializes Filer server flag options

--- a/weed/command/server.go
+++ b/weed/command/server.go
@@ -108,7 +108,7 @@ func init() {
 	masterOptions.heartbeatInterval = cmdServer.Flag.Duration("master.heartbeatInterval", 300*time.Millisecond, "heartbeat interval of master servers, and will be randomly multiplied by [1, 1.25)")
 	masterOptions.electionTimeout = cmdServer.Flag.Duration("master.electionTimeout", 10*time.Second, "election timeout of master servers")
 	masterOptions.telemetryUrl = cmdServer.Flag.String("master.telemetry.url", "https://telemetry.seaweedfs.com/api/collect", "telemetry server URL to send usage statistics")
-	masterOptions.telemetryEnabled = cmdServer.Flag.Bool("master.telemetry", false, "enable telemetry reporting")
+	masterOptions.telemetryEnabled = cmdServer.Flag.Bool("master.telemetry", true, "report anonymous cluster statistics to master.telemetry.url, use -master.telemetry=false to opt out")
 
 	filerOptions.filerGroup = cmdServer.Flag.String("filer.filerGroup", "", "share metadata with other filers in the same filerGroup")
 	filerOptions.collection = cmdServer.Flag.String("filer.collection", "", "all data will be stored in this collection")

--- a/weed/telemetry/collector.go
+++ b/weed/telemetry/collector.go
@@ -79,7 +79,7 @@ func (c *Collector) StartPeriodicCollection(interval time.Duration) {
 		return
 	}
 
-	glog.V(0).Infof("Starting telemetry collection every %v", interval)
+	glog.V(0).Infof("Reporting anonymous cluster statistics to %s every %v, use -telemetry=false to opt out", c.client.url, interval)
 
 	// Send initial telemetry after a short delay
 	go func() {


### PR DESCRIPTION
`-telemetry` has been off by default since it landed, so the data we get back covers a handful of clusters and tells us almost nothing about which versions and cluster sizes are actually out there. This flips the default to on for `weed master`, `weed server` and `weed mini`.

Nothing new is collected. Still the same daily report from the leader master only: an in-memory cluster id that is regenerated on every restart, version, os/arch, volume server / filer / broker counts, volume count, total disk bytes. No hostnames, no IPs, no paths, no per-file or per-user data.

Opting out:

    weed master -telemetry=false
    weed server -master.telemetry=false
    weed mini -master.telemetry=false

Air-gapped clusters that never set the flag will try one POST to telemetry.seaweedfs.com a day and log a V(1) failure; the 10s client timeout is on its own goroutine, so nothing else waits on it.

The flag help now names the opt-out, and the master logs the destination and the opt-out flag at V(0) when it starts reporting:

    Reporting anonymous cluster statistics to https://telemetry.seaweedfs.com/api/collect every 24h0m0s, use -telemetry=false to opt out

`master.follower` keeps reporting disabled - a follower never wins leadership, so it would never send anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Telemetry reporting is now enabled by default for master, server, and mini modes.
  * Added clearer options to disable telemetry or redirect reports to a custom endpoint.
  * Startup messaging now shows where anonymous cluster statistics are reported and the reporting interval.

* **Documentation**
  * Updated telemetry documentation with new defaults, configuration examples, privacy details, and opt-out instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->