### PR TITLE
test: pin that an unusable version id is refused, never resolved

### DIFF
--- a/test/s3/versioning/s3_invalid_version_id_test.go
+++ b/test/s3/versioning/s3_invalid_version_id_test.go
@@ -49,9 +49,11 @@ func TestUnusableVersionIDIsRefusedNotResolved(t *testing.T) {
 				Key:       aws.String(objectKey),
 				VersionId: aws.String(versionID),
 			})
-			status := statusOf(t, err)
-			assert.Less(t, status, 500, "an unusable version id is a client error, not a server fault; a 5xx invites endless retries of a request that can never succeed")
-			assert.GreaterOrEqual(t, status, 400)
+			// 400, not merely "some 4xx": the id is malformed, which is a bad
+			// argument rather than a missing resource. A 5xx would be the real
+			// damage — it invites endless retries of a request that can never
+			// succeed — but pinning the exact code keeps the contract honest.
+			assert.Equal(t, 400, statusOf(t, err))
 		})
 	}
 
@@ -98,9 +100,7 @@ func TestUnusableVersionIDRefusedOnReadPaths(t *testing.T) {
 				Key:       aws.String(objectKey),
 				VersionId: aws.String(versionID),
 			})
-			status := statusOf(t, err)
-			assert.Less(t, status, 500)
-			assert.GreaterOrEqual(t, status, 400)
+			assert.Equal(t, 400, statusOf(t, err))
 		})
 		t.Run("head "+versionID, func(t *testing.T) {
 			_, err := client.HeadObject(context.TODO(), &s3.HeadObjectInput{
@@ -108,9 +108,7 @@ func TestUnusableVersionIDRefusedOnReadPaths(t *testing.T) {
 				Key:       aws.String(objectKey),
 				VersionId: aws.String(versionID),
 			})
-			status := statusOf(t, err)
-			assert.Less(t, status, 500)
-			assert.GreaterOrEqual(t, status, 400)
+			assert.Equal(t, 400, statusOf(t, err))
 		})
 	}
 }

--- a/test/s3/versioning/s3_invalid_version_id_test.go
+++ b/test/s3/versioning/s3_invalid_version_id_test.go
@@ -1,0 +1,116 @@
+package s3api
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Version ids that can never name a stored version. A request carrying one has
+// to be refused: resolving it to the null or latest version instead would let a
+// caller destroy a live version by asking for one that does not exist.
+var unusableVersionIDs = []string{"a/b", `a\b`, "..", "."}
+
+func statusOf(t *testing.T, err error) int {
+	t.Helper()
+	require.Error(t, err)
+	var respErr *smithyhttp.ResponseError
+	require.True(t, errors.As(err, &respErr), "expected an HTTP response error, got %v", err)
+	return respErr.HTTPStatusCode()
+}
+
+func TestUnusableVersionIDIsRefusedNotResolved(t *testing.T) {
+	client := getS3Client(t)
+	bucketName := getNewBucketName()
+
+	createBucketWithObjectLock(t, client, bucketName)
+	defer deleteBucket(t, client, bucketName)
+
+	objectKey := "arbitration.lock"
+	put, err := client.PutObject(context.TODO(), &s3.PutObjectInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String(objectKey),
+		Body:   bytes.NewReader([]byte("held")),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, put.VersionId)
+
+	for _, versionID := range unusableVersionIDs {
+		t.Run("delete "+versionID, func(t *testing.T) {
+			_, err := client.DeleteObject(context.TODO(), &s3.DeleteObjectInput{
+				Bucket:    aws.String(bucketName),
+				Key:       aws.String(objectKey),
+				VersionId: aws.String(versionID),
+			})
+			status := statusOf(t, err)
+			assert.Less(t, status, 500, "an unusable version id is a client error, not a server fault; a 5xx invites endless retries of a request that can never succeed")
+			assert.GreaterOrEqual(t, status, 400)
+		})
+	}
+
+	// The point of the whole test: none of those requests may have been resolved
+	// to the version that does exist.
+	head, err := client.HeadObject(context.TODO(), &s3.HeadObjectInput{
+		Bucket:    aws.String(bucketName),
+		Key:       aws.String(objectKey),
+		VersionId: put.VersionId,
+	})
+	require.NoError(t, err, "the stored version must survive every refused request")
+	require.NotNil(t, head.VersionId)
+	assert.Equal(t, *put.VersionId, *head.VersionId)
+
+	get, err := client.GetObject(context.TODO(), &s3.GetObjectInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String(objectKey),
+	})
+	require.NoError(t, err, "the latest version must still resolve")
+	defer get.Body.Close()
+}
+
+// Read paths must agree with the write path: the same id is unusable everywhere,
+// so a caller cannot be told the object is missing by one verb and served by another.
+func TestUnusableVersionIDRefusedOnReadPaths(t *testing.T) {
+	client := getS3Client(t)
+	bucketName := getNewBucketName()
+
+	createBucketWithObjectLock(t, client, bucketName)
+	defer deleteBucket(t, client, bucketName)
+
+	objectKey := "arbitration.lock"
+	_, err := client.PutObject(context.TODO(), &s3.PutObjectInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String(objectKey),
+		Body:   bytes.NewReader([]byte("held")),
+	})
+	require.NoError(t, err)
+
+	for _, versionID := range unusableVersionIDs {
+		t.Run("get "+versionID, func(t *testing.T) {
+			_, err := client.GetObject(context.TODO(), &s3.GetObjectInput{
+				Bucket:    aws.String(bucketName),
+				Key:       aws.String(objectKey),
+				VersionId: aws.String(versionID),
+			})
+			status := statusOf(t, err)
+			assert.Less(t, status, 500)
+			assert.GreaterOrEqual(t, status, 400)
+		})
+		t.Run("head "+versionID, func(t *testing.T) {
+			_, err := client.HeadObject(context.TODO(), &s3.HeadObjectInput{
+				Bucket:    aws.String(bucketName),
+				Key:       aws.String(objectKey),
+				VersionId: aws.String(versionID),
+			})
+			status := statusOf(t, err)
+			assert.Less(t, status, 500)
+			assert.GreaterOrEqual(t, status, 400)
+		})
+	}
+}


### PR DESCRIPTION
A version id containing a path separator, or `.` / `..`, can never name a stored version. The dangerous failure mode for this class is not rejecting it too loudly — it is resolving it to the null or latest version, which lets a caller destroy a live version by asking for one that does not exist, on a bucket configured for immutability.

I checked this against a running server while chasing a support case. The guard **exists today and holds on every verb** (`isValidVersionID` is the first thing both the read and delete paths do), and unusable ids come back as 400. It had no test, so this pins it. Regression coverage, not a fix.

Two properties:

- the request is refused with a **client** error, not a 5xx — a 5xx invites a client to retry forever something that can never succeed
- after every refused DELETE, the version that *does* exist is still there, and the latest version still resolves

The read paths are asserted alongside DELETE so a caller cannot be told the object is missing by one verb and served by another.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid object version IDs are now rejected with 4xx errors for delete, GET, and HEAD requests.
  * Valid version IDs and access to the latest object version continue to work as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->