### PR TITLE
test: wait for every queued flush before deleting the log files

### DIFF
--- a/weed/server/filer_subscribe_loop_test.go
+++ b/weed/server/filer_subscribe_loop_test.go
@@ -507,10 +507,16 @@ func TestSubscribeLoop_BoundedSubscriptionTerminates(t *testing.T) {
 func TestSubscribeLoop_FlushProvenGapSkipsToRetained(t *testing.T) {
 	h := newSubscribeHarness(t)
 
-	for w := 0; w < log_buffer.PreviousBufferCount+2; w++ {
+	windows := log_buffer.PreviousBufferCount + 2
+	for w := 0; w < windows; w++ {
 		h.append(h.tsAt(w, 0))
 	}
-	waitForFlushedFiles(t, h)
+	// The last append seals the window before it, so every window but the
+	// current one is queued for flush. Wait for all of them, not just the one
+	// the eviction watermark names: a flush still in flight writes its file
+	// back after the delete below, and the subscriber then serves that window
+	// from disk instead of taking the gap path this test is about.
+	waitForFlushedFiles(t, h, h.tsAt(windows-2, 0))
 	if h.f.LocalMetaLogBuffer.GetLastEvictedTsNs() == 0 {
 		t.Fatal("precondition: nothing evicted")
 	}
@@ -518,7 +524,7 @@ func TestSubscribeLoop_FlushProvenGapSkipsToRetained(t *testing.T) {
 
 	earliest := h.f.LocalMetaLogBuffer.GetEarliestTime().UnixNano()
 	var retained []int64
-	for w := 0; w < log_buffer.PreviousBufferCount+2; w++ {
+	for w := 0; w < windows; w++ {
 		if ts := h.tsAt(w, 0); ts >= earliest {
 			retained = append(retained, ts)
 		}
@@ -528,11 +534,14 @@ func TestSubscribeLoop_FlushProvenGapSkipsToRetained(t *testing.T) {
 	waitForEvents(t, r, retained, 5*time.Second)
 }
 
-func waitForFlushedFiles(t *testing.T, h *subscribeHarness) {
+// waitForFlushedFiles waits until the flush of the window ending at
+// throughTsNs has landed. Flushes run in queue order on one goroutine, so that
+// also proves every window sealed before it is on disk and none is in flight.
+func waitForFlushedFiles(t *testing.T, h *subscribeHarness, throughTsNs int64) {
 	t.Helper()
 	deadline := time.Now().Add(3 * time.Second)
 	for time.Now().Before(deadline) {
-		if h.f.LocalMetaLogBuffer.GetLastFlushTsNs() >= h.f.LocalMetaLogBuffer.GetLastEvictedTsNs() {
+		if h.f.LocalMetaLogBuffer.GetLastFlushTsNs() >= throughTsNs {
 			return
 		}
 		time.Sleep(10 * time.Millisecond)


### PR DESCRIPTION
`TestSubscribeLoop_FlushProvenGapSkipsToRetained` is flaky on a loaded machine, e.g. https://github.com/seaweedfs/seaweedfs/actions/runs/30793878310/job/91623004198. The race is entirely in this file.

The test wants every metadata log file gone, so the subscriber has to take the gap-skip path: the flush watermark proves the gap empty, the resolver skips to the retained ring, and memory delivers the rest.

`waitForFlushedFiles` waited for `GetLastFlushTsNs() >= GetLastEvictedTsNs()`, which is the *first* queued window — the one whose eviction set the watermark. The windows sealed after it were still in `loopFlush`'s queue. `deleteAllLogFiles` then ran mid-flight, and those later flushes wrote their files back afterwards. The subscriber found those windows on disk and served them from there, silently advancing its cursor past the windows whose files really had been deleted, so they never arrived:

```
delivered [1785747984000000000 1785748104000000000 1785748224000000000],
want [1785747744000000000 1785747864000000000 1785747984000000000 1785748104000000000 1785748224000000000]
```

Three delivered of five, and they are the last three — the two whose flushes landed before the delete are the ones missing.

Flushes run in queue order on a single goroutine, so waiting for the last sealed window's flush also proves every earlier one is on disk and none is in flight.

Reproduced deterministically by making the last two windows flush late, which yields exactly the failure above; green under those same conditions with this change, and `TestSubscribeLoop` x3 green on master otherwise. Test-only.