### PR TITLE
ci: key the Rust cargo cache on the toolchain that built it

### DIFF
--- a/.github/workflows/rust-volume-server-tests.yml
+++ b/.github/workflows/rust-volume-server-tests.yml
@@ -42,6 +42,12 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      # cargo tracks its own inputs but not the runner's C toolchain, so a cached
+      # target/ can carry C objects built against a different glibc than we link against.
+      - name: Fingerprint build toolchain
+        id: toolchain
+        run: echo "fingerprint=$(getconf GNU_LIBC_VERSION | tr ' ' '-')-rustc-$(rustc -V | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+
       - name: Cache cargo registry and target
         uses: actions/cache@v6
         with:
@@ -49,9 +55,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             seaweed-volume/target
-          key: rust-${{ hashFiles('seaweed-volume/Cargo.lock') }}
+          key: rust-${{ steps.toolchain.outputs.fingerprint }}-${{ hashFiles('seaweed-volume/Cargo.lock') }}
           restore-keys: |
-            rust-
+            rust-${{ steps.toolchain.outputs.fingerprint }}-
 
       - name: Build Rust volume server
         run: cd seaweed-volume && cargo build --release
@@ -79,6 +85,12 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      # cargo tracks its own inputs but not the runner's C toolchain, so a cached
+      # target/ can carry C objects built against a different glibc than we link against.
+      - name: Fingerprint build toolchain
+        id: toolchain
+        run: echo "fingerprint=$(getconf GNU_LIBC_VERSION | tr ' ' '-')-rustc-$(rustc -V | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+
       - name: Cache cargo registry and target
         uses: actions/cache@v6
         with:
@@ -86,9 +98,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             seaweed-volume/target
-          key: rust-${{ hashFiles('seaweed-volume/Cargo.lock') }}
+          key: rust-${{ steps.toolchain.outputs.fingerprint }}-${{ hashFiles('seaweed-volume/Cargo.lock') }}
           restore-keys: |
-            rust-
+            rust-${{ steps.toolchain.outputs.fingerprint }}-
 
       - name: Build Go weed binary
         run: |
@@ -155,6 +167,12 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      # cargo tracks its own inputs but not the runner's C toolchain, so a cached
+      # target/ can carry C objects built against a different glibc than we link against.
+      - name: Fingerprint build toolchain
+        id: toolchain
+        run: echo "fingerprint=$(getconf GNU_LIBC_VERSION | tr ' ' '-')-rustc-$(rustc -V | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+
       - name: Cache cargo registry and target
         uses: actions/cache@v6
         with:
@@ -162,9 +180,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             seaweed-volume/target
-          key: rust-${{ hashFiles('seaweed-volume/Cargo.lock') }}
+          key: rust-${{ steps.toolchain.outputs.fingerprint }}-${{ hashFiles('seaweed-volume/Cargo.lock') }}
           restore-keys: |
-            rust-
+            rust-${{ steps.toolchain.outputs.fingerprint }}-
 
       - name: Build Go weed binary
         run: |


### PR DESCRIPTION
The Rust volume server jobs are currently red on every PR that touches `seaweed-volume/`, with a link failure that has nothing to do with the code under test:

```
rust-lld: error: undefined symbol: __isoc23_sscanf
  >>> referenced by bcm.c
  >>>               bcm.o:(aws_lc_0_39_1_handle_cpu_env) in archive libaws_lc_sys-*.rlib
rust-lld: error: undefined symbol: __isoc23_strtol
```

## Cause

The cache key was `rust-${{ hashFiles('seaweed-volume/Cargo.lock') }}` with a bare `rust-` restore prefix — no runner OS, image, or toolchain in it. One `seaweed-volume/target` therefore survives across runner images indefinitely.

`cargo` tracks its own inputs but not the runner's C toolchain, so build-script output for C dependencies is restored as-is even when the system libc underneath it has changed. The cached `aws-lc-sys` objects were compiled against glibc >= 2.38, where `sscanf` and `strtol` are macro-redirected to `__isoc23_sscanf` / `__isoc23_strtol`. The jobs run on `ubuntu-22.04`, glibc 2.35, which has no such symbols — so the link fails.

The build log makes it plain: only `reed-solomon-erasure` and `weed-volume` compile, everything else including `aws-lc-sys` comes straight from the restored cache. Re-running does not help, since the same poisoned entry is hit every time.

## Fix

Fold the glibc and rustc versions into the cache key, so a toolchain change misses the cache and rebuilds rather than silently producing an unlinkable `target/`:

```
key: rust-<glibc-2.35-rustc-1.97.1>-<Cargo.lock hash>
restore-keys: rust-<glibc-2.35-rustc-1.97.1>-
```

Applied to all three jobs (`rust-unit-tests`, `rust-integration-tests`, `rust-volume-go-tests`), which shared the key. The first run after this lands rebuilds the Rust dependency graph once and repopulates the cache.

This PR touches only the workflow, and the workflow is in its own `paths` filter, so the run on this PR exercises the change directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rust build caching to prevent incompatible cached artifacts from being reused across different system and compiler toolchains.
  * Increased build reliability and consistency across Rust-related workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->