### PR TITLE
placement: let callers reject candidates placement cannot judge

### DIFF
--- a/weed/placement/placement.go
+++ b/weed/placement/placement.go
@@ -20,6 +20,12 @@ type PlacementPreference struct {
 	// Exclude names nodes already spoken for by the same plan, so a caller
 	// placing several copies does not stack them on one node.
 	Exclude map[string]bool
+	// Accept rejects candidates the caller cannot use for reasons placement does
+	// not model -- replica placement rules, a node already holding the volume.
+	// It receives the candidate's rack and data center because the constraints
+	// that need them are exactly the ones a bare node cannot express. Nil
+	// accepts everything.
+	Accept func(node *master_pb.DataNodeInfo, dataCenter, rack string) bool
 	// VolumeBytes is what this move will actually consume on the destination.
 	// Zero falls back to the tier's average volume size, which is all a caller
 	// planning a not-yet-created volume can know.
@@ -71,6 +77,9 @@ func PickTarget(topo *master_pb.TopologyInfo, pref PlacementPreference) *master_
 		}
 		d := n.disk(pref.DiskType)
 		if d == nil || d.VolumeCount >= d.MaxVolumeCount {
+			continue
+		}
+		if pref.Accept != nil && !pref.Accept(n.info, n.dc, n.rack) {
 			continue
 		}
 		c := candidate{node: n}

--- a/weed/placement/placement_test.go
+++ b/weed/placement/placement_test.go
@@ -224,3 +224,35 @@ func TestPickTargetReservesTheVolumeSize(t *testing.T) {
 		t.Fatalf("second pick %q, want a2 after 800 bytes were spent on a1", second.GetId())
 	}
 }
+
+func TestPickTargetHonoursTheCallerPredicate(t *testing.T) {
+	// Constraints placement does not model -- replica placement, a node already
+	// holding the volume -- stay with the caller, which keeps them out of the
+	// ranking rather than duplicating them here.
+	topo := placementTopo(
+		placementNode("a1", 10, 1, 1000, 900),
+		placementNode("a2", 10, 1, 1000, 500),
+	)
+	got := PickTarget(topo, PlacementPreference{
+		Source: "z9", DiskType: types.SsdType,
+		Accept: func(n *master_pb.DataNodeInfo, dc, rack string) bool { return n.Id != "a1" },
+	})
+	if got.GetId() != "a2" {
+		t.Fatalf("got %q, want a2 -- a1 was rejected despite being emptier", got.GetId())
+	}
+}
+
+func TestPickTargetPredicateSeesRackAndDataCenter(t *testing.T) {
+	topo := placementTopo(placementNode("a1", 10, 1, 1000, 900))
+	var sawDc, sawRack string
+	PickTarget(topo, PlacementPreference{
+		Source: "z9", DiskType: types.SsdType,
+		Accept: func(n *master_pb.DataNodeInfo, dc, rack string) bool {
+			sawDc, sawRack = dc, rack
+			return true
+		},
+	})
+	if sawDc != "dc1" || sawRack != "a" {
+		t.Fatalf("predicate saw dc=%q rack=%q, want dc1/a", sawDc, sawRack)
+	}
+}


### PR DESCRIPTION
Option A from the #10580 discussion: placement owns "which candidate is emptiest and nearest", callers own "which candidates are legal".

```go
Accept func(node *master_pb.DataNodeInfo, dataCenter, rack string) bool
```

Nil accepts everything, so nothing changes for existing use.

**The signature is not what I proposed.** I expected `func(*master_pb.DataNodeInfo) bool`, but the first real constraint — `satisfyReplicaPlacement` in `volume.tier.move` — needs the candidate's rack and data center, and a bare node cannot express that. Placement already knows both, so it passes them. The constraints that need dc/rack are precisely the ones that motivated the hook, so a predicate without them would have been useless to its intended caller.

**I said this should land with its first adopter, and it does not.** `volume.tier.move` turned out not to be a clean swap: its loop iterates `allLocations` picking several copies inline, threading `additionalCopiesNeeded`, `preserveServers` and `nodesWithVolume` through a body that also performs the replication. Converting it to per-pick calls with an accumulating `Exclude` is a real behavioural change to a working command, and I would rather it be its own reviewed PR than a rider on this one. So this ships as a hook with tests but no consumer yet — a compromise I am flagging rather than hiding, since a hook nobody calls is how dead parameters start.

If reviewers would rather not carry it until the adopter exists, holding this until the `volume.tier.move` PR is ready is reasonable.

Two tests: the predicate rejecting an otherwise-winning candidate, and the predicate actually receiving the candidate's dc and rack.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional placement filtering so callers can accept or reject candidate nodes using node, data-center, and rack information.
  * Rejected candidates are skipped before placement ranking.

* **Bug Fixes**
  * Improved placement selection to honor caller-defined eligibility rules consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->