### PR TITLE
mount: keep the xattr flag constants off freebsd

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -75,8 +75,8 @@ jobs:
     - name: Build
       run: cd weed; go build -tags "elastic gocdk sqlite ydb tarantool tikv rclone" -v .
 
-  build-windows:
-    name: Build windows
+  build-cross:
+    name: Build cross-platform
     runs-on: ubuntu-latest
     steps:
     - name: Check out code into the Go module directory
@@ -85,10 +85,14 @@ jobs:
       uses: actions/setup-go@v7
       with:
         go-version-file: 'go.mod'
-    # weed/mount builds here but cannot mount yet. Without this the unix-only
-    # syscall constants it needs creep back in unnoticed.
-    - name: Build windows/amd64
-      run: GOOS=windows GOARCH=amd64 go build ./weed/...
+    # Nothing else on a PR compiles these, so per-OS syscall constants creep
+    # back into shared files unnoticed and only a release build catches it.
+    - name: Cross-compile
+      run: |
+        for target in windows/amd64 windows/arm64 freebsd/amd64 darwin/arm64; do
+          echo "== $target"
+          GOOS=${target%/*} GOARCH=${target#*/} go build ./weed/...
+        done
 
   test:
     name: Test

--- a/weed/mount/syscall_shim_unix.go
+++ b/weed/mount/syscall_shim_unix.go
@@ -2,18 +2,11 @@
 
 package mount
 
-import (
-	"syscall"
-
-	sys "golang.org/x/sys/unix"
-)
+import "syscall"
 
 const (
 	f_RDLCK   = syscall.F_RDLCK
 	f_WRLCK   = syscall.F_WRLCK
 	f_UNLCK   = syscall.F_UNLCK
 	o_ACCMODE = syscall.O_ACCMODE
-
-	xattr_CREATE  = sys.XATTR_CREATE
-	xattr_REPLACE = sys.XATTR_REPLACE
 )

--- a/weed/mount/weedfs_xattr_flags_unix.go
+++ b/weed/mount/weedfs_xattr_flags_unix.go
@@ -1,0 +1,10 @@
+//go:build !windows && !freebsd
+
+package mount
+
+import sys "golang.org/x/sys/unix"
+
+const (
+	xattr_CREATE  = sys.XATTR_CREATE
+	xattr_REPLACE = sys.XATTR_REPLACE
+)


### PR DESCRIPTION
master does not build for freebsd right now. `x/sys/unix` has no `XATTR_CREATE` or `XATTR_REPLACE` there, which is why `weedfs_xattr.go` is tagged away from freebsd already; #10535 put those two constants in a `!windows` file and dragged them back in. This moves them to a file tagged `!windows && !freebsd`.

The second commit widens the cross-compile job that #10535 added, which only covered windows and so missed a break in the very file it was there to guard — freebsd and darwin are only compiled by the release workflows, which do not run on pull requests. `go build` is clean on freebsd, windows, linux and darwin, and the mount tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded cross-platform build coverage to include Windows (amd64 and arm64), FreeBSD amd64, and macOS arm64.

* **Bug Fixes**
  * Improved extended-attribute support across Unix-based platforms by applying platform-appropriate system flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->