### PR TITLE
s3: retire the suspended null marker only once the PUT has committed

### DIFF
--- a/test/s3/versioning/s3_suspended_versioning_test.go
+++ b/test/s3/versioning/s3_suspended_versioning_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestSuspendedVersioningNullOverwrite tests the scenario where:
@@ -254,4 +256,42 @@ func TestEnabledVersioningReturnsVersionId(t *testing.T) {
 	for i, v := range listResp.Versions {
 		t.Logf("  Version %d: VersionId=%s, Size=%d, IsLatest=%v", i, *v.VersionId, v.Size, v.IsLatest)
 	}
+}
+
+// The suspended PUT retires the null delete marker a preceding DELETE left, the same
+// as the copy and multipart paths. While the regular-path object owns the null slot a
+// leftover marker is shadowed, so it only shows once that null version goes away.
+func TestSuspendedPutRetiresDeleteMarker(t *testing.T) {
+	client := getS3Client(t)
+	bucketName := getNewBucketName()
+
+	createBucket(t, client, bucketName)
+	defer deleteBucket(t, client, bucketName)
+
+	objectKey := "suspended-put-after-delete.txt"
+
+	enableVersioning(t, client, bucketName)
+	putObject(t, client, bucketName, objectKey, "pre-suspension-content")
+	suspendVersioning(t, client, bucketName)
+
+	putObject(t, client, bucketName, objectKey, "null-version-content")
+	deleteKey(t, client, bucketName, objectKey)
+	putObject(t, client, bucketName, objectKey, "replacement-content")
+
+	headObject(t, client, bucketName, objectKey)
+
+	// Drop the null version just written; a retired marker leaves nothing behind.
+	_, err := client.DeleteObject(context.TODO(), &s3.DeleteObjectInput{
+		Bucket:    aws.String(bucketName),
+		Key:       aws.String(objectKey),
+		VersionId: aws.String("null"),
+	})
+	require.NoError(t, err)
+
+	listResp, err := client.ListObjectVersions(context.TODO(), &s3.ListObjectVersionsInput{
+		Bucket: aws.String(bucketName),
+		Prefix: aws.String(objectKey),
+	})
+	require.NoError(t, err)
+	assert.Empty(t, listResp.DeleteMarkers, "the suspended PUT should have retired the null delete marker")
 }

--- a/weed/s3api/s3api_object_handlers_put.go
+++ b/weed/s3api/s3api_object_handlers_put.go
@@ -1293,10 +1293,6 @@ func (s3a *S3ApiServer) putSuspendedVersioningObject(r *http.Request, bucket, ob
 	glog.V(3).Infof("putSuspendedVersioningObject: START bucket=%s, object=%s, normalized=%s",
 		bucket, object, normalizedObject)
 
-	// The null version now lives at the regular path, so any null version recorded in
-	// .versions is stale (S3 has the suspended write overwrite it, not accumulate).
-	s3a.removeNullVersionFile(bucket, normalizedObject)
-
 	filePath := s3a.toFilerPath(bucket, normalizedObject)
 
 	body := dataReader
@@ -1360,15 +1356,18 @@ func (s3a *S3ApiServer) putSuspendedVersioningObject(r *http.Request, bucket, ob
 	}
 
 	// Versioned/suspended bucket → resolver returns 0; pass it directly.
-	// afterCreate clears the prior latest pointer and stamps the displaced version
-	// with NoncurrentSinceNs — off-ring under the write lock, routed off-lock after
-	// the PUT. Best-effort either way: a stale flag self-heals on the next list.
+	// afterCreate retires the null delete marker a preceding DELETE left, clears the
+	// prior latest pointer and stamps the displaced version with NoncurrentSinceNs —
+	// off-ring under the write lock, routed off-lock after the PUT. Only once the write
+	// has committed: retiring the marker for a write that then fails leaves the pointer
+	// naming a marker that is gone, and the read path heals that by promoting an older
+	// version, republishing the deleted key. Best-effort, as a stale flag self-heals on
+	// the next list.
 	etag, errCode, sseMetadata = s3a.putToFiler(r, filePath, body, bucket, normalizedObject, 1, 0, &putFinalize{
-		afterCreate: func(_ *filer_pb.Entry) s3err.ErrorCode {
-			if err := s3a.updateIsLatestFlagsForSuspendedVersioning(bucket, normalizedObject); err != nil {
-				// Best-effort: a stale IsLatest flag is recoverable on the
-				// next list-versions resync, so don't fail the PUT.
-				glog.Warningf("putSuspendedVersioningObject: failed to update IsLatest flags: %v", err)
+		afterCreate: func(entry *filer_pb.Entry) s3err.ErrorCode {
+			writtenETag := string(entry.Extended[s3_constants.ExtETagKey])
+			if err := s3a.finalizeSuspendedNullWrite("", bucket, normalizedObject, s3_constants.ExtETagKey, writtenETag); err != nil {
+				glog.Warningf("putSuspendedVersioningObject: failed to retire the null delete marker: %v", err)
 			}
 			return s3err.ErrNone
 		},


### PR DESCRIPTION
Follow-up to #10585, which added `finalizeSuspendedNullWrite`. Rebased onto master now that it has merged.

`putSuspendedVersioningObject` retired the null delete marker **before** its write, where the multipart and copy paths now do it after:

```go
s3a.removeNullVersionFile(bucket, normalizedObject)   // before
...
putToFiler(..., afterCreate: updateIsLatestFlagsForSuspendedVersioning)   // after
```

If the write fails in between, the marker is gone and the `.versions` pointer names a file that no longer exists. The read path heals a dangling pointer by rescanning and promoting the newest survivor — an older real version. A key the caller had deleted comes back.

Injected a failure right after the marker removal, on a key with an older real version behind it:

```
[after delete]                     GET -> NoSuchKey
[put] failed as injected:          InternalError
[after the failed suspended PUT]   GET -> b'OLD-REAL-VERSION'
```

Not transient either — the heal rewrote the stored pointer to the older version:

```
v_null present: False
pointer: {'File-Name': 'v_6737060148...', 'Is-Delete-Marker': 'false', 'Size': '16'}
```

With the retire moved into `afterCreate`, the same injection leaves the delete standing:

```
[after delete]                     GET -> NoSuchKey
[put] failed as injected:          InternalError
[after the failed suspended PUT]   GET -> NoSuchKey
v_null present: True
```

Going through `finalizeSuspendedNullWrite` also brings the ownership check the other two paths have, so a DELETE landing between the write and the cleanup keeps its own marker rather than losing it. `removeNullVersionFile` is now called from exactly one place, and all three suspended write paths finalize the same way.

The disposition is unchanged: still best-effort, still warns. A PUT has no upload directory to replay from, so failing it would only turn a recoverable stale pointer into a 500; the caller simply re-PUTs.

`TestSuspendedPutRetiresDeleteMarker` covers the retirement. Being straight about its limits: it passes on the old code too, since the pre-write removal reached the same end state on the success path. It locks in that the PUT path still retires the marker after the move. The ordering fix itself is not reachable through the S3 API — it needs a write failure — so it is verified by the injection above rather than by a test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed object replacement behavior when versioning is suspended.
  * Replacing an object now correctly retires a preceding delete marker, keeps the new object accessible, and prevents stale delete markers from remaining after deletion.

* **Tests**
  * Added regression coverage for suspended-versioning object replacement and delete-marker cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->