### PR TITLE
telemetry: build the over-time charts from confirmed clusters

### DIFF
--- a/telemetry/server/dashboard/dashboard.go
+++ b/telemetry/server/dashboard/dashboard.go
@@ -155,11 +155,13 @@ func (h *Handler) ServeIndex(w http.ResponseWriter, r *http.Request) {
 
             <div class="chart-container">
                 <div class="chart-title">Volume Servers Over Time</div>
+                <div class="chart-subtitle">Confirmed clusters only</div>
                 <canvas id="serverChart" width="400" height="200"></canvas>
             </div>
 
             <div class="chart-container">
                 <div class="chart-title">Total Disk Usage Over Time</div>
+                <div class="chart-subtitle">Confirmed clusters only</div>
                 <canvas id="diskChart" width="400" height="200"></canvas>
             </div>
 

--- a/telemetry/server/storage/history.go
+++ b/telemetry/server/storage/history.go
@@ -40,6 +40,25 @@ func (s *PrometheusStorage) appendHistory(data *proto.TelemetryData, receivedAt 
 	s.histories[data.TopologyId] = h
 }
 
+// seriesHistories picks the clusters the fleet-wide series are built from: the
+// confirmed ones. A cluster that only ever reported on one day is usually a CI
+// or test cluster that lived for a minute, and those arrive faster than they
+// age out, so counting them makes every fleet total climb forever. Falls back to
+// all clusters while none is confirmed yet, so a fresh server still draws its
+// charts. Callers must hold s.mu.
+func (s *PrometheusStorage) seriesHistories() map[string][]HistorySample {
+	confirmed := make(map[string][]HistorySample, len(s.histories))
+	for id, history := range s.histories {
+		if len(history) >= confirmDays {
+			confirmed[id] = history
+		}
+	}
+	if len(confirmed) == 0 {
+		return s.histories
+	}
+	return confirmed
+}
+
 func sameUTCDay(a, b int64) bool {
 	ta, tb := time.Unix(a, 0).UTC(), time.Unix(b, 0).UTC()
 	return ta.Year() == tb.Year() && ta.YearDay() == tb.YearDay()

--- a/telemetry/server/storage/metrics_test.go
+++ b/telemetry/server/storage/metrics_test.go
@@ -70,7 +70,7 @@ func TestGetMetricsWindowStartsAtOldestSample(t *testing.T) {
 	}
 
 	// History reaching past the requested window still clips to the window.
-	seedSamples(s, "old", HistorySample{TotalDiskBytes: 50, VolumeServerCount: 1}, -40)
+	seedSamples(s, "old", HistorySample{TotalDiskBytes: 50, VolumeServerCount: 1}, -40, -39)
 	metrics, err = s.GetMetrics(10)
 	if err != nil {
 		t.Fatal(err)
@@ -86,7 +86,7 @@ func TestGetMetricsAgreesWithClusterSizes(t *testing.T) {
 	s := newPrometheusStorage(prometheus.NewRegistry())
 	seedSamples(s, "daily", HistorySample{TotalDiskBytes: 300, VolumeServerCount: 3},
 		-9, -8, -7, -6, -5, -4, -3, -2, -1, 0)
-	seedSamples(s, "lagging", HistorySample{TotalDiskBytes: 200, VolumeServerCount: 2}, -2)
+	seedSamples(s, "lagging", HistorySample{TotalDiskBytes: 200, VolumeServerCount: 2}, -3, -2)
 	seedSamples(s, "gone", HistorySample{TotalDiskBytes: 900, VolumeServerCount: 9}, -9, -8)
 
 	metrics, err := s.GetMetrics(10)
@@ -101,6 +101,45 @@ func TestGetMetricsAgreesWithClusterSizes(t *testing.T) {
 	}
 	if len(disk) != len(sizes.Dates) {
 		t.Errorf("metrics has %d days, cluster sizes has %d", len(disk), len(sizes.Dates))
+	}
+}
+
+// Short-lived clusters -- a CI run, a docker-compose demo -- report once under a
+// fresh raft topology id and never again. Held forward for the whole active
+// window they would stack up into a fleet that grows every day, so they stay out
+// of the totals until they are confirmed.
+func TestGetMetricsExcludesUnconfirmedClusters(t *testing.T) {
+	s := newPrometheusStorage(prometheus.NewRegistry())
+
+	seedSamples(s, "real", HistorySample{TotalDiskBytes: 300, VolumeServerCount: 3}, -3, -2, -1, 0)
+	for _, id := range []string{"ci-1", "ci-2", "ci-3"} {
+		seedSamples(s, id, HistorySample{TotalDiskBytes: 5, VolumeServerCount: 14}, -1)
+	}
+
+	metrics, err := s.GetMetrics(4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := metrics["server_counts"].([]int64); !equalInt64(got, []int64{3, 3, 3, 3}) {
+		t.Errorf("server_counts = %v, want the confirmed cluster alone", got)
+	}
+	if got := metrics["disk_usage"].([]uint64); !equal(got, []uint64{300, 300, 300, 300}) {
+		t.Errorf("disk_usage = %v, want the confirmed cluster alone", got)
+	}
+}
+
+// Until any cluster has two days of history the charts fall back to every
+// cluster, so a fresh server doesn't serve empty series.
+func TestGetMetricsFallsBackWhenNoneConfirmed(t *testing.T) {
+	s := newPrometheusStorage(prometheus.NewRegistry())
+	seedSamples(s, "new", HistorySample{TotalDiskBytes: 100, VolumeServerCount: 2}, 0)
+
+	metrics, err := s.GetMetrics(7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := metrics["server_counts"].([]int64); !equalInt64(got, []int64{2}) {
+		t.Errorf("server_counts = %v, want today's only cluster", got)
 	}
 }
 

--- a/telemetry/server/storage/prometheus.go
+++ b/telemetry/server/storage/prometheus.go
@@ -164,21 +164,22 @@ func (s *PrometheusStorage) GetInstances(limit int) ([]*telemetryData, error) {
 	return instances, nil
 }
 
-// GetMetrics returns fleet-wide daily totals for the last `days` days, in the
-// parallel-array shape the dashboard charts expect. Totals come from the daily
-// histories rather than from s.instances, which holds only each cluster's most
-// recent report and so would credit every cluster to the single day it last
-// reported on.
+// GetMetrics returns fleet-wide daily totals across confirmed clusters for the
+// last `days` days, in the parallel-array shape the dashboard charts expect.
+// Totals come from the daily histories rather than from s.instances, which holds
+// only each cluster's most recent report and so would credit every cluster to
+// the single day it last reported on.
 func (s *PrometheusStorage) GetMetrics(days int) (map[string]interface{}, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	axis := newDailySeries(days, s.histories)
+	histories := s.seriesHistories()
+	axis := newDailySeries(days, histories)
 	activeSince := time.Now().UTC().AddDate(0, 0, -activeDays).Unix()
 
 	diskUsage := make([]uint64, len(axis.dates))
 	serverCounts := make([]int64, len(axis.dates))
-	for _, history := range s.histories {
+	for _, history := range histories {
 		if disk, ok := axis.align(history, activeSince, diskBytes); ok {
 			for i, v := range disk {
 				diskUsage[i] += v

--- a/telemetry/server/storage/sizes.go
+++ b/telemetry/server/storage/sizes.go
@@ -29,18 +29,19 @@ type ClusterSizeSeries struct {
 	TotalDisk    uint64          `json:"total_disk"` // across all clusters on the last day
 }
 
-// GetClusterSizeSeries returns the last `days` days of per-cluster disk usage.
-// Clusters beyond `limit` are folded into Other.
+// GetClusterSizeSeries returns the last `days` days of per-cluster disk usage
+// across confirmed clusters. Clusters beyond `limit` are folded into Other.
 func (s *PrometheusStorage) GetClusterSizeSeries(days, limit int) ClusterSizeSeries {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	axis := newDailySeries(days, s.histories)
+	histories := s.seriesHistories()
+	axis := newDailySeries(days, histories)
 	activeSince := time.Now().UTC().AddDate(0, 0, -activeDays).Unix()
 	last := len(axis.dates) - 1
 	series := ClusterSizeSeries{Dates: axis.dates}
 
-	for id, history := range s.histories {
+	for id, history := range histories {
 		disk, ok := axis.align(history, activeSince, diskBytes)
 		if !ok {
 			continue

--- a/telemetry/server/storage/sizes_test.go
+++ b/telemetry/server/storage/sizes_test.go
@@ -31,9 +31,11 @@ func TestClusterSizeSeries(t *testing.T) {
 	seedHistory(s, "daily", 300, -9, -8, -7, -6, -5, -4, -3, -2, -1, 0)
 	// Reported two days ago and not since: still active, so its size is held
 	// to the right edge instead of dropping out of the stack.
-	seedHistory(s, "lagging", 200, -2)
+	seedHistory(s, "lagging", 200, -3, -2)
 	// Stopped reporting past the active window: its own days only.
 	seedHistory(s, "gone", 900, -9, -8)
+	// One day of history only: unconfirmed, so it stays out of the stack.
+	seedHistory(s, "oneshot", 400, -1)
 
 	series := s.GetClusterSizeSeries(10, 0)
 	if len(series.Dates) != 10 {
@@ -50,11 +52,14 @@ func TestClusterSizeSeries(t *testing.T) {
 	if got := byId["daily"]; !equal(got, []uint64{300, 300, 300, 300, 300, 300, 300, 300, 300, 300}) {
 		t.Errorf("daily = %v, want 300 every day", got)
 	}
-	if got := byId["lagging"]; !equal(got, []uint64{0, 0, 0, 0, 0, 0, 0, 200, 200, 200}) {
+	if got := byId["lagging"]; !equal(got, []uint64{0, 0, 0, 0, 0, 0, 200, 200, 200, 200}) {
 		t.Errorf("lagging = %v, want its size carried to the right edge", got)
 	}
 	if got := byId["gone"]; !equal(got, []uint64{900, 900, 0, 0, 0, 0, 0, 0, 0, 0}) {
 		t.Errorf("gone = %v, want no capacity after its last report", got)
+	}
+	if _, ok := byId["oneshot"]; ok {
+		t.Errorf("unconfirmed cluster in the stack: %v", byId["oneshot"])
 	}
 
 	// The total is the last day's stack height: daily + lagging, not gone.
@@ -74,7 +79,7 @@ func TestClusterSizeSeries(t *testing.T) {
 	if series.Other == nil || series.Other.Count != 2 {
 		t.Fatalf("other = %+v, want 2 clusters", series.Other)
 	}
-	if !equal(series.Other.Disk, []uint64{900, 900, 0, 0, 0, 0, 0, 200, 200, 200}) {
+	if !equal(series.Other.Disk, []uint64{900, 900, 0, 0, 0, 0, 200, 200, 200, 200}) {
 		t.Errorf("other = %v, want lagging+gone summed per day", series.Other.Disk)
 	}
 	if series.ClusterCount != 3 || series.TotalDisk != 500 {


### PR DESCRIPTION
"Volume Servers Over Time" on telemetry.seaweedfs.com climbs every day while total capacity stays flat, which can't both be true.

Short-lived clusters are the cause. `topologyId` is a raft-persisted UUID, so every CI run, docker-compose demo, or `weed server` on a wiped data dir mints a fresh one; the master's first report goes out 61s after start and then every 24h, so those clusters report exactly once and never again. `align` treats any sample from the last 7 days as still reporting and holds its value to the right edge, so a week of CI runs is charted as a fleet of live clusters. Capacity doesn't move because they carry about 5 MB each while the real petabytes sit in a handful of stable clusters.

On the live server, 177 of 200 sampled clusters had one day of history and accounted for 95% of the charted volume servers. Most of them share one fingerprint - 14 servers, 5 MB, 7 volumes - repeated hundreds of times under different UUIDs.

Sum the fleet series over confirmed clusters only, the same >=2 distinct days the version and OS charts already use, falling back to all clusters while none is confirmed so a fresh server still draws its charts. Replayed over 1000 live clusters, the server line goes from 1069 -> 8714 across the window to a flat 287 -> 313, and total disk moves by 0.07%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Fleet-wide metrics and cluster size charts now focus on confirmed clusters with sufficient history.
  - Added “Confirmed clusters only” subtitles to volume server and total disk usage charts.
  - When no clusters are confirmed, charts continue displaying available data instead of appearing empty.

- **Bug Fixes**
  - Improved fleet totals and daily cluster size reporting by excluding short-lived or unconfirmed cluster data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->