### PR TITLE
test: stop comparing two JWTs minted a second apart

### DIFF
--- a/weed/server/filer_server_handlers_proxy_test.go
+++ b/weed/server/filer_server_handlers_proxy_test.go
@@ -79,12 +79,6 @@ func (v *proxyTestVolume) requireReached(t *testing.T) {
 // header, so a caller-supplied one would outrank the token the filer attaches
 // on a read -- the credential the volume server evaluates has to be the filer's.
 func TestProxyReadDropsCallerJwtQueryParam(t *testing.T) {
-	minted := &FilerServer{volumeGuard: security.NewGuard([]string{}, proxyTestWriteKey, 10, proxyTestReadKey, 10)}
-	want := minted.maybeGetVolumeReadJwtAuthorizationToken(proxyTestFileId)
-	if want == "" {
-		t.Fatal("no read token minted despite a configured read key")
-	}
-
 	for _, method := range []string{http.MethodGet, http.MethodHead} {
 		t.Run(method, func(t *testing.T) {
 			volume := newProxyTestVolume(t)
@@ -98,8 +92,19 @@ func TestProxyReadDropsCallerJwtQueryParam(t *testing.T) {
 			if got := volume.seenEffectiveJwt(); got == "caller-supplied" {
 				t.Fatal("caller's jwt query param outranked the filer-minted token")
 			}
-			if got := volume.seenEffectiveJwt(); got != want {
-				t.Fatalf("volume server would evaluate %q, want the minted token %q", got, want)
+			// The credential has to be a filer-minted read token for THIS file.
+			// Comparing it against a separately minted token would also say that,
+			// but only within the second that minted both: the expiry claim has
+			// one-second resolution, so two mints either side of a tick differ in
+			// the encoded string while carrying the same authority and file id.
+			claims := &security.SeaweedFileIdClaims{}
+			if _, err := security.DecodeJwt(security.SigningKey(proxyTestReadKey),
+				security.EncodedJwt(volume.seenEffectiveJwt()), claims); err != nil {
+				t.Fatalf("volume server would evaluate %q, which does not validate against the read key: %v",
+					volume.seenEffectiveJwt(), err)
+			}
+			if claims.Fid != proxyTestFileId {
+				t.Fatalf("token authorizes file %q, want %q", claims.Fid, proxyTestFileId)
 			}
 			if q := volume.seenRawQuery(); strings.Contains(q, "jwt=") {
 				t.Fatalf("jwt survived in the forwarded query: %q", q)


### PR DESCRIPTION
`TestProxyReadDropsCallerJwtQueryParam` fails intermittently on the 32-bit job:

```
filer_server_handlers_proxy_test.go:102: volume server would evaluate "***", want the minted token "***"
```

## Why

The test mints a read token up front and requires the token the volume server would evaluate to equal it **byte for byte**:

```go
want := minted.maybeGetVolumeReadJwtAuthorizationToken(proxyTestFileId)
...
if got := volume.seenEffectiveJwt(); got != want {
```

The expiry claim has one-second resolution — `GenJwtForVolumeServer` sets it from `jwt.NewNumericDate(time.Now().Add(...))` — so two mints on either side of a tick produce different strings for the same authority and the same file. The assertion then fails for a reason the test isn't about.

It shows up on the 32-bit runner because it's slow enough that the **HEAD** subtest — the second one, after a full proxy round trip — lands in a later second than the mint at the top of the test. That matches the observed signature: `GET` passes, `HEAD` fails.

Confirmed directly rather than inferred — minting the same file id with the same key either side of a boundary:

```
same key, same file, different second -> different token: true   (3/3)
```

## Fix

Assert what the test is actually about: the credential decodes against the read key and authorizes this file id. That holds whatever second it was minted in, and is a closer statement of the property than string equality — a token that merely matched some other mint wouldn't prove it was valid or scoped to this file, and this does.

The two assertions that carry the test's real intent are untouched: the caller-supplied `jwt` query param must not outrank the filer's token, and it must not survive into the forwarded query.

`go test ./weed/server/ -run 'TestProxyRead|TestProxyWrite' -count=5` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened validation for proxied file reads by verifying that forwarded authorization tokens are cryptographically valid.
  * Confirmed that tokens contain the correct file identifier and are not reused directly from caller-provided values.
  * Improved test resilience by validating token claims rather than relying on exact encoded token strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->