### PR TITLE
mount: keep a sealed chunk alive until its own upload finishes

### DIFF
--- a/weed/mount/page_writer/upload_pipeline.go
+++ b/weed/mount/page_writer/upload_pipeline.go
@@ -221,8 +221,11 @@ func (up *UploadPipeline) moveToSealed(memChunk PageChunk, logicChunkIndex Logic
 		oldMemChunk.FreeReference(fmt.Sprintf("%s replace chunk %d", up.filepath, logicChunkIndex))
 	}
 	sealedChunk := &SealedChunk{
-		chunk:            memChunk,
-		referenceCounter: 1, // default 1 is for uploading process
+		chunk: memChunk,
+		// One for the sealedChunks slot, one for the upload below, which
+		// drops its own. Execute() returns before SaveContent reads the
+		// chunk, so a later seal must not free the buffer under it.
+		referenceCounter: 2,
 		accountant:       up.accountant,
 		chunkSize:        up.ChunkSize,
 	}
@@ -252,8 +255,12 @@ func (up *UploadPipeline) moveToSealed(memChunk PageChunk, logicChunkIndex Logic
 			up.readerCountCond.Wait()
 		}
 
-		// then remove from sealed chunks
-		delete(up.sealedChunks, logicChunkIndex)
+		// then remove from sealed chunks, unless a later seal took over the
+		// index — deleting that one would hide its dirty pages from readers
+		if up.sealedChunks[logicChunkIndex] == sealedChunk {
+			delete(up.sealedChunks, logicChunkIndex)
+			sealedChunk.FreeReference(fmt.Sprintf("%s unindex chunk %d", up.filepath, logicChunkIndex))
+		}
 		sealedChunk.FreeReference(fmt.Sprintf("%s finished uploading chunk %d", up.filepath, logicChunkIndex))
 
 	})
@@ -388,9 +395,8 @@ func (up *UploadPipeline) Shutdown() {
 		delete(up.writableChunks, logicChunkIndex)
 	}
 	for logicChunkIndex, sealedChunk := range up.sealedChunks {
-		// FreeReference releases the accountant slot on the refcount-zero
-		// transition; a racing async uploader will call FreeReference again
-		// and be a no-op, so there is no double-release.
+		// only the slot reference; an in-flight upload frees the chunk itself
 		sealedChunk.FreeReference(fmt.Sprintf("%s uploadpipeline shutdown chunk %d", up.filepath, logicChunkIndex))
+		delete(up.sealedChunks, logicChunkIndex)
 	}
 }

--- a/weed/mount/page_writer/upload_pipeline_reseal_test.go
+++ b/weed/mount/page_writer/upload_pipeline_reseal_test.go
@@ -1,0 +1,121 @@
+package page_writer
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/util"
+)
+
+// gatedChunk parks in SaveContent until the test opens its gate: the state
+// moveToSealed leaves an upload in, submitted but not yet reading its buffer.
+type gatedChunk struct {
+	gate        chan struct{}
+	saved       chan struct{}
+	freedBefore bool // FreeResource had already run when SaveContent began
+	freeCount   atomic.Int32
+}
+
+func newGatedChunk() *gatedChunk {
+	return &gatedChunk{
+		gate:  make(chan struct{}),
+		saved: make(chan struct{}),
+	}
+}
+
+func (c *gatedChunk) FreeResource()                         { c.freeCount.Add(1) }
+func (c *gatedChunk) WriteDataAt([]byte, int64, int64) int  { return 0 }
+func (c *gatedChunk) ReadDataAt([]byte, int64, int64) int64 { return 0 }
+func (c *gatedChunk) IsComplete() bool                      { return false }
+func (c *gatedChunk) IsContiguouslyWritten() bool           { return true }
+func (c *gatedChunk) ActivityScore() int64                  { return 0 }
+func (c *gatedChunk) WrittenSize() int64                    { return 0 }
+func (c *gatedChunk) LastWriteTsNs() int64                  { return 0 }
+func (c *gatedChunk) SaveContent(saveFn SaveToStorageFunc) {
+	<-c.gate
+	c.freedBefore = c.freeCount.Load() > 0
+	close(c.saved)
+}
+
+// Sealing the same index twice must not free the first chunk: freeing it
+// returns a live buffer to the slot pool and the in-flight upload then ships
+// whatever the next NewMemChunk writes there.
+func TestMoveToSealed_ReplaceKeepsUploadReference(t *testing.T) {
+	up := NewUploadPipeline(util.NewLimitedConcurrentExecutor(2), 2*1024*1024, nil, 16, "", nil)
+
+	first, second := newGatedChunk(), newGatedChunk()
+
+	up.chunksLock.Lock()
+	up.moveToSealed(first, 0)
+	up.moveToSealed(second, 0) // takes over index 0 while first is uploading
+	up.chunksLock.Unlock()
+
+	// both seals are done, so any premature free has already happened
+	close(first.gate)
+	select {
+	case <-first.saved:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first chunk's SaveContent never ran")
+	}
+	if first.freedBefore {
+		t.Error("first chunk was freed before its upload read it")
+	}
+
+	// a finished upload must leave the newer chunk indexed for readers
+	waitForFree(t, first)
+	up.chunksLock.Lock()
+	indexed := up.sealedChunks[0]
+	up.chunksLock.Unlock()
+	if indexed == nil || indexed.chunk != second {
+		t.Errorf("index 0 should still hold the second chunk, got %v", indexed)
+	}
+
+	close(second.gate)
+	waitForFree(t, second)
+	if got := first.freeCount.Load(); got != 1 {
+		t.Errorf("first chunk freed %d times, want 1", got)
+	}
+	if got := second.freeCount.Load(); got != 1 {
+		t.Errorf("second chunk freed %d times, want 1", got)
+	}
+}
+
+// Shutdown drops only the slot reference; the in-flight upload keeps the
+// chunk alive until it is done, then frees it exactly once.
+func TestShutdown_LeavesInFlightUploadItsReference(t *testing.T) {
+	up := NewUploadPipeline(util.NewLimitedConcurrentExecutor(2), 2*1024*1024, nil, 16, t.TempDir(), nil)
+
+	chunk := newGatedChunk()
+	up.chunksLock.Lock()
+	up.moveToSealed(chunk, 0)
+	up.chunksLock.Unlock()
+
+	up.Shutdown()
+
+	close(chunk.gate)
+	select {
+	case <-chunk.saved:
+	case <-time.After(5 * time.Second):
+		t.Fatal("SaveContent never ran")
+	}
+	if chunk.freedBefore {
+		t.Error("Shutdown freed the chunk before its upload read it")
+	}
+	waitForFree(t, chunk)
+	if got := chunk.freeCount.Load(); got != 1 {
+		t.Errorf("chunk freed %d times, want 1", got)
+	}
+}
+
+func waitForFree(t *testing.T, c *gatedChunk) {
+	t.Helper()
+	<-c.saved
+	deadline := time.Now().Add(5 * time.Second)
+	for c.freeCount.Load() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("chunk was never freed after its upload finished")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}


### PR DESCRIPTION
## Problem

A FUSE mount under concurrent random writes can upload bytes it never hashed. `fio --rw=randwrite --bs=128k --numjobs=8` on a single file makes every write return `EIO`, with the volume server rejecting the needle:

```
Content-MD5 did not match md5 of file data
  expected [2C3hbzCwY+iu6cFfd7q4Iw==] received [ZS/iQN9anTFFpqUm15iIlg==] size 393216   ← attempt 0
  expected [2C3hbzCwY+iu6cFfd7q4Iw==] received [MKrGiS5wQRKHpxjbEX1WhA==] size 393216   ← attempts 1, 2
```

`expected` is the client's own `Content-MD5` header and stays constant across the three inner retries; `received` is what the server actually got and changes between them. The client hashed one thing and sent another — its payload buffer was rewritten while the upload was in flight.

## Cause

`moveToSealed` gives a `SealedChunk` a single reference, "for the uploading process", and then lets a later seal of the same logic chunk index drop it:

```go
if oldMemChunk, found := up.sealedChunks[logicChunkIndex]; found {
    oldMemChunk.FreeReference(...)   // refcount 0 -> chunk.FreeResource() -> mem.Free(buf)
}
```

`LimitedConcurrentExecutor.Execute` returns as soon as the job is handed to a goroutine, so the old chunk's `SaveContent` may not have taken its read lock yet. In that window `MemChunk.FreeResource` returns a live `ChunkSize` buffer to the `util/mem` slot pool, the next `NewMemChunk` picks it up, and the in-flight upload — which uploads `mc.buf[startOffset:stopOffset]` by reference — ships whatever the new writer wrote there.

Random writes take the mem-chunk path in this workload: `SeqTolerance` is 8 MiB, so writes anywhere in a 16 MiB file keep `IsSequentialMode` true.

The same function also has the completing uploader call `delete(up.sealedChunks, logicChunkIndex)` unconditionally. If a later seal already took over that index, this evicts the newer sealed chunk and hides its dirty pages from `MaybeReadDataAt`.

Only the FUSE mount sets `WantMd5: true`, which is why this shows up as a hard `EIO` there rather than silently stored wrong bytes.

## Fix

A sealed chunk now carries two references — one for the `sealedChunks` slot, one for the upload — and the upload's reference is dropped only by the upload itself. The uploader unindexes itself only while it still owns the index. `Shutdown` drops just the slot reference and leaves any in-flight upload's alone, so the chunk is still freed exactly once.

## Testing

Two regression tests using a gated `PageChunk` that parks in exactly the state `moveToSealed` leaves an upload in. Both fail on `master`:

```
--- FAIL: TestMoveToSealed_ReplaceKeepsUploadReference
    first chunk was freed before its upload read it
    index 0 should still hold the second chunk, got <nil>
--- FAIL: TestShutdown_LeavesInFlightUploadItsReference
    Shutdown freed the chunk before its upload read it
```

`./weed/mount` and `./weed/mount/page_writer` pass under `-race`. The pre-existing `TestUploadPipeline` is the one exception: it takes ~60s without `-race` and exceeds the 10m timeout with it (~54k 4-byte writes against the O(n) interval list). It never reaches the sealing path, and that slowness is unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upload cleanup when sealed chunks are replaced or the system shuts down.
  * Prevented in-progress uploads from being released prematurely.
  * Ensured newer sealed chunks remain indexed correctly during replacement.
  * Prevented duplicate cleanup of chunks after uploads complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->