### PR TITLE
test: wait for async write-budget release after pipeline shutdown

### DIFF
--- a/weed/mount/page_writer/write_buffer_cap_integration_test.go
+++ b/weed/mount/page_writer/write_buffer_cap_integration_test.go
@@ -160,6 +160,12 @@ func TestWriteBufferCap_SharedAcrossPipelines(t *testing.T) {
 	if got := observedMax.Load(); got > capBytes {
 		t.Fatalf("observed Used()=%d exceeded cap=%d", got, capBytes)
 	}
+	// An uploader goroutine releases its budget slot only after reacquiring
+	// chunksLock post-Shutdown, so the last releases may land asynchronously.
+	drainDeadline := time.Now().Add(5 * time.Second)
+	for acc.Used() != 0 && time.Now().Before(drainDeadline) {
+		time.Sleep(2 * time.Millisecond)
+	}
 	if got := acc.Used(); got != 0 {
 		t.Fatalf("expected 0 used after shutdown, got %d", got)
 	}


### PR DESCRIPTION
TestWriteBufferCap_SharedAcrossPipelines asserts Used()==0 immediately after Shutdown, but Shutdown only drops the sealed-chunk map references. An in-flight uploader goroutine still holds the final reference and releases its budget slot only after reacquiring chunksLock, so on slow runners the assert can observe one or two chunks still reserved. Seen failing in CI with "expected 0 used after shutdown, got 131072" — exactly two undrained chunks.

Poll for the release with a bounded 5s deadline before asserting. Passes 30x with -race locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved shutdown test reliability by allowing asynchronous write-buffer reservations time to be released before verifying resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->