### PR TITLE
test(filer): fix flaky TestSubscribeLoop_FlushProvenGapSkipsToRetained

### DIFF
--- a/weed/server/filer_subscribe_loop_test.go
+++ b/weed/server/filer_subscribe_loop_test.go
@@ -507,10 +507,14 @@ func TestSubscribeLoop_BoundedSubscriptionTerminates(t *testing.T) {
 func TestSubscribeLoop_FlushProvenGapSkipsToRetained(t *testing.T) {
 	h := newSubscribeHarness(t)
 
+	lastSealed := log_buffer.PreviousBufferCount
 	for w := 0; w < log_buffer.PreviousBufferCount+2; w++ {
 		h.append(h.tsAt(w, 0))
 	}
-	waitForFlushedFiles(t, h)
+	// Through the last sealed window, not just the evicted one: a flush landing
+	// after the delete would put that window back on disk, and the disk pass
+	// would drag the cursor past the retained windows this test is about.
+	waitForFlushedThrough(t, h, h.tsAt(lastSealed, 0))
 	if h.f.LocalMetaLogBuffer.GetLastEvictedTsNs() == 0 {
 		t.Fatal("precondition: nothing evicted")
 	}
@@ -528,11 +532,14 @@ func TestSubscribeLoop_FlushProvenGapSkipsToRetained(t *testing.T) {
 	waitForEvents(t, r, retained, 5*time.Second)
 }
 
-func waitForFlushedFiles(t *testing.T, h *subscribeHarness) {
+// waitForFlushedThrough waits until every window up to throughTsNs is on disk.
+// Windows flush in seal order, so the watermark reaching it means nothing
+// earlier is still queued behind it.
+func waitForFlushedThrough(t *testing.T, h *subscribeHarness, throughTsNs int64) {
 	t.Helper()
 	deadline := time.Now().Add(3 * time.Second)
 	for time.Now().Before(deadline) {
-		if h.f.LocalMetaLogBuffer.GetLastFlushTsNs() >= h.f.LocalMetaLogBuffer.GetLastEvictedTsNs() {
+		if h.f.LocalMetaLogBuffer.GetLastFlushTsNs() >= throughTsNs {
 			return
 		}
 		time.Sleep(10 * time.Millisecond)


### PR DESCRIPTION
`TestSubscribeLoop_FlushProvenGapSkipsToRetained` fails intermittently on loaded CI runners, e.g. https://github.com/seaweedfs/seaweedfs/actions/runs/30793878310/job/91623004198:

```
filer_subscribe_loop_test.go:528: delivered [1785742420000000000 1785742540000000000 1785742660000000000], want [1785742180000000000 1785742300000000000 1785742420000000000 1785742540000000000 1785742660000000000]
```

The harness is at fault, not the subscribe loop.

The test appends `PreviousBufferCount+2` windows, which seals w0..w4 and queues five flushes. `waitForFlushedFiles` waited for `lastFlushTsNs >= lastEvictedTsNs`, and the eviction watermark is w0's stop time - so it returned as soon as the *first* of those five flushes landed, with w1..w4 still sitting in the flush queue.

`deleteAllLogFiles` then ran concurrently with that tail. Windows flushed before `DeleteFolderChildren` got deleted; windows flushed after it were written back to disk. The subscriber's disk pass read those late arrivals, advanced its cursor past w1/w2 - which by then lived only in memory - and delivered three events instead of five.

Wait through the last sealed window instead. Windows flush in seal order through a single channel and flush goroutine, so the watermark reaching w4 proves nothing earlier is still queued.

The window is normally a few hundred microseconds; 40 local runs of the unfixed test all passed. Widening it with a 50ms sleep between the directory listing and `DeleteFolderChildren` reproduces the exact last-3-of-5 failure on the first run, and passes with this change. `-run TestSubscribeLoop -count=20` and the full `./weed/server/` package pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log cleanup test reliability by ensuring all data through the latest sealed window is flushed before log files are deleted.
  * Added more precise verification of flush completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->