### PR TITLE
test: cover delete-on-close on the windows mount

### DIFF
--- a/test/winfsp/deleteonclose.go
+++ b/test/winfsp/deleteonclose.go
@@ -1,0 +1,7 @@
+package winfsp
+
+import "errors"
+
+// errWindowsOnly marks the platforms with no way to ask for delete-on-close,
+// so the test can tell that apart from the flag being refused.
+var errWindowsOnly = errors.New("delete-on-close is a windows flag")

--- a/test/winfsp/deleteonclose_other.go
+++ b/test/winfsp/deleteonclose_other.go
@@ -2,11 +2,8 @@
 
 package winfsp
 
-import "errors"
-
 type handle uintptr
 
-var errWindowsOnly = errors.New("windows only")
-
 func createDeleteOnClose(path string) (handle, error) { return 0, errWindowsOnly }
-func closeHandle(h handle) error                      { return errWindowsOnly }
+
+func closeHandle(h handle) error { return errWindowsOnly }

--- a/test/winfsp/deleteonclose_other.go
+++ b/test/winfsp/deleteonclose_other.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package winfsp
+
+import "errors"
+
+type handle uintptr
+
+var errWindowsOnly = errors.New("windows only")
+
+func createDeleteOnClose(path string) (handle, error) { return 0, errWindowsOnly }
+func closeHandle(h handle) error                      { return errWindowsOnly }

--- a/test/winfsp/deleteonclose_windows.go
+++ b/test/winfsp/deleteonclose_windows.go
@@ -1,0 +1,24 @@
+package winfsp
+
+import "golang.org/x/sys/windows"
+
+// createDeleteOnClose opens a new file that Windows removes when the last
+// handle to it closes. Installers and editors use this for temporaries, and
+// os has no way to ask for it.
+func createDeleteOnClose(path string) (windows.Handle, error) {
+	p, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return windows.InvalidHandle, err
+	}
+	return windows.CreateFile(
+		p,
+		windows.GENERIC_READ|windows.GENERIC_WRITE,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+		nil,
+		windows.CREATE_NEW,
+		windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_DELETE_ON_CLOSE,
+		0,
+	)
+}
+
+func closeHandle(h windows.Handle) error { return windows.CloseHandle(h) }

--- a/test/winfsp/semantics_test.go
+++ b/test/winfsp/semantics_test.go
@@ -490,3 +490,34 @@ func TestStatfsIsSelfConsistent(t *testing.T) {
 		t.Fatalf("total free (%d) exceeds total (%d)", totalFree, total)
 	}
 }
+
+// TestDeleteOnClose covers the pattern Windows software uses for temporaries:
+// the file goes away when the last handle closes, with no explicit delete. A
+// filesystem that ignores the flag leaves the name behind, and the next
+// program to create it gets a collision.
+func TestDeleteOnClose(t *testing.T) {
+	dir := testRoot(t)
+	path := filepath.Join(dir, "ephemeral.tmp")
+
+	h, err := createDeleteOnClose(path)
+	if err != nil {
+		t.Skipf("cannot open with delete-on-close here: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		closeHandle(h)
+		t.Fatalf("file is not visible while open: %v", err)
+	}
+	if err := closeHandle(h); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("file outlived its last handle: %v", err)
+	}
+	// The name has to be free again, which is what the conformance suite
+	// tripped over when an aborted test left its file behind.
+	h, err = createDeleteOnClose(path)
+	if err != nil {
+		t.Fatalf("recreating the same name failed: %v", err)
+	}
+	closeHandle(h)
+}

--- a/test/winfsp/semantics_test.go
+++ b/test/winfsp/semantics_test.go
@@ -2,6 +2,7 @@ package winfsp
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -501,17 +502,22 @@ func TestDeleteOnClose(t *testing.T) {
 
 	h, err := createDeleteOnClose(path)
 	if err != nil {
-		t.Skipf("cannot open with delete-on-close here: %v", err)
+		if errors.Is(err, errWindowsOnly) {
+			t.Skip("delete-on-close needs the Win32 create call")
+		}
+		t.Fatalf("open with delete-on-close: %v", err)
 	}
 	if _, err := os.Stat(path); err != nil {
 		closeHandle(h)
-		t.Fatalf("file is not visible while open: %v", err)
+		t.Fatalf("file is not visible while its handle is open: %v", err)
 	}
 	if err := closeHandle(h); err != nil {
 		t.Fatalf("close: %v", err)
 	}
-	if _, err := os.Stat(path); !os.IsNotExist(err) {
-		t.Fatalf("file outlived its last handle: %v", err)
+	if _, err := os.Stat(path); err == nil {
+		t.Fatal("file outlived its last handle")
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("stat after close: %v", err)
 	}
 	// The name has to be free again, which is what the conformance suite
 	// tripped over when an aborted test left its file behind.
@@ -519,5 +525,7 @@ func TestDeleteOnClose(t *testing.T) {
 	if err != nil {
 		t.Fatalf("recreating the same name failed: %v", err)
 	}
-	closeHandle(h)
+	if err := closeHandle(h); err != nil {
+		t.Fatalf("close after recreate: %v", err)
+	}
 }


### PR DESCRIPTION
Follow-up to the conformance work in #10555.

Running winfsp-tests one test at a time showed `create_test`, `create_sd_test`, `create_share_test` and `delete_pending_test` all failing with `STATUS_OBJECT_NAME_COLLISION`. They were not independent failures: `getfileinfo_test` creates `file0` with `FILE_FLAG_DELETE_ON_CLOSE`, aborts on its own assertion, and the file **survived** — so every later test collided on the name.

Per-test isolation (#10557) stops that cascade, but it would also hide the question underneath it: does the mount honour delete-on-close at all? That matters on its own, because it is how Windows software writes temporaries — no explicit delete, the file goes away when the last handle closes.

Nothing in the hand-written suite asked for the flag, because `os` offers no way to request it. This adds a test that opens with it through the Win32 call, checks the file is visible while open, gone after the last handle closes, and that the name is free to create again. It skips rather than passes quietly where the flag is unavailable.

I do not yet know whether this passes — that is the point of adding it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for delete-on-close behavior on Windows.
  * Verified files remain accessible while open, are removed after the final handle closes, and can be recreated at the same path.
  * Unsupported environments now skip the test appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->