### PR TITLE
placement: move the target picker out of the shell package

### DIFF
--- a/weed/placement/placement.go
+++ b/weed/placement/placement.go
@@ -1,4 +1,4 @@
-package shell
+package placement
 
 import (
 	"sort"
@@ -46,7 +46,7 @@ type PlacementPreference struct {
 // since each pick would see the capacity its predecessors already took. Callers
 // therefore pass a snapshot they own and may mutate.
 func PickTarget(topo *master_pb.TopologyInfo, pref PlacementPreference) *master_pb.DataNodeInfo {
-	nodes := collectVolumeServersByDcRackNode(topo, pref.AnchorDataCenter, "", "")
+	nodes := candidateNodes(topo, pref.AnchorDataCenter)
 
 	var srcDc, srcRack string
 	for _, n := range nodes {
@@ -57,7 +57,7 @@ func PickTarget(topo *master_pb.TopologyInfo, pref PlacementPreference) *master_
 	}
 
 	type candidate struct {
-		node     *Node
+		node     *node
 		locality int // 0 same rack, 1 same dc, 2 elsewhere
 		bytes    uint64
 		hasBytes bool
@@ -69,15 +69,13 @@ func PickTarget(topo *master_pb.TopologyInfo, pref PlacementPreference) *master_
 		if n.info.Id == pref.Source || pref.Exclude[n.info.Id] {
 			continue
 		}
-		if !n.hasFreeVolumeSlot(pref.DiskType) {
+		d := n.disk(pref.DiskType)
+		if d == nil || d.VolumeCount >= d.MaxVolumeCount {
 			continue
 		}
 		c := candidate{node: n}
-		_, free, ok := n.diskBytes(pref.DiskType)
-		c.bytes, c.hasBytes = free, ok
-		if d, found := n.info.DiskInfos[string(pref.DiskType)]; found && d != nil {
-			c.slots = d.MaxVolumeCount - d.VolumeCount
-		}
+		c.bytes, c.hasBytes = d.DiskFreeBytes, d.DiskTotalBytes != 0
+		c.slots = d.MaxVolumeCount - d.VolumeCount
 		switch {
 		case srcRack != "" && n.rack == srcRack && n.dc == srcDc:
 			c.locality = 0
@@ -144,4 +142,36 @@ func max64(a, b int64) int64 {
 		return a
 	}
 	return b
+}
+
+// node is a volume server as a placement snapshot sees it: where it sits and
+// what it has free. Deliberately smaller than the balancer's Node, which also
+// carries the volumes it holds -- placement never needs those.
+type node struct {
+	info *master_pb.DataNodeInfo
+	dc   string
+	rack string
+}
+
+func (n *node) disk(diskType types.DiskType) *master_pb.DiskInfo {
+	d, found := n.info.DiskInfos[string(diskType)]
+	if !found {
+		return nil
+	}
+	return d
+}
+
+// candidateNodes flattens the topology, keeping one data center when anchored.
+func candidateNodes(topo *master_pb.TopologyInfo, anchorDataCenter string) (nodes []*node) {
+	for _, dc := range topo.GetDataCenterInfos() {
+		if anchorDataCenter != "" && dc.GetId() != anchorDataCenter {
+			continue
+		}
+		for _, rack := range dc.GetRackInfos() {
+			for _, dn := range rack.GetDataNodeInfos() {
+				nodes = append(nodes, &node{info: dn, dc: dc.GetId(), rack: rack.GetId()})
+			}
+		}
+	}
+	return nodes
 }

--- a/weed/placement/placement_test.go
+++ b/weed/placement/placement_test.go
@@ -1,4 +1,4 @@
-package shell
+package placement
 
 import (
 	"testing"


### PR DESCRIPTION
Follow-up to #10579, addressing the "should this be in `shell`?" question raised on it. It should not.

`weed/shell` is the CLI command layer — every file there registers a command in `init()`. Anything importing it for placement drags that entire command surface, and its registration side effects, into a binary that runs no CLI. The motivating consumer is a background worker, so that dependency is backwards.

`weed/placement` now depends only on `master_pb` and `storage/types`. `PickTarget` and `PlacementPreference` keep their names and behaviour; the 13 tests move with them unchanged and still pass.

**One deliberate departure from a pure move.** #10579 collected candidates via the balancer's `collectVolumeServersByDcRackNode` and `Node`. Rather than export `Node` and its four unexported fields — ~270 accesses across seven shell files, a rename that compiles cleanly even when it rebinds the wrong thing — placement now has its own small `node`: id, dc, rack, and the disk it cares about. The balancer's `Node` also carries `selectedVolumes` for density planning, which placement never uses.

So the two are not the same abstraction and the reuse argument from #10579 does not apply to the *candidate collection*. It does still apply to the *ranking*, which is what "what does full mean" actually turns on, and that moved wholesale rather than being reimplemented.

`weed/shell` is untouched apart from losing the two files, and its suite still passes. Whole tree builds.

Next: point the shell commands at this package, so an extracted helper does not rot with one consumer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved placement decisions by using current disk capacity and status information.
  * More accurately filters eligible disks and tracks available placement slots.
  * Preserved data-center placement preferences and ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->