### PR TITLE
fix(volume): persist the leveldb needle map watermark at batch boundaries

### DIFF
--- a/weed/storage/needle_map_leveldb.go
+++ b/weed/storage/needle_map_leveldb.go
@@ -186,7 +186,7 @@ func (m *LevelDbNeedleMap) Put(key NeedleId, offset Offset, size Size) error {
 		watermark = (m.recordCount / watermarkBatchSize) * watermarkBatchSize
 		glog.V(1).Infof("put cnt:%d for %s,watermark: %d", m.recordCount, m.dbFileName, watermark)
 	}
-	return levelDbWrite(m.db, key, offset, size, watermark == 0, watermark)
+	return levelDbWrite(m.db, key, offset, size, watermark != 0, watermark)
 }
 
 func getWatermark(db *leveldb.DB) uint64 {
@@ -252,7 +252,7 @@ func (m *LevelDbNeedleMap) Delete(key NeedleId, offset Offset) error {
 	} else {
 		watermark = (m.recordCount / watermarkBatchSize) * watermarkBatchSize
 	}
-	return levelDbWrite(m.db, key, oldNeedle.Offset, -oldNeedle.Size, watermark == 0, watermark)
+	return levelDbWrite(m.db, key, oldNeedle.Offset, -oldNeedle.Size, watermark != 0, watermark)
 }
 
 func (m *LevelDbNeedleMap) Close() {

--- a/weed/storage/needle_map_leveldb_test.go
+++ b/weed/storage/needle_map_leveldb_test.go
@@ -71,6 +71,43 @@ func TestGenerateLevelDbFileStaleWatermarkRebuilds(t *testing.T) {
 	}
 }
 
+// The write on a watermarkBatchSize boundary is the one that must persist the
+// replay watermark; the ordinary writes in between must leave it alone. Passing
+// "watermark == 0" inverted that and pinned the stored watermark at 0, so every
+// rebuild replayed the whole .idx. Deletes count too: tombstones are .idx
+// entries and advance the watermark the same way.
+func TestLevelDbNeedleMapWatermarkAdvances(t *testing.T) {
+	dir := t.TempDir()
+
+	indexFile, err := os.Create(filepath.Join(dir, "wm.idx"))
+	if err != nil {
+		t.Fatalf("create index file: %v", err)
+	}
+	m, err := NewLevelDbNeedleMap(filepath.Join(dir, "wm.ldb"), indexFile, nil, 0, needle.GetCurrentVersion())
+	if err != nil {
+		t.Fatalf("NewLevelDbNeedleMap: %v", err)
+	}
+	defer m.Close()
+
+	for i := uint64(1); i <= watermarkBatchSize; i++ {
+		if err := m.Put(types.Uint64ToNeedleId(i), types.ToOffset(int64(i*1024)), types.Size(512)); err != nil {
+			t.Fatalf("put %d: %v", i, err)
+		}
+	}
+	if got := getWatermark(m.db); got != watermarkBatchSize {
+		t.Errorf("after %d puts: watermark = %d, want %d", watermarkBatchSize, got, watermarkBatchSize)
+	}
+
+	for i := uint64(1); i <= watermarkBatchSize; i++ {
+		if err := m.Delete(types.Uint64ToNeedleId(i), types.ToOffset(int64(i*1024))); err != nil {
+			t.Fatalf("delete %d: %v", i, err)
+		}
+	}
+	if got, want := getWatermark(m.db), uint64(2*watermarkBatchSize); got != want {
+		t.Errorf("after %d deletes: watermark = %d, want %d", watermarkBatchSize, got, want)
+	}
+}
+
 func TestLevelDbNeedleMap_Concurrency(t *testing.T) {
 	dir, err := os.MkdirTemp("", "test_leveldb_concurrency")
 	if err != nil {


### PR DESCRIPTION
# What problem are we solving?

The LevelDB needle map checkpoints a watermark every `watermarkBatchSize`
(10000) index entries so that a rebuild can skip the prefix of `.idx` already
applied to the `.ldb`.

`levelDbWrite` persists that watermark when its `updateWatermark` argument is
true. `Put` and `Delete` pass `watermark == 0` — but the local `watermark`
variable is set to `0` precisely on the writes that carry no checkpoint, and to
a real value on the batch boundary that does. The two cases are inverted:

```
recordCount % watermarkBatchSize != 0  ->  watermark 0, flag true
    -> re-persists a zero on 9999 of every 10000 writes
recordCount % watermarkBatchSize == 0  ->  watermark N, flag false
    -> drops the only value worth saving
```

So the stored watermark never leaves 0.

This is **not** a correctness bug: replaying `.idx` from offset 0 is a superset
of replaying from N, and replay is idempotent, so nothing fails loudly. That is
why it has gone unnoticed. The costs are:

1. `generateLevelDbFile` walks the entire index on every rebuild, so the
   optimization has never actually taken effect.
2. Every needle write pays a second leveldb `Put` to rewrite the same zero.

# How are we solving the problem?

Pass `watermark != 0`, so the boundary write checkpoints and the ordinary
writes in between leave the key alone. Two characters, at both call sites.

# How is the PR tested?

New test `TestLevelDbNeedleMapWatermarkAdvances` drives a full batch of `Put`s
and a full batch of `Delete`s (tombstones are `.idx` entries too, so they
advance the watermark the same way) to cover both changed call sites.

It fails on master:

```
after 10000 puts: watermark = 0, want 10000
after 10000 deletes: watermark = 0, want 20000
```

and passes with the fix.

Measured on a 25000-needle volume: the stored watermark now reads 20000 instead
of 0, and a rebuild replays 5000 entries instead of 25000.

Existing tests pass, including `TestGenerateLevelDbFileStaleWatermarkRebuilds`
— relevant here because a working (non-zero) watermark makes that staleness
guard load-bearing for the first time.

Locally verified: `go vet`, `GOOS=linux GOARCH=386 go vet`, the tagged build
(`elastic gocdk sqlite ydb tarantool tikv rclone`), and `go test ./weed/storage/...`
including `-race`. The 32-bit test suite was compile-checked only, since 386
binaries do not execute natively on arm64.

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved watermark updates so they occur at the correct batch boundaries.
  * Ensured watermark progression remains accurate when records are deleted.

* **Tests**
  * Added coverage verifying watermark persistence and advancement during updates and deletions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->