### PR TITLE
s3: keep the list marker exclusive for versioned objects

### DIFF
--- a/test/s3/versioning/s3_versioning_list_marker_test.go
+++ b/test/s3/versioning/s3_versioning_list_marker_test.go
@@ -1,0 +1,62 @@
+package s3api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVersionedListMarkerIsExclusive covers start-after and marker on a versioned bucket,
+// where an object is stored in a "<key>.versions" directory and so never matches the
+// marker by entry name.
+func TestVersionedListMarkerIsExclusive(t *testing.T) {
+	client := getS3Client(t)
+	bucketName := getNewBucketName()
+
+	createBucket(t, client, bucketName)
+	defer deleteBucket(t, client, bucketName)
+	enableVersioning(t, client, bucketName)
+
+	for _, key := range []string{"file-0", "file-1", "file-2", "logs/file-0", "logs/file-1", "logs/file-2"} {
+		putObject(t, client, bucketName, key, "content")
+	}
+
+	listV2 := func(prefix, startAfter string) []string {
+		t.Helper()
+		resp, err := client.ListObjectsV2(context.TODO(), &s3.ListObjectsV2Input{
+			Bucket:     aws.String(bucketName),
+			Prefix:     aws.String(prefix),
+			StartAfter: aws.String(startAfter),
+		})
+		require.NoError(t, err)
+		return contentKeys(resp.Contents)
+	}
+	listV1 := func(prefix, marker string) []string {
+		t.Helper()
+		resp, err := client.ListObjects(context.TODO(), &s3.ListObjectsInput{
+			Bucket: aws.String(bucketName),
+			Prefix: aws.String(prefix),
+			Marker: aws.String(marker),
+		})
+		require.NoError(t, err)
+		return contentKeys(resp.Contents)
+	}
+
+	assert.Equal(t, []string{"file-2"}, listV2("file-", "file-1"))
+	assert.Equal(t, []string{"file-2"}, listV1("file-", "file-1"))
+	assert.Equal(t, []string{"logs/file-2"}, listV2("logs/", "logs/file-1"))
+	assert.Equal(t, []string{"logs/file-2"}, listV1("logs/", "logs/file-1"))
+}
+
+func contentKeys(contents []types.Object) []string {
+	keys := make([]string, 0, len(contents))
+	for _, c := range contents {
+		keys = append(keys, *c.Key)
+	}
+	return keys
+}

--- a/weed/s3api/s3api_object_handlers_list.go
+++ b/weed/s3api/s3api_object_handlers_list.go
@@ -678,13 +678,13 @@ func (s3a *S3ApiServer) doListFilerEntries(ctx context.Context, client filer_pb.
 			// listFilerEntries always calls doListFilerEntries with inclusiveStartFrom=false
 			// (S3 marker semantics are exclusive), but keep the guard explicit to preserve
 			// behavior if inclusive callers are introduced in the future.
-			// A versioned object lives in a "<key>.versions" directory, so compare the
-			// object name the marker is expressed in.
+			// A versioned object lives in a "<key>.versions" directory, so the marker also
+			// has to be matched against the object name that directory stands for.
 			markerName := entry.Name
 			if entry.IsDirectory {
 				markerName = strings.TrimSuffix(markerName, s3_constants.VersionsFolder)
 			}
-			if !inclusiveStartFrom && marker != "" && markerName == marker {
+			if !inclusiveStartFrom && marker != "" && (entry.Name == marker || markerName == marker) {
 				continue
 			}
 

--- a/weed/s3api/s3api_object_handlers_list.go
+++ b/weed/s3api/s3api_object_handlers_list.go
@@ -678,7 +678,13 @@ func (s3a *S3ApiServer) doListFilerEntries(ctx context.Context, client filer_pb.
 			// listFilerEntries always calls doListFilerEntries with inclusiveStartFrom=false
 			// (S3 marker semantics are exclusive), but keep the guard explicit to preserve
 			// behavior if inclusive callers are introduced in the future.
-			if !inclusiveStartFrom && marker != "" && entry.Name == marker {
+			// A versioned object lives in a "<key>.versions" directory, so compare the
+			// object name the marker is expressed in.
+			markerName := entry.Name
+			if entry.IsDirectory {
+				markerName = strings.TrimSuffix(markerName, s3_constants.VersionsFolder)
+			}
+			if !inclusiveStartFrom && marker != "" && markerName == marker {
 				continue
 			}
 

--- a/weed/s3api/s3api_object_handlers_list_versioned_test.go
+++ b/weed/s3api/s3api_object_handlers_list_versioned_test.go
@@ -684,3 +684,52 @@ func TestProcessDirectorySkipsBeforeMarker(t *testing.T) {
 		})
 	}
 }
+
+// TestVersionedListSkipsMarkerObject covers the exclusive marker on a versioned bucket,
+// where the marker names an object but the entry is its ".versions" directory.
+func TestVersionedListSkipsMarkerObject(t *testing.T) {
+	s3a := &S3ApiServer{option: &S3ApiServerOption{BucketsPath: "/buckets"}}
+	client := &testFilerClient{
+		entriesByDir: map[string][]*filer_pb.Entry{
+			"/buckets/test-bucket": {
+				liveVersionsDir("file-1"),
+				liveVersionsDir("file-2"),
+			},
+		},
+	}
+
+	cursor := &ListingCursor{maxKeys: 1000}
+	var seen []string
+	_, err := s3a.doListFilerEntries(context.Background(), client, listDirectoryRequest{dir: "/buckets/test-bucket", marker: "file-1", bucket: "test-bucket"}, cursor, func(dir string, entry *filer_pb.Entry) {
+		seen = append(seen, entry.Name)
+		cursor.maxKeys--
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"file-2"}, seen, "the marker object should not be returned")
+}
+
+// TestVersionedListSkipsEchoedVersionsMarker covers a backend that echoes the marker it
+// was given, when that marker is a ".versions" directory name.
+func TestVersionedListSkipsEchoedVersionsMarker(t *testing.T) {
+	s3a := &S3ApiServer{option: &S3ApiServerOption{BucketsPath: "/buckets"}}
+	client := &markerEchoFilerClient{
+		entriesByDir: map[string][]*filer_pb.Entry{
+			"/buckets/test-bucket": {
+				liveVersionsDir("file-1"),
+				liveVersionsDir("file-2"),
+			},
+		},
+		returnFollowing: true,
+	}
+
+	cursor := &ListingCursor{maxKeys: 1000}
+	var seen []string
+	_, err := s3a.doListFilerEntries(context.Background(), client, listDirectoryRequest{dir: "/buckets/test-bucket", marker: "file-1" + s3_constants.VersionsFolder, bucket: "test-bucket"}, cursor, func(dir string, entry *filer_pb.Entry) {
+		seen = append(seen, entry.Name)
+		cursor.maxKeys--
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"file-2"}, seen, "the echoed marker entry should not be returned")
+}


### PR DESCRIPTION
# What problem are we solving?

`start-after` (ListObjectsV2) and `marker` (ListObjectsV1) were inclusive on versioning-enabled buckets, so a listing returned the marker key itself. They are exclusive everywhere else.

A versioned object is stored in a `<key>.versions` directory, so the exclusive-marker skip in `doListFilerEntries` compared `file-1.versions` against the marker `file-1` and never matched. The filer's own `StartFromFileName` does not catch it either, since `file-1.versions` sorts after `file-1`.

On a versioned bucket holding `p/file-0` through `p/file-5`:

```
$ aws s3api list-objects-v2 --bucket versioned --prefix p/ --start-after p/file-1 --query 'Contents[].Key'
["p/file-1", "p/file-2", "p/file-3", "p/file-4", "p/file-5"]   # p/file-1 should not be here
```

The same bucket without versioning correctly starts at `p/file-2`.

# How are we solving the problem?

Match the marker against the raw entry name or the object name the `.versions` directory stands for.

Both forms are needed. The raw name still has to match for a backend that echoes `StartFromFileName` back even in exclusive mode, which is the case this guard was added for and which `markerEchoFilerClient` already simulates.

# How is the PR tested?

Two unit tests in `weed/s3api/s3api_object_handlers_list_versioned_test.go`, one per half of the condition. Each half is load-bearing:

| condition | `TestVersionedListSkipsMarkerObject` | `TestVersionedListSkipsEchoedVersionsMarker` |
|---|---|---|
| `entry.Name == marker` (before this PR) | FAIL | pass |
| `markerName == marker` | pass | FAIL |
| both (this PR) | pass | pass |

Integration test `TestVersionedListMarkerIsExclusive` in `test/s3/versioning` covers ListObjectsV1 `marker` and ListObjectsV2 `start-after`, at the bucket root and under a prefix. It fails on master and passes here.

`go test ./weed/s3api/...` passes. The `test/s3/versioning` suite passes except `TestBucketCreationWithDifferentUsers`, which needs the second identity from the test S3 config that my local server did not have.

Found by running Apache OpenDAL's S3 behavior suite against SeaweedFS: `test_list_with_start_after` failed only on a versioning-enabled bucket. With this fix and #10497 the suite is 126/126 there.

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging. (no wiki surface: this restores documented S3 marker semantics)
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.
