### PR TITLE
s3 lifecycle: bound the daily-replay pass so a quiet cluster stops wedging the job

### DIFF
--- a/test/s3/lifecycle/s3_lifecycle_admin_dispatch_test.go
+++ b/test/s3/lifecycle/s3_lifecycle_admin_dispatch_test.go
@@ -36,12 +36,65 @@ func TestLifecycleAdminDispatchSucceedsWithCustomFilerGrpcPort(t *testing.T) {
 
 	waitForLifecycleWorkerReady(t, adminEndpoint)
 
-	// Lifecycle is a long-running batch; the run endpoint cancels it at
-	// this timeout, which converts a healthy run into canceled_count=1.
-	const runTimeoutSeconds = 30
-	body, err := json.Marshal(map[string]any{
-		"timeout_seconds": runTimeoutSeconds,
-	})
+	payload := runLifecycleJob(t, adminEndpoint, 30)
+
+	require.GreaterOrEqual(t, jsonNumber(t, payload, "detected_count"), 1)
+	require.Equal(t, 0, jsonNumber(t, payload, "error_count"),
+		"dispatched job errored — likely filer_grpc_address was raw host:httpPort.grpcPort")
+
+	require.Eventuallyf(t, func() bool {
+		_, err := c.HeadObject(context.Background(), &s3.HeadObjectInput{
+			Bucket: aws.String(bucket), Key: aws.String(oldKey),
+		})
+		return err != nil
+	}, 30*time.Second, 500*time.Millisecond,
+		"expected %s/%s to be deleted after admin-dispatched lifecycle run", bucket, oldKey)
+}
+
+// A worker-dispatched pass with rules in place but nothing due: the
+// invariant is that a pass returns on its own, so the admin never has to
+// cancel it and the executor slot is free for the next one.
+//
+// Not a regression test for the wedge this scenario comes from. Before
+// the subscription was bounded a pass ended only when some write landed
+// past its boundary, and on a shared test cluster something usually
+// does — verified: the whole suite passes on the unfixed build. The
+// deterministic guards are the dailyrun unit tests. This covers the
+// worker path end-to-end and would catch a pass that hangs
+// unconditionally.
+func TestLifecycleAdminDispatchCompletesWithNothingDue(t *testing.T) {
+	adminEndpoint := envOr("ADMIN_ENDPOINT", defaultAdminEndpoint)
+
+	c := s3Client(t)
+	bucket := uniqueBucket("admin-idle")
+	mustCreateBucket(t, c, bucket)
+	putExpirationLifecycle(t, c, bucket, "expire/", 1)
+	// Deliberately not backdated: the rule matches the prefix but nothing
+	// is due, so the pass dispatches nothing.
+	putObject(t, c, bucket, "expire/fresh.txt", "fresh")
+
+	waitForLifecycleWorkerReady(t, adminEndpoint)
+
+	// Let the writes above settle below the pass boundary, or one of them
+	// ends the pass and the wedge is masked.
+	time.Sleep(2 * time.Second)
+
+	payload := runLifecycleJob(t, adminEndpoint, 30)
+
+	require.Equal(t, 0, jsonNumber(t, payload, "canceled_count"),
+		"pass did not return on its own; the admin cancelled it at the run timeout")
+	require.GreaterOrEqual(t, jsonNumber(t, payload, "success_count"), 1,
+		"expected the dispatched pass to complete")
+	require.Equal(t, 0, jsonNumber(t, payload, "skipped_active_count"),
+		"a previous pass still held the executor slot")
+}
+
+// runLifecycleJob drives the admin's run endpoint and returns its decoded
+// response. timeoutSeconds bounds the run admin-side: a pass that never
+// returns comes back as canceled_count=1 after that long.
+func runLifecycleJob(t *testing.T, adminEndpoint string, timeoutSeconds int) map[string]any {
+	t.Helper()
+	body, err := json.Marshal(map[string]any{"timeout_seconds": timeoutSeconds})
 	require.NoError(t, err)
 	req, err := http.NewRequestWithContext(
 		context.Background(), http.MethodPost,
@@ -59,18 +112,7 @@ func TestLifecycleAdminDispatchSucceedsWithCustomFilerGrpcPort(t *testing.T) {
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&payload))
 	t.Logf("admin /api/plugin/job-types/s3_lifecycle/run response: %v", payload)
 	require.Equal(t, http.StatusOK, resp.StatusCode, "admin run endpoint failed: %v", payload)
-
-	require.GreaterOrEqual(t, jsonNumber(t, payload, "detected_count"), 1)
-	require.Equal(t, 0, jsonNumber(t, payload, "error_count"),
-		"dispatched job errored — likely filer_grpc_address was raw host:httpPort.grpcPort")
-
-	require.Eventuallyf(t, func() bool {
-		_, err := c.HeadObject(context.Background(), &s3.HeadObjectInput{
-			Bucket: aws.String(bucket), Key: aws.String(oldKey),
-		})
-		return err != nil
-	}, 30*time.Second, 500*time.Millisecond,
-		"expected %s/%s to be deleted after admin-dispatched lifecycle run", bucket, oldKey)
+	return payload
 }
 
 func jsonNumber(t *testing.T, payload map[string]any, key string) int {

--- a/weed/s3api/s3lifecycle/DESIGN.md
+++ b/weed/s3api/s3lifecycle/DESIGN.md
@@ -108,7 +108,7 @@ One filer `SubscribeMetadata` stream per `dailyrun.Run()` call, covering every s
 
 `globalStartTsNs = min(per-shard cursor, runNow - maxTTL)`. Pre-loaded once at pass start so the subscription's `StartTsNs` covers every shard's needed range; per-shard drains then filter `ev.TsNs <= shard.startTsNs` locally.
 
-Fan-out cancels the reader on the first `ev.TsNs > runNow` (meta-log events arrive in TsNs order; everything after is past the pass boundary). Per-shard channels are buffered to 256 events — large enough to absorb bursts without back-pressuring the fan-out.
+The subscription is bounded: `UntilNs = runNow`, so the filer ends the stream once it has delivered everything up to the pass boundary and the pass ends on its own. Fan-out also cancels the reader on the first `ev.TsNs > runNow` as a backstop (meta-log events arrive in TsNs order; everything after is past the boundary) — that used to be the *only* way a pass ended, which wedged the job for as long as the cluster stayed quiet. Per-shard channels are buffered to 256 events — large enough to absorb bursts without back-pressuring the fan-out.
 
 ## Action kinds and dispatch paths
 
@@ -140,7 +140,7 @@ type Cursor struct {
 
 `LastWalkedNs` is JSON-omitempty, so cursor files written before that field existed decode cleanly as zero (treated as "never walked steady-state" → next pass seeds the anchor).
 
-Cursor save uses a fresh `context.Background()` with a 5s timeout because the steady-state drain exits via passCtx cancellation (the only way an idle subscription ends). Saving with the canceled passCtx would silently drop the cursor and the next pass would re-replay from the same floor.
+Cursor save uses a fresh `context.Background()` with a 5s timeout because a caller-imposed wall-clock cap on the pass (the shell driver's `-runtime`) cancels the drain's context. Saving with the canceled context would silently drop the cursor and the next pass would re-replay from the same floor.
 
 In steady state the start position honors the cursor verbatim — the floor `runNow - maxTTL` is applied only on cold start (`!found`). The drain freezes the cursor at the last pre-skip event so pending matches with `DueTime == TsNs + maxTTL` stay in scope across passes; bumping forward in steady state would orphan exactly those events.
 

--- a/weed/s3api/s3lifecycle/dailyrun/process_matches_test.go
+++ b/weed/s3api/s3lifecycle/dailyrun/process_matches_test.go
@@ -19,19 +19,25 @@ import (
 
 // recordingClient captures every LifecycleDelete request the
 // daily-run path emits. Default outcome is DONE; tests that need
-// other outcomes set responses by index.
+// other outcomes set responses by index, or outcomeByObject when
+// shards dispatch concurrently and call order isn't fixed.
 type recordingClient struct {
-	mu        sync.Mutex
-	requests  []*s3_lifecycle_pb.LifecycleDeleteRequest
-	responses []s3_lifecycle_pb.LifecycleDeleteOutcome
-	calls     atomic.Int32
+	mu              sync.Mutex
+	requests        []*s3_lifecycle_pb.LifecycleDeleteRequest
+	responses       []s3_lifecycle_pb.LifecycleDeleteOutcome
+	outcomeByObject map[string]s3_lifecycle_pb.LifecycleDeleteOutcome
+	calls           atomic.Int32
 }
 
 func (c *recordingClient) LifecycleDelete(_ context.Context, req *s3_lifecycle_pb.LifecycleDeleteRequest) (*s3_lifecycle_pb.LifecycleDeleteResponse, error) {
 	c.mu.Lock()
 	c.requests = append(c.requests, req)
 	idx := int(c.calls.Add(1)) - 1
+	byObject, pinned := c.outcomeByObject[req.ObjectPath]
 	c.mu.Unlock()
+	if pinned {
+		return &s3_lifecycle_pb.LifecycleDeleteResponse{Outcome: byObject}, nil
+	}
 	out := s3_lifecycle_pb.LifecycleDeleteOutcome_DONE
 	if idx < len(c.responses) {
 		out = c.responses[idx]

--- a/weed/s3api/s3lifecycle/dailyrun/run.go
+++ b/weed/s3api/s3lifecycle/dailyrun/run.go
@@ -159,6 +159,14 @@ func Run(ctx context.Context, cfg Config) error {
 			if err := runShard(ctx, cfg, snap, runNow, sh, ch); err != nil {
 				errCh <- err
 			}
+			// runShard can return before its channel is closed — a
+			// halted dispatch stops the drain mid-stream. Keep
+			// discarding, or the fan-out blocks on this shard's full
+			// buffer and starves every other shard's drain.
+			if ch != nil {
+				for range ch {
+				}
+			}
 		}()
 	}
 	wg.Wait()

--- a/weed/s3api/s3lifecycle/dailyrun/run.go
+++ b/weed/s3api/s3lifecycle/dailyrun/run.go
@@ -140,8 +140,9 @@ func Run(ctx context.Context, cfg Config) error {
 		fanoutDone      chan struct{}
 		cancelRead      context.CancelFunc
 		globalStartTsNs int64
-		// Fan-out ended the pass itself; see stoppedOnPurpose below.
-		pastBoundary atomic.Bool
+		// Set by the reader goroutine when it stops for a reason we asked
+		// for, rather than a broken stream.
+		stoppedOnPurpose atomic.Bool
 	)
 	if rsh != [32]byte{} {
 		// Pre-load all per-shard cursors so the shared subscription
@@ -151,7 +152,7 @@ func Run(ctx context.Context, cfg Config) error {
 		// exactly the case where a rule's TTL equals maxTTL and an
 		// older event still has DueTime <= runNow.
 		globalStartTsNs = computeGlobalStartTsNs(ctx, cfg, runNow, maxTTL)
-		shardEvents, readerDone, fanoutDone, cancelRead = startSharedSubscription(ctx, cfg, runNow, globalStartTsNs, &pastBoundary)
+		shardEvents, readerDone, fanoutDone, cancelRead = startSharedSubscription(ctx, cfg, runNow, globalStartTsNs, &stoppedOnPurpose)
 		defer cancelRead()
 	}
 
@@ -186,12 +187,9 @@ func Run(ctx context.Context, cfg Config) error {
 	// so their goroutines don't outlive Run.
 	var readerErr error
 	if cancelRead != nil {
-		// Not decidable from the error: a stream we cancel and one the
-		// filer cancels both arrive as codes.Canceled. Track intent.
-		stoppedOnPurpose := ctx.Err() != nil || pastBoundary.Load()
 		cancelRead()
 		<-fanoutDone
-		if rerr := <-readerDone; rerr != nil && !stoppedOnPurpose {
+		if rerr := <-readerDone; rerr != nil && !stoppedOnPurpose.Load() {
 			// The drains ended on a closed channel, so the pass is
 			// truncated. Cursors hold what was processed; what matters is
 			// that the job doesn't go green on a dead subscription.
@@ -311,7 +309,9 @@ func computeGlobalStartTsNs(ctx context.Context, cfg Config, runNow time.Time, m
 // Events arriving with TsNs > runUpTo (the pass boundary) cause the
 // fan-out to cancel the reader and close all per-shard channels,
 // ending the pass.
-func startSharedSubscription(ctx context.Context, cfg Config, runNow time.Time, globalStartTsNs int64, pastBoundary *atomic.Bool) (map[int]chan *reader.Event, chan error, chan struct{}, context.CancelFunc) {
+func startSharedSubscription(ctx context.Context, cfg Config, runNow time.Time, globalStartTsNs int64, stoppedOnPurpose *atomic.Bool) (map[int]chan *reader.Event, chan error, chan struct{}, context.CancelFunc) {
+	// Set by the fan-out when it ends the pass on an event past runUpTo.
+	var pastBoundary atomic.Bool
 	shardSet := make(map[int]bool, len(cfg.Shards))
 	shardEvents := make(map[int]chan *reader.Event, len(cfg.Shards))
 	for _, sh := range cfg.Shards {
@@ -354,7 +354,13 @@ func startSharedSubscription(ctx context.Context, cfg Config, runNow time.Time, 
 	readerCtx, cancelReader := context.WithCancel(ctx)
 	readerDone := make(chan error, 1)
 	go func() {
-		readerDone <- rd.Run(readerCtx, cfg.FilerClient, clientName, clientID)
+		rerr := rd.Run(readerCtx, cfg.FilerClient, clientName, clientID)
+		// Not decidable from the error: a stream we cancel and one the
+		// filer cancels both arrive as codes.Canceled. Snapshot intent
+		// here rather than after teardown, or a deadline expiring during
+		// the drains and cursor saves masks a real failure.
+		stoppedOnPurpose.Store(ctx.Err() != nil || pastBoundary.Load())
+		readerDone <- rerr
 		// Only sender. Closing is what ends the fan-out, and through it
 		// every drain, when the stream finishes on its own.
 		close(events)

--- a/weed/s3api/s3lifecycle/dailyrun/run.go
+++ b/weed/s3api/s3lifecycle/dailyrun/run.go
@@ -301,22 +301,33 @@ func startSharedSubscription(ctx context.Context, cfg Config, runNow time.Time, 
 		clientID = int32(util.RandomInt32())
 	}
 
+	runUpTo := runNow.UnixNano()
 	events := make(chan *reader.Event, 4*len(cfg.Shards))
 	rd := &reader.Reader{
 		ShardPredicate: func(id int) bool { return shardSet[id] },
 		BucketsPath:    cfg.BucketsPath,
 		StartTsNs:      globalStartTsNs,
-		Events:         events,
-		EventBudget:    cfg.EventBudget,
+		// The pass covers (globalStartTsNs, runUpTo]; bounding the
+		// subscription there makes the filer end the stream once it has
+		// delivered that range. Without it the pass ends only when some
+		// unrelated write pushes an event past runUpTo, so a cluster
+		// that goes quiet parks the reader in Recv, starves all shard
+		// drains, and wedges the job indefinitely.
+		UntilTsNs:   runUpTo,
+		Events:      events,
+		EventBudget: cfg.EventBudget,
 	}
 
 	readerCtx, cancelReader := context.WithCancel(ctx)
 	readerDone := make(chan error, 1)
 	go func() {
 		readerDone <- rd.Run(readerCtx, cfg.FilerClient, clientName, clientID)
+		// The reader is the only sender; closing here is what ends the
+		// fan-out (and through it every shard drain) when the stream
+		// finishes on its own rather than by cancellation.
+		close(events)
 	}()
 
-	runUpTo := runNow.UnixNano()
 	fanoutDone := make(chan struct{})
 	go func() {
 		defer close(fanoutDone)
@@ -554,18 +565,18 @@ func runShard(ctx context.Context, cfg Config, snap *engine.Snapshot, runNow tim
 	}
 
 	lastOK, _, drainErr := drainShardEvents(ctx, cfg, runNow, shardID, snap, startTsNs, events)
-	// Cursor save uses a fresh ctx because the steady-state drain exits
-	// via passCtx cancellation (the only signal the filer subscription
-	// gets when no new events arrive). Saving with the canceled passCtx
-	// would silently drop the cursor and the next pass would re-replay
-	// from the same floor — defeating advancement entirely.
+	// Cursor save uses a fresh ctx because a caller-imposed wall-clock
+	// cap on the pass (the shell driver's -runtime) cancels the drain's
+	// ctx. Saving with the canceled ctx would silently drop the cursor
+	// and the next pass would re-replay from the same floor — defeating
+	// advancement entirely.
 	saveCtx, saveCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer saveCancel()
 	if drainErr != nil {
 		_ = saveCursorAndPublish(saveCtx, cfg.Persister, shardID, Cursor{TsNs: lastOK, RuleSetHash: rsh, PromotedHash: promoted, LastWalkedNs: lastWalkedNs})
-		// passCtx timeout is the expected end-of-pass for an idle
-		// subscription; not a real error. Other drain errors still
-		// propagate.
+		// A pass cut short by its wall-clock cap is a truncated pass,
+		// not a failure; the cursor above carries the progress forward.
+		// Other drain errors still propagate.
 		if errors.Is(drainErr, context.DeadlineExceeded) || errors.Is(drainErr, context.Canceled) {
 			return nil
 		}

--- a/weed/s3api/s3lifecycle/dailyrun/run.go
+++ b/weed/s3api/s3lifecycle/dailyrun/run.go
@@ -90,18 +90,12 @@ type Config struct {
 	// 0 -> unbounded.
 	EventBudget int
 
-	// SubscriptionReceiveTimeout bounds the gap between responses on the
-	// shared meta-log stream; 0 takes defaultSubscriptionReceiveTimeout.
-	// UntilNs already ends a healthy stream and gRPC keepalive catches a
-	// dead connection — this is the remaining case, a filer that answers
-	// pings but stops producing.
+	// 0 -> defaultSubscriptionReceiveTimeout.
 	SubscriptionReceiveTimeout time.Duration
 }
 
-// defaultSubscriptionReceiveTimeout sits above the filer's 15-minute
-// metadata-gap recovery budget (maxGapStall in
-// weed/server/filer_grpc_server_sub_meta.go), so a subscriber legitimately
-// parked on a gap is never mistaken for a stalled one.
+// Above the filer's 15m maxGapStall, so a subscriber parked on a gap is
+// not mistaken for a stalled one.
 const defaultSubscriptionReceiveTimeout = 20 * time.Minute
 
 // Run executes the daily replay for every shard in cfg.Shards
@@ -146,9 +140,7 @@ func Run(ctx context.Context, cfg Config) error {
 		fanoutDone      chan struct{}
 		cancelRead      context.CancelFunc
 		globalStartTsNs int64
-		// Set when the fan-out ends the pass itself on an event past
-		// runUpTo, so the reader's resulting cancellation is read as an
-		// intentional stop rather than a broken stream.
+		// Fan-out ended the pass itself; see stoppedOnPurpose below.
 		pastBoundary atomic.Bool
 	)
 	if rsh != [32]byte{} {
@@ -177,10 +169,9 @@ func Run(ctx context.Context, cfg Config) error {
 			if err := runShard(ctx, cfg, snap, runNow, sh, ch); err != nil {
 				errCh <- err
 			}
-			// runShard can return before its channel is closed — a
-			// halted dispatch stops the drain mid-stream. Keep
+			// A halted dispatch returns runShard mid-stream. Keep
 			// discarding, or the fan-out blocks on this shard's full
-			// buffer and starves every other shard's drain.
+			// buffer and starves every other drain.
 			if ch != nil {
 				for range ch {
 				}
@@ -193,22 +184,17 @@ func Run(ctx context.Context, cfg Config) error {
 	// Tear down the shared subscription. cancelRead unblocks both the
 	// reader's gRPC stream and the fan-out's send loop; we wait on both
 	// so their goroutines don't outlive Run.
-	// Whether the reader stopped because we asked it to. Deciding this
-	// from the error is not possible: a stream we cancel and a stream the
-	// filer cancels both arrive as codes.Canceled, so classifying by
-	// status would let a truncated pass report success. The two ways a
-	// stop is intentional are both knowable here.
-	stoppedOnPurpose := ctx.Err() != nil || pastBoundary.Load()
 	var readerErr error
 	if cancelRead != nil {
+		// Not decidable from the error: a stream we cancel and one the
+		// filer cancels both arrive as codes.Canceled. Track intent.
+		stoppedOnPurpose := ctx.Err() != nil || pastBoundary.Load()
 		cancelRead()
 		<-fanoutDone
 		if rerr := <-readerDone; rerr != nil && !stoppedOnPurpose {
-			// A stream that dies mid-pass ends every shard's drain on a
-			// closed channel, so the pass is truncated. Cursors still
-			// hold what was processed and the next pass resumes there,
-			// but this must not report success — a job that goes green
-			// on a dead subscription is how lifecycle silently stops.
+			// The drains ended on a closed channel, so the pass is
+			// truncated. Cursors hold what was processed; what matters is
+			// that the job doesn't go green on a dead subscription.
 			readerErr = fmt.Errorf("shared meta-log subscription: %w", rerr)
 			glog.Warningf("daily_run: %v", readerErr)
 		}
@@ -356,12 +342,9 @@ func startSharedSubscription(ctx context.Context, cfg Config, runNow time.Time, 
 		ShardPredicate: func(id int) bool { return shardSet[id] },
 		BucketsPath:    cfg.BucketsPath,
 		StartTsNs:      globalStartTsNs,
-		// The pass covers (globalStartTsNs, runUpTo]; bounding the
-		// subscription there makes the filer end the stream once it has
-		// delivered that range. Without it the pass ends only when some
-		// unrelated write pushes an event past runUpTo, so a cluster
-		// that goes quiet parks the reader in Recv, starves all shard
-		// drains, and wedges the job indefinitely.
+		// The pass covers (globalStartTsNs, runUpTo]. Unbounded, it ends
+		// only when an unrelated write pushes an event past runUpTo — so
+		// a quiet cluster wedges it.
 		UntilTsNs:      runUpTo,
 		Events:         events,
 		EventBudget:    cfg.EventBudget,
@@ -372,9 +355,8 @@ func startSharedSubscription(ctx context.Context, cfg Config, runNow time.Time, 
 	readerDone := make(chan error, 1)
 	go func() {
 		readerDone <- rd.Run(readerCtx, cfg.FilerClient, clientName, clientID)
-		// The reader is the only sender; closing here is what ends the
-		// fan-out (and through it every shard drain) when the stream
-		// finishes on its own rather than by cancellation.
+		// Only sender. Closing is what ends the fan-out, and through it
+		// every drain, when the stream finishes on its own.
 		close(events)
 	}()
 
@@ -451,8 +433,7 @@ func validate(cfg Config) error {
 	if cfg.WalkerInterval < 0 {
 		return fmt.Errorf("daily_run: negative WalkerInterval %v (0 = unthrottled, positive values throttle)", cfg.WalkerInterval)
 	}
-	// Negative would reach the reader as "disabled" only by accident;
-	// 0 is the documented way to take the default.
+	// Negative would reach the reader as "disabled" by accident.
 	if cfg.SubscriptionReceiveTimeout < 0 {
 		return fmt.Errorf("daily_run: negative SubscriptionReceiveTimeout %v (0 = default %v)", cfg.SubscriptionReceiveTimeout, defaultSubscriptionReceiveTimeout)
 	}
@@ -621,18 +602,15 @@ func runShard(ctx context.Context, cfg Config, snap *engine.Snapshot, runNow tim
 	}
 
 	lastOK, _, drainErr := drainShardEvents(ctx, cfg, runNow, shardID, snap, startTsNs, events)
-	// Cursor save uses a fresh ctx because a caller-imposed wall-clock
-	// cap on the pass (the shell driver's -runtime) cancels the drain's
-	// ctx. Saving with the canceled ctx would silently drop the cursor
-	// and the next pass would re-replay from the same floor — defeating
-	// advancement entirely.
+	// Fresh ctx: a wall-clock cap on the pass (the shell driver's
+	// -runtime) cancels the drain's, and saving with it would drop the
+	// cursor and re-replay from the same floor next pass.
 	saveCtx, saveCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer saveCancel()
 	if drainErr != nil {
 		_ = saveCursorAndPublish(saveCtx, cfg.Persister, shardID, Cursor{TsNs: lastOK, RuleSetHash: rsh, PromotedHash: promoted, LastWalkedNs: lastWalkedNs})
-		// A pass cut short by its wall-clock cap is a truncated pass,
-		// not a failure; the cursor above carries the progress forward.
-		// Other drain errors still propagate.
+		// Cut short by its wall-clock cap: truncated, not failed — the
+		// cursor above carries progress forward.
 		if errors.Is(drainErr, context.DeadlineExceeded) || errors.Is(drainErr, context.Canceled) {
 			return nil
 		}

--- a/weed/s3api/s3lifecycle/dailyrun/run.go
+++ b/weed/s3api/s3lifecycle/dailyrun/run.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
@@ -18,8 +19,6 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/stats"
 	"github.com/seaweedfs/seaweedfs/weed/util"
 	"golang.org/x/time/rate"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // LifecycleClient mirrors dispatcher's contract; duplicated to avoid an
@@ -134,6 +133,10 @@ func Run(ctx context.Context, cfg Config) error {
 		fanoutDone      chan struct{}
 		cancelRead      context.CancelFunc
 		globalStartTsNs int64
+		// Set when the fan-out ends the pass itself on an event past
+		// runUpTo, so the reader's resulting cancellation is read as an
+		// intentional stop rather than a broken stream.
+		pastBoundary atomic.Bool
 	)
 	if rsh != [32]byte{} {
 		// Pre-load all per-shard cursors so the shared subscription
@@ -143,7 +146,7 @@ func Run(ctx context.Context, cfg Config) error {
 		// exactly the case where a rule's TTL equals maxTTL and an
 		// older event still has DueTime <= runNow.
 		globalStartTsNs = computeGlobalStartTsNs(ctx, cfg, runNow, maxTTL)
-		shardEvents, readerDone, fanoutDone, cancelRead = startSharedSubscription(ctx, cfg, runNow, globalStartTsNs)
+		shardEvents, readerDone, fanoutDone, cancelRead = startSharedSubscription(ctx, cfg, runNow, globalStartTsNs, &pastBoundary)
 		defer cancelRead()
 	}
 
@@ -177,11 +180,17 @@ func Run(ctx context.Context, cfg Config) error {
 	// Tear down the shared subscription. cancelRead unblocks both the
 	// reader's gRPC stream and the fan-out's send loop; we wait on both
 	// so their goroutines don't outlive Run.
+	// Whether the reader stopped because we asked it to. Deciding this
+	// from the error is not possible: a stream we cancel and a stream the
+	// filer cancels both arrive as codes.Canceled, so classifying by
+	// status would let a truncated pass report success. The two ways a
+	// stop is intentional are both knowable here.
+	stoppedOnPurpose := ctx.Err() != nil || pastBoundary.Load()
 	var readerErr error
 	if cancelRead != nil {
 		cancelRead()
 		<-fanoutDone
-		if rerr := <-readerDone; rerr != nil && !isCanceled(rerr) {
+		if rerr := <-readerDone; rerr != nil && !stoppedOnPurpose {
 			// A stream that dies mid-pass ends every shard's drain on a
 			// closed channel, so the pass is truncated. Cursors still
 			// hold what was processed and the next pass resumes there,
@@ -303,7 +312,7 @@ func computeGlobalStartTsNs(ctx context.Context, cfg Config, runNow time.Time, m
 // Events arriving with TsNs > runUpTo (the pass boundary) cause the
 // fan-out to cancel the reader and close all per-shard channels,
 // ending the pass.
-func startSharedSubscription(ctx context.Context, cfg Config, runNow time.Time, globalStartTsNs int64) (map[int]chan *reader.Event, chan error, chan struct{}, context.CancelFunc) {
+func startSharedSubscription(ctx context.Context, cfg Config, runNow time.Time, globalStartTsNs int64, pastBoundary *atomic.Bool) (map[int]chan *reader.Event, chan error, chan struct{}, context.CancelFunc) {
 	shardSet := make(map[int]bool, len(cfg.Shards))
 	shardEvents := make(map[int]chan *reader.Event, len(cfg.Shards))
 	for _, sh := range cfg.Shards {
@@ -375,6 +384,7 @@ func startSharedSubscription(ctx context.Context, cfg Config, runNow time.Time, 
 				// too. Cancel the reader so subsequent passes don't
 				// pay for stream tail we'd drop anyway.
 				if ev.TsNs > runUpTo {
+					pastBoundary.Store(true)
 					cancelReader()
 					return
 				}
@@ -392,21 +402,6 @@ func startSharedSubscription(ctx context.Context, cfg Config, runNow time.Time, 
 	}()
 
 	return shardEvents, readerDone, fanoutDone, cancelReader
-}
-
-// isCanceled reports whether err is the pass ending on purpose — its
-// own teardown, or a caller-imposed wall-clock cap. A canceled gRPC
-// stream surfaces as a status code rather than a wrapped
-// context.Canceled, so both forms have to be checked.
-func isCanceled(err error) bool {
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return true
-	}
-	switch status.Code(err) {
-	case codes.Canceled, codes.DeadlineExceeded:
-		return true
-	}
-	return false
 }
 
 func validate(cfg Config) error {

--- a/weed/s3api/s3lifecycle/dailyrun/run.go
+++ b/weed/s3api/s3lifecycle/dailyrun/run.go
@@ -89,7 +89,20 @@ type Config struct {
 
 	// 0 -> unbounded.
 	EventBudget int
+
+	// SubscriptionReceiveTimeout bounds the gap between responses on the
+	// shared meta-log stream; 0 takes defaultSubscriptionReceiveTimeout.
+	// UntilNs already ends a healthy stream and gRPC keepalive catches a
+	// dead connection — this is the remaining case, a filer that answers
+	// pings but stops producing.
+	SubscriptionReceiveTimeout time.Duration
 }
+
+// defaultSubscriptionReceiveTimeout sits above the filer's 15-minute
+// metadata-gap recovery budget (maxGapStall in
+// weed/server/filer_grpc_server_sub_meta.go), so a subscriber legitimately
+// parked on a gap is never mistaken for a stalled one.
+const defaultSubscriptionReceiveTimeout = 20 * time.Minute
 
 // Run executes the daily replay for every shard in cfg.Shards
 // concurrently. Returns the first shard error; the rest log and run to
@@ -334,6 +347,10 @@ func startSharedSubscription(ctx context.Context, cfg Config, runNow time.Time, 
 	}
 
 	runUpTo := runNow.UnixNano()
+	receiveTimeout := cfg.SubscriptionReceiveTimeout
+	if receiveTimeout == 0 {
+		receiveTimeout = defaultSubscriptionReceiveTimeout
+	}
 	events := make(chan *reader.Event, 4*len(cfg.Shards))
 	rd := &reader.Reader{
 		ShardPredicate: func(id int) bool { return shardSet[id] },
@@ -345,9 +362,10 @@ func startSharedSubscription(ctx context.Context, cfg Config, runNow time.Time, 
 		// unrelated write pushes an event past runUpTo, so a cluster
 		// that goes quiet parks the reader in Recv, starves all shard
 		// drains, and wedges the job indefinitely.
-		UntilTsNs:   runUpTo,
-		Events:      events,
-		EventBudget: cfg.EventBudget,
+		UntilTsNs:      runUpTo,
+		Events:         events,
+		EventBudget:    cfg.EventBudget,
+		ReceiveTimeout: receiveTimeout,
 	}
 
 	readerCtx, cancelReader := context.WithCancel(ctx)
@@ -432,6 +450,11 @@ func validate(cfg Config) error {
 	// a loud failure instead.
 	if cfg.WalkerInterval < 0 {
 		return fmt.Errorf("daily_run: negative WalkerInterval %v (0 = unthrottled, positive values throttle)", cfg.WalkerInterval)
+	}
+	// Negative would reach the reader as "disabled" only by accident;
+	// 0 is the documented way to take the default.
+	if cfg.SubscriptionReceiveTimeout < 0 {
+		return fmt.Errorf("daily_run: negative SubscriptionReceiveTimeout %v (0 = default %v)", cfg.SubscriptionReceiveTimeout, defaultSubscriptionReceiveTimeout)
 	}
 	for _, sh := range cfg.Shards {
 		if sh < 0 || sh >= s3lifecycle.ShardCount {

--- a/weed/s3api/s3lifecycle/dailyrun/run.go
+++ b/weed/s3api/s3lifecycle/dailyrun/run.go
@@ -18,6 +18,8 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/stats"
 	"github.com/seaweedfs/seaweedfs/weed/util"
 	"golang.org/x/time/rate"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // LifecycleClient mirrors dispatcher's contract; duplicated to avoid an
@@ -175,11 +177,18 @@ func Run(ctx context.Context, cfg Config) error {
 	// Tear down the shared subscription. cancelRead unblocks both the
 	// reader's gRPC stream and the fan-out's send loop; we wait on both
 	// so their goroutines don't outlive Run.
+	var readerErr error
 	if cancelRead != nil {
 		cancelRead()
 		<-fanoutDone
-		if rerr := <-readerDone; rerr != nil && !errors.Is(rerr, context.Canceled) && !errors.Is(rerr, context.DeadlineExceeded) {
-			glog.V(2).Infof("daily_run: shared reader returned: %v", rerr)
+		if rerr := <-readerDone; rerr != nil && !isCanceled(rerr) {
+			// A stream that dies mid-pass ends every shard's drain on a
+			// closed channel, so the pass is truncated. Cursors still
+			// hold what was processed and the next pass resumes there,
+			// but this must not report success — a job that goes green
+			// on a dead subscription is how lifecycle silently stops.
+			readerErr = fmt.Errorf("shared meta-log subscription: %w", rerr)
+			glog.Warningf("daily_run: %v", readerErr)
 		}
 	}
 
@@ -191,6 +200,12 @@ func Run(ctx context.Context, cfg Config) error {
 			first = err
 		} else {
 			glog.V(1).Infof("daily_run: additional shard error: %v", err)
+		}
+	}
+	if readerErr != nil {
+		errCount++
+		if first == nil {
+			first = readerErr
 		}
 	}
 	status := "ok"
@@ -377,6 +392,21 @@ func startSharedSubscription(ctx context.Context, cfg Config, runNow time.Time, 
 	}()
 
 	return shardEvents, readerDone, fanoutDone, cancelReader
+}
+
+// isCanceled reports whether err is the pass ending on purpose — its
+// own teardown, or a caller-imposed wall-clock cap. A canceled gRPC
+// stream surfaces as a status code rather than a wrapped
+// context.Canceled, so both forms have to be checked.
+func isCanceled(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	switch status.Code(err) {
+	case codes.Canceled, codes.DeadlineExceeded:
+		return true
+	}
+	return false
 }
 
 func validate(cfg Config) error {

--- a/weed/s3api/s3lifecycle/dailyrun/run_bounded_test.go
+++ b/weed/s3api/s3lifecycle/dailyrun/run_bounded_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle/engine"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle/reader"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -189,6 +190,48 @@ func TestRun_CappedPassIsNotAFailure(t *testing.T) {
 	case <-time.After(10 * time.Second):
 		t.Fatal("Run did not return after the pass was capped")
 	}
+}
+
+// TestRun_StalledSubscriptionTimesOutThePass covers the case neither
+// UntilNs nor gRPC keepalive reaches: the connection is healthy and
+// answering pings, but the filer's handler has stopped producing. The
+// pass must end on the watchdog rather than wait out the job's
+// effectively-unlimited execution timeout.
+func TestRun_StalledSubscriptionTimesOutThePass(t *testing.T) {
+	e := engine.New()
+	e.Compile([]engine.CompileInput{
+		{Bucket: "b1", Rules: []*s3lifecycle.Rule{
+			{ID: "r", Status: s3lifecycle.StatusEnabled, ExpirationDays: 30},
+		}},
+	}, engine.CompileOptions{})
+
+	cfg := Config{
+		Shards:                     []int{0, 1},
+		BucketsPath:                "/buckets",
+		Engine:                     e,
+		FilerClient:                &blockingSubscribeClient{},
+		Client:                     stubLifecycleClient{},
+		Persister:                  newMemPersister(),
+		Lister:                     stubSiblingLister{},
+		SubscriptionReceiveTimeout: 50 * time.Millisecond,
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- Run(context.Background(), cfg) }()
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, reader.ErrReceiveTimeout)
+	case <-time.After(10 * time.Second):
+		t.Fatal("Run did not return on a stalled subscription")
+	}
+}
+
+func TestValidate_RejectsNegativeSubscriptionReceiveTimeout(t *testing.T) {
+	cfg := validatableConfig()
+	cfg.SubscriptionReceiveTimeout = -time.Second
+	require.ErrorContains(t, validate(cfg), "SubscriptionReceiveTimeout")
+	cfg.SubscriptionReceiveTimeout = 0
+	require.NoError(t, validate(cfg))
 }
 
 // TestRun_ServerSideCancelFailsThePass is the case status-code

--- a/weed/s3api/s3lifecycle/dailyrun/run_bounded_test.go
+++ b/weed/s3api/s3lifecycle/dailyrun/run_bounded_test.go
@@ -219,6 +219,53 @@ func TestValidate_RejectsNegativeSubscriptionReceiveTimeout(t *testing.T) {
 	require.NoError(t, validate(cfg))
 }
 
+// slowSavePersister stretches teardown past the caller's deadline.
+type slowSavePersister struct {
+	*memPersister
+	delay time.Duration
+}
+
+func (p *slowSavePersister) Save(ctx context.Context, shardID int, c Cursor) error {
+	time.Sleep(p.delay)
+	return p.memPersister.Save(ctx, shardID, c)
+}
+
+// A reader that fails while the caller's deadline is still live, on a
+// pass whose teardown then outlives that deadline. Sampling ctx.Err()
+// after the drains and cursor saves would read the late deadline as
+// intent and report the truncated pass as a success.
+func TestRun_LateDeadlineDoesNotMaskReaderFailure(t *testing.T) {
+	e := engine.New()
+	e.Compile([]engine.CompileInput{
+		{Bucket: "b1", Rules: []*s3lifecycle.Rule{
+			{ID: "r", Status: s3lifecycle.StatusEnabled, ExpirationDays: 30},
+		}},
+	}, engine.CompileOptions{})
+
+	cfg := Config{
+		Shards:      []int{0, 1},
+		BucketsPath: "/buckets",
+		Engine:      e,
+		FilerClient: &failingSubscribeClient{err: status.Error(codes.Unavailable, "filer down")},
+		Client:      stubLifecycleClient{},
+		Persister:   &slowSavePersister{memPersister: newMemPersister(), delay: 300 * time.Millisecond},
+		Lister:      stubSiblingLister{},
+	}
+
+	// Deadline lands during the cursor saves, well after the reader failed.
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- Run(ctx, cfg) }()
+	select {
+	case err := <-done:
+		require.Error(t, err, "a deadline expiring during teardown must not excuse an earlier reader failure")
+		require.NotNil(t, ctx.Err(), "test is meaningless unless the deadline did expire")
+	case <-time.After(10 * time.Second):
+		t.Fatal("Run did not return")
+	}
+}
+
 // The case status-code classification could not express: the filer
 // cancels while the caller's context is untouched.
 func TestRun_ServerSideCancelFailsThePass(t *testing.T) {

--- a/weed/s3api/s3lifecycle/dailyrun/run_bounded_test.go
+++ b/weed/s3api/s3lifecycle/dailyrun/run_bounded_test.go
@@ -133,11 +133,70 @@ func TestRun_ReaderFailureFailsThePass(t *testing.T) {
 	}
 }
 
-// TestRun_CancellationIsNotAPassFailure keeps the wall-clock-capped
-// pass (the shell driver's -runtime) reporting success. gRPC surfaces a
-// canceled stream as a status code, not a wrapped context.Canceled, so
-// a naive errors.Is check would turn every capped pass into a failure.
-func TestRun_CancellationIsNotAPassFailure(t *testing.T) {
+// blockingSubscribeStream never delivers, so the pass can only end by
+// the caller's wall-clock cap. Models the shell driver's -runtime.
+type blockingSubscribeStream struct {
+	grpc.ClientStream
+	ctx context.Context
+}
+
+func (s *blockingSubscribeStream) Recv() (*filer_pb.SubscribeMetadataResponse, error) {
+	<-s.ctx.Done()
+	// What gRPC actually returns for a canceled stream: a status code,
+	// not a wrapped context.Canceled.
+	return nil, status.Error(codes.Canceled, "context canceled")
+}
+
+type blockingSubscribeClient struct {
+	filer_pb.SeaweedFilerClient
+}
+
+func (c *blockingSubscribeClient) SubscribeMetadata(ctx context.Context, _ *filer_pb.SubscribeMetadataRequest, _ ...grpc.CallOption) (filer_pb.SeaweedFiler_SubscribeMetadataClient, error) {
+	return &blockingSubscribeStream{ctx: ctx}, nil
+}
+
+// TestRun_CappedPassIsNotAFailure keeps a wall-clock-capped pass (the
+// shell driver's -runtime) reporting success. It is the counterweight
+// to TestRun_ReaderFailureFailsThePass: both end with the reader
+// returning codes.Canceled, and only the caller's intent separates the
+// truncated-on-purpose pass from the broken one — which is why the
+// decision reads ctx rather than the error.
+func TestRun_CappedPassIsNotAFailure(t *testing.T) {
+	e := engine.New()
+	e.Compile([]engine.CompileInput{
+		{Bucket: "b1", Rules: []*s3lifecycle.Rule{
+			{ID: "r", Status: s3lifecycle.StatusEnabled, ExpirationDays: 30},
+		}},
+	}, engine.CompileOptions{})
+
+	cfg := Config{
+		Shards:      []int{0, 1},
+		BucketsPath: "/buckets",
+		Engine:      e,
+		FilerClient: &blockingSubscribeClient{},
+		Client:      stubLifecycleClient{},
+		Persister:   newMemPersister(),
+		Lister:      stubSiblingLister{},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- Run(ctx, cfg) }()
+	select {
+	case err := <-done:
+		require.NoError(t, err, "a pass truncated by its own wall-clock cap is not a failure")
+	case <-time.After(10 * time.Second):
+		t.Fatal("Run did not return after the pass was capped")
+	}
+}
+
+// TestRun_ServerSideCancelFailsThePass is the case status-code
+// classification could not express: the filer cancels the stream while
+// the caller's context is untouched. Indistinguishable from the capped
+// pass above by error alone, so a codes.Canceled check would report a
+// truncated pass as a success.
+func TestRun_ServerSideCancelFailsThePass(t *testing.T) {
 	e := engine.New()
 	e.Compile([]engine.CompileInput{
 		{Bucket: "b1", Rules: []*s3lifecycle.Rule{
@@ -159,7 +218,7 @@ func TestRun_CancellationIsNotAPassFailure(t *testing.T) {
 	go func() { done <- Run(context.Background(), cfg) }()
 	select {
 	case err := <-done:
-		require.NoError(t, err)
+		require.Error(t, err, "a peer-canceled stream truncates the pass and must not report success")
 	case <-time.After(10 * time.Second):
 		t.Fatal("Run did not return after the subscription was canceled")
 	}

--- a/weed/s3api/s3lifecycle/dailyrun/run_bounded_test.go
+++ b/weed/s3api/s3lifecycle/dailyrun/run_bounded_test.go
@@ -1,0 +1,89 @@
+package dailyrun
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle/engine"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// idleSubscribeStream models the filer's SubscribeMetadata stream on a
+// cluster with no writes past the pass boundary: everything up to
+// UntilNs has been delivered (here: nothing), so a bounded subscription
+// ends with io.EOF and an unbounded one blocks in Recv forever.
+type idleSubscribeStream struct {
+	grpc.ClientStream
+	ctx     context.Context
+	untilNs int64
+}
+
+func (s *idleSubscribeStream) Recv() (*filer_pb.SubscribeMetadataResponse, error) {
+	if s.untilNs != 0 {
+		return nil, io.EOF
+	}
+	<-s.ctx.Done()
+	return nil, s.ctx.Err()
+}
+
+type idleSubscribeClient struct {
+	filer_pb.SeaweedFilerClient
+	gotReq chan *filer_pb.SubscribeMetadataRequest
+}
+
+func (c *idleSubscribeClient) SubscribeMetadata(ctx context.Context, req *filer_pb.SubscribeMetadataRequest, _ ...grpc.CallOption) (filer_pb.SeaweedFiler_SubscribeMetadataClient, error) {
+	select {
+	case c.gotReq <- req:
+	default:
+	}
+	return &idleSubscribeStream{ctx: ctx, untilNs: req.UntilNs}, nil
+}
+
+// TestRun_EndsOnIdleSubscription is the regression for a daily-replay
+// pass that never returned: the pass only ended when an unrelated write
+// pushed a meta-log event past its boundary, so on a quiet cluster the
+// reader parked in Recv, all 16 shard drains starved, and Run's
+// WaitGroup never reached zero. Bounding the subscription at the pass
+// boundary makes the end of the pass the filer's decision, not the
+// cluster's write traffic.
+func TestRun_EndsOnIdleSubscription(t *testing.T) {
+	e := engine.New()
+	e.Compile([]engine.CompileInput{
+		{Bucket: "b1", Rules: []*s3lifecycle.Rule{
+			{ID: "r", Status: s3lifecycle.StatusEnabled, ExpirationDays: 30},
+		}},
+	}, engine.CompileOptions{})
+	require.NotEqual(t, [32]byte{}, engine.ReplayContentHash(e.Snapshot()),
+		"rule must be replay-eligible or Run skips the subscription entirely")
+
+	client := &idleSubscribeClient{gotReq: make(chan *filer_pb.SubscribeMetadataRequest, 1)}
+	runNow := time.Now().UTC()
+	cfg := Config{
+		Shards:      []int{0, 1, 2},
+		BucketsPath: "/buckets",
+		Engine:      e,
+		FilerClient: client,
+		Client:      stubLifecycleClient{},
+		Persister:   newMemPersister(),
+		Lister:      stubSiblingLister{},
+		Now:         func() time.Time { return runNow },
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- Run(context.Background(), cfg) }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("Run did not return on an idle subscription")
+	}
+
+	req := <-client.gotReq
+	assert.Equal(t, runNow.UnixNano(), req.UntilNs, "subscription must stop at the pass boundary")
+}

--- a/weed/s3api/s3lifecycle/dailyrun/run_bounded_test.go
+++ b/weed/s3api/s3lifecycle/dailyrun/run_bounded_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // idleSubscribeStream models the filer's SubscribeMetadata stream on a
@@ -86,4 +88,79 @@ func TestRun_EndsOnIdleSubscription(t *testing.T) {
 
 	req := <-client.gotReq
 	assert.Equal(t, runNow.UnixNano(), req.UntilNs, "subscription must stop at the pass boundary")
+}
+
+// failingSubscribeClient fails the subscribe call outright.
+type failingSubscribeClient struct {
+	filer_pb.SeaweedFilerClient
+	err error
+}
+
+func (c *failingSubscribeClient) SubscribeMetadata(_ context.Context, _ *filer_pb.SubscribeMetadataRequest, _ ...grpc.CallOption) (filer_pb.SeaweedFiler_SubscribeMetadataClient, error) {
+	return nil, c.err
+}
+
+// TestRun_ReaderFailureFailsThePass guards the flip side of closing the
+// event channel when the reader exits: every shard drain now ends
+// cleanly on a dead subscription, so without this the pass would report
+// success and the job would go green while lifecycle processed nothing.
+func TestRun_ReaderFailureFailsThePass(t *testing.T) {
+	e := engine.New()
+	e.Compile([]engine.CompileInput{
+		{Bucket: "b1", Rules: []*s3lifecycle.Rule{
+			{ID: "r", Status: s3lifecycle.StatusEnabled, ExpirationDays: 30},
+		}},
+	}, engine.CompileOptions{})
+
+	cfg := Config{
+		Shards:      []int{0, 1},
+		BucketsPath: "/buckets",
+		Engine:      e,
+		FilerClient: &failingSubscribeClient{err: status.Error(codes.Unavailable, "filer down")},
+		Client:      stubLifecycleClient{},
+		Persister:   newMemPersister(),
+		Lister:      stubSiblingLister{},
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- Run(context.Background(), cfg) }()
+	select {
+	case err := <-done:
+		require.Error(t, err, "a dead subscription must not report a successful pass")
+		assert.Contains(t, err.Error(), "subscription")
+	case <-time.After(10 * time.Second):
+		t.Fatal("Run did not return after the subscription failed")
+	}
+}
+
+// TestRun_CancellationIsNotAPassFailure keeps the wall-clock-capped
+// pass (the shell driver's -runtime) reporting success. gRPC surfaces a
+// canceled stream as a status code, not a wrapped context.Canceled, so
+// a naive errors.Is check would turn every capped pass into a failure.
+func TestRun_CancellationIsNotAPassFailure(t *testing.T) {
+	e := engine.New()
+	e.Compile([]engine.CompileInput{
+		{Bucket: "b1", Rules: []*s3lifecycle.Rule{
+			{ID: "r", Status: s3lifecycle.StatusEnabled, ExpirationDays: 30},
+		}},
+	}, engine.CompileOptions{})
+
+	cfg := Config{
+		Shards:      []int{0, 1},
+		BucketsPath: "/buckets",
+		Engine:      e,
+		FilerClient: &failingSubscribeClient{err: status.Error(codes.Canceled, "context canceled")},
+		Client:      stubLifecycleClient{},
+		Persister:   newMemPersister(),
+		Lister:      stubSiblingLister{},
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- Run(context.Background(), cfg) }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("Run did not return after the subscription was canceled")
+	}
 }

--- a/weed/s3api/s3lifecycle/dailyrun/run_bounded_test.go
+++ b/weed/s3api/s3lifecycle/dailyrun/run_bounded_test.go
@@ -17,10 +17,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// idleSubscribeStream models the filer's SubscribeMetadata stream on a
-// cluster with no writes past the pass boundary: everything up to
-// UntilNs has been delivered (here: nothing), so a bounded subscription
-// ends with io.EOF and an unbounded one blocks in Recv forever.
+// idleSubscribeStream: nothing to deliver past the pass boundary. A
+// bounded subscription gets EOF; an unbounded one blocks forever.
 type idleSubscribeStream struct {
 	grpc.ClientStream
 	ctx     context.Context
@@ -48,13 +46,9 @@ func (c *idleSubscribeClient) SubscribeMetadata(ctx context.Context, req *filer_
 	return &idleSubscribeStream{ctx: ctx, untilNs: req.UntilNs}, nil
 }
 
-// TestRun_EndsOnIdleSubscription is the regression for a daily-replay
-// pass that never returned: the pass only ended when an unrelated write
-// pushed a meta-log event past its boundary, so on a quiet cluster the
-// reader parked in Recv, all 16 shard drains starved, and Run's
-// WaitGroup never reached zero. Bounding the subscription at the pass
-// boundary makes the end of the pass the filer's decision, not the
-// cluster's write traffic.
+// The reported wedge: the pass ended only when an unrelated write pushed
+// an event past its boundary, so a quiet cluster starved every drain and
+// Run's WaitGroup never reached zero.
 func TestRun_EndsOnIdleSubscription(t *testing.T) {
 	e := engine.New()
 	e.Compile([]engine.CompileInput{
@@ -101,10 +95,9 @@ func (c *failingSubscribeClient) SubscribeMetadata(_ context.Context, _ *filer_p
 	return nil, c.err
 }
 
-// TestRun_ReaderFailureFailsThePass guards the flip side of closing the
-// event channel when the reader exits: every shard drain now ends
-// cleanly on a dead subscription, so without this the pass would report
-// success and the job would go green while lifecycle processed nothing.
+// Flip side of closing the event channel: the drains now end cleanly on
+// a dead subscription, so the pass would otherwise go green having
+// processed nothing.
 func TestRun_ReaderFailureFailsThePass(t *testing.T) {
 	e := engine.New()
 	e.Compile([]engine.CompileInput{
@@ -134,8 +127,7 @@ func TestRun_ReaderFailureFailsThePass(t *testing.T) {
 	}
 }
 
-// blockingSubscribeStream never delivers, so the pass can only end by
-// the caller's wall-clock cap. Models the shell driver's -runtime.
+// blockingSubscribeStream never delivers; only a cap ends the pass.
 type blockingSubscribeStream struct {
 	grpc.ClientStream
 	ctx context.Context
@@ -143,8 +135,7 @@ type blockingSubscribeStream struct {
 
 func (s *blockingSubscribeStream) Recv() (*filer_pb.SubscribeMetadataResponse, error) {
 	<-s.ctx.Done()
-	// What gRPC actually returns for a canceled stream: a status code,
-	// not a wrapped context.Canceled.
+	// A canceled gRPC stream returns a status code, not context.Canceled.
 	return nil, status.Error(codes.Canceled, "context canceled")
 }
 
@@ -156,12 +147,9 @@ func (c *blockingSubscribeClient) SubscribeMetadata(ctx context.Context, _ *file
 	return &blockingSubscribeStream{ctx: ctx}, nil
 }
 
-// TestRun_CappedPassIsNotAFailure keeps a wall-clock-capped pass (the
-// shell driver's -runtime) reporting success. It is the counterweight
-// to TestRun_ReaderFailureFailsThePass: both end with the reader
-// returning codes.Canceled, and only the caller's intent separates the
-// truncated-on-purpose pass from the broken one — which is why the
-// decision reads ctx rather than the error.
+// Counterweight to TestRun_ServerSideCancelFailsThePass: same
+// codes.Canceled from the reader, opposite verdict. Only intent
+// separates them, which is why the decision reads ctx not the error.
 func TestRun_CappedPassIsNotAFailure(t *testing.T) {
 	e := engine.New()
 	e.Compile([]engine.CompileInput{
@@ -192,11 +180,8 @@ func TestRun_CappedPassIsNotAFailure(t *testing.T) {
 	}
 }
 
-// TestRun_StalledSubscriptionTimesOutThePass covers the case neither
-// UntilNs nor gRPC keepalive reaches: the connection is healthy and
-// answering pings, but the filer's handler has stopped producing. The
-// pass must end on the watchdog rather than wait out the job's
-// effectively-unlimited execution timeout.
+// Neither UntilNs nor keepalive reaches this: a healthy connection whose
+// filer has stopped producing.
 func TestRun_StalledSubscriptionTimesOutThePass(t *testing.T) {
 	e := engine.New()
 	e.Compile([]engine.CompileInput{
@@ -234,11 +219,8 @@ func TestValidate_RejectsNegativeSubscriptionReceiveTimeout(t *testing.T) {
 	require.NoError(t, validate(cfg))
 }
 
-// TestRun_ServerSideCancelFailsThePass is the case status-code
-// classification could not express: the filer cancels the stream while
-// the caller's context is untouched. Indistinguishable from the capped
-// pass above by error alone, so a codes.Canceled check would report a
-// truncated pass as a success.
+// The case status-code classification could not express: the filer
+// cancels while the caller's context is untouched.
 func TestRun_ServerSideCancelFailsThePass(t *testing.T) {
 	e := engine.New()
 	e.Compile([]engine.CompileInput{

--- a/weed/s3api/s3lifecycle/dailyrun/run_fanout_test.go
+++ b/weed/s3api/s3lifecycle/dailyrun/run_fanout_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/pb/s3_lifecycle_pb"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle/engine"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
@@ -104,8 +105,10 @@ func TestRun_HaltedShardDoesNotStarveOthers(t *testing.T) {
 	responses = append(responses, subscribeResponse(bucket, starvedKey, evTime, runNow.Add(-time.Hour).UnixNano()))
 
 	// BLOCKED halts the first shard's drain on its very first dispatch.
-	client := &recordingClient{responses: []s3_lifecycle_pb.LifecycleDeleteOutcome{
-		s3_lifecycle_pb.LifecycleDeleteOutcome_BLOCKED,
+	// Pinned per object rather than by call index: the two shards
+	// dispatch from separate goroutines.
+	client := &recordingClient{outcomeByObject: map[string]s3_lifecycle_pb.LifecycleDeleteOutcome{
+		haltedKey: s3_lifecycle_pb.LifecycleDeleteOutcome_BLOCKED,
 	}}
 
 	// Seed cursors so both shards resume from before the events rather
@@ -141,4 +144,14 @@ func TestRun_HaltedShardDoesNotStarveOthers(t *testing.T) {
 	case <-time.After(10 * time.Second):
 		t.Fatal("Run wedged: the fan-out blocked on a shard that had stopped draining")
 	}
+
+	// Returning isn't enough — dropping the starved shard's events
+	// would return just as cleanly. It has to have been dispatched, and
+	// its cursor has to have advanced onto that event.
+	assert.Contains(t, client.seenObjects(), starvedKey,
+		"the shard behind the halted one must still get its events")
+	starvedCursor, found, err := persister.Load(context.Background(), starvedShard)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Greater(t, starvedCursor.TsNs, seeded.TsNs, "starved shard's cursor must advance")
 }

--- a/weed/s3api/s3lifecycle/dailyrun/run_fanout_test.go
+++ b/weed/s3api/s3lifecycle/dailyrun/run_fanout_test.go
@@ -16,8 +16,8 @@ import (
 	"google.golang.org/grpc"
 )
 
-// scriptedSubscribeStream replays a fixed response list and then ends
-// the stream, standing in for a filer honoring the pass's UntilNs.
+// scriptedSubscribeStream replays a fixed list, then EOFs like a filer
+// honoring UntilNs.
 type scriptedSubscribeStream struct {
 	grpc.ClientStream
 	responses []*filer_pb.SubscribeMetadataResponse
@@ -68,12 +68,9 @@ func keyForShard(t *testing.T, bucket string, shardID int) string {
 	return ""
 }
 
-// TestRun_HaltedShardDoesNotStarveOthers pins the second way a pass
-// could wedge: a shard whose drain stops early (a BLOCKED dispatch
-// halts it) leaves its per-shard channel unread, and once the 256-event
-// buffer fills, the shared fan-out blocks on the send. Every other
-// shard then starves, Run's WaitGroup never drains, and nothing
-// cancels the reader because that only happens after the wait.
+// The second wedge: a drain halted by a BLOCKED dispatch stops reading
+// its channel, the fan-out blocks once the 256 buffer fills, and every
+// other shard starves behind it.
 func TestRun_HaltedShardDoesNotStarveOthers(t *testing.T) {
 	const bucket = "bk"
 	rule := &s3lifecycle.Rule{ID: "r", Status: s3lifecycle.StatusEnabled, ExpirationDays: 1}
@@ -95,26 +92,21 @@ func TestRun_HaltedShardDoesNotStarveOthers(t *testing.T) {
 
 	runNow := time.Now().UTC()
 	evTime := runNow.Add(-48 * time.Hour) // past the 1-day expiration
-	// One more than the per-shard channel buffer, so the fan-out is
-	// guaranteed to block on the halted shard before it ever reaches
-	// the starved shard's event.
+	// Past the 256 buffer, so the fan-out blocks on the halted shard
+	// before reaching the starved shard's event.
 	var responses []*filer_pb.SubscribeMetadataResponse
 	for i := 0; i < 300; i++ {
 		responses = append(responses, subscribeResponse(bucket, haltedKey, evTime, evTime.UnixNano()+int64(i)))
 	}
 	responses = append(responses, subscribeResponse(bucket, starvedKey, evTime, runNow.Add(-time.Hour).UnixNano()))
 
-	// BLOCKED halts the first shard's drain on its very first dispatch.
-	// Pinned per object rather than by call index: the two shards
-	// dispatch from separate goroutines.
+	// Pinned per object, not call index: the shards dispatch concurrently.
 	client := &recordingClient{outcomeByObject: map[string]s3_lifecycle_pb.LifecycleDeleteOutcome{
 		haltedKey: s3_lifecycle_pb.LifecycleDeleteOutcome_BLOCKED,
 	}}
 
-	// Seed cursors so both shards resume from before the events rather
-	// than from the cold-start floor, which would skip them as already
-	// past. Hashes must match or runShard takes the recovery branch and
-	// returns before draining.
+	// Resume from before the events; the cold-start floor would skip them.
+	// Hashes must match or runShard takes the recovery branch instead.
 	persister := newMemPersister()
 	seeded := Cursor{
 		TsNs:         runNow.Add(-72 * time.Hour).UnixNano(),
@@ -145,9 +137,8 @@ func TestRun_HaltedShardDoesNotStarveOthers(t *testing.T) {
 		t.Fatal("Run wedged: the fan-out blocked on a shard that had stopped draining")
 	}
 
-	// Returning isn't enough — dropping the starved shard's events
-	// would return just as cleanly. It has to have been dispatched, and
-	// its cursor has to have advanced onto that event.
+	// Returning isn't enough: dropping the starved shard's events would
+	// return just as cleanly.
 	assert.Contains(t, client.seenObjects(), starvedKey,
 		"the shard behind the halted one must still get its events")
 	starvedCursor, found, err := persister.Load(context.Background(), starvedShard)

--- a/weed/s3api/s3lifecycle/dailyrun/run_fanout_test.go
+++ b/weed/s3api/s3lifecycle/dailyrun/run_fanout_test.go
@@ -1,0 +1,144 @@
+package dailyrun
+
+import (
+	"context"
+	"io"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/pb/s3_lifecycle_pb"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3lifecycle/engine"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// scriptedSubscribeStream replays a fixed response list and then ends
+// the stream, standing in for a filer honoring the pass's UntilNs.
+type scriptedSubscribeStream struct {
+	grpc.ClientStream
+	responses []*filer_pb.SubscribeMetadataResponse
+	next      int
+}
+
+func (s *scriptedSubscribeStream) Recv() (*filer_pb.SubscribeMetadataResponse, error) {
+	if s.next >= len(s.responses) {
+		return nil, io.EOF
+	}
+	resp := s.responses[s.next]
+	s.next++
+	return resp, nil
+}
+
+type scriptedSubscribeClient struct {
+	filer_pb.SeaweedFilerClient
+	responses []*filer_pb.SubscribeMetadataResponse
+}
+
+func (c *scriptedSubscribeClient) SubscribeMetadata(_ context.Context, _ *filer_pb.SubscribeMetadataRequest, _ ...grpc.CallOption) (filer_pb.SeaweedFiler_SubscribeMetadataClient, error) {
+	return &scriptedSubscribeStream{responses: c.responses}, nil
+}
+
+func subscribeResponse(bucket, key string, mtime time.Time, tsNs int64) *filer_pb.SubscribeMetadataResponse {
+	return &filer_pb.SubscribeMetadataResponse{
+		TsNs: tsNs,
+		EventNotification: &filer_pb.EventNotification{
+			NewParentPath: "/buckets/" + bucket,
+			NewEntry: &filer_pb.Entry{
+				Name:       key,
+				Attributes: &filer_pb.FuseAttributes{Mtime: mtime.Unix(), FileSize: 1},
+			},
+		},
+	}
+}
+
+// keyForShard finds an object key in bucket that hashes to shardID.
+func keyForShard(t *testing.T, bucket string, shardID int) string {
+	t.Helper()
+	for i := 0; i < 10000; i++ {
+		key := "k" + strconv.Itoa(i)
+		if s3lifecycle.ShardID(bucket, key) == shardID {
+			return key
+		}
+	}
+	t.Fatalf("no key hashes to shard %d", shardID)
+	return ""
+}
+
+// TestRun_HaltedShardDoesNotStarveOthers pins the second way a pass
+// could wedge: a shard whose drain stops early (a BLOCKED dispatch
+// halts it) leaves its per-shard channel unread, and once the 256-event
+// buffer fills, the shared fan-out blocks on the send. Every other
+// shard then starves, Run's WaitGroup never drains, and nothing
+// cancels the reader because that only happens after the wait.
+func TestRun_HaltedShardDoesNotStarveOthers(t *testing.T) {
+	const bucket = "bk"
+	rule := &s3lifecycle.Rule{ID: "r", Status: s3lifecycle.StatusEnabled, ExpirationDays: 1}
+	prior := map[s3lifecycle.ActionKey]engine.PriorState{}
+	ruleHash := s3lifecycle.RuleHash(rule)
+	for _, k := range s3lifecycle.RuleActionKinds(rule) {
+		prior[s3lifecycle.ActionKey{Bucket: bucket, RuleHash: ruleHash, ActionKind: k}] = engine.PriorState{
+			BootstrapComplete: true,
+			Mode:              engine.ModeEventDriven,
+		}
+	}
+	e := engine.New()
+	snap := e.Compile([]engine.CompileInput{{Bucket: bucket, Rules: []*s3lifecycle.Rule{rule}}},
+		engine.CompileOptions{PriorStates: prior})
+
+	haltedShard, starvedShard := 0, 1
+	haltedKey := keyForShard(t, bucket, haltedShard)
+	starvedKey := keyForShard(t, bucket, starvedShard)
+
+	runNow := time.Now().UTC()
+	evTime := runNow.Add(-48 * time.Hour) // past the 1-day expiration
+	// One more than the per-shard channel buffer, so the fan-out is
+	// guaranteed to block on the halted shard before it ever reaches
+	// the starved shard's event.
+	var responses []*filer_pb.SubscribeMetadataResponse
+	for i := 0; i < 300; i++ {
+		responses = append(responses, subscribeResponse(bucket, haltedKey, evTime, evTime.UnixNano()+int64(i)))
+	}
+	responses = append(responses, subscribeResponse(bucket, starvedKey, evTime, runNow.Add(-time.Hour).UnixNano()))
+
+	// BLOCKED halts the first shard's drain on its very first dispatch.
+	client := &recordingClient{responses: []s3_lifecycle_pb.LifecycleDeleteOutcome{
+		s3_lifecycle_pb.LifecycleDeleteOutcome_BLOCKED,
+	}}
+
+	// Seed cursors so both shards resume from before the events rather
+	// than from the cold-start floor, which would skip them as already
+	// past. Hashes must match or runShard takes the recovery branch and
+	// returns before draining.
+	persister := newMemPersister()
+	seeded := Cursor{
+		TsNs:         runNow.Add(-72 * time.Hour).UnixNano(),
+		RuleSetHash:  engine.ReplayContentHash(snap),
+		PromotedHash: engine.PromotedHash(snap, engine.MaxEffectiveTTL(snap)),
+	}
+	for _, sh := range []int{haltedShard, starvedShard} {
+		require.NoError(t, persister.Save(context.Background(), sh, seeded))
+	}
+
+	cfg := Config{
+		Shards:      []int{haltedShard, starvedShard},
+		BucketsPath: "/buckets",
+		Engine:      e,
+		FilerClient: &scriptedSubscribeClient{responses: responses},
+		Client:      client,
+		Persister:   persister,
+		Lister:      stubSiblingLister{},
+		Now:         func() time.Time { return runNow },
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- Run(context.Background(), cfg) }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("Run wedged: the fan-out blocked on a shard that had stopped draining")
+	}
+}

--- a/weed/s3api/s3lifecycle/dailyrun/walker_recovery_test.go
+++ b/weed/s3api/s3lifecycle/dailyrun/walker_recovery_test.go
@@ -3,6 +3,7 @@ package dailyrun
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -15,19 +16,25 @@ import (
 // memPersister is a minimal in-memory CursorPersister. Phase 4b tests
 // drive runShard directly; the recovery-branch path returns before
 // drainShardEvents so the heavier filer/client/lister fakes aren't
-// needed here.
+// needed here. Locked because Run fans out a goroutine per shard and
+// they all load and save through the same persister.
 type memPersister struct {
+	mu    sync.Mutex
 	store map[int]Cursor
 }
 
 func newMemPersister() *memPersister { return &memPersister{store: map[int]Cursor{}} }
 
 func (p *memPersister) Load(_ context.Context, shardID int) (Cursor, bool, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	c, ok := p.store[shardID]
 	return c, ok, nil
 }
 
 func (p *memPersister) Save(_ context.Context, shardID int, c Cursor) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.store[shardID] = c
 	return nil
 }

--- a/weed/s3api/s3lifecycle/reader/reader.go
+++ b/weed/s3api/s3lifecycle/reader/reader.go
@@ -75,11 +75,9 @@ type Reader struct {
 	StartTsNs int64
 	Events    chan<- *Event
 
-	// UntilTsNs bounds the subscription: the filer ends the stream once
-	// it has delivered everything up to this timestamp, and Run returns
-	// nil. Zero follows the meta-log indefinitely, which only terminates
-	// on ctx cancellation or a stream error — a caller running a bounded
-	// pass must set this, or an idle cluster parks it in Recv forever.
+	// UntilTsNs ends the stream once the filer has delivered through this
+	// timestamp. Zero follows forever, which on an idle cluster parks a
+	// bounded caller in Recv until something unrelated is written.
 	UntilTsNs int64
 
 	// EventBudget caps how many events Run processes before returning nil.
@@ -87,16 +85,11 @@ type Reader struct {
 	// error. Used by the worker scheduler to bound a single READ task.
 	EventBudget int
 
-	// ReceiveTimeout bounds the wait for the next response on an open
-	// stream. UntilTsNs ends a healthy stream, and gRPC keepalive catches
-	// a dead connection, but neither covers a filer whose handler stops
-	// producing while the transport keeps answering pings. Setting this
-	// also opts into the filer's idle heartbeats, so a caught-up stream
-	// proves liveness instead of looking stalled. Zero disables it.
-	//
-	// Keep it above the filer's metadata-gap recovery budget (maxGapStall,
-	// 15m in weed/server/filer_grpc_server_sub_meta.go): a subscriber
-	// parked on a gap sends nothing and is not stuck.
+	// ReceiveTimeout bounds the wait for each response, covering a filer
+	// that stops producing while the transport still answers keepalives.
+	// Also opts into idle heartbeats so a caught-up stream stays alive.
+	// Keep above the filer's 15m maxGapStall — a subscriber parked on a
+	// gap sends nothing and is not stuck. Zero disables it.
 	ReceiveTimeout time.Duration
 
 	// bucketsPathSlash is BucketsPath with a guaranteed trailing slash,
@@ -105,8 +98,7 @@ type Reader struct {
 	bucketsPathSlash string
 }
 
-// ErrReceiveTimeout reports that a stream stayed open but stopped
-// delivering both events and the idle heartbeats it negotiated.
+// ErrReceiveTimeout: stream still open, but no events and no heartbeats.
 var ErrReceiveTimeout = errors.New("reader: metadata receive timeout")
 
 type receiveResult struct {
@@ -114,10 +106,9 @@ type receiveResult struct {
 	err  error
 }
 
-// awaitResponse waits for the next stream response, bounded by
-// ReceiveTimeout. The timer covers only the wait for the filer — it is
-// started per call, so a slow consumer downstream of Events (which
-// blocks in dispatchOne, not here) can never trip the watchdog.
+// awaitResponse waits for the next response under ReceiveTimeout. Started
+// per call, so it times the filer only — a slow Events consumer blocks in
+// dispatchOne, outside this window, and can't trip the watchdog.
 func (r *Reader) awaitResponse(ctx context.Context, received <-chan receiveResult) (*filer_pb.SubscribeMetadataResponse, error, bool) {
 	var timeout <-chan time.Time
 	if r.ReceiveTimeout > 0 {
@@ -163,8 +154,7 @@ func (r *Reader) Run(ctx context.Context, client filer_pb.SeaweedFilerClient, cl
 	if sinceNs == 0 && r.Cursor != nil {
 		sinceNs = r.Cursor.MinTsNs()
 	}
-	// The stream gets its own context so the watchdog can abort the RPC,
-	// which is what unblocks the receive goroutine below.
+	// Own context: aborting the RPC is the only way to unblock Recv.
 	streamCtx, cancelStream := context.WithCancel(ctx)
 	defer cancelStream()
 	stream, err := client.SubscribeMetadata(streamCtx, &filer_pb.SubscribeMetadataRequest{
@@ -174,19 +164,15 @@ func (r *Reader) Run(ctx context.Context, client filer_pb.SeaweedFilerClient, cl
 		UntilNs:                r.UntilTsNs,
 		ClientId:               clientID,
 		ClientSupportsBatching: true,
-		// Heartbeats arrive as responses with no EventNotification;
-		// dispatchOne drops them, but reaching the watchdog at all is
-		// the point — they distinguish caught-up from stalled.
+		// dispatchOne drops these, but arriving at all is the point.
 		ClientSupportsIdleHeartbeat: r.ReceiveTimeout > 0,
 	})
 	if err != nil {
 		return fmt.Errorf("subscribe: %w", err)
 	}
 
-	// Recv is only interruptible by killing the RPC, so it runs on its own
-	// goroutine and the loop below waits on the result with a deadline.
-	// Buffered by one so a response handed over just as the watchdog fires
-	// doesn't leak the goroutine.
+	// Buffered so a response landing as the watchdog fires doesn't strand
+	// this goroutine.
 	received := make(chan receiveResult, 1)
 	go func() {
 		for {
@@ -206,9 +192,7 @@ func (r *Reader) Run(ctx context.Context, client filer_pb.SeaweedFilerClient, cl
 	for {
 		resp, recvErr, timedOut := r.awaitResponse(streamCtx, received)
 		if timedOut {
-			// Cancel before returning so the receive goroutine's blocked
-			// Recv unwinds instead of outliving the pass.
-			cancelStream()
+			cancelStream() // unwind the goroutine blocked in Recv
 			return fmt.Errorf("%w after %s", ErrReceiveTimeout, r.ReceiveTimeout)
 		}
 		if recvErr == io.EOF {

--- a/weed/s3api/s3lifecycle/reader/reader.go
+++ b/weed/s3api/s3lifecycle/reader/reader.go
@@ -75,6 +75,13 @@ type Reader struct {
 	StartTsNs int64
 	Events    chan<- *Event
 
+	// UntilTsNs bounds the subscription: the filer ends the stream once
+	// it has delivered everything up to this timestamp, and Run returns
+	// nil. Zero follows the meta-log indefinitely, which only terminates
+	// on ctx cancellation or a stream error — a caller running a bounded
+	// pass must set this, or an idle cluster parks it in Recv forever.
+	UntilTsNs int64
+
 	// EventBudget caps how many events Run processes before returning nil.
 	// Zero = unbounded; the run continues until ctx cancellation or stream
 	// error. Used by the worker scheduler to bound a single READ task.
@@ -115,6 +122,7 @@ func (r *Reader) Run(ctx context.Context, client filer_pb.SeaweedFilerClient, cl
 		ClientName:             clientName,
 		PathPrefix:             r.BucketsPath,
 		SinceNs:                sinceNs,
+		UntilNs:                r.UntilTsNs,
 		ClientId:               clientID,
 		ClientSupportsBatching: true,
 	})

--- a/weed/s3api/s3lifecycle/reader/reader.go
+++ b/weed/s3api/s3lifecycle/reader/reader.go
@@ -87,10 +87,52 @@ type Reader struct {
 	// error. Used by the worker scheduler to bound a single READ task.
 	EventBudget int
 
+	// ReceiveTimeout bounds the wait for the next response on an open
+	// stream. UntilTsNs ends a healthy stream, and gRPC keepalive catches
+	// a dead connection, but neither covers a filer whose handler stops
+	// producing while the transport keeps answering pings. Setting this
+	// also opts into the filer's idle heartbeats, so a caught-up stream
+	// proves liveness instead of looking stalled. Zero disables it.
+	//
+	// Keep it above the filer's metadata-gap recovery budget (maxGapStall,
+	// 15m in weed/server/filer_grpc_server_sub_meta.go): a subscriber
+	// parked on a gap sends nothing and is not stuck.
+	ReceiveTimeout time.Duration
+
 	// bucketsPathSlash is BucketsPath with a guaranteed trailing slash,
 	// computed once on Run and reused per event to avoid recomputing the
 	// normalized prefix in extractBucketKey.
 	bucketsPathSlash string
+}
+
+// ErrReceiveTimeout reports that a stream stayed open but stopped
+// delivering both events and the idle heartbeats it negotiated.
+var ErrReceiveTimeout = errors.New("reader: metadata receive timeout")
+
+type receiveResult struct {
+	resp *filer_pb.SubscribeMetadataResponse
+	err  error
+}
+
+// awaitResponse waits for the next stream response, bounded by
+// ReceiveTimeout. The timer covers only the wait for the filer — it is
+// started per call, so a slow consumer downstream of Events (which
+// blocks in dispatchOne, not here) can never trip the watchdog.
+func (r *Reader) awaitResponse(ctx context.Context, received <-chan receiveResult) (*filer_pb.SubscribeMetadataResponse, error, bool) {
+	var timeout <-chan time.Time
+	if r.ReceiveTimeout > 0 {
+		timer := time.NewTimer(r.ReceiveTimeout)
+		defer timer.Stop()
+		timeout = timer.C
+	}
+	select {
+	case result := <-received:
+		return result.resp, result.err, false
+	case <-timeout:
+		return nil, nil, true
+	case <-ctx.Done():
+		return nil, ctx.Err(), false
+	}
 }
 
 // Run subscribes via SubscribeMetadata starting at the configured position,
@@ -109,6 +151,9 @@ func (r *Reader) Run(ctx context.Context, client filer_pb.SeaweedFilerClient, cl
 	if r.BucketsPath == "" {
 		return errors.New("reader: empty BucketsPath")
 	}
+	if r.ReceiveTimeout < 0 {
+		return fmt.Errorf("reader: negative ReceiveTimeout %v", r.ReceiveTimeout)
+	}
 	r.bucketsPathSlash = r.BucketsPath
 	if !strings.HasSuffix(r.bucketsPathSlash, "/") {
 		r.bucketsPathSlash += "/"
@@ -118,21 +163,54 @@ func (r *Reader) Run(ctx context.Context, client filer_pb.SeaweedFilerClient, cl
 	if sinceNs == 0 && r.Cursor != nil {
 		sinceNs = r.Cursor.MinTsNs()
 	}
-	stream, err := client.SubscribeMetadata(ctx, &filer_pb.SubscribeMetadataRequest{
+	// The stream gets its own context so the watchdog can abort the RPC,
+	// which is what unblocks the receive goroutine below.
+	streamCtx, cancelStream := context.WithCancel(ctx)
+	defer cancelStream()
+	stream, err := client.SubscribeMetadata(streamCtx, &filer_pb.SubscribeMetadataRequest{
 		ClientName:             clientName,
 		PathPrefix:             r.BucketsPath,
 		SinceNs:                sinceNs,
 		UntilNs:                r.UntilTsNs,
 		ClientId:               clientID,
 		ClientSupportsBatching: true,
+		// Heartbeats arrive as responses with no EventNotification;
+		// dispatchOne drops them, but reaching the watchdog at all is
+		// the point — they distinguish caught-up from stalled.
+		ClientSupportsIdleHeartbeat: r.ReceiveTimeout > 0,
 	})
 	if err != nil {
 		return fmt.Errorf("subscribe: %w", err)
 	}
 
+	// Recv is only interruptible by killing the RPC, so it runs on its own
+	// goroutine and the loop below waits on the result with a deadline.
+	// Buffered by one so a response handed over just as the watchdog fires
+	// doesn't leak the goroutine.
+	received := make(chan receiveResult, 1)
+	go func() {
+		for {
+			resp, recvErr := stream.Recv()
+			select {
+			case received <- receiveResult{resp: resp, err: recvErr}:
+			case <-streamCtx.Done():
+				return
+			}
+			if recvErr != nil {
+				return
+			}
+		}
+	}()
+
 	processed := 0
 	for {
-		resp, recvErr := stream.Recv()
+		resp, recvErr, timedOut := r.awaitResponse(streamCtx, received)
+		if timedOut {
+			// Cancel before returning so the receive goroutine's blocked
+			// Recv unwinds instead of outliving the pass.
+			cancelStream()
+			return fmt.Errorf("%w after %s", ErrReceiveTimeout, r.ReceiveTimeout)
+		}
 		if recvErr == io.EOF {
 			return nil
 		}

--- a/weed/s3api/s3lifecycle/reader/receive_timeout_test.go
+++ b/weed/s3api/s3lifecycle/reader/receive_timeout_test.go
@@ -12,8 +12,8 @@ import (
 	"google.golang.org/grpc"
 )
 
-// stalledStream stays open and never delivers — the filer answering
-// keepalive pings while its handler has stopped producing.
+// stalledStream stays open and never delivers: keepalives answered, no
+// progress.
 type stalledStream struct {
 	grpc.ClientStream
 	ctx context.Context
@@ -55,8 +55,7 @@ func TestRun_ReceiveTimeoutOnStalledStream(t *testing.T) {
 		"a reader with a receive timeout must ask for heartbeats, or a caught-up stream looks stalled")
 }
 
-// heartbeatStream delivers only idle heartbeats: responses carrying a
-// timestamp and no EventNotification.
+// heartbeatStream delivers only heartbeats: a ts, no EventNotification.
 type heartbeatStream struct {
 	grpc.ClientStream
 	every time.Duration
@@ -82,9 +81,8 @@ func (c *heartbeatClient) SubscribeMetadata(_ context.Context, _ *filer_pb.Subsc
 	return c.stream, nil
 }
 
-// TestRun_HeartbeatsHoldTheStreamOpen is the reason the timeout is safe
-// to set at all: a caught-up stream keeps arriving as heartbeats, so the
-// watchdog only fires on real silence, not on an idle cluster.
+// Why the timeout is safe to set: a caught-up stream keeps arriving, so
+// the watchdog fires on real silence, not on an idle cluster.
 func TestRun_HeartbeatsHoldTheStreamOpen(t *testing.T) {
 	stream := &heartbeatStream{every: 20 * time.Millisecond, max: 10}
 	r := &Reader{

--- a/weed/s3api/s3lifecycle/reader/receive_timeout_test.go
+++ b/weed/s3api/s3lifecycle/reader/receive_timeout_test.go
@@ -1,0 +1,119 @@
+package reader
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// stalledStream stays open and never delivers — the filer answering
+// keepalive pings while its handler has stopped producing.
+type stalledStream struct {
+	grpc.ClientStream
+	ctx context.Context
+}
+
+func (s *stalledStream) Recv() (*filer_pb.SubscribeMetadataResponse, error) {
+	<-s.ctx.Done()
+	return nil, s.ctx.Err()
+}
+
+type stalledClient struct {
+	filer_pb.SeaweedFilerClient
+	req *filer_pb.SubscribeMetadataRequest
+}
+
+func (c *stalledClient) SubscribeMetadata(ctx context.Context, req *filer_pb.SubscribeMetadataRequest, _ ...grpc.CallOption) (filer_pb.SeaweedFiler_SubscribeMetadataClient, error) {
+	c.req = req
+	return &stalledStream{ctx: ctx}, nil
+}
+
+func TestRun_ReceiveTimeoutOnStalledStream(t *testing.T) {
+	client := &stalledClient{}
+	r := &Reader{
+		ShardPredicate: func(int) bool { return true },
+		BucketsPath:    "/buckets",
+		Events:         make(chan *Event, 1),
+		ReceiveTimeout: 50 * time.Millisecond,
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- r.Run(context.Background(), client, "test", 1) }()
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, ErrReceiveTimeout)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not time out on a stalled stream")
+	}
+	assert.True(t, client.req.ClientSupportsIdleHeartbeat,
+		"a reader with a receive timeout must ask for heartbeats, or a caught-up stream looks stalled")
+}
+
+// heartbeatStream delivers only idle heartbeats: responses carrying a
+// timestamp and no EventNotification.
+type heartbeatStream struct {
+	grpc.ClientStream
+	every time.Duration
+	sent  int
+	max   int
+}
+
+func (s *heartbeatStream) Recv() (*filer_pb.SubscribeMetadataResponse, error) {
+	if s.sent >= s.max {
+		return nil, context.Canceled
+	}
+	time.Sleep(s.every)
+	s.sent++
+	return &filer_pb.SubscribeMetadataResponse{TsNs: int64(s.sent)}, nil
+}
+
+type heartbeatClient struct {
+	filer_pb.SeaweedFilerClient
+	stream *heartbeatStream
+}
+
+func (c *heartbeatClient) SubscribeMetadata(_ context.Context, _ *filer_pb.SubscribeMetadataRequest, _ ...grpc.CallOption) (filer_pb.SeaweedFiler_SubscribeMetadataClient, error) {
+	return c.stream, nil
+}
+
+// TestRun_HeartbeatsHoldTheStreamOpen is the reason the timeout is safe
+// to set at all: a caught-up stream keeps arriving as heartbeats, so the
+// watchdog only fires on real silence, not on an idle cluster.
+func TestRun_HeartbeatsHoldTheStreamOpen(t *testing.T) {
+	stream := &heartbeatStream{every: 20 * time.Millisecond, max: 10}
+	r := &Reader{
+		ShardPredicate: func(int) bool { return true },
+		BucketsPath:    "/buckets",
+		Events:         make(chan *Event, 1),
+		ReceiveTimeout: 200 * time.Millisecond,
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- r.Run(context.Background(), &heartbeatClient{stream: stream}, "test", 1) }()
+	select {
+	case err := <-done:
+		assert.False(t, errors.Is(err, ErrReceiveTimeout),
+			"heartbeats spanning more than one timeout window must keep the stream alive")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run never returned")
+	}
+	assert.Equal(t, 10, stream.sent, "every heartbeat should have been consumed")
+}
+
+func TestRun_RejectsNegativeReceiveTimeout(t *testing.T) {
+	r := &Reader{
+		ShardPredicate: func(int) bool { return true },
+		BucketsPath:    "/buckets",
+		Events:         make(chan *Event, 1),
+		ReceiveTimeout: -time.Second,
+	}
+	err := r.Run(context.Background(), &stalledClient{}, "test", 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ReceiveTimeout")
+}


### PR DESCRIPTION
Fixes #10574. Supersedes #10577, whose receive-timeout watchdog is ported here.

## The wedge

`dailyrun.Run` opens one meta-log subscription, starts 16 shard drains, and blocks on a WaitGroup. Nothing ever told the subscription where the pass ends: the only exit was the fan-out spotting an event with `TsNs > runNow` — i.e. some unrelated write landing under `/buckets` *after* the pass started.

That makes the end of a lifecycle pass a function of unrelated cluster write traffic. When the cluster goes quiet, the reader parks in `Recv()`, all 16 `drainShardEvents` selects starve, `wg.Wait()` never returns, and `Execute` never comes back. The job sits at stage `starting` holding the executor slot, the worker keeps heartbeating (only this one goroutine tree is stuck), and nothing logs — which is exactly the goroutine dump in the issue. Expiry stops cluster-wide until someone restarts the worker.

The reporter read the stack as a half-dead gRPC stream. It isn't: `pb.GrpcDial` already sets client keepalive (60s ping / 20s timeout), so a black-holed connection would surface as an error. The stream is healthy and simply has nothing to send. The shell driver never hit this because it always caps a pass with `-runtime`/`-refresh`; the worker path passes `ctx` straight through, and `s3_lifecycle` is the one job type with `ExecutionTimeoutSeconds: math.MaxInt32`.

## What changed

**1. Bound the subscription at the pass boundary.** A pass covers `(globalStartTsNs, runNow]`, so say so: set `UntilNs`. The filer already supports bounded subscriptions (`command_fs_verify` and `filer_meta_tail` use the same path) and ends the stream once it has shipped that range. The reader closes the event channel on the way out, which unblocks the fan-out and every drain when the stream finishes on its own rather than by cancellation. That also retires a second silent hang: a reader that failed early previously left every drain waiting forever too.

**2. A halted shard no longer starves the fan-out.** Independent wedge, found while testing the first: a drain that halts mid-stream (`BLOCKED` / `RETRY_LATER` / an RPC error on dispatch) returns while the fan-out is still routing that shard's events. After 256 of them the per-shard buffer fills, the fan-out blocks on the send, and no other shard sees another event — `wg.Wait()` never drains and the teardown that would cancel the reader sits behind it. One S3 hiccup during a backlog replay is enough. The shard goroutine now keeps discarding its channel after `runShard` returns; those events are past its saved cursor and get re-scanned next pass anyway.

**3. A dead subscription fails the pass.** Closing the event channel is what unblocks the drains, but it also means a subscribe that never opened, or a stream that broke mid-pass, now ends every drain cleanly — so a filer failure would produce a green lifecycle job that had processed nothing. The reader error is now the pass error.

Classifying that by error turned out to be impossible: a stream we cancel and a stream the filer cancels both arrive as `codes.Canceled`. Intent is knowable exactly, so the decision reads that instead — the pass stops on purpose only when the caller's context ended (the shell driver's `-runtime` cap) or the fan-out hit the boundary itself. `TestRun_ServerSideCancelFailsThePass` and `TestRun_CappedPassIsNotAFailure` are the same `codes.Canceled` with opposite verdicts.

**4. A receive-timeout watchdog, ported from #10577.** `UntilNs` ends a healthy stream and keepalive catches a dead connection, but neither reaches a filer that keeps answering pings while its handler has stopped producing. Each response wait is now bounded at 20 minutes, with `ClientSupportsIdleHeartbeat` so a caught-up stream proves liveness instead of looking stalled. The default sits above the filer's 15-minute `maxGapStall`, so a subscriber legitimately parked on a gap is never mistaken for a stalled one. The timer covers only the wait on the filer — dispatch to `Events` happens outside it, so a slow consumer can't trip it.

## Reproduced

Against a live `weed mini` with one bucket, one `Expiration: Days 1` rule, one object, and no other write traffic — an unbounded pass, which is what the worker runs (`EventBudget` is 0 there):

```
s3.lifecycle.run-shard -shards 0-15 -s3 localhost:18433 -events 0 -runtime 0
```

| | result |
|---|---|
| before | still running at 90s, killed — no output past `loaded lifecycle for 1 bucket(s)` |
| after | `shards 0-15 complete; cursors checkpointed` in 0.4s |

Each hang has a unit regression that fails on its parent commit (`TestRun_EndsOnIdleSubscription`, `TestRun_HaltedShardDoesNotStarveOthers`, `TestRun_ReaderFailureFailsThePass`, `TestRun_StalledSubscriptionTimesOutThePass`). `test/s3/lifecycle` passes end-to-end against a real filer, which is what confirms the bounded subscription still delivers every event it should.

`memPersister` in the dailyrun tests picked up a mutex: these are the first tests to drive `Run`'s per-shard fan-out, and `-race` catches the unsynchronized map.

## On #10577

Same root cause, same `UntilNs` fix, reached independently. Two differences decided which to build on:

- It releases the fan-out with `cancelReader()` rather than closing the event channel. Both unblock it, but with `cancelReader()` the fan-out's `select` has both `readerCtx.Done()` and buffered `events` ready, and Go picks uniformly at random — so events already received from the filer get dropped. Measured on that branch: **10 of 20 trials dropped part of the tail** (196–199 of 200 events routed), against 0 of 20 here. Not data loss, since cursors don't advance past dropped events, but on an idle cluster the same tail is the tail again next pass.
- It doesn't address the halted-shard starvation, and its watchdog doesn't reach that case either — the reader is blocked *pushing* to `Events`, not waiting in `Recv`.

Its reader-error propagation is here too, with the cancellation classification corrected.

## Not addressed here

- The issue's suggestion 3 (a log line per `Execute()` phase). With the pass bounded, `daily_run: status=... duration=... cursor_lag_max=...` now actually prints once per pass, which covers part of it.
- The secondary observation — admin keeping a job assigned to a restarted worker container — is a separate defect in the admin's worker tracking, not in this path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable receive timeouts and heartbeat support for lifecycle subscriptions.
  - Lifecycle runs now honor configured time boundaries.

- **Bug Fixes**
  - Improved handling of idle, canceled, failed, and stalled subscriptions.
  - Prevented blocked shards from delaying other shard processing.
  - Improved cursor persistence when runs reach their runtime limit.

- **Tests**
  - Added coverage for timeout, cancellation, boundary, and shard fan-out scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->