### PR TITLE
test: random needles always carry at least one byte

### DIFF
--- a/weed/storage/volume_vacuum_test.go
+++ b/weed/storage/volume_vacuum_test.go
@@ -397,7 +397,8 @@ type needleInfo struct {
 
 func newRandomNeedle(id uint64) *needle.Needle {
 	n := new(needle.Needle)
-	n.Data = make([]byte, rand.Intn(1024))
+	// never zero bytes: an empty needle writes a size-0 .dat record, indistinguishable from a delete marker
+	n.Data = make([]byte, 1+rand.Intn(1023))
 	rand.Read(n.Data)
 
 	n.Checksum = needle.NewCRC(n.Data)


### PR DESCRIPTION
TestRepairIdxHeadTombstones_ReadOnlyVolume flaked in CI with "read needle 2: not found": the repair found 2 offset-0 tombstones but recovered only 1 row.

newRandomNeedle sizes its data with rand.Intn(1024), so once in 1024 writes a needle carries zero bytes. A zero-data needle lands in .dat as a size-0 record, byte-identical to a delete marker (the flags byte only exists when DataSize > 0), so the idx-head repair scan counts it as deleted and drops it from recovery. With 8 needles per run and the first two under test, that is roughly one failure in 500 runs; 5 of 1500 local runs failed before the fix, 2000 after it pass.

The helper now always writes at least one byte. None of its callers exercise zero-size needles on purpose.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved randomized storage testing by ensuring generated data is never empty, preventing confusion with deletion markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->