### PR TITLE
master: count only writable volumes as crowded when deciding growth

### DIFF
--- a/weed/topology/volume_layout.go
+++ b/weed/topology/volume_layout.go
@@ -783,7 +783,17 @@ func ceilDiv(a, b uint32) uint32 {
 func (vl *VolumeLayout) GetWritableVolumeCount() (active, crowded int) {
 	vl.accessLock.RLock()
 	defer vl.accessLock.RUnlock()
-	return len(vl.writables), len(vl.crowded)
+	// The crowded map retains volumes that later became unwritable (full,
+	// read-only), so their state survives transient writability flips. Count
+	// only the writable ones: growth decisions compare crowded against
+	// writables, and a raw len(vl.crowded) can exceed len(vl.writables)
+	// permanently, demanding growth forever.
+	for _, vid := range vl.writables {
+		if _, ok := vl.crowded[vid]; ok {
+			crowded++
+		}
+	}
+	return len(vl.writables), crowded
 }
 
 func (vl *VolumeLayout) CloneWritableVolumes() (writables []needle.VolumeId) {

--- a/weed/topology/volume_layout_grow_test.go
+++ b/weed/topology/volume_layout_grow_test.go
@@ -240,6 +240,35 @@ func TestPlanRackAwareGrowth_EvenDistributionAcrossUnevenDCs(t *testing.T) {
 	}
 }
 
+// Volumes packed to capacity (e.g. by fs.mergeVolumes) go crowded and then
+// unwritable, but stay in the crowded map. ShouldGrowVolumes must count only
+// writable crowded volumes, or those leftovers keep writable <= crowded true
+// forever and every assign-path grow request passes the gate.
+func TestShouldGrowVolumes_UnwritableCrowdedVolumes(t *testing.T) {
+	rp, _ := super_block.NewReplicaPlacementFromString("000")
+	vl := NewVolumeLayout(rp, needle.EMPTY_TTL, types.HardDriveType, 30000, false)
+
+	vl.accessLock.Lock()
+	vl.setVolumeWritable(1)
+	vl.setVolumeWritable(2)
+	vl.accessLock.Unlock()
+
+	vl.SetVolumeCrowded(1)
+	vl.SetVolumeCapacityFull(1)
+
+	if _, crowded := vl.GetWritableVolumeCount(); crowded != 0 {
+		t.Fatalf("expected 0 writable crowded volumes, got %d", crowded)
+	}
+	if vl.ShouldGrowVolumes() {
+		t.Fatal("volume 2 still has room, growth is not needed")
+	}
+
+	vl.SetVolumeCrowded(2)
+	if !vl.ShouldGrowVolumes() {
+		t.Fatal("every writable volume is crowded, growth is needed")
+	}
+}
+
 func restoreCopyCounts(copy1, copy2 uint32) {
 	VolumeGrowStrategy.Copy1Count = copy1
 	VolumeGrowStrategy.Copy2Count = copy2


### PR DESCRIPTION
Fixes #10518.

`ShouldGrowVolumes` compares `writable <= crowded`, which assumes every crowded volume is writable. That stopped holding: the crowded map intentionally keeps a volume's state across transient unwritability so it does not flap, and volumes that end up both crowded and permanently unwritable — packed to capacity by `fs.mergeVolumes`, or read-only — sit above the crowded threshold and get re-marked on every heartbeat. The raw map size then permanently exceeds the writable count, `ShouldGrowVolumes` returns true forever, every assign-path grow request passes the gate, and the periodic grow loop fires as well. With `-volumePreallocate` each phantom volume also burns real disk, which fills disks and makes more volumes unwritable-but-crowded, feeding the loop.

`GetWritableVolumeCount` now reports the crowded count as the intersection with the writable list. The crowded map still retains entries across transient writability flips, but growth decisions and the `volume_layout_crowded` gauge only see crowded volumes that can actually take writes. The regression test pins that a crowded volume removed from writables stops counting toward `ShouldGrowVolumes`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved volume growth decisions by excluding capacity-full volumes from writable volume counts.
  * Prevented unnecessary volume growth when an available writable volume remains.
  * Ensured growth occurs once all writable volumes are crowded.

* **Tests**
  * Added regression coverage for crowded and capacity-full volume scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->