### PR TITLE
s3: let a suspended-versioning multipart completion replace the null delete marker

### DIFF
--- a/test/s3/versioning/s3_copy_versioning_regression_test.go
+++ b/test/s3/versioning/s3_copy_versioning_regression_test.go
@@ -250,3 +250,59 @@ func TestSelfCopyWithSuspendedVersioningIsRejected(t *testing.T) {
 		assert.Equal(t, "InvalidRequest", apiErr.ErrorCode())
 	}
 }
+
+// A suspended-versioning CopyObject writes the null version at the regular path, so
+// like PutObject and multipart completion it has to retire the null delete marker a
+// preceding DELETE left in .versions. While the regular-path object owns the null
+// slot the leftover marker is shadowed, but it resurfaces as a phantom delete the
+// moment that null version goes away.
+func TestSuspendedCopyRetiresDeleteMarker(t *testing.T) {
+	client := getS3Client(t)
+	bucketName := getNewBucketName()
+
+	createBucket(t, client, bucketName)
+	defer deleteBucket(t, client, bucketName)
+
+	sourceKey := "suspended-copy-source.txt"
+	objectKey := "suspended-copy-dest.txt"
+
+	enableVersioning(t, client, bucketName)
+	putObject(t, client, bucketName, objectKey, "pre-suspension-content")
+	suspendVersioning(t, client, bucketName)
+
+	putObject(t, client, bucketName, sourceKey, "source-content")
+	putObject(t, client, bucketName, objectKey, "null-version-content")
+	deleteKey(t, client, bucketName, objectKey)
+
+	_, err := client.CopyObject(context.TODO(), &s3.CopyObjectInput{
+		Bucket:     aws.String(bucketName),
+		Key:        aws.String(objectKey),
+		CopySource: aws.String(versioningCopySource(bucketName, sourceKey)),
+	})
+	require.NoError(t, err)
+
+	getResp, err := client.GetObject(context.TODO(), &s3.GetObjectInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String(objectKey),
+	})
+	require.NoError(t, err)
+	defer getResp.Body.Close()
+	body, err := io.ReadAll(getResp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, "source-content", string(body))
+
+	// Drop the null version the copy just wrote; a retired marker leaves nothing behind.
+	_, err = client.DeleteObject(context.TODO(), &s3.DeleteObjectInput{
+		Bucket:    aws.String(bucketName),
+		Key:       aws.String(objectKey),
+		VersionId: aws.String("null"),
+	})
+	require.NoError(t, err)
+
+	listResp, err := client.ListObjectVersions(context.TODO(), &s3.ListObjectVersionsInput{
+		Bucket: aws.String(bucketName),
+		Prefix: aws.String(objectKey),
+	})
+	require.NoError(t, err)
+	assert.Empty(t, listResp.DeleteMarkers, "the copy should have retired the null delete marker")
+}

--- a/test/s3/versioning/s3_suspended_delete_marker_regression_test.go
+++ b/test/s3/versioning/s3_suspended_delete_marker_regression_test.go
@@ -97,12 +97,7 @@ func TestSuspendedMultipartOverwritesDeleteMarker(t *testing.T) {
 
 	// The cleanup retires only the null version, never the key's real history.
 	enableVersioning(t, client, bucketName)
-	realVersion, err := client.PutObject(context.TODO(), &s3.PutObjectInput{
-		Bucket: aws.String(bucketName),
-		Key:    aws.String(objectKey),
-		Body:   bytes.NewReader([]byte("pre-suspension-content")),
-	})
-	require.NoError(t, err)
+	realVersion := putObject(t, client, bucketName, objectKey, "pre-suspension-content")
 	require.NotNil(t, realVersion.VersionId)
 	suspendVersioning(t, client, bucketName)
 
@@ -135,20 +130,10 @@ func TestSuspendedMultipartOverwritesDeleteMarker(t *testing.T) {
 	}
 
 	completeSuspendedMultipart()
-
-	_, err = client.DeleteObject(context.TODO(), &s3.DeleteObjectInput{
-		Bucket: aws.String(bucketName),
-		Key:    aws.String(objectKey),
-	})
-	require.NoError(t, err)
-
+	deleteKey(t, client, bucketName, objectKey)
 	completeSuspendedMultipart()
 
-	headResp, err := client.HeadObject(context.TODO(), &s3.HeadObjectInput{
-		Bucket: aws.String(bucketName),
-		Key:    aws.String(objectKey),
-	})
-	require.NoError(t, err)
+	headResp := headObject(t, client, bucketName, objectKey)
 	require.NotNil(t, headResp.ContentLength)
 	assert.Equal(t, int64(len(partData)), *headResp.ContentLength)
 
@@ -169,10 +154,9 @@ func TestSuspendedMultipartOverwritesDeleteMarker(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, listResp.DeleteMarkers)
 
-	listedVersionIds := make([]string, 0, len(listResp.Versions))
+	var listedVersionIds []string
 	for _, version := range listResp.Versions {
-		require.NotNil(t, version.VersionId)
-		listedVersionIds = append(listedVersionIds, *version.VersionId)
+		listedVersionIds = append(listedVersionIds, aws.ToString(version.VersionId))
 	}
 	assert.ElementsMatch(t, []string{*realVersion.VersionId, "null"}, listedVersionIds)
 

--- a/test/s3/versioning/s3_suspended_delete_marker_regression_test.go
+++ b/test/s3/versioning/s3_suspended_delete_marker_regression_test.go
@@ -93,11 +93,20 @@ func TestSuspendedMultipartOverwritesDeleteMarker(t *testing.T) {
 	createBucket(t, client, bucketName)
 	defer deleteBucket(t, client, bucketName)
 
-	enableVersioning(t, client, bucketName)
-	suspendVersioning(t, client, bucketName)
-
 	objectKey := "suspended-multipart-after-delete.bin"
 	partData := bytes.Repeat([]byte("a"), 5*1024*1024)
+
+	// A real version from before suspension must survive the whole sequence: the
+	// cleanup below only retires the null version, never the key's real history.
+	enableVersioning(t, client, bucketName)
+	realVersion, err := client.PutObject(context.TODO(), &s3.PutObjectInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String(objectKey),
+		Body:   bytes.NewReader([]byte("pre-suspension-content")),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, realVersion.VersionId)
+	suspendVersioning(t, client, bucketName)
 
 	completeSuspendedMultipart := func() {
 		t.Helper()
@@ -129,7 +138,7 @@ func TestSuspendedMultipartOverwritesDeleteMarker(t *testing.T) {
 
 	completeSuspendedMultipart()
 
-	_, err := client.DeleteObject(context.TODO(), &s3.DeleteObjectInput{
+	_, err = client.DeleteObject(context.TODO(), &s3.DeleteObjectInput{
 		Bucket: aws.String(bucketName),
 		Key:    aws.String(objectKey),
 	})
@@ -161,7 +170,22 @@ func TestSuspendedMultipartOverwritesDeleteMarker(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Empty(t, listResp.DeleteMarkers)
-	require.Len(t, listResp.Versions, 1)
-	require.NotNil(t, listResp.Versions[0].VersionId)
-	assert.Equal(t, "null", *listResp.Versions[0].VersionId)
+
+	listedVersionIds := make([]string, 0, len(listResp.Versions))
+	for _, version := range listResp.Versions {
+		require.NotNil(t, version.VersionId)
+		listedVersionIds = append(listedVersionIds, *version.VersionId)
+	}
+	assert.ElementsMatch(t, []string{*realVersion.VersionId, "null"}, listedVersionIds)
+
+	realVersionResp, err := client.GetObject(context.TODO(), &s3.GetObjectInput{
+		Bucket:    aws.String(bucketName),
+		Key:       aws.String(objectKey),
+		VersionId: realVersion.VersionId,
+	})
+	require.NoError(t, err)
+	defer realVersionResp.Body.Close()
+	realVersionBody, err := io.ReadAll(realVersionResp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, "pre-suspension-content", string(realVersionBody))
 }

--- a/test/s3/versioning/s3_suspended_delete_marker_regression_test.go
+++ b/test/s3/versioning/s3_suspended_delete_marker_regression_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -79,4 +80,88 @@ func TestSuspendedDeleteCreatesDeleteMarker(t *testing.T) {
 	body, err := io.ReadAll(getVersionedResp.Body)
 	require.NoError(t, err)
 	assert.Equal(t, "versioned-content", string(body))
+}
+
+// A suspended-versioning multipart completion writes the null version at the regular
+// path, so it has to drop the null delete marker a preceding DELETE left in .versions.
+// Otherwise the completion reports 200 and the object lists, but HEAD/GET keep
+// resolving to the delete marker and answer NoSuchKey.
+func TestSuspendedMultipartOverwritesDeleteMarker(t *testing.T) {
+	client := getS3Client(t)
+	bucketName := getNewBucketName()
+
+	createBucket(t, client, bucketName)
+	defer deleteBucket(t, client, bucketName)
+
+	enableVersioning(t, client, bucketName)
+	suspendVersioning(t, client, bucketName)
+
+	objectKey := "suspended-multipart-after-delete.bin"
+	partData := bytes.Repeat([]byte("a"), 5*1024*1024)
+
+	completeSuspendedMultipart := func() {
+		t.Helper()
+		createResp, err := client.CreateMultipartUpload(context.TODO(), &s3.CreateMultipartUploadInput{
+			Bucket: aws.String(bucketName),
+			Key:    aws.String(objectKey),
+		})
+		require.NoError(t, err)
+
+		uploadResp, err := client.UploadPart(context.TODO(), &s3.UploadPartInput{
+			Bucket:     aws.String(bucketName),
+			Key:        aws.String(objectKey),
+			UploadId:   createResp.UploadId,
+			PartNumber: aws.Int32(1),
+			Body:       bytes.NewReader(partData),
+		})
+		require.NoError(t, err)
+
+		_, err = client.CompleteMultipartUpload(context.TODO(), &s3.CompleteMultipartUploadInput{
+			Bucket:   aws.String(bucketName),
+			Key:      aws.String(objectKey),
+			UploadId: createResp.UploadId,
+			MultipartUpload: &types.CompletedMultipartUpload{
+				Parts: []types.CompletedPart{{ETag: uploadResp.ETag, PartNumber: aws.Int32(1)}},
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	completeSuspendedMultipart()
+
+	_, err := client.DeleteObject(context.TODO(), &s3.DeleteObjectInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String(objectKey),
+	})
+	require.NoError(t, err)
+
+	completeSuspendedMultipart()
+
+	headResp, err := client.HeadObject(context.TODO(), &s3.HeadObjectInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String(objectKey),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, headResp.ContentLength)
+	assert.Equal(t, int64(len(partData)), *headResp.ContentLength)
+
+	getResp, err := client.GetObject(context.TODO(), &s3.GetObjectInput{
+		Bucket: aws.String(bucketName),
+		Key:    aws.String(objectKey),
+	})
+	require.NoError(t, err)
+	defer getResp.Body.Close()
+	written, err := io.Copy(io.Discard, getResp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, int64(len(partData)), written)
+
+	listResp, err := client.ListObjectVersions(context.TODO(), &s3.ListObjectVersionsInput{
+		Bucket: aws.String(bucketName),
+		Prefix: aws.String(objectKey),
+	})
+	require.NoError(t, err)
+	assert.Empty(t, listResp.DeleteMarkers)
+	require.Len(t, listResp.Versions, 1)
+	require.NotNil(t, listResp.Versions[0].VersionId)
+	assert.Equal(t, "null", *listResp.Versions[0].VersionId)
 }

--- a/test/s3/versioning/s3_suspended_delete_marker_regression_test.go
+++ b/test/s3/versioning/s3_suspended_delete_marker_regression_test.go
@@ -82,10 +82,9 @@ func TestSuspendedDeleteCreatesDeleteMarker(t *testing.T) {
 	assert.Equal(t, "versioned-content", string(body))
 }
 
-// A suspended-versioning multipart completion writes the null version at the regular
-// path, so it has to drop the null delete marker a preceding DELETE left in .versions.
-// Otherwise the completion reports 200 and the object lists, but HEAD/GET keep
-// resolving to the delete marker and answer NoSuchKey.
+// A suspended-versioning completion must drop the null delete marker a preceding
+// DELETE left in .versions, or it reports 200 and the object lists while HEAD/GET
+// keep resolving the marker and answer NoSuchKey.
 func TestSuspendedMultipartOverwritesDeleteMarker(t *testing.T) {
 	client := getS3Client(t)
 	bucketName := getNewBucketName()
@@ -96,8 +95,7 @@ func TestSuspendedMultipartOverwritesDeleteMarker(t *testing.T) {
 	objectKey := "suspended-multipart-after-delete.bin"
 	partData := bytes.Repeat([]byte("a"), 5*1024*1024)
 
-	// A real version from before suspension must survive the whole sequence: the
-	// cleanup below only retires the null version, never the key's real history.
+	// The cleanup retires only the null version, never the key's real history.
 	enableVersioning(t, client, bucketName)
 	realVersion, err := client.PutObject(context.TODO(), &s3.PutObjectInput{
 		Bucket: aws.String(bucketName),

--- a/weed/s3api/filer_multipart.go
+++ b/weed/s3api/filer_multipart.go
@@ -649,9 +649,10 @@ func (s3a *S3ApiServer) completeMultipartUpload(r *http.Request, input *s3.Compl
 			glog.Errorf("completeMultipartUpload: failed to get versioning state for bucket %s: %v", *input.Bucket, vErr)
 			return s3err.ErrInternalError
 		}
+		// Full object key, not just entryName, so the right .versions directory is used.
+		normalizedKey := s3_constants.NormalizeObjectKey(*input.Key)
+
 		if versioningState == s3_constants.VersioningEnabled {
-			// Use full object key (not just entryName) to ensure correct .versions directory is checked
-			normalizedKey := strings.TrimPrefix(*input.Key, "/")
 			useInvertedFormat := s3a.getVersionIdFormat(*input.Bucket, normalizedKey)
 			versionId := generateVersionId(useInvertedFormat)
 			versionFileName := s3a.getVersionFileName(versionId)
@@ -769,8 +770,6 @@ func (s3a *S3ApiServer) completeMultipartUpload(r *http.Request, input *s3.Compl
 		}
 
 		if versioningState == s3_constants.VersioningSuspended {
-			normalizedKey := strings.TrimPrefix(*input.Key, "/")
-
 			// For suspended versioning, add "null" version ID metadata and return "null" version ID
 			if err := s3a.writeMultipartObject(owner, routeKey, dirName, entryName, completionState.finalParts, func(entry *filer_pb.Entry) {
 				if entry.Extended == nil {
@@ -825,38 +824,26 @@ func (s3a *S3ApiServer) completeMultipartUpload(r *http.Request, input *s3.Compl
 				return s3err.ErrInternalError
 			}
 
-			// Retire the null delete marker a suspended DELETE leaves, now that the
-			// replacement null version is at the regular path. Only after the write commits:
-			// undoing it on a failed write republishes the deleted key as an older version.
-			// Read back from the filer that took the write — getObjectEntryRoutedByKey drops
-			// a recently-unreachable owner and reads local-first, so it can miss the write.
-			// A concurrent DELETE owns the null slot instead; narrows that race, not closes it.
-			var currentEntry *filer_pb.Entry
-			var currentErr error
-			if owner != "" {
-				currentEntry, currentErr = s3a.lookupEntryOnFiler(owner, dirName, entryName)
-			} else {
-				currentEntry, currentErr = s3a.getEntry(dirName, entryName)
-			}
+			// The cleanup rewrites shared .versions state, and the routed completion runs
+			// off the object write lock, so only run it while this upload still owns the
+			// key: a DELETE that landed in between owns the null slot now, and retiring
+			// its marker would resurrect an older version under a deleted key. Narrows
+			// that race, does not close it.
+			currentEntry, currentErr := s3a.lookupEntryPreferringOwner(owner, dirName, entryName)
 			if currentErr != nil && !errors.Is(currentErr, filer_pb.ErrNotFound) {
 				glog.Errorf("completeMultipartUpload: failed to re-read %s/%s before the null cleanup: %v", *input.Bucket, normalizedKey, currentErr)
 				return s3err.ErrInternalError
 			}
-			supersededByConcurrentWrite := currentEntry == nil ||
-				string(currentEntry.Extended[s3_constants.SeaweedFSUploadId]) != *input.UploadId
-
-			if supersededByConcurrentWrite {
-				glog.V(2).Infof("completeMultipartUpload: skipping the null cleanup for %s/%s, superseded by a concurrent write", *input.Bucket, normalizedKey)
-			} else {
-				// Pointer first: removing the marker while the pointer still names it makes
-				// reads rescan and promote an older version. A failed clear leaves the key
-				// reading as deleted, so fail instead of returning 200 — a non-ErrNone
-				// finalize keeps the upload directory, so the caller's retry replays.
-				if err := s3a.updateIsLatestFlagsForSuspendedVersioning(*input.Bucket, normalizedKey); err != nil {
-					glog.Errorf("completeMultipartUpload: failed to clear the latest-version pointer for %s/%s: %v", *input.Bucket, normalizedKey, err)
+			if currentEntry != nil && string(currentEntry.Extended[s3_constants.SeaweedFSUploadId]) == *input.UploadId {
+				// A failed finalize leaves the key reading as deleted, so fail rather than
+				// return 200 — a non-ErrNone finalize keeps the upload directory, so the
+				// caller's retry replays.
+				if err := s3a.finalizeSuspendedNullWrite(*input.Bucket, normalizedKey); err != nil {
+					glog.Errorf("completeMultipartUpload: failed to retire the null delete marker for %s/%s: %v", *input.Bucket, normalizedKey, err)
 					return s3err.ErrInternalError
 				}
-				s3a.removeNullVersionFile(*input.Bucket, normalizedKey)
+			} else {
+				glog.V(2).Infof("completeMultipartUpload: skipping the null cleanup for %s/%s, superseded by a concurrent write", *input.Bucket, normalizedKey)
 			}
 
 			// Note: Suspended versioning should NOT return VersionId field according to AWS S3 spec

--- a/weed/s3api/filer_multipart.go
+++ b/weed/s3api/filer_multipart.go
@@ -769,6 +769,12 @@ func (s3a *S3ApiServer) completeMultipartUpload(r *http.Request, input *s3.Compl
 		}
 
 		if versioningState == s3_constants.VersioningSuspended {
+			normalizedKey := strings.TrimPrefix(*input.Key, "/")
+
+			// The null version lands at the regular path below, so drop the stale one .versions
+			// still holds — a suspended DELETE leaves a null delete marker reads resolve to.
+			s3a.removeNullVersionFile(*input.Bucket, normalizedKey)
+
 			// For suspended versioning, add "null" version ID metadata and return "null" version ID
 			if err := s3a.writeMultipartObject(owner, routeKey, dirName, entryName, completionState.finalParts, func(entry *filer_pb.Entry) {
 				if entry.Extended == nil {
@@ -821,6 +827,12 @@ func (s3a *S3ApiServer) completeMultipartUpload(r *http.Request, input *s3.Compl
 			}); err != nil {
 				glog.Errorf("completeMultipartUpload: failed to create suspended versioning object: %v", err)
 				return s3err.ErrInternalError
+			}
+
+			// Clear the .versions latest pointer so the null object just written wins the read.
+			// Best-effort, as in putSuspendedVersioningObject: a stale flag self-heals on the next list.
+			if err := s3a.updateIsLatestFlagsForSuspendedVersioning(*input.Bucket, normalizedKey); err != nil {
+				glog.Warningf("completeMultipartUpload: failed to update IsLatest flags for %s/%s: %v", *input.Bucket, normalizedKey, err)
 			}
 
 			// Note: Suspended versioning should NOT return VersionId field according to AWS S3 spec

--- a/weed/s3api/filer_multipart.go
+++ b/weed/s3api/filer_multipart.go
@@ -830,18 +830,38 @@ func (s3a *S3ApiServer) completeMultipartUpload(r *http.Request, input *s3.Compl
 			// regular path. Both steps run only after the write commits: undoing them on a
 			// failed write would republish the deleted key as its newest real version.
 			//
-			// Clearing the pointer is what hands the read back to the regular path, so it must
-			// come first — removing the marker while the pointer still names it makes reads
-			// rescan and promote an older version. Failing it leaves the key reading as deleted,
-			// so report that rather than answering 200 for an object HEAD and GET still miss;
-			// the caller's retry replays the completion, since a non-ErrNone finalize keeps the
-			// upload directory. Dropping the marker afterwards is only list hygiene: with the
-			// pointer gone the regular-path null version already wins the read.
-			if err := s3a.updateIsLatestFlagsForSuspendedVersioning(*input.Bucket, normalizedKey); err != nil {
-				glog.Errorf("completeMultipartUpload: failed to clear the latest-version pointer for %s/%s: %v", *input.Bucket, normalizedKey, err)
+			// They rewrite shared .versions state unconditionally, and the routed completion
+			// runs off the object write lock, so first confirm the object we just wrote is
+			// still the current one. A DELETE that landed in between owns the null slot now,
+			// and clearing its pointer would resurrect an older version under a key that was
+			// successfully deleted. This narrows the window rather than closing it — a delete
+			// landing after this read still loses; a compare-and-set pointer flip is the real
+			// answer and wants its own change.
+			currentEntry, currentErr := s3a.getObjectEntryRoutedByKey(*input.Bucket, normalizedKey)
+			if currentErr != nil && !errors.Is(currentErr, filer_pb.ErrNotFound) {
+				glog.Errorf("completeMultipartUpload: failed to re-read %s/%s before the null cleanup: %v", *input.Bucket, normalizedKey, currentErr)
 				return s3err.ErrInternalError
 			}
-			s3a.removeNullVersionFile(*input.Bucket, normalizedKey)
+			supersededByConcurrentWrite := currentEntry == nil ||
+				string(currentEntry.Extended[s3_constants.SeaweedFSUploadId]) != *input.UploadId
+
+			if supersededByConcurrentWrite {
+				// Last writer wins: the completion did happen, someone else moved the key on.
+				glog.V(2).Infof("completeMultipartUpload: skipping the null cleanup for %s/%s, superseded by a concurrent write", *input.Bucket, normalizedKey)
+			} else {
+				// Clearing the pointer is what hands the read back to the regular path, so it
+				// must come first — removing the marker while the pointer still names it makes
+				// reads rescan and promote an older version. Failing it leaves the key reading
+				// as deleted, so report that rather than answering 200 for an object HEAD and
+				// GET still miss; the caller's retry replays the completion, since a non-ErrNone
+				// finalize keeps the upload directory. Dropping the marker afterwards is only
+				// list hygiene: with the pointer gone the regular-path null version already wins.
+				if err := s3a.updateIsLatestFlagsForSuspendedVersioning(*input.Bucket, normalizedKey); err != nil {
+					glog.Errorf("completeMultipartUpload: failed to clear the latest-version pointer for %s/%s: %v", *input.Bucket, normalizedKey, err)
+					return s3err.ErrInternalError
+				}
+				s3a.removeNullVersionFile(*input.Bucket, normalizedKey)
+			}
 
 			// Note: Suspended versioning should NOT return VersionId field according to AWS S3 spec
 			output = &CompleteMultipartUploadResult{

--- a/weed/s3api/filer_multipart.go
+++ b/weed/s3api/filer_multipart.go
@@ -771,10 +771,6 @@ func (s3a *S3ApiServer) completeMultipartUpload(r *http.Request, input *s3.Compl
 		if versioningState == s3_constants.VersioningSuspended {
 			normalizedKey := strings.TrimPrefix(*input.Key, "/")
 
-			// The null version lands at the regular path below, so drop the stale one .versions
-			// still holds — a suspended DELETE leaves a null delete marker reads resolve to.
-			s3a.removeNullVersionFile(*input.Bucket, normalizedKey)
-
 			// For suspended versioning, add "null" version ID metadata and return "null" version ID
 			if err := s3a.writeMultipartObject(owner, routeKey, dirName, entryName, completionState.finalParts, func(entry *filer_pb.Entry) {
 				if entry.Extended == nil {
@@ -829,11 +825,23 @@ func (s3a *S3ApiServer) completeMultipartUpload(r *http.Request, input *s3.Compl
 				return s3err.ErrInternalError
 			}
 
-			// Clear the .versions latest pointer so the null object just written wins the read.
-			// Best-effort, as in putSuspendedVersioningObject: a stale flag self-heals on the next list.
+			// A suspended DELETE leaves a null delete marker in .versions that reads keep
+			// resolving to, so retire it now that the replacement null version exists at the
+			// regular path. Both steps run only after the write commits: undoing them on a
+			// failed write would republish the deleted key as its newest real version.
+			//
+			// Clearing the pointer is what hands the read back to the regular path, so it must
+			// come first — removing the marker while the pointer still names it makes reads
+			// rescan and promote an older version. Failing it leaves the key reading as deleted,
+			// so report that rather than answering 200 for an object HEAD and GET still miss;
+			// the caller's retry replays the completion, since a non-ErrNone finalize keeps the
+			// upload directory. Dropping the marker afterwards is only list hygiene: with the
+			// pointer gone the regular-path null version already wins the read.
 			if err := s3a.updateIsLatestFlagsForSuspendedVersioning(*input.Bucket, normalizedKey); err != nil {
-				glog.Warningf("completeMultipartUpload: failed to update IsLatest flags for %s/%s: %v", *input.Bucket, normalizedKey, err)
+				glog.Errorf("completeMultipartUpload: failed to clear the latest-version pointer for %s/%s: %v", *input.Bucket, normalizedKey, err)
+				return s3err.ErrInternalError
 			}
+			s3a.removeNullVersionFile(*input.Bucket, normalizedKey)
 
 			// Note: Suspended versioning should NOT return VersionId field according to AWS S3 spec
 			output = &CompleteMultipartUploadResult{

--- a/weed/s3api/filer_multipart.go
+++ b/weed/s3api/filer_multipart.go
@@ -824,26 +824,12 @@ func (s3a *S3ApiServer) completeMultipartUpload(r *http.Request, input *s3.Compl
 				return s3err.ErrInternalError
 			}
 
-			// The cleanup rewrites shared .versions state, and the routed completion runs
-			// off the object write lock, so only run it while this upload still owns the
-			// key: a DELETE that landed in between owns the null slot now, and retiring
-			// its marker would resurrect an older version under a deleted key. Narrows
-			// that race, does not close it.
-			currentEntry, currentErr := s3a.lookupEntryPreferringOwner(owner, dirName, entryName)
-			if currentErr != nil && !errors.Is(currentErr, filer_pb.ErrNotFound) {
-				glog.Errorf("completeMultipartUpload: failed to re-read %s/%s before the null cleanup: %v", *input.Bucket, normalizedKey, currentErr)
+			// A failed finalize leaves the key reading as deleted, so fail rather than
+			// return 200 — a non-ErrNone finalize keeps the upload directory, so the
+			// caller's retry replays.
+			if err := s3a.finalizeSuspendedNullWrite(owner, *input.Bucket, normalizedKey, s3_constants.SeaweedFSUploadId, *input.UploadId); err != nil {
+				glog.Errorf("completeMultipartUpload: failed to retire the null delete marker for %s/%s: %v", *input.Bucket, normalizedKey, err)
 				return s3err.ErrInternalError
-			}
-			if currentEntry != nil && string(currentEntry.Extended[s3_constants.SeaweedFSUploadId]) == *input.UploadId {
-				// A failed finalize leaves the key reading as deleted, so fail rather than
-				// return 200 — a non-ErrNone finalize keeps the upload directory, so the
-				// caller's retry replays.
-				if err := s3a.finalizeSuspendedNullWrite(*input.Bucket, normalizedKey); err != nil {
-					glog.Errorf("completeMultipartUpload: failed to retire the null delete marker for %s/%s: %v", *input.Bucket, normalizedKey, err)
-					return s3err.ErrInternalError
-				}
-			} else {
-				glog.V(2).Infof("completeMultipartUpload: skipping the null cleanup for %s/%s, superseded by a concurrent write", *input.Bucket, normalizedKey)
 			}
 
 			// Note: Suspended versioning should NOT return VersionId field according to AWS S3 spec

--- a/weed/s3api/filer_multipart.go
+++ b/weed/s3api/filer_multipart.go
@@ -825,24 +825,12 @@ func (s3a *S3ApiServer) completeMultipartUpload(r *http.Request, input *s3.Compl
 				return s3err.ErrInternalError
 			}
 
-			// A suspended DELETE leaves a null delete marker in .versions that reads keep
-			// resolving to, so retire it now that the replacement null version exists at the
-			// regular path. Both steps run only after the write commits: undoing them on a
-			// failed write would republish the deleted key as its newest real version.
-			//
-			// They rewrite shared .versions state unconditionally, and the routed completion
-			// runs off the object write lock, so first confirm the object we just wrote is
-			// still the current one: a DELETE that landed in between owns the null slot now,
-			// and clearing its pointer would resurrect an older version under a key that was
-			// successfully deleted. Narrows that window rather than closing it — a delete
-			// landing after this read still wins. Closing it wants a conditional cleanup
-			// transaction (ObjectTransaction condition_key + IF_ETAG_MATCH on the object),
-			// across this path and putSuspendedVersioningObject both, in its own change.
-			//
-			// Read back from whichever filer took the write, not via getObjectEntryRoutedByKey:
-			// that skips an owner it recently found unreachable and reads local-first, which
-			// can miss a write that just landed on the owner and read as superseded — skipping
-			// the cleanup and leaving the key unreadable, the very bug this fixes.
+			// Retire the null delete marker a suspended DELETE leaves, now that the
+			// replacement null version is at the regular path. Only after the write commits:
+			// undoing it on a failed write republishes the deleted key as an older version.
+			// Read back from the filer that took the write — getObjectEntryRoutedByKey drops
+			// a recently-unreachable owner and reads local-first, so it can miss the write.
+			// A concurrent DELETE owns the null slot instead; narrows that race, not closes it.
 			var currentEntry *filer_pb.Entry
 			var currentErr error
 			if owner != "" {
@@ -858,16 +846,12 @@ func (s3a *S3ApiServer) completeMultipartUpload(r *http.Request, input *s3.Compl
 				string(currentEntry.Extended[s3_constants.SeaweedFSUploadId]) != *input.UploadId
 
 			if supersededByConcurrentWrite {
-				// Last writer wins: the completion did happen, someone else moved the key on.
 				glog.V(2).Infof("completeMultipartUpload: skipping the null cleanup for %s/%s, superseded by a concurrent write", *input.Bucket, normalizedKey)
 			} else {
-				// Clearing the pointer is what hands the read back to the regular path, so it
-				// must come first — removing the marker while the pointer still names it makes
-				// reads rescan and promote an older version. Failing it leaves the key reading
-				// as deleted, so report that rather than answering 200 for an object HEAD and
-				// GET still miss; the caller's retry replays the completion, since a non-ErrNone
-				// finalize keeps the upload directory. Dropping the marker afterwards is only
-				// list hygiene: with the pointer gone the regular-path null version already wins.
+				// Pointer first: removing the marker while the pointer still names it makes
+				// reads rescan and promote an older version. A failed clear leaves the key
+				// reading as deleted, so fail instead of returning 200 — a non-ErrNone
+				// finalize keeps the upload directory, so the caller's retry replays.
 				if err := s3a.updateIsLatestFlagsForSuspendedVersioning(*input.Bucket, normalizedKey); err != nil {
 					glog.Errorf("completeMultipartUpload: failed to clear the latest-version pointer for %s/%s: %v", *input.Bucket, normalizedKey, err)
 					return s3err.ErrInternalError

--- a/weed/s3api/filer_multipart.go
+++ b/weed/s3api/filer_multipart.go
@@ -832,12 +832,24 @@ func (s3a *S3ApiServer) completeMultipartUpload(r *http.Request, input *s3.Compl
 			//
 			// They rewrite shared .versions state unconditionally, and the routed completion
 			// runs off the object write lock, so first confirm the object we just wrote is
-			// still the current one. A DELETE that landed in between owns the null slot now,
+			// still the current one: a DELETE that landed in between owns the null slot now,
 			// and clearing its pointer would resurrect an older version under a key that was
-			// successfully deleted. This narrows the window rather than closing it — a delete
-			// landing after this read still loses; a compare-and-set pointer flip is the real
-			// answer and wants its own change.
-			currentEntry, currentErr := s3a.getObjectEntryRoutedByKey(*input.Bucket, normalizedKey)
+			// successfully deleted. Narrows that window rather than closing it — a delete
+			// landing after this read still wins. Closing it wants a conditional cleanup
+			// transaction (ObjectTransaction condition_key + IF_ETAG_MATCH on the object),
+			// across this path and putSuspendedVersioningObject both, in its own change.
+			//
+			// Read back from whichever filer took the write, not via getObjectEntryRoutedByKey:
+			// that skips an owner it recently found unreachable and reads local-first, which
+			// can miss a write that just landed on the owner and read as superseded — skipping
+			// the cleanup and leaving the key unreadable, the very bug this fixes.
+			var currentEntry *filer_pb.Entry
+			var currentErr error
+			if owner != "" {
+				currentEntry, currentErr = s3a.lookupEntryOnFiler(owner, dirName, entryName)
+			} else {
+				currentEntry, currentErr = s3a.getEntry(dirName, entryName)
+			}
 			if currentErr != nil && !errors.Is(currentErr, filer_pb.ErrNotFound) {
 				glog.Errorf("completeMultipartUpload: failed to re-read %s/%s before the null cleanup: %v", *input.Bucket, normalizedKey, currentErr)
 				return s3err.ErrInternalError

--- a/weed/s3api/s3api_object_handlers_copy.go
+++ b/weed/s3api/s3api_object_handlers_copy.go
@@ -583,7 +583,8 @@ func (s3a *S3ApiServer) finalizeCopyDestination(dstBucket, dstObject, dstVersion
 			return "", "", err
 		}
 
-		if err = s3a.finalizeSuspendedNullWrite(dstBucket, normalizedObject); err != nil {
+		// mkFile writes through the default filer, so the ownership check reads there too.
+		if err = s3a.finalizeSuspendedNullWrite("", dstBucket, normalizedObject, s3_constants.ExtETagKey, etag); err != nil {
 			glog.Warningf("CopyObjectHandler: failed to retire the null delete marker for %s/%s: %v", dstBucket, normalizedObject, err)
 		}
 

--- a/weed/s3api/s3api_object_handlers_copy.go
+++ b/weed/s3api/s3api_object_handlers_copy.go
@@ -583,8 +583,8 @@ func (s3a *S3ApiServer) finalizeCopyDestination(dstBucket, dstObject, dstVersion
 			return "", "", err
 		}
 
-		if err = s3a.updateIsLatestFlagsForSuspendedVersioning(dstBucket, normalizedObject); err != nil {
-			glog.Warningf("CopyObjectHandler: failed to update suspended version latest flags for %s/%s: %v", dstBucket, normalizedObject, err)
+		if err = s3a.finalizeSuspendedNullWrite(dstBucket, normalizedObject); err != nil {
+			glog.Warningf("CopyObjectHandler: failed to retire the null delete marker for %s/%s: %v", dstBucket, normalizedObject, err)
 		}
 
 		return "", etag, nil

--- a/weed/s3api/s3api_object_routed_read.go
+++ b/weed/s3api/s3api_object_routed_read.go
@@ -80,6 +80,16 @@ func (s3a *S3ApiServer) ownerRecentlyUnreachable(owner pb.ServerAddress) bool {
 	return false
 }
 
+// lookupEntryPreferringOwner reads an entry back from a known write owner, so a
+// caller that just wrote there sees its own write. Unlike getObjectEntryRoutedByKey
+// it never drops the owner for a healthier peer, which would read behind the write.
+func (s3a *S3ApiServer) lookupEntryPreferringOwner(owner pb.ServerAddress, dir, name string) (*filer_pb.Entry, error) {
+	if owner == "" {
+		return s3a.getEntry(dir, name)
+	}
+	return s3a.lookupEntryOnFiler(owner, dir, name)
+}
+
 // lookupEntryOnFiler resolves dir/name against a single filer, without failover.
 func (s3a *S3ApiServer) lookupEntryOnFiler(filer pb.ServerAddress, dir, name string) (*filer_pb.Entry, error) {
 	var entry *filer_pb.Entry

--- a/weed/s3api/s3api_object_versioned_finalize.go
+++ b/weed/s3api/s3api_object_versioned_finalize.go
@@ -1,6 +1,8 @@
 package s3api
 
 import (
+	"errors"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -201,7 +203,25 @@ func (s3a *S3ApiServer) versionedFinalize(bucket, object, versionId, versionFile
 // makes reads rescan .versions and promote an older version. Call only once the
 // write has committed — retiring the marker for a write that then fails republishes
 // the deleted key.
-func (s3a *S3ApiServer) finalizeSuspendedNullWrite(bucket, object string) error {
+//
+// identityKey/identityValue name the extended attribute that marks the entry as the
+// caller's write (an upload id, an etag). The cleanup rewrites shared .versions state
+// off the object write lock, so it is skipped unless the regular path still holds that
+// write: a DELETE that landed in between owns the null slot, and retiring its marker
+// would resurrect an older version under a key that was deleted. Narrows that race,
+// does not close it. owner, when set, is the filer the write went to, so the check
+// reads its own write back rather than a peer that may be behind.
+func (s3a *S3ApiServer) finalizeSuspendedNullWrite(owner pb.ServerAddress, bucket, object, identityKey, identityValue string) error {
+	dir, name := util.FullPath(s3a.toFilerPath(bucket, object)).DirAndName()
+	current, err := s3a.lookupEntryPreferringOwner(owner, dir, name)
+	if err != nil && !errors.Is(err, filer_pb.ErrNotFound) {
+		return fmt.Errorf("re-read %s/%s: %w", bucket, object, err)
+	}
+	if current == nil || string(current.Extended[identityKey]) != identityValue {
+		glog.V(2).Infof("finalizeSuspendedNullWrite: %s/%s superseded by a concurrent write", bucket, object)
+		return nil
+	}
+
 	if err := s3a.updateIsLatestFlagsForSuspendedVersioning(bucket, object); err != nil {
 		return err
 	}

--- a/weed/s3api/s3api_object_versioned_finalize.go
+++ b/weed/s3api/s3api_object_versioned_finalize.go
@@ -194,3 +194,19 @@ func (s3a *S3ApiServer) versionedFinalize(bucket, object, versionId, versionFile
 		},
 	}
 }
+
+// finalizeSuspendedNullWrite retires the null delete marker a suspended DELETE left
+// in .versions, so reads resolve the null version the caller just wrote at the
+// regular path. Pointer first: clearing the marker while the pointer still names it
+// makes reads rescan .versions and promote an older version. Call only once the
+// write has committed — retiring the marker for a write that then fails republishes
+// the deleted key.
+func (s3a *S3ApiServer) finalizeSuspendedNullWrite(bucket, object string) error {
+	if err := s3a.updateIsLatestFlagsForSuspendedVersioning(bucket, object); err != nil {
+		return err
+	}
+	// Best-effort: with the pointer gone the regular-path object already owns the
+	// null slot, so a surviving marker is neither read nor listed.
+	s3a.removeNullVersionFile(bucket, object)
+	return nil
+}


### PR DESCRIPTION
Fixes #10583.

In a bucket whose versioning is *suspended*, `DeleteObject` writes a null delete marker into the key's `.versions/` directory and removes the null version from the regular path. A following `CompleteMultipartUpload` wrote the new null version back at the regular path but left that delete marker untouched, so:

- `CompleteMultipartUpload` returns 200 and `ListObjectsV2` shows the object (both read the regular path)
- `HeadObject`/`GetObject` go through `getLatestObjectVersion`, see the `.versions` pointer still aimed at the null delete marker, and answer `NoSuchKey`

The key stays unreadable for as long as the marker is there, which matches the report: it only breaks on a key that was deleted earlier, and a fresh key is fine.

`putSuspendedVersioningObject` already gets this right — it drops the stale null entry before the write and clears the `.versions` latest pointer afterwards. The multipart completion now does the same.

Reproduced against `weed mini` (filer store `sqlite`, i.e. the same bucket-aware SQL path as `postgres2`):

```
[run-1] CMU ETag="c07b...-3"   ListV2 found=True   HEAD OK   GET OK
delete_object
[run-2] CMU ETag="c07b...-3"   ListV2 found=True   HEAD 404  GET NoSuchKey
```

and the filer showing the cause:

```
/buckets/b/test/multipart-repro.bin           file, 15728640 bytes, version-id=null
/buckets/b/test/multipart-repro.bin.versions  dir, latest-version-id=null,
                                              latest-version-is-delete-marker=true
```

After the fix both runs pass, a pre-suspension real version is left alone and still retrievable by version id, and `ListObjectVersions` shows one null version with no leftover delete marker.

`TestSuspendedMultipartOverwritesDeleteMarker` covers the sequence; it fails with `HeadObject 404` on the current code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed multipart upload completion when bucket versioning is suspended and a delete marker exists.
  * Newly completed uploads are immediately readable and correctly replace stale delete markers.
  * Preserved the prior version while ensuring only one null version remains after completion.
  * Prevented cleanup from removing a newer version created by a concurrent write.
  * Improved reliability when concurrent updates occur during multipart completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->