### PR TITLE
shell: pick tier.move replica targets with the shared placement picker

### DIFF
--- a/weed/shell/command_volume_tier_move.go
+++ b/weed/shell/command_volume_tier_move.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"github.com/seaweedfs/seaweedfs/weed/placement"
 	"io"
 	"path/filepath"
 	"sync"
@@ -489,26 +490,36 @@ func (c *commandVolumeTierMove) ensureReplicationFulfilled(commandEnv *CommandEn
 
 	fmt.Fprintf(writer, "volume %d: creating %d additional replica(s) for replication %s\n", vid, additionalCopiesNeeded, replicaPlacement)
 
-	fn := capacityByFreeVolumeCount(toDiskType)
+	// One picker decides where copies go, so this command spreads and stays near
+	// the source the same way every other mover does. Constraints it cannot model
+	// -- replica placement, and a node already holding the volume -- stay here.
+	topo := topologyFromLocations(allLocations)
+	// The picker answers with a node; replica placement is judged on where that
+	// node sits, so keep the mapping back to its rack and data center.
+	placeOf := make(map[string]location, len(allLocations))
+	for _, l := range allLocations {
+		placeOf[l.dataNode.Id] = l
+	}
+	taken := make(map[string]bool)
 	copiesMade := 0
-	for _, candidateDst := range allLocations {
-		if copiesMade >= additionalCopiesNeeded {
+	for copiesMade < additionalCopiesNeeded {
+		dst := placement.PickTarget(topo, placement.PlacementPreference{
+			Source:   sourceAddress.String(),
+			DiskType: toDiskType,
+			Exclude:  taken,
+			Accept: func(dn *master_pb.DataNodeInfo, dc, rack string) bool {
+				if nodesWithVolume[dn.Id] {
+					return false
+				}
+				return satisfyReplicaPlacement(replicaPlacement, targetTierReplicas, newLocation(dc, rack, dn))
+			},
+		})
+		if dst == nil {
 			break
 		}
-		if fn(candidateDst.dataNode) <= 0 {
-			continue
-		}
-		// Skip nodes that already host this volume on any disk type to avoid
-		// VolumeCopy conflicts (e.g., same volume on source tier and target tier).
-		if nodesWithVolume[candidateDst.dataNode.Id] {
-			continue
-		}
-		if !satisfyReplicaPlacement(replicaPlacement, targetTierReplicas, candidateDst) {
-			continue
-		}
-
-		candidateAddress := pb.NewServerAddressFromDataNode(candidateDst.dataNode)
-		fmt.Fprintf(writer, "volume %d: replicating from %s to %s\n", vid, sourceAddress, candidateDst.dataNode.Id)
+		taken[dst.Id] = true
+		candidateDst := placeOf[dst.Id]
+		candidateAddress := pb.NewServerAddressFromDataNode(dst)
 
 		if copyErr := replicateVolumeToServer(context.Background(), commandEnv.option.GrpcDialOption, writer, vid, sourceAddress, candidateAddress, toDiskType.ReadableString()); copyErr != nil {
 			return nil, fmt.Errorf("replicate volume %d to %s: %v", vid, candidateDst.dataNode.Id, copyErr)
@@ -527,7 +538,8 @@ func (c *commandVolumeTierMove) ensureReplicationFulfilled(commandEnv *CommandEn
 			location: &candidateDst,
 			info:     targetTierReplicas[0].info,
 		})
-		addVolumeCount(candidateDst.dataNode.DiskInfos[string(toDiskType)], 1)
+		// PickTarget already spent the slot in topo, which shares these DataNodeInfo
+		// pointers with allLocations, so counting it again here would double it.
 		copiesMade++
 	}
 
@@ -590,4 +602,32 @@ func collectVolumeIdsForTierChange(topologyInfo *master_pb.TopologyInfo, volumeS
 	}
 
 	return
+}
+
+// topologyFromLocations rebuilds a topology snapshot from the locations a
+// command already collected, so placement sees exactly the candidate set the
+// command would have iterated.
+func topologyFromLocations(locations []location) *master_pb.TopologyInfo {
+	dcs := make(map[string]map[string][]*master_pb.DataNodeInfo)
+	var dcOrder []string
+	rackOrder := make(map[string][]string)
+	for _, l := range locations {
+		if _, ok := dcs[l.dc]; !ok {
+			dcs[l.dc] = make(map[string][]*master_pb.DataNodeInfo)
+			dcOrder = append(dcOrder, l.dc)
+		}
+		if _, ok := dcs[l.dc][l.rack]; !ok {
+			rackOrder[l.dc] = append(rackOrder[l.dc], l.rack)
+		}
+		dcs[l.dc][l.rack] = append(dcs[l.dc][l.rack], l.dataNode)
+	}
+	topo := &master_pb.TopologyInfo{}
+	for _, dc := range dcOrder {
+		dcInfo := &master_pb.DataCenterInfo{Id: dc}
+		for _, rack := range rackOrder[dc] {
+			dcInfo.RackInfos = append(dcInfo.RackInfos, &master_pb.RackInfo{Id: rack, DataNodeInfos: dcs[dc][rack]})
+		}
+		topo.DataCenterInfos = append(topo.DataCenterInfos, dcInfo)
+	}
+	return topo
 }


### PR DESCRIPTION
The consumer #10581's `Accept` hook was added for. With this, `weed/placement` has a real caller and stops being a helper with no consumer.

`volume.tier.move` chose destinations for additional replicas by walking `allLocations` in order and taking the first that had capacity and satisfied replica placement. So it neither preferred a node near the source nor spread a burst of copies — the same gaps that motivated the picker.

Now it calls `placement.PickTarget` once per copy:

- **replica placement and "this node already holds the volume" move into `Accept`**, which is exactly the split #10581 set up — placement ranks, the caller decides legality
- **`Exclude` accumulates** the nodes already chosen, replacing the single ordered pass
- `topologyFromLocations` rebuilds a snapshot from the locations the command already collected, so the candidate set is unchanged — this is not a widening of what it considers

**Two bugs I hit while writing it, both worth a reviewer's eye since they are the kind that pass a build:**

1. The picker returns a node, but a replica's recorded `location` needs its dc and rack — and `satisfyReplicaPlacement` judges later copies against those records. Constructing the location with empty dc/rack compiled fine and would have silently degraded placement decisions for the second and subsequent copies. There is now a node-id → location map so the real rack comes back.

2. The loop called `addVolumeCount` after each copy. `PickTarget` already spends the slot in the topology, and `topologyFromLocations` reuses the same `DataNodeInfo` pointers as `allLocations` — so the count was applied twice. Removed, with a comment saying why, because "the accounting is over there now" is not obvious from the call site.

`AnchorDataCenter` is deliberately not passed: the existing candidate loop does not filter by `toDataCenter`, and adding that here would be a behaviour change unrelated to the refactor. `VolumeBytes` is likewise left zero — the command does not have the volume's size to hand, so the reservation falls back to the tier average, same as before this PR.

Full `weed/shell` suite passes, including the 17 tier-move and replication tests; `weed/placement` passes; whole tree builds.