### PR TITLE
test(s3): give the copying suite room for a collection per bucket

### DIFF
--- a/.github/workflows/s3tests.yml
+++ b/.github/workflows/s3tests.yml
@@ -694,10 +694,12 @@ jobs:
           export WEED_DATA_DIR="/tmp/seaweedfs-copy-test-$(date +%s)"
           mkdir -p "$WEED_DATA_DIR"
           set -x
+          # Each test bucket is its own collection and grows 7 volumes; the suite runs
+          # faster than the heartbeat that returns slots from the deleted collections.
           weed -v 0 server -filer -filer.maxMB=64 -s3 -ip.bind 0.0.0.0 \
             -dir="$WEED_DATA_DIR" \
             -master.raftHashicorp -master.electionTimeout 1s -master.volumeSizeLimitMB=100 \
-            -volume.max=100 -volume.preStopSeconds=1 \
+            -volume.max=300 -volume.preStopSeconds=1 \
             -master.port=9336 -volume.port=8083 -filer.port=8891 -s3.port=8003 -metricsPort=9327 \
             -s3.allowDeleteBucketNotEmpty=true -s3.config="$GITHUB_WORKSPACE/docker/compose/s3.json" -master.peers=none &
           pid=$!


### PR DESCRIPTION
The Custom S3 Copy job wedged on master: the last test failed its PutObject with a 500, and the master logged `No writable volumes and no free volumes left` / `create 7 volume, created 0: Not enough data nodes found!`.

It is not the code under test. Every test bucket is its own collection and each new collection grows `Copy1Count = 7` volumes, so the 20-bucket suite asks for 140 while the job starts the volume server with `-volume.max=100`.

Deleting a collection does not give the slots back right away. `Store.DeleteCollection` deliberately skips `DeletedVolumesChan` and leaves it to the next full heartbeat, and `Topo.DeleteCollection` only drops the collection map entry, so the master keeps counting those volumes against the node until the volume server's next 5s pulse. The whole suite runs in about five seconds, so exactly one reconciliation tick lands mid-run and the run lives or dies on how many buckets happened to be deleted before it:

| run | volumes created | freed on the tick | peak live |
| --- | --- | --- | --- |
| 7063b3e14 (pass) | 140 | 42 | 98 |
| 5269d93fa (fail) | 128 | 28 | 100 |

The passing run cleared by two slots.

Raise the cap to 300 so the suite has room for its own worst case plus new tests. An explicit number rather than `-volume.max=0` keeps the budget off whatever disk the runner has free; reservations are slot-based and nothing is preallocated, so the higher cap costs no disk.

The other jobs in this workflow stay at 100 - they run the ceph suite over several minutes, slow enough for heartbeat reclamation to keep up.

Worth fixing separately: once the volume servers ack a collection delete, the master could drop those volumes from the data node accounting instead of waiting for the pulse. A real cluster near its volume cap refuses assignments for up to a heartbeat after a bucket is dropped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased test storage capacity to support more per-test bucket collections.
  * Documented the updated capacity in the test workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->