### PR TITLE
webdav: answer PROPFIND child stats from the listing

### DIFF
--- a/weed/server/webdav_listed_entries.go
+++ b/weed/server/webdav_listed_entries.go
@@ -1,0 +1,72 @@
+package weed_server
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+// A PROPFIND on a directory lists it once, then golang.org/x/net/webdav's walkFS
+// throws the listing's FileInfo away and stats every child again - one filer
+// lookup per entry, serially. listedEntries hands those stats back the entries the
+// listing already fetched, for the lifetime of a single request.
+type listedEntries struct {
+	mu     sync.Mutex
+	byPath map[string]*FileInfo
+}
+
+// maxListedEntries bounds the per-request memory. Past it, children fall back to
+// individual lookups.
+const maxListedEntries = 100000
+
+type listedEntriesKey struct{}
+
+func withListedEntries(ctx context.Context) context.Context {
+	return context.WithValue(ctx, listedEntriesKey{}, &listedEntries{byPath: make(map[string]*FileInfo)})
+}
+
+func listedEntriesFrom(ctx context.Context) *listedEntries {
+	if ctx == nil {
+		return nil
+	}
+	listed, _ := ctx.Value(listedEntriesKey{}).(*listedEntries)
+	return listed
+}
+
+// trailing slashes are optional on directory paths, so both sides normalize
+func listedEntryKey(fullPath string) string {
+	if len(fullPath) > 1 {
+		return strings.TrimSuffix(fullPath, "/")
+	}
+	return fullPath
+}
+
+func (listed *listedEntries) put(fullPath string, fi *FileInfo) {
+	if listed == nil {
+		return
+	}
+	listed.mu.Lock()
+	defer listed.mu.Unlock()
+	if len(listed.byPath) >= maxListedEntries {
+		return
+	}
+	listed.byPath[listedEntryKey(fullPath)] = fi
+}
+
+func (listed *listedEntries) get(fullPath string) *FileInfo {
+	if listed == nil {
+		return nil
+	}
+	listed.mu.Lock()
+	defer listed.mu.Unlock()
+	return listed.byPath[listedEntryKey(fullPath)]
+}
+
+type listedEntriesHandler struct {
+	next http.Handler
+}
+
+func (h listedEntriesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.next.ServeHTTP(w, r.WithContext(withListedEntries(r.Context())))
+}

--- a/weed/server/webdav_listed_entries_test.go
+++ b/weed/server/webdav_listed_entries_test.go
@@ -1,0 +1,69 @@
+package weed_server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestListedEntriesTrailingSlash(t *testing.T) {
+	ctx := withListedEntries(context.Background())
+	listed := listedEntriesFrom(ctx)
+
+	listed.put("/dir/child", &FileInfo{name: "/dir/child", isDirectory: true})
+
+	if listed.get("/dir/child") == nil {
+		t.Error("exact path missed")
+	}
+	if listed.get("/dir/child/") == nil {
+		t.Error("trailing slash missed: OpenFile stats directories as dir/")
+	}
+	if listed.get("/dir/other") != nil {
+		t.Error("unlisted path hit")
+	}
+}
+
+func TestListedEntriesWithoutCache(t *testing.T) {
+	var missing *listedEntries
+
+	missing.put("/dir/child", &FileInfo{name: "/dir/child"})
+	if missing.get("/dir/child") != nil {
+		t.Error("nil cache returned an entry")
+	}
+	if listedEntriesFrom(context.Background()) != nil {
+		t.Error("plain context carried a cache")
+	}
+	if listedEntriesFrom(nil) != nil {
+		t.Error("nil context carried a cache")
+	}
+}
+
+func TestListedEntriesCap(t *testing.T) {
+	listed := &listedEntries{byPath: make(map[string]*FileInfo)}
+	for i := 0; i < maxListedEntries+10; i++ {
+		listed.put(string(rune('a'+i%26))+string(rune(i)), &FileInfo{})
+	}
+	if len(listed.byPath) > maxListedEntries {
+		t.Errorf("cache grew to %d, past the %d cap", len(listed.byPath), maxListedEntries)
+	}
+}
+
+func TestListedEntriesPerRequest(t *testing.T) {
+	var caches []*listedEntries
+
+	handler := listedEntriesHandler{next: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		caches = append(caches, listedEntriesFrom(r.Context()))
+	})}
+
+	for i := 0; i < 2; i++ {
+		handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("PROPFIND", "/dir/", nil))
+	}
+
+	if caches[0] == nil || caches[1] == nil {
+		t.Fatal("request context carried no cache")
+	}
+	if caches[0] == caches[1] {
+		t.Error("two requests shared one cache")
+	}
+}

--- a/weed/server/webdav_server.go
+++ b/weed/server/webdav_server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path"
 	"strings"
@@ -45,7 +46,7 @@ type WebDavOption struct {
 type WebDavServer struct {
 	option         *WebDavOption
 	grpcDialOption grpc.DialOption
-	Handler        *webdav.Handler
+	Handler        http.Handler
 }
 
 func max(x, y int64) int64 {
@@ -71,9 +72,11 @@ func NewWebDavServer(option *WebDavOption) (ws *WebDavServer, err error) {
 	ws = &WebDavServer{
 		option:         option,
 		grpcDialOption: security.LoadClientTLS(util.GetViper(), "grpc.filer"),
-		Handler: &webdav.Handler{
-			FileSystem: fs,
-			LockSystem: webdav.NewMemLS(),
+		Handler: listedEntriesHandler{
+			next: &webdav.Handler{
+				FileSystem: fs,
+				LockSystem: webdav.NewMemLS(),
+			},
 		},
 	}
 
@@ -370,30 +373,43 @@ func (fs *WebDavFileSystem) stat(ctx context.Context, fullFilePath string) (os.F
 
 	fullpath := util.FullPath(fullFilePath)
 
-	var fi FileInfo
+	if listedFi := listedEntriesFrom(ctx).get(string(fullpath)); listedFi != nil {
+		// the caller's spelling of the path, trailing slash and all, is what a
+		// lookup would have reported back
+		fi := *listedFi
+		fi.name = string(fullpath)
+		return &fi, nil
+	}
+
 	entry, _, _, err := filer_pb.GetEntry(context.Background(), fs, fullpath)
 	if err != nil {
 		if err == filer_pb.ErrNotFound {
 			return nil, os.ErrNotExist
 		}
-		fi.err = err
-		return &fi, nil
+		return &FileInfo{err: err}, nil
 	}
 	if entry == nil {
 		return nil, os.ErrNotExist
 	}
-	fi.size = int64(filer.FileSize(entry))
-	fi.name = string(fullpath)
-	fi.mode = os.FileMode(entry.Attributes.FileMode)
-	fi.modifiedTime = time.Unix(entry.Attributes.Mtime, 0)
-	fi.etag = filer.ETag(entry)
-	fi.isDirectory = entry.IsDirectory
+
+	return toFileInfo(fullpath, entry), nil
+}
+
+func toFileInfo(fullpath util.FullPath, entry *filer_pb.Entry) *FileInfo {
+	fi := &FileInfo{
+		size:         int64(filer.FileSize(entry)),
+		name:         string(fullpath),
+		mode:         os.FileMode(entry.Attributes.FileMode),
+		modifiedTime: time.Unix(entry.Attributes.Mtime, 0),
+		etag:         filer.ETag(entry),
+		isDirectory:  entry.IsDirectory,
+	}
 
 	if fi.name == "/" {
 		fi.modifiedTime = time.Now()
 		fi.isDirectory = true
 	}
-	return &fi, nil
+	return fi
 }
 
 func (fs *WebDavFileSystem) Stat(ctx context.Context, name string) (os.FileInfo, error) {
@@ -566,6 +582,8 @@ func (f *WebDavFile) Readdir(count int) (ret []os.FileInfo, err error) {
 
 	dir, _ := util.FullPath(f.name).DirAndName()
 
+	listed := listedEntriesFrom(f.ctx)
+
 	err = filer_pb.ReadDirAllEntries(context.Background(), f.fs, util.FullPath(dir), "", func(entry *filer_pb.Entry, isLast bool) error {
 		fi := FileInfo{
 			size:         int64(filer.FileSize(entry)),
@@ -578,7 +596,12 @@ func (f *WebDavFile) Readdir(count int) (ret []os.FileInfo, err error) {
 		if !strings.HasSuffix(fi.name, "/") && fi.IsDir() {
 			fi.name += "/"
 		}
+
 		glog.V(4).Infof("entry: %v", fi.name)
+
+		childPath := util.NewFullPath(dir, entry.Name)
+		listed.put(string(childPath), toFileInfo(childPath, entry))
+
 		ret = append(ret, &fi)
 		return nil
 	})
@@ -631,7 +654,10 @@ func (f *WebDavFile) Stat() (os.FileInfo, error) {
 
 	glog.V(2).Infof("WebDavFile.Stat %v", f.name)
 
-	ctx := context.Background()
+	ctx := f.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
 
 	return f.fs.stat(ctx, f.name)
 }

--- a/weed/server/webdav_server.go
+++ b/weed/server/webdav_server.go
@@ -381,7 +381,7 @@ func (fs *WebDavFileSystem) stat(ctx context.Context, fullFilePath string) (os.F
 		return &fi, nil
 	}
 
-	entry, _, _, err := filer_pb.GetEntry(context.Background(), fs, fullpath)
+	entry, _, _, err := filer_pb.GetEntry(ctx, fs, fullpath)
 	if err != nil {
 		if err == filer_pb.ErrNotFound {
 			return nil, os.ErrNotExist
@@ -582,9 +582,10 @@ func (f *WebDavFile) Readdir(count int) (ret []os.FileInfo, err error) {
 
 	dir, _ := util.FullPath(f.name).DirAndName()
 
-	listed := listedEntriesFrom(f.ctx)
+	ctx := f.requestContext()
+	listed := listedEntriesFrom(ctx)
 
-	err = filer_pb.ReadDirAllEntries(context.Background(), f.fs, util.FullPath(dir), "", func(entry *filer_pb.Entry, isLast bool) error {
+	err = filer_pb.ReadDirAllEntries(ctx, f.fs, util.FullPath(dir), "", func(entry *filer_pb.Entry, isLast bool) error {
 		fi := FileInfo{
 			size:         int64(filer.FileSize(entry)),
 			name:         entry.Name,
@@ -633,7 +634,7 @@ func (f *WebDavFile) Seek(offset int64, whence int) (int64, error) {
 
 	glog.V(2).Infof("WebDavFile.Seek %v %v %v", f.name, offset, whence)
 
-	ctx := context.Background()
+	ctx := f.requestContext()
 
 	var err error
 	switch whence {
@@ -654,10 +655,14 @@ func (f *WebDavFile) Stat() (os.FileInfo, error) {
 
 	glog.V(2).Infof("WebDavFile.Stat %v", f.name)
 
-	ctx := f.ctx
-	if ctx == nil {
-		ctx = context.Background()
-	}
+	return f.fs.stat(f.requestContext(), f.name)
+}
 
-	return f.fs.stat(ctx, f.name)
+// the context of the request that opened the file, or a bare one for files
+// opened outside a request
+func (f *WebDavFile) requestContext() context.Context {
+	if f.ctx != nil {
+		return f.ctx
+	}
+	return context.Background()
 }


### PR DESCRIPTION
A WebDAV directory listing goes through `golang.org/x/net/webdav`'s `walkFS`, which throws away the `FileInfo` that `Readdir` handed it and stats every child again - five times per entry between `walkFS`, `allprop` and `props`. Every one of those was a filer `LookupDirectoryEntry`, issued serially, and `WebDavFile.Stat` dropped the request context on top of it.

So a PROPFIND on a directory with 3000 subdirectories made 15006 filer lookups. Windows Explorer mounts a share, opens a large folder, and gives up.

This keeps the entries a listing already fetched in the request context and answers those stats from them. Positive entries only, populated from `Readdir` alone, discarded with the request, capped at 100k so one PROPFIND cannot balloon.

Measured against a leveldb2 filer on loopback, `weed webdav` in front of `weed server`:

| directory | lookups before | after | PROPFIND before | after |
|---|---|---|---|---|
| 3000 subdirs | 15006 | 6 | 1.41s | 0.035s |
| 6000 subdirs | | | 3.43s | 0.048s |
| 24000 subdirs | | | 13.4s | 0.248s |
| 60000 subdirs | | | 23.7s | 0.538s |
| 200 files | | | 0.102s | 0.005s |

Same bytes on the wire: response sizes are byte-identical and the `href`, `displayname`, `getcontentlength`, `getetag`, `getlastmodified` sets match the old server exactly, for directories and for files. MKCOL, PUT, GET, MOVE, COPY -Depth infinity, DELETE and PROPFIND at depth 0/1/infinity all behave as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved WebDAV directory browsing by reusing directory listing information within each request.
  * Reduced redundant WebDAV metadata fetches by caching per-request directory entries.

* **Bug Fixes**
  * Improved lookup consistency for WebDAV paths with or without trailing slashes.
  * Ensured request-scoped caching is isolated between separate WebDAV requests.
  * Prevented unbounded growth of temporary directory listing data by enforcing a cache size limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->