### PR TITLE
ci: deal volume server tests across shards instead of bucketing by letter

### DIFF
--- a/.github/workflows/rust-volume-server-tests.yml
+++ b/.github/workflows/rust-volume-server-tests.yml
@@ -146,6 +146,9 @@ jobs:
     name: Go Tests with Rust Volume (${{ matrix.test-type }} - Shard ${{ matrix.shard }})
     runs-on: ubuntu-22.04
     timeout-minutes: 45
+    env:
+      # Keep in step with the length of matrix.shard below.
+      SHARD_COUNT: 3
     strategy:
       fail-fast: false
       matrix:
@@ -194,30 +197,28 @@ jobs:
       - name: Build Rust volume binary
         run: cd seaweed-volume && cargo build --release
 
+      # Dealing the listed tests out one by one keeps the shards even. Bucketing
+      # them by first letter did not: names cluster, so ^Test[I-S] drew 50 of
+      # the 114 grpc tests and ran nearly twice as long as the other two shards.
+      - name: Select this shard's tests
+        env:
+          TEST_TYPE: ${{ matrix.test-type }}
+          SHARD: ${{ matrix.shard }}
+        run: |
+          tests=$(go test -tags 5BytesOffset ./test/volume_server/"$TEST_TYPE"/... -list '.*' | grep '^Test' | sort -u)
+          # An empty list would make -run match nothing and the shard pass vacuously.
+          [ -n "$tests" ] || { echo "listed no tests in test/volume_server/$TEST_TYPE"; exit 1; }
+          selected=$(echo "$tests" | awk -v n="$SHARD_COUNT" -v i="$SHARD" 'NR % n == i - 1')
+          echo "shard $SHARD of $SHARD_COUNT runs $(echo "$selected" | wc -l) of $(echo "$tests" | wc -l) tests"
+          echo "TEST_PATTERN=^($(echo "$selected" | paste -sd'|' -))\$" >> "$GITHUB_ENV"
+
       - name: Run volume server integration tests with Rust volume
         env:
           WEED_BINARY: ${{ github.workspace }}/weed/weed
           RUST_VOLUME_BINARY: ${{ github.workspace }}/seaweed-volume/target/release/weed-volume
           VOLUME_SERVER_IMPL: rust
         run: |
-          if [ "${{ matrix.test-type }}" == "grpc" ]; then
-            if [ "${{ matrix.shard }}" == "1" ]; then
-              TEST_PATTERN="^Test[A-H]"
-            elif [ "${{ matrix.shard }}" == "2" ]; then
-              TEST_PATTERN="^Test[I-S]"
-            else
-              TEST_PATTERN="^Test[T-Z]"
-            fi
-          else
-            if [ "${{ matrix.shard }}" == "1" ]; then
-              TEST_PATTERN="^Test[A-G]"
-            elif [ "${{ matrix.shard }}" == "2" ]; then
-              TEST_PATTERN="^Test[H-R]"
-            else
-              TEST_PATTERN="^Test[S-Z]"
-            fi
-          fi
-          echo "Running Go volume server tests with Rust volume for ${{ matrix.test-type }} (Shard ${{ matrix.shard }}, pattern: ${TEST_PATTERN})..."
+          echo "Running Go volume server tests with Rust volume for ${{ matrix.test-type }} (Shard ${{ matrix.shard }} of ${SHARD_COUNT})..."
           go test -v -count=1 -tags 5BytesOffset -timeout=30m ./test/volume_server/${{ matrix.test-type }}/... -run "${TEST_PATTERN}"
 
       - name: Collect logs on failure
@@ -238,23 +239,6 @@ jobs:
       - name: Test summary
         if: always()
         run: |
-          if [ "${{ matrix.test-type }}" == "grpc" ]; then
-            if [ "${{ matrix.shard }}" == "1" ]; then
-              TEST_PATTERN="^Test[A-H]"
-            elif [ "${{ matrix.shard }}" == "2" ]; then
-              TEST_PATTERN="^Test[I-S]"
-            else
-              TEST_PATTERN="^Test[T-Z]"
-            fi
-          else
-            if [ "${{ matrix.shard }}" == "1" ]; then
-              TEST_PATTERN="^Test[A-G]"
-            elif [ "${{ matrix.shard }}" == "2" ]; then
-              TEST_PATTERN="^Test[H-R]"
-            else
-              TEST_PATTERN="^Test[S-Z]"
-            fi
-          fi
           echo "## Rust Volume - Go Test Summary (${{ matrix.test-type }} - Shard ${{ matrix.shard }})" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Suite: test/volume_server/${{ matrix.test-type }} (Pattern: ${TEST_PATTERN})" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Suite: test/volume_server/${{ matrix.test-type }} (shard ${{ matrix.shard }} of ${SHARD_COUNT}, see 'Select this shard's tests' for the split)" >> "$GITHUB_STEP_SUMMARY"
           echo "- Volume server: Rust (VOLUME_SERVER_IMPL=rust)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/volume-server-integration-tests.yml
+++ b/.github/workflows/volume-server-integration-tests.yml
@@ -29,6 +29,8 @@ permissions:
 
 env:
   TEST_TIMEOUT: '30m'
+  # Keep in step with the length of matrix.shard below.
+  SHARD_COUNT: 3
 
 jobs:
   volume-server-integration-tests:
@@ -57,28 +59,26 @@ jobs:
           chmod +x weed
           ./weed version
 
+      # Dealing the listed tests out one by one keeps the shards even. Bucketing
+      # them by first letter did not: names cluster, so ^Test[I-S] drew 50 of
+      # the 114 grpc tests and ran nearly twice as long as the other two shards.
+      - name: Select this shard's tests
+        env:
+          TEST_TYPE: ${{ matrix.test-type }}
+          SHARD: ${{ matrix.shard }}
+        run: |
+          tests=$(go test ./test/volume_server/"$TEST_TYPE"/... -list '.*' | grep '^Test' | sort -u)
+          # An empty list would make -run match nothing and the shard pass vacuously.
+          [ -n "$tests" ] || { echo "listed no tests in test/volume_server/$TEST_TYPE"; exit 1; }
+          selected=$(echo "$tests" | awk -v n="$SHARD_COUNT" -v i="$SHARD" 'NR % n == i - 1')
+          echo "shard $SHARD of $SHARD_COUNT runs $(echo "$selected" | wc -l) of $(echo "$tests" | wc -l) tests"
+          echo "TEST_PATTERN=^($(echo "$selected" | paste -sd'|' -))\$" >> "$GITHUB_ENV"
+
       - name: Run volume server integration tests
         env:
           WEED_BINARY: ${{ github.workspace }}/weed/weed
         run: |
-          if [ "${{ matrix.test-type }}" == "grpc" ]; then
-            if [ "${{ matrix.shard }}" == "1" ]; then
-              TEST_PATTERN="^Test[A-H]"
-            elif [ "${{ matrix.shard }}" == "2" ]; then
-              TEST_PATTERN="^Test[I-S]"
-            else
-              TEST_PATTERN="^Test[T-Z]"
-            fi
-          else
-            if [ "${{ matrix.shard }}" == "1" ]; then
-              TEST_PATTERN="^Test[A-G]"
-            elif [ "${{ matrix.shard }}" == "2" ]; then
-              TEST_PATTERN="^Test[H-R]"
-            else
-              TEST_PATTERN="^Test[S-Z]"
-            fi
-          fi
-          echo "Running volume server integration tests for ${{ matrix.test-type }} (Shard ${{ matrix.shard }}, pattern: ${TEST_PATTERN})..."
+          echo "Running volume server integration tests for ${{ matrix.test-type }} (Shard ${{ matrix.shard }} of ${SHARD_COUNT})..."
           go test -v -count=1 -timeout=${{ env.TEST_TIMEOUT }} ./test/volume_server/${{ matrix.test-type }}/... -run "${TEST_PATTERN}"
 
       - name: Collect logs on failure
@@ -99,23 +99,6 @@ jobs:
       - name: Test summary
         if: always()
         run: |
-          if [ "${{ matrix.test-type }}" == "grpc" ]; then
-            if [ "${{ matrix.shard }}" == "1" ]; then
-              TEST_PATTERN="^Test[A-H]"
-            elif [ "${{ matrix.shard }}" == "2" ]; then
-              TEST_PATTERN="^Test[I-S]"
-            else
-              TEST_PATTERN="^Test[T-Z]"
-            fi
-          else
-            if [ "${{ matrix.shard }}" == "1" ]; then
-              TEST_PATTERN="^Test[A-G]"
-            elif [ "${{ matrix.shard }}" == "2" ]; then
-              TEST_PATTERN="^Test[H-R]"
-            else
-              TEST_PATTERN="^Test[S-Z]"
-            fi
-          fi
           echo "## Volume Server Integration Test Summary (${{ matrix.test-type }} - Shard ${{ matrix.shard }})" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Suite: test/volume_server/${{ matrix.test-type }} (Pattern: ${TEST_PATTERN})" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Command: go test -v -count=1 -timeout=${{ env.TEST_TIMEOUT }} ./test/volume_server/${{ matrix.test-type }}/... -run \"${TEST_PATTERN}\"" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Suite: test/volume_server/${{ matrix.test-type }} (shard ${{ matrix.shard }} of ${SHARD_COUNT}, see 'Select this shard's tests' for the split)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Command: go test -v -count=1 -timeout=${{ env.TEST_TIMEOUT }} ./test/volume_server/${{ matrix.test-type }}/... -run \"\${TEST_PATTERN}\"" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What changed

`volume-server-integration-tests.yml` and `rust-volume-server-tests.yml` both sharded the suite by the first letter of the test name, `^Test[A-H]` / `^Test[I-S]` / `^Test[T-Z]` for grpc and `[A-G]` / `[H-R]` / `[S-Z]` for http. Each now lists the tests and deals them out one at a time.

## Why

Test names cluster, so the middle bucket took roughly half of each suite:

| suite | shard 1 | shard 2 | shard 3 |
|---|---|---|---|
| grpc (114 tests) | 32 | **50** | 32 |
| http (64 tests) | 16 | **30** | 18 |

The timings follow it. Volume Server Integration Tests grpc: **13m51s** for shard 2 against 7m48s and 9m09s. http: 8m17s against 5m31s and 5m23s. Rust Volume Server Tests copied the same ranges and skews the same way, grpc shard 2 at 7m10s against 4m00s and 4m31s. The job is already parallel; the work was just handed out unevenly, and the whole workflow waited on shard 2.

Dealing round-robin over the sorted listing splits them 38/38/38 and 21/22/21. It also keeps splitting evenly as tests are added, where the letter ranges quietly re-skew depending on what a new test is named.

`go test -list` needs no cluster here: neither package defines `TestMain`, and each matrix leg resolves to a single package.

## Also

The pattern was duplicated into each file's `Test summary` step, four copies that had to be edited together. It is now computed once into `$GITHUB_ENV`, and the summary refers to the selection step instead of reprinting the regex.

The listing is checked for emptiness. Without that, a package that failed to list would yield an empty `-run` pattern, match nothing, and let the shard pass having run no tests.

## Validation

- `actionlint` on both files
- Ran the selection step as CI executes it: `shard 2 of 3 runs 38 of 114 tests`, one well-formed `TEST_PATTERN` line
- Checked the three shard patterns partition each suite exactly, 114 and 64 tests covered, no test in two shards and none dropped
- Confirmed the generated pattern selects the same 38 under Go's own `regexp`, which is what `-run` matches with

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test sharding by dynamically distributing discovered tests across three shards.
  * Added validation to fail runs when no tests are found.
  * Enhanced test logs and summaries to report shard counts and selected test commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->