### PR TITLE
volume: skip directory fsync on Windows, report a failed makeupDiff

### DIFF
--- a/.github/workflows/mount-windows-conformance.yml
+++ b/.github/workflows/mount-windows-conformance.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - 'weed/mount/**'
       - 'weed/command/mount*.go'
+      - 'weed/storage/volume_vacuum*.go'
+      - 'weed/storage/volume_loading.go'
+      - 'weed/storage/disk_location.go'
       - 'test/winfsp-conformance/**'
       - '.github/workflows/mount-windows-conformance.yml'
   # No base branch filter: this is the only thing that runs the Windows mount,
@@ -14,6 +17,9 @@ on:
     paths:
       - 'weed/mount/**'
       - 'weed/command/mount*.go'
+      - 'weed/storage/volume_vacuum*.go'
+      - 'weed/storage/volume_loading.go'
+      - 'weed/storage/disk_location.go'
       - 'test/winfsp-conformance/**'
       - '.github/workflows/mount-windows-conformance.yml'
 

--- a/.github/workflows/mount-windows.yml
+++ b/.github/workflows/mount-windows.yml
@@ -6,7 +6,9 @@ on:
     paths:
       - 'weed/mount/**'
       - 'weed/command/mount*.go'
-      - 'weed/storage/volume_vacuum.go'
+      - 'weed/storage/volume_vacuum*.go'
+      - 'weed/storage/volume_loading.go'
+      - 'weed/storage/disk_location.go'
       - 'test/winfsp/**'
       - '.github/workflows/mount-windows.yml'
   # No base branch filter: this is the only thing that runs the Windows mount,
@@ -15,7 +17,9 @@ on:
     paths:
       - 'weed/mount/**'
       - 'weed/command/mount*.go'
-      - 'weed/storage/volume_vacuum.go'
+      - 'weed/storage/volume_vacuum*.go'
+      - 'weed/storage/volume_loading.go'
+      - 'weed/storage/disk_location.go'
       - 'test/winfsp/**'
       - '.github/workflows/mount-windows.yml'
 

--- a/.github/workflows/mount-windows.yml
+++ b/.github/workflows/mount-windows.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'weed/mount/**'
       - 'weed/command/mount*.go'
+      - 'weed/storage/volume_vacuum.go'
       - 'test/winfsp/**'
       - '.github/workflows/mount-windows.yml'
   # No base branch filter: this is the only thing that runs the Windows mount,
@@ -14,6 +15,7 @@ on:
     paths:
       - 'weed/mount/**'
       - 'weed/command/mount*.go'
+      - 'weed/storage/volume_vacuum.go'
       - 'test/winfsp/**'
       - '.github/workflows/mount-windows.yml'
 

--- a/seaweed-volume/src/storage/volume.rs
+++ b/seaweed-volume/src/storage/volume.rs
@@ -3627,7 +3627,7 @@ fn get_append_at_ns(last: u64) -> u64 {
 /// durable, propagating a sync failure so the commit path can abort rather than
 /// proceed with an undurable rename or marker. A path with no openable parent is
 /// tolerated; directory fsync is unsupported on Windows, so it is a no-op there
-/// (matching the Go fsyncDir helper, which ignores that error).
+/// (matching the Go fsyncDir helper, which skips it too).
 pub(crate) fn fsync_dir(path: &str) -> io::Result<()> {
     #[cfg(windows)]
     {

--- a/weed/storage/volume_vacuum.go
+++ b/weed/storage/volume_vacuum.go
@@ -380,6 +380,9 @@ func (v *Volume) cleanupCompact() error {
 // A failure to open the directory for sync is non-fatal on platforms that do
 // not support it.
 func fsyncDir(dir string) error {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
 	d, err := os.Open(dir)
 	if err != nil {
 		return nil

--- a/weed/storage/volume_vacuum.go
+++ b/weed/storage/volume_vacuum.go
@@ -187,36 +187,36 @@ func (v *Volume) CommitCompact() error {
 	v.DataBackend = nil
 	stats.VolumeServerVolumeGauge.WithLabelValues(v.Collection, "volume").Dec()
 
-	var e error
-	if e = v.makeupDiff(v.FileName(".cpd"), v.FileName(".cpx"), v.FileName(".dat"), v.FileName(".idx")); e != nil {
-		glog.V(0).Infof("makeupDiff in CommitCompact volume %d failed %v", v.Id, e)
-		e = os.Remove(v.FileName(".cpd"))
-		if e != nil {
+	if compactErr := v.makeupDiff(v.FileName(".cpd"), v.FileName(".cpx"), v.FileName(".dat"), v.FileName(".idx")); compactErr != nil {
+		glog.V(0).Infof("makeupDiff in CommitCompact volume %d failed %v", v.Id, compactErr)
+		if e := os.Remove(v.FileName(".cpd")); e != nil {
 			return e
 		}
-		e = os.Remove(v.FileName(".cpx"))
-		if e != nil {
+		if e := os.Remove(v.FileName(".cpx")); e != nil {
 			return e
 		}
-	} else {
-		// makeupDiff has fsynced the .cpd/.cpx contents. Persist a durable .cpc
-		// commit marker BEFORE renaming so the two renames are atomic across a
-		// crash: a marker on disk means the swap is decided and reconcile rolls
-		// forward; no marker means roll back. Without it, a crash between the
-		// two renames leaves a stale .idx that a later vacuum compacts to empty.
-		if e = v.writeCompactCommitMarker(); e != nil {
-			return e
-		}
-		if e = v.applyCompactSwap(); e != nil {
-			return e
-		}
+		// The compaction is abandoned, not committed: report it instead of
+		// falling through to reload the volume against the discarded generation.
+		return compactErr
+	}
+
+	// makeupDiff has fsynced the .cpd/.cpx contents. Persist a durable .cpc
+	// commit marker BEFORE renaming so the two renames are atomic across a
+	// crash: a marker on disk means the swap is decided and reconcile rolls
+	// forward; no marker means roll back. Without it, a crash between the
+	// two renames leaves a stale .idx that a later vacuum compacts to empty.
+	if e := v.writeCompactCommitMarker(); e != nil {
+		return e
+	}
+	if e := v.applyCompactSwap(); e != nil {
+		return e
 	}
 
 	//glog.V(3).Infof("Pretending to be vacuuming...")
 	//time.Sleep(20 * time.Second)
 
 	glog.V(3).Infof("Loading volume %d commit file...", v.Id)
-	if e = v.load(true, false, v.needleMapKind, 0, v.Version()); e != nil {
+	if e := v.load(true, false, v.needleMapKind, 0, v.Version()); e != nil {
 		return e
 	}
 	glog.V(3).Infof("Finish committing volume %d", v.Id)

--- a/weed/storage/volume_vacuum.go
+++ b/weed/storage/volume_vacuum.go
@@ -377,8 +377,9 @@ func (v *Volume) cleanupCompact() error {
 }
 
 // fsyncDir fsyncs a directory so a rename/create/unlink inside it is durable.
-// A failure to open the directory for sync is non-fatal on platforms that do
-// not support it.
+// Windows has no directory fsync, so the .cpc protocol leans on NTFS metadata
+// ordering there. An unopenable directory is tolerated, unlike util.FsyncDir,
+// because the caller has already closed the needle map.
 func fsyncDir(dir string) error {
 	if runtime.GOOS == "windows" {
 		return nil

--- a/weed/storage/volume_vacuum.go
+++ b/weed/storage/volume_vacuum.go
@@ -189,14 +189,14 @@ func (v *Volume) CommitCompact() error {
 
 	if compactErr := v.makeupDiff(v.FileName(".cpd"), v.FileName(".cpx"), v.FileName(".dat"), v.FileName(".idx")); compactErr != nil {
 		glog.V(0).Infof("makeupDiff in CommitCompact volume %d failed %v", v.Id, compactErr)
-		if e := os.Remove(v.FileName(".cpd")); e != nil {
-			return e
+		if e := os.Remove(v.FileName(".cpd")); e != nil && !os.IsNotExist(e) {
+			glog.V(0).Infof("remove %s: %v", v.FileName(".cpd"), e)
 		}
-		if e := os.Remove(v.FileName(".cpx")); e != nil {
-			return e
+		if e := os.Remove(v.FileName(".cpx")); e != nil && !os.IsNotExist(e) {
+			glog.V(0).Infof("remove %s: %v", v.FileName(".cpx"), e)
 		}
-		// The compaction is abandoned, not committed: report it instead of
-		// falling through to reload the volume against the discarded generation.
+		// Report the abandoned compaction rather than a cleanup failure that
+		// reconcile rolls back anyway, and never fall through to the reload.
 		return compactErr
 	}
 


### PR DESCRIPTION
## What changed

- Skip directory `Sync` in the Go vacuum commit path on Windows, where it is unsupported and returns `Access is denied`.
- Return a failed `makeupDiff` from `CommitCompact` instead of letting the cleanup removes overwrite it.
- Trigger both Windows workflows on the compact, load and reconcile files, so this path is exercised by the reproducing integration job.

## Root cause

The Windows mount job triggered automatic vacuum. After the compacted files and commit marker were synced, `os.File.Sync` on the `C:\seaweed-data` directory returned `Access is denied`, aborting `CommitCompact` after it had closed the live needle map and data backend.

This matches the repository's existing platform behavior in `weed/util.FsyncDir` and the Rust volume server's `fsync_dir`, both of which already skip unsupported directory fsync on Windows. File contents and the commit marker are still synced before the directory step, and Windows has no directory fsync to fall back on, so the `.cpc` protocol leans on NTFS metadata ordering there.

`fsyncDir` keeps tolerating an unopenable directory, unlike `util.FsyncDir`, so the two are not collapsed: the needle map is already closed by the time it runs, and returning an error there would take the volume down.

Failing job: https://github.com/seaweedfs/seaweedfs/actions/runs/30964152788/job/92174346443

## makeupDiff

The cleanup path assigned `os.Remove`'s result to the same `err` that held the `makeupDiff` failure, so an aborted compaction returned nil once both removes succeeded. The master recorded the vacuum as committed, and the volume went on to reload against the discarded generation. It now returns the original failure, matching what the Rust `do_commit_compact` already did.

## Not fixed here

`CommitCompact` closes and nils the needle map and data backend before `writeCompactCommitMarker` and `applyCompactSwap`, so any failure in that window still leaves the volume unserviceable until a restart. This removes the observed trigger; the window itself wants its own change.

## CI

Both Windows jobs start the same `weed mini` cluster, so both run the volume server's vacuum path. `mount-windows-conformance.yml` watched no storage paths at all.

## Validation

- `go test ./weed/storage -count=1`
- `go vet ./weed/storage`
- `gofmt -l weed/storage/volume_vacuum.go`
- `actionlint .github/workflows/mount-windows.yml .github/workflows/mount-windows-conformance.yml`
- `GOOS=windows GOARCH=amd64 go build ./weed/storage/...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved volume compaction error handling to preserve the original failure, clean up temporary files, and prevent incomplete reloads.
  - Adjusted directory synchronization behavior on Windows to avoid unsupported operations.
  - Clarified documentation for directory-sync failures.

- **Tests**
  - Expanded Windows mount workflow coverage so relevant volume vacuuming, loading, and disk-location changes trigger validation automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->