### PR TITLE
mount: drop the unused go-fuse fs package dependency

### DIFF
--- a/weed/mount/weedfs.go
+++ b/weed/mount/weedfs.go
@@ -31,8 +31,6 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/util/grace"
 	"github.com/seaweedfs/seaweedfs/weed/util/version"
 	"github.com/seaweedfs/seaweedfs/weed/wdclient"
-
-	"github.com/seaweedfs/go-fuse/v2/fs"
 )
 
 type Option struct {
@@ -136,7 +134,6 @@ type WFS struct {
 	// follow https://github.com/hanwen/go-fuse/blob/master/fuse/api.go
 	fuse.RawFileSystem
 	mount_pb.UnimplementedSeaweedMountServer
-	fs.Inode
 	option                *Option
 	metaCache             *meta_cache.MetaCache
 	stats                 statsCache

--- a/weed/mount/weedfs_rename.go
+++ b/weed/mount/weedfs_rename.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/seaweedfs/go-fuse/v2/fs"
 	"github.com/seaweedfs/go-fuse/v2/fuse"
 	"github.com/seaweedfs/seaweedfs/weed/cluster/lock_manager"
 	"github.com/seaweedfs/seaweedfs/weed/glog"
@@ -160,7 +159,7 @@ renameat2()
 const (
 	RenameEmptyFlag = 0
 	RenameNoReplace = 1
-	RenameExchange  = fs.RENAME_EXCHANGE
+	RenameExchange  = 2
 	RenameWhiteout  = 3
 )
 


### PR DESCRIPTION
WFS embedded `fs.Inode` but never called any of its methods, and the only other reference to the package was `RENAME_EXCHANGE` — a constant sitting next to three integer literals. Removing both leaves `weed/mount` depending on `go-fuse/v2/fuse` alone, down from `fs` plus five `internal/*` packages.

Mostly a tidy-up, but it also keeps the build graph small for the Windows mount work discussed in #10533, where every extra package is one more thing to port. Mount tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal filesystem integration by removing unused components.
  * Updated rename-exchange handling while preserving existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->