### PR TITLE
EC scrubbing: list shards for needles failing scrubs in the result output.

### DIFF
--- a/weed/storage/store_ec_scrub.go
+++ b/weed/storage/store_ec_scrub.go
@@ -39,6 +39,13 @@ func (s *Store) ScrubEcVolume(vid needle.VolumeId, forceDeletedNeedlesCheck bool
 		data := make([]byte, 0, needle.GetActualSize(size, ecv.Version))
 		intervals := ecv.LocateEcShardNeedleInterval(ecv.Version, offset.ToActualOffset(), size)
 
+		shardIds := make([]erasure_coding.ShardId, len(intervals))
+		for i, iv := range intervals {
+			sid, _ := s.IntervalToShardIdAndOffset(iv)
+			shardIds[i] = sid
+		}
+		slices.Sort(shardIds)
+
 		for i, iv := range intervals {
 			chunk := make([]byte, iv.Size)
 			shardId, offset := s.IntervalToShardIdAndOffset(iv)
@@ -73,7 +80,7 @@ func (s *Store) ScrubEcVolume(vid needle.VolumeId, forceDeletedNeedlesCheck bool
 		}
 
 		if got, want := int64(len(data)), needle.GetActualSize(size, ecv.Version); got != want {
-			errs = append(errs, fmt.Errorf("expected %d bytes for needle %d, got %d", want, id, got))
+			errs = append(errs, fmt.Errorf("EC volume %d, needle %d on shards %v: expected %d bytes, got %d", ecv.VolumeId, id, shardIds, want, got))
 			return nil
 		}
 
@@ -83,7 +90,7 @@ func (s *Store) ScrubEcVolume(vid needle.VolumeId, forceDeletedNeedlesCheck bool
 			// be properly hydrated, as the header read by needle.ReadBytes() will mismatch.
 			deleteSizeMismatch := size.IsDeleted() != (n.Size == 0)
 			if !errors.Is(err, needle.ErrorSizeMismatch) || !deleteSizeMismatch || forceDeletedNeedlesCheck {
-				errs = append(errs, fmt.Errorf("needle %d on EC volume %d: %v", id, ecv.VolumeId, err))
+				errs = append(errs, fmt.Errorf("EC volume %d, needle %d on shards %v: %v", ecv.VolumeId, id, shardIds, err))
 			}
 		}
 


### PR DESCRIPTION
# What problem are we solving?

Provide increased visibility into invalid/corrupted EC volumes.

# How are we solving the problem?

EC scrubbing results now list all affected shards for failed needle reads; this allows to pinpoint failures to a subset of
 shards, which can then be bisected and potentially reconstructed.

# How is the PR tested?

No tests affected.

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages during volume scrubbing by including the affected shard IDs.
  * Added shard context to incomplete-read and needle parsing errors for easier troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->