### PR TITLE
fix(master): bump seaweedfs/raft to v1.2.0 for the snapshot race

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/seaweedfs/goexif v1.0.3
-	github.com/seaweedfs/raft v1.1.8
+	github.com/seaweedfs/raft v1.2.0
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1812,8 +1812,8 @@ github.com/seaweedfs/go-fuse/v2 v2.9.3 h1:rJufGrHImTx7yoGUmetUi+To4LrmTQJROJnBHW
 github.com/seaweedfs/go-fuse/v2 v2.9.3/go.mod h1:zABdmWEa6A0bwaBeEOBUeUkGIZlxUhcdv+V1Dcc/U/I=
 github.com/seaweedfs/goexif v1.0.3 h1:ve/OjI7dxPW8X9YQsv3JuVMaxEyF9Rvfd04ouL+Bz30=
 github.com/seaweedfs/goexif v1.0.3/go.mod h1:Oni780Z236sXpIQzk1XoJlTwqrJ02smEin9zQeff7Fk=
-github.com/seaweedfs/raft v1.1.8 h1:a5f+wSnriRjINLqLqMY7DDNNfU1+kv6TKBuOZa0KDwU=
-github.com/seaweedfs/raft v1.1.8/go.mod h1:fgs/rAVEzjQ7e04XMzG3eJhwZZRmBW+2uRtjakeCGeU=
+github.com/seaweedfs/raft v1.2.0 h1:Ez4Hw9ifBbTT7wg54DvGHBjw1vRlTb4roH0TKl0Oj9Y=
+github.com/seaweedfs/raft v1.2.0/go.mod h1:fgs/rAVEzjQ7e04XMzG3eJhwZZRmBW+2uRtjakeCGeU=
 github.com/secure-systems-lab/go-securesystemslib v0.10.0 h1:l+H5ErcW0PAehBNrBxoGv1jjNpGYdZ9RcheFkB2WI14=
 github.com/secure-systems-lab/go-securesystemslib v0.10.0/go.mod h1:MRKONWmRoFzPNQ9USRF9i1mc7MvAVvF1LlW8X5VWDvk=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=


### PR DESCRIPTION
The master could die with a nil pointer dereference inside the raft library:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x1 addr=0x18 pc=0x7ff78f2124df]

github.com/seaweedfs/raft.(*server).TakeSnapshot(0x26e932019560)
        raft@v1.1.8/server.go:1292 +0x45f
github.com/seaweedfs/raft.(*server).maybeTakeSnapshot.func1()
        raft@v1.1.8/server.go:1245 +0x55
```

The leader and follower loops ask for a snapshot on every iteration, and `TakeSnapshot` is exported for callers to invoke directly — `ensureTopologyId` does. Nothing serialized them, so several goroutines could be building a snapshot at once, all writing to the single `pendingSnapshot` field. Whichever finished first saved it and set the field to nil, and the rest resumed from `stateMachine.Save()` and wrote through it.

The reported fault address pins it: `Snapshot.Peers` sits at struct offset `0x10`, so its slice length word is at `0x18`, which is `s.pendingSnapshot.Peers = peers` on a nil pointer.

Under tighter timing the same race is silent instead: the stragglers get past that write and into `saveSnapshot`, which re-reads the field and stores **nil** as the current snapshot. The master then reports having no snapshot at all, so a lagging peer can never be caught up with one.

`-race` on raft v1.1.8 flags exactly this pair — write at `server.go:1277` in `TakeSnapshot` against read at `server.go:1241` in `maybeTakeSnapshot` — in its own `TestSnapshot` and `TestSnapshotRecovery`.

A single master with `-master.peers=none` is affected the same way, since the loops that ask for snapshots run regardless of peer count.

## What v1.2.0 contains

- snapshot creation is serialized on a mutex, and the snapshot being built is kept in a local, so nothing shared can be pulled out from under a caller. A failed `Save` no longer wedges snapshotting, and with it log compaction, for the life of the process
- a snapshot recovery that cannot be completed is no longer reported as done: the follower keeps the entries it still has instead of discarding them and telling the leader it is caught up
- snapshots are written beside their path and renamed into place, so a crash partway through cannot leave a half-written snapshot where a whole one belongs
- the snapshot covering the most of the log is loaded on restart, rather than the last filename in text order, under which `1_10.ss` sorts before `1_9.ss`
- the peer map is read and written under the lock that already covered it. `Peers` and `MemberCount` took `s.mutex` but `AddPeer` and `RemovePeer` did not, so a snapshot cloning the peer list alongside a membership change was a concurrent map iteration and write, which the runtime answers by killing the process

## Verification

`go build ./weed/...` clean, `./weed/server/...` and `./weed/topology/...` pass against the released tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency to a newer version to improve maintenance, compatibility, and long-term stability.
  * No visible changes to the product’s behavior are expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
