### PR TITLE
test: pin verb parity on lock-arbitration keys through acquire and release

### DIFF
--- a/test/s3/versioning/s3_lock_key_verb_parity_test.go
+++ b/test/s3/versioning/s3_lock_key_verb_parity_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"strings"
 	"testing"
 
@@ -63,6 +64,9 @@ func probe(t *testing.T, client *s3.Client, bucket, key string) existence {
 		Bucket: aws.String(bucket), Key: aws.String(key),
 	})
 	if err == nil {
+		// Drain before closing so the connection goes back to the pool; these
+		// probes run in tight loops and a discarded body forces a new connection.
+		_, _ = io.Copy(io.Discard, getResp.Body)
 		getResp.Body.Close()
 		e.get = true
 	} else {
@@ -171,29 +175,32 @@ func TestLockKeyVerbParityAcrossReacquireCycles(t *testing.T) {
 	createBucketWithObjectLock(t, client, bucketName)
 	defer deleteBucket(t, client, bucketName)
 
-	key := lockArbitrationKeys[0]
-	for cycle := 0; cycle < 3; cycle++ {
-		put, err := client.PutObject(context.TODO(), &s3.PutObjectInput{
-			Bucket: aws.String(bucketName),
-			Key:    aws.String(key),
-			Body:   bytes.NewReader([]byte("held")),
+	for _, key := range lockArbitrationKeys {
+		t.Run(strings.ReplaceAll(key, "/", "_"), func(t *testing.T) {
+			for cycle := 0; cycle < 3; cycle++ {
+				put, err := client.PutObject(context.TODO(), &s3.PutObjectInput{
+					Bucket: aws.String(bucketName),
+					Key:    aws.String(key),
+					Body:   bytes.NewReader([]byte("held")),
+				})
+				require.NoError(t, err)
+				require.NotNil(t, put.VersionId)
+
+				held := probe(t, client, bucketName, key)
+				require.True(t, held.agree(), "cycle %d: verbs disagree while held: %+v", cycle, held)
+				require.True(t, held.get, "cycle %d: key should be present while held: %+v", cycle, held)
+
+				_, err = client.DeleteObject(context.TODO(), &s3.DeleteObjectInput{
+					Bucket:    aws.String(bucketName),
+					Key:       aws.String(key),
+					VersionId: put.VersionId,
+				})
+				require.NoError(t, err)
+
+				released := probe(t, client, bucketName, key)
+				require.True(t, released.agree(), "cycle %d: verbs disagree after release: %+v", cycle, released)
+				require.False(t, released.get, "cycle %d: key should be absent after release: %+v", cycle, released)
+			}
 		})
-		require.NoError(t, err)
-		require.NotNil(t, put.VersionId)
-
-		held := probe(t, client, bucketName, key)
-		require.True(t, held.agree(), "cycle %d: verbs disagree while held: %+v", cycle, held)
-		require.True(t, held.get, "cycle %d: key should be present while held: %+v", cycle, held)
-
-		_, err = client.DeleteObject(context.TODO(), &s3.DeleteObjectInput{
-			Bucket:    aws.String(bucketName),
-			Key:       aws.String(key),
-			VersionId: put.VersionId,
-		})
-		require.NoError(t, err)
-
-		released := probe(t, client, bucketName, key)
-		require.True(t, released.agree(), "cycle %d: verbs disagree after release: %+v", cycle, released)
-		require.False(t, released.get, "cycle %d: key should be absent after release: %+v", cycle, released)
 	}
 }

--- a/test/s3/versioning/s3_lock_key_verb_parity_test.go
+++ b/test/s3/versioning/s3_lock_key_verb_parity_test.go
@@ -1,0 +1,199 @@
+package s3api
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Backup clients arbitrate ownership by writing and retracting small keys under a
+// fixed prefix, then re-probing them. Each probe uses a different verb, and the
+// client trusts them to agree: a key reported present by one and absent by another
+// makes it either spin or conclude the repository is corrupt. The keys are written
+// and immediately deleted by version, which is the cycle that leaves versioning
+// residue behind, so parity has to hold on both sides of the delete.
+
+var lockArbitrationKeys = []string{
+	"Metadata/Lock/create.checkpoint/lock",
+	"Metadata/Lock/create.checkpoint/try",
+	"Metadata/Lock/create.checkpoint/declare",
+	"Metadata/Lock/delete.checkpoint/lock",
+}
+
+// existence reports what each verb believes about a key, so a disagreement names
+// the verbs rather than just failing.
+type existence struct {
+	get         bool
+	head        bool
+	listObjects bool
+	listVersion bool
+}
+
+func (e existence) agree() bool {
+	return e.get == e.head && e.head == e.listObjects && e.listObjects == e.listVersion
+}
+
+func notFound(t *testing.T, err error) bool {
+	t.Helper()
+	if err == nil {
+		return false
+	}
+	var respErr *smithyhttp.ResponseError
+	if errors.As(err, &respErr) {
+		require.Less(t, respErr.HTTPStatusCode(), 500, "probing a lock key must never fault the server: %v", err)
+		return respErr.HTTPStatusCode() == 404
+	}
+	t.Fatalf("unexpected error probing lock key: %v", err)
+	return false
+}
+
+func probe(t *testing.T, client *s3.Client, bucket, key string) existence {
+	t.Helper()
+	var e existence
+
+	getResp, err := client.GetObject(context.TODO(), &s3.GetObjectInput{
+		Bucket: aws.String(bucket), Key: aws.String(key),
+	})
+	if err == nil {
+		getResp.Body.Close()
+		e.get = true
+	} else {
+		require.True(t, notFound(t, err), "GET must answer present or 404, got %v", err)
+	}
+
+	if _, err := client.HeadObject(context.TODO(), &s3.HeadObjectInput{
+		Bucket: aws.String(bucket), Key: aws.String(key),
+	}); err == nil {
+		e.head = true
+	} else {
+		require.True(t, notFound(t, err), "HEAD must answer present or 404, got %v", err)
+	}
+
+	listed, err := client.ListObjectsV2(context.TODO(), &s3.ListObjectsV2Input{
+		Bucket: aws.String(bucket), Prefix: aws.String(key),
+	})
+	require.NoError(t, err)
+	for _, obj := range listed.Contents {
+		if obj.Key != nil && *obj.Key == key {
+			e.listObjects = true
+		}
+	}
+
+	versions, err := client.ListObjectVersions(context.TODO(), &s3.ListObjectVersionsInput{
+		Bucket: aws.String(bucket), Prefix: aws.String(key),
+	})
+	require.NoError(t, err)
+	for _, v := range versions.Versions {
+		// A version is only "the object exists" if it is the current one; a
+		// superseded version coexists with a delete marker on a live key.
+		if v.Key != nil && *v.Key == key && v.IsLatest != nil && *v.IsLatest {
+			e.listVersion = true
+		}
+	}
+
+	return e
+}
+
+func TestLockKeyVerbParityWhilePresent(t *testing.T) {
+	client := getS3Client(t)
+	bucketName := getNewBucketName()
+
+	createBucketWithObjectLock(t, client, bucketName)
+	defer deleteBucket(t, client, bucketName)
+
+	for _, key := range lockArbitrationKeys {
+		_, err := client.PutObject(context.TODO(), &s3.PutObjectInput{
+			Bucket: aws.String(bucketName),
+			Key:    aws.String(key),
+			Body:   bytes.NewReader([]byte("held")),
+		})
+		require.NoError(t, err)
+	}
+
+	for _, key := range lockArbitrationKeys {
+		t.Run(strings.ReplaceAll(key, "/", "_"), func(t *testing.T) {
+			e := probe(t, client, bucketName, key)
+			assert.True(t, e.agree(), "verbs disagree on a present lock key: %+v", e)
+			assert.True(t, e.get, "lock key should be present: %+v", e)
+		})
+	}
+}
+
+// The retract half of the cycle: write, then delete by version id — the sequence
+// that empties a version container. Every verb must then agree the key is gone.
+func TestLockKeyVerbParityAfterVersionDelete(t *testing.T) {
+	client := getS3Client(t)
+	bucketName := getNewBucketName()
+
+	createBucketWithObjectLock(t, client, bucketName)
+	defer deleteBucket(t, client, bucketName)
+
+	for _, key := range lockArbitrationKeys {
+		put, err := client.PutObject(context.TODO(), &s3.PutObjectInput{
+			Bucket: aws.String(bucketName),
+			Key:    aws.String(key),
+			Body:   bytes.NewReader([]byte("held")),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, put.VersionId)
+
+		_, err = client.DeleteObject(context.TODO(), &s3.DeleteObjectInput{
+			Bucket:    aws.String(bucketName),
+			Key:       aws.String(key),
+			VersionId: put.VersionId,
+		})
+		require.NoError(t, err)
+	}
+
+	for _, key := range lockArbitrationKeys {
+		t.Run(strings.ReplaceAll(key, "/", "_"), func(t *testing.T) {
+			e := probe(t, client, bucketName, key)
+			assert.True(t, e.agree(), "verbs disagree on a retracted lock key: %+v", e)
+			assert.False(t, e.get, "retracted lock key should be absent: %+v", e)
+		})
+	}
+}
+
+// Re-acquiring after a retract is the steady-state loop. Residue left by the
+// previous cycle must not make the new key invisible to any verb.
+func TestLockKeyVerbParityAcrossReacquireCycles(t *testing.T) {
+	client := getS3Client(t)
+	bucketName := getNewBucketName()
+
+	createBucketWithObjectLock(t, client, bucketName)
+	defer deleteBucket(t, client, bucketName)
+
+	key := lockArbitrationKeys[0]
+	for cycle := 0; cycle < 3; cycle++ {
+		put, err := client.PutObject(context.TODO(), &s3.PutObjectInput{
+			Bucket: aws.String(bucketName),
+			Key:    aws.String(key),
+			Body:   bytes.NewReader([]byte("held")),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, put.VersionId)
+
+		held := probe(t, client, bucketName, key)
+		require.True(t, held.agree(), "cycle %d: verbs disagree while held: %+v", cycle, held)
+		require.True(t, held.get, "cycle %d: key should be present while held: %+v", cycle, held)
+
+		_, err = client.DeleteObject(context.TODO(), &s3.DeleteObjectInput{
+			Bucket:    aws.String(bucketName),
+			Key:       aws.String(key),
+			VersionId: put.VersionId,
+		})
+		require.NoError(t, err)
+
+		released := probe(t, client, bucketName, key)
+		require.True(t, released.agree(), "cycle %d: verbs disagree after release: %+v", cycle, released)
+		require.False(t, released.get, "cycle %d: key should be absent after release: %+v", cycle, released)
+	}
+}


### PR DESCRIPTION
Backup clients arbitrate repository ownership by writing and retracting small keys under a fixed prefix, then re-probing them — each probe using a different verb (`GET`, `HEAD`, `ListObjectsV2`, `ListObjectVersions`). They trust those verbs to agree.

This class of bug is nasty because it is invisible from the storage side: a key reported present by one verb and absent by another makes the client spin or declare the repository corrupt, while every individual answer is locally correct and nothing is logged as an error.

I verified this against a running server while chasing a support case. **Parity holds today** — this is regression coverage, not a fix.

What is covered:

- all four verbs agree while the key is held
- all four agree after the key is retracted by `DELETE ?versionId=` — the sequence that empties a version container, so it is where the two views are most likely to drift apart
- parity survives repeated acquire/release cycles on the same key, where residue from previous cycles accumulates

`ListObjectVersions` only counts a key as present when the matching version is `IsLatest`, so a superseded version sitting behind a delete marker is not mistaken for a live key.

On failure the assertion prints which verbs disagreed rather than just that something did.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify consistent lock-key visibility across GET, HEAD, object listing, and version listing operations.
  * Added validation for lock-key behavior after version deletion and through repeated acquire-and-release cycles.
  * Expanded checks to ensure probing returns only expected not-found responses when keys are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->