### PR TITLE
wdclient: read the vid map cache link before the live map

### DIFF
--- a/weed/wdclient/vid_map.go
+++ b/weed/wdclient/vid_map.go
@@ -129,6 +129,11 @@ func (vc *vidMap) GetVidLocations(vid string) (locations []Location, err error) 
 
 func (vc *vidMap) GetLocations(vid uint32) (locations []Location, found bool) {
 	// glog.V(4).Infof("~ lookup volume id %d: %+v ec:%+v", vid, vc.vid2Locations, vc.ecVid2Locations)
+	// Read the cache link before the live map: resetVidMap trims the chain, so a
+	// link loaded after the local miss may already be severed, turning a lookup
+	// that could have been served by the cache into a spurious miss.
+	cachedMap := vc.cache.Load()
+
 	locations, found = vc.getLocations(vid)
 	if found {
 		// If volume is explicitly tracked (found=true), return its locations even if empty.
@@ -143,7 +148,7 @@ func (vc *vidMap) GetLocations(vid uint32) (locations []Location, found bool) {
 	}
 
 	// Volume not found in current map - check cache for unknown volumes
-	if cachedMap := vc.cache.Load(); cachedMap != nil {
+	if cachedMap != nil {
 		return cachedMap.GetLocations(vid)
 	}
 
@@ -185,13 +190,16 @@ func (vc *vidMap) hasVolumeServer(addr pb.ServerAddress) bool {
 	if key == "" {
 		return false
 	}
+	// Same ordering requirement as GetLocations: grab the cache link before the
+	// local lookup so a concurrent reset cannot sever it underneath us.
+	cachedMap := vc.cache.Load()
 	vc.RLock()
 	count := vc.serverRefCount[key]
 	vc.RUnlock()
 	if count > 0 {
 		return true
 	}
-	if cachedMap := vc.cache.Load(); cachedMap != nil {
+	if cachedMap != nil {
 		return cachedMap.hasVolumeServer(addr)
 	}
 	return false


### PR DESCRIPTION
`TestConcurrentGetLocations` fails intermittently in CI ("vid map invalid due to data racing"). It reproduces locally roughly once per 200 runs, more often on a low-core runner.

### Cause

Not a memory race — a logical one in the vidMap cache chain:

1. A reader captures the current head map in the window between `resetVidMap()` and the subsequent `addLocation()`, while the head is still empty.
2. It misses in the head's own map.
3. It gets descheduled. Meanwhile the reset loop keeps going, and once the head ages past `vidMapCacheSize`, the trim in `resetVidMap` (`node.cache.Store(nil)`) severs its link to the ancestors that still hold the volume.
4. The reader resumes, loads `vc.cache`, sees `nil`, and reports `found=false` for a volume that was resolvable the entire time.

### Fix

Load the cache link before consulting the live map, so the reader captures it while it is still guaranteed live (a head's link is set before the map is published).

This cannot return staler data: once a `vidMap` is published, its `cache` pointer only ever transitions from its ancestor to `nil` — the only mutation sites are `nvm.cache.Store(tail)` before publication and the trim. So the earlier load either sees the same pointer or preserves one the late load would have found severed.

`hasVolumeServer` had the identical pattern, where a spurious `false` misreports a known volume server, so it gets the same treatment.

### Evidence

Instrumenting the reader's gap between the local miss and the link load, with a `runtime.Gosched()` standing in for being descheduled:

| load order | walks | local misses | link severed in gap |
| --- | --- | --- | --- |
| before (link loaded after the miss) | 305M | 113,665 | **501** |
| after (link loaded first) | 234M | 12,021 | **0** |

### Testing

- `go test -run TestConcurrentGetLocations -count=250` — pass (before the fix, a 200-run loop failed)
- `go test -race -count=3` over the vid-map tests — pass, no race reports
- `go test ./weed/wdclient/...` and `go vet` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when retrieving volume locations during concurrent cache updates.
  * Preserved access to cached location data while cache chains are being refreshed.
  * Improved volume server availability checks when live or cached data is accessed concurrently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->