### PR TITLE
test: cover listings spanning a run of retracted keys

### DIFF
--- a/test/s3/versioning/s3_hidden_version_listing_test.go
+++ b/test/s3/versioning/s3_hidden_version_listing_test.go
@@ -1,0 +1,162 @@
+package s3api
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A listing walks entries and drops the ones whose current version is a delete
+// marker. When a whole run of consecutive entries drops out, the page it was
+// filling can come back empty — and an empty page is easily mistaken for the end
+// of the listing. Everything after the run then never appears, and the caller is
+// told the objects do not exist. Backup repositories hit this shape constantly:
+// they retract a batch of keys under one prefix and keep writing under the next.
+
+func putObjectVersioned(t *testing.T, client *s3.Client, bucket, key string) {
+	t.Helper()
+	_, err := client.PutObject(context.TODO(), &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+		Body:   bytes.NewReader([]byte("x")),
+	})
+	require.NoError(t, err)
+}
+
+func listAllKeys(t *testing.T, client *s3.Client, bucket string, maxKeys int32) []string {
+	t.Helper()
+	var keys []string
+	var token *string
+	for {
+		in := &s3.ListObjectsV2Input{Bucket: aws.String(bucket), ContinuationToken: token}
+		if maxKeys > 0 {
+			in.MaxKeys = aws.Int32(maxKeys)
+		}
+		resp, err := client.ListObjectsV2(context.TODO(), in)
+		require.NoError(t, err)
+		for _, o := range resp.Contents {
+			require.NotNil(t, o.Key)
+			keys = append(keys, *o.Key)
+		}
+		if resp.IsTruncated == nil || !*resp.IsTruncated {
+			break
+		}
+		require.NotNil(t, resp.NextContinuationToken, "a truncated listing must carry a continuation token")
+		token = resp.NextContinuationToken
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func TestListingSurvivesRunOfHiddenVersions(t *testing.T) {
+	client := getS3Client(t)
+	bucketName := getNewBucketName()
+
+	createBucket(t, client, bucketName)
+	defer deleteBucket(t, client, bucketName)
+	enableVersioning(t, client, bucketName)
+
+	// A long run of retracted keys, sorting before the live ones.
+	const hidden = 25
+	for i := 0; i < hidden; i++ {
+		key := fmt.Sprintf("aretracted/%03d.lock", i)
+		putObjectVersioned(t, client, bucketName, key)
+		_, err := client.DeleteObject(context.TODO(), &s3.DeleteObjectInput{
+			Bucket: aws.String(bucketName), Key: aws.String(key),
+		})
+		require.NoError(t, err)
+	}
+
+	var live []string
+	for i := 0; i < 5; i++ {
+		key := fmt.Sprintf("blive/%03d.blk", i)
+		putObjectVersioned(t, client, bucketName, key)
+		live = append(live, key)
+	}
+	sort.Strings(live)
+
+	// Unpaginated: the retracted run must not hide what follows it.
+	assert.Equal(t, live, listAllKeys(t, client, bucketName, 0),
+		"a run of retracted keys must not truncate the listing")
+
+	// Paginated with pages smaller than the retracted run, so at least one page
+	// is filled entirely from entries that get dropped.
+	for _, pageSize := range []int32{1, 2, 5, 10} {
+		t.Run(fmt.Sprintf("maxKeys=%d", pageSize), func(t *testing.T) {
+			assert.Equal(t, live, listAllKeys(t, client, bucketName, pageSize),
+				"pagination across a retracted run must not lose the keys after it")
+		})
+	}
+}
+
+// The same shape with the retracted run in the middle, so both a preceding and a
+// following key have to survive it.
+func TestListingSurvivesHiddenVersionsBetweenLiveKeys(t *testing.T) {
+	client := getS3Client(t)
+	bucketName := getNewBucketName()
+
+	createBucket(t, client, bucketName)
+	defer deleteBucket(t, client, bucketName)
+	enableVersioning(t, client, bucketName)
+
+	putObjectVersioned(t, client, bucketName, "a-first.blk")
+
+	for i := 0; i < 20; i++ {
+		key := fmt.Sprintf("m-retracted/%03d.lock", i)
+		putObjectVersioned(t, client, bucketName, key)
+		_, err := client.DeleteObject(context.TODO(), &s3.DeleteObjectInput{
+			Bucket: aws.String(bucketName), Key: aws.String(key),
+		})
+		require.NoError(t, err)
+	}
+
+	putObjectVersioned(t, client, bucketName, "z-last.blk")
+
+	want := []string{"a-first.blk", "z-last.blk"}
+	for _, pageSize := range []int32{0, 1, 3, 10} {
+		t.Run(fmt.Sprintf("maxKeys=%d", pageSize), func(t *testing.T) {
+			assert.Equal(t, want, listAllKeys(t, client, bucketName, pageSize),
+				"keys on both sides of a retracted run must both be listed")
+		})
+	}
+}
+
+// ListObjectVersions sees the same namespace from the other side: the retracted
+// keys are still there as versions plus delete markers, and must all be reported.
+func TestListObjectVersionsReportsRetractedKeys(t *testing.T) {
+	client := getS3Client(t)
+	bucketName := getNewBucketName()
+
+	createBucket(t, client, bucketName)
+	defer deleteBucket(t, client, bucketName)
+	enableVersioning(t, client, bucketName)
+
+	const retracted = 10
+	for i := 0; i < retracted; i++ {
+		key := fmt.Sprintf("retracted/%03d.lock", i)
+		putObjectVersioned(t, client, bucketName, key)
+		_, err := client.DeleteObject(context.TODO(), &s3.DeleteObjectInput{
+			Bucket: aws.String(bucketName), Key: aws.String(key),
+		})
+		require.NoError(t, err)
+	}
+
+	resp, err := client.ListObjectVersions(context.TODO(), &s3.ListObjectVersionsInput{
+		Bucket: aws.String(bucketName),
+	})
+	require.NoError(t, err)
+
+	assert.Len(t, resp.Versions, retracted, "every written version must still be reported")
+	assert.Len(t, resp.DeleteMarkers, retracted, "every retraction must be reported as a delete marker")
+
+	// And the current-version view of the same namespace is empty.
+	assert.Empty(t, listAllKeys(t, client, bucketName, 0),
+		"no key should be current once every one has been retracted")
+}

--- a/test/s3/versioning/s3_hidden_version_listing_test.go
+++ b/test/s3/versioning/s3_hidden_version_listing_test.go
@@ -88,7 +88,7 @@ func TestListingSurvivesRunOfHiddenVersions(t *testing.T) {
 
 	// Paginated with pages smaller than the retracted run, so at least one page
 	// is filled entirely from entries that get dropped.
-	for _, pageSize := range []int32{1, 2, 5, 10} {
+	for _, pageSize := range []int32{1, 2, 3, 5, 10} {
 		t.Run(fmt.Sprintf("maxKeys=%d", pageSize), func(t *testing.T) {
 			assert.Equal(t, live, listAllKeys(t, client, bucketName, pageSize),
 				"pagination across a retracted run must not lose the keys after it")
@@ -120,7 +120,7 @@ func TestListingSurvivesHiddenVersionsBetweenLiveKeys(t *testing.T) {
 	putObjectVersioned(t, client, bucketName, "z-last.blk")
 
 	want := []string{"a-first.blk", "z-last.blk"}
-	for _, pageSize := range []int32{0, 1, 3, 10} {
+	for _, pageSize := range []int32{0, 1, 2, 3, 5, 10} {
 		t.Run(fmt.Sprintf("maxKeys=%d", pageSize), func(t *testing.T) {
 			assert.Equal(t, want, listAllKeys(t, client, bucketName, pageSize),
 				"keys on both sides of a retracted run must both be listed")
@@ -148,13 +148,30 @@ func TestListObjectVersionsReportsRetractedKeys(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	resp, err := client.ListObjectVersions(context.TODO(), &s3.ListObjectVersionsInput{
-		Bucket: aws.String(bucketName),
-	})
-	require.NoError(t, err)
+	// Paginated with a page far smaller than the run, so the continuation markers
+	// have to carry the walk across it — the same path the plain listing exercises
+	// above, but on the version side.
+	var versions, markers int
+	var keyMarker, versionIDMarker *string
+	for {
+		resp, err := client.ListObjectVersions(context.TODO(), &s3.ListObjectVersionsInput{
+			Bucket:          aws.String(bucketName),
+			MaxKeys:         aws.Int32(3),
+			KeyMarker:       keyMarker,
+			VersionIdMarker: versionIDMarker,
+		})
+		require.NoError(t, err)
+		versions += len(resp.Versions)
+		markers += len(resp.DeleteMarkers)
+		if resp.IsTruncated == nil || !*resp.IsTruncated {
+			break
+		}
+		require.NotNil(t, resp.NextKeyMarker, "a truncated version listing must carry a key marker")
+		keyMarker, versionIDMarker = resp.NextKeyMarker, resp.NextVersionIdMarker
+	}
 
-	assert.Len(t, resp.Versions, retracted, "every written version must still be reported")
-	assert.Len(t, resp.DeleteMarkers, retracted, "every retraction must be reported as a delete marker")
+	assert.Equal(t, retracted, versions, "every written version must still be reported")
+	assert.Equal(t, retracted, markers, "every retraction must be reported as a delete marker")
 
 	// And the current-version view of the same namespace is empty.
 	assert.Empty(t, listAllKeys(t, client, bucketName, 0),


### PR DESCRIPTION
A listing drops entries whose current version is a delete marker. When a *run* of consecutive entries drops out, the page being filled can come back empty — and an empty page is easily mistaken for the end of the listing. Everything after the run then never appears, and the caller is told those objects do not exist.

Backup repositories produce exactly this shape constantly: a batch of keys under one prefix is retracted while writing continues under the next. The failure is silent on the storage side, because a listing that stops early looks identical to a listing that finished.

Behaviour is correct today; this is regression coverage. Found while chasing a support case where a backup client reported keys as missing.

Covers:

- a retracted run of 25 keys sorting **before** the live keys
- a retracted run of 20 keys sorting **between** two live keys, so a key on each side has to survive it
- both walked unpaginated and with `MaxKeys` of 1/2/3/5/10 — all smaller than the run, so at least one page is filled entirely from entries that get dropped and the continuation token has to carry the walk past them
- the version view of the same namespace, also paginated (`MaxKeys=3`, walking `KeyMarker`/`VersionIdMarker`): every version and every delete marker still reported, while the current-version view is empty

Both pagination helpers assert that a truncated response carries the marker needed to continue, so a listing cannot claim more results and then fail to provide a way to reach them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for object listings containing consecutive hidden delete markers.
  * Verified paginated and unpaginated listings consistently return subsequent live objects.
  * Confirmed version listings include all object versions and delete markers, even when current-object listings are empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->