### PR TITLE
ci: cross-compile each target in its own job

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -76,8 +76,17 @@ jobs:
       run: cd weed; go build -tags "elastic gocdk sqlite ydb tarantool tikv rclone" -v .
 
   build-cross:
-    name: Build cross-platform
+    name: Build cross-platform (${{ matrix.goos }}/${{ matrix.goarch }})
     runs-on: ubuntu-latest
+    strategy:
+      # One target's breakage should not hide the other three.
+      fail-fast: false
+      matrix:
+        include:
+          - { goos: windows, goarch: amd64 }
+          - { goos: windows, goarch: arm64 }
+          - { goos: freebsd, goarch: amd64 }
+          - { goos: darwin, goarch: arm64 }
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v7
@@ -88,16 +97,16 @@ jobs:
     # Nothing else on a PR compiles these, so per-OS syscall constants creep
     # back into shared files unnoticed and only a release build catches it.
     - name: Cross-compile
+      env:
+        GOOS: ${{ matrix.goos }}
+        GOARCH: ${{ matrix.goarch }}
       run: |
-        for target in windows/amd64 windows/arm64 freebsd/amd64 darwin/arm64; do
-          echo "== $target"
-          GOOS=${target%/*} GOARCH=${target#*/} go build ./weed/...
-          # Tests too: they reach for per-OS syscall constants the build does
-          # not, and only compiling them catches an untagged one.
-          GOOS=${target%/*} GOARCH=${target#*/} go vet ./weed/mount/... ./weed/command/... 2>&1 |
-            grep -v "MessageState contains sync.Mutex" | tee /tmp/vet-$$.txt
-          if grep -q "vet:" /tmp/vet-$$.txt; then exit 1; fi
-        done
+        go build ./weed/...
+        # Tests too: they reach for per-OS syscall constants the build does
+        # not, and only compiling them catches an untagged one.
+        go vet ./weed/mount/... ./weed/command/... 2>&1 |
+          grep -v "MessageState contains sync.Mutex" | tee /tmp/vet.txt
+        if grep -q "vet:" /tmp/vet.txt; then exit 1; fi
 
   test:
     name: Test


### PR DESCRIPTION
## What changed

`build-cross` becomes a four-leg matrix over `windows/amd64`, `windows/arm64`, `freebsd/amd64` and `darwin/arm64`, one job per target. `GOOS`/`GOARCH` move to the step's `env`, so the run block drops the loop and the `${target%/*}` splitting.

## Why

The targets ran in a shell loop. On https://github.com/seaweedfs/seaweedfs/actions/runs/30972716337 each one took an almost identical 3m13s:

```
== windows/amd64   03:36:36
== windows/arm64   03:39:53
== freebsd/amd64   03:43:06
== darwin/arm64    03:46:19
   done            03:49:36
```

13m29s for the job, against 8m13s for the slowest of everything else in that run, so this job alone decided when the workflow finished. Run concurrently it is ~3m45s: 30s of checkout and setup-go, then one target.

The legs share nothing worth serializing for. setup-go's cache is keyed on `go.sum` alone and holds no cross-target build objects, so each target already compiled its std lib and deps cold inside the loop.

`fail-fast: false` because this job exists to catch per-OS constants creeping into shared files. Cancelling the siblings on the first break would surface one broken target per push.

## Check names

`Build cross-platform` becomes `Build cross-platform (windows/amd64)` and three more. `master` has no branch protection or rulesets, so nothing pins the old name.

## Not done here

A per-target `actions/cache` on `GOCACHE`, keyed by `goos`/`goarch`, would take warm runs well under a minute. It trades against the repo's cache budget, so it wants its own change.

## Validation

- `actionlint .github/workflows/go.yml`
- The rewritten run block for `windows/amd64`, `go build ./weed/...` and the `go vet` pipeline, clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved cross-platform build validation for Windows, FreeBSD, and macOS targets.
  * Builds now run independently, so an issue with one platform does not stop validation for others.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->