### PR TITLE
fix(helm): mark filer db-init ConfigMap volume optional

### DIFF
--- a/k8s/charts/seaweedfs/templates/filer/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer/filer-statefulset.yaml
@@ -356,6 +356,7 @@ spec:
         - name: db-schema-config-volume
           configMap:
             name: {{ default (printf "%s-db-init-config" (include "seaweedfs.fullname" .)) .Values.filer.dbInitConfigName }}
+            optional: true
         {{- if and .Values.filer.s3.enabled .Values.filer.s3.enableAuth }}
         - name: config-users
           secret:


### PR DESCRIPTION
## What problem are we solving?

The filer StatefulSet currently declares `db-schema-config-volume` unconditionally:

```yaml
- name: db-schema-config-volume
  configMap:
    name: {{ default (printf "%s-db-init-config" (include "seaweedfs.fullname" .)) .Values.filer.dbInitConfigName }}
```

However, the chart does not render this ConfigMap. The README documents it as an operator-supplied resource:

> This database should be pre-configured and initialized... You can override this name via `filer.dbInitConfigName`.

As a result, any installation that has not pre-created the ConfigMap produces a filer pod specification that references a non-existent resource.

This reference is currently inert because no container mounts `db-schema-config-volume`. Kubelet therefore never attempts to set it up, and no `FailedMount` event is raised. However, the dangling reference is confusing enough to be reported as a chart bug, and it would become a hard pod-start failure if a corresponding `volumeMount` were added in the future.

The chart already handles the analogous database secret references correctly: the adjacent `WEED_MYSQL_USERNAME` and `WEED_MYSQL_PASSWORD` references to `<fullname>-db-secret` are marked as optional.

This change brings the ConfigMap volume behavior in line with those secret references.

## How are we solving the problem?

Add `optional: true` to the ConfigMap volume declaration:

```yaml
- name: db-schema-config-volume
  configMap:
    name: {{ default (printf "%s-db-init-config" (include "seaweedfs.fullname" .)) .Values.filer.dbInitConfigName }}
    optional: true
```

This is a one-line, backwards-compatible change:

* Existing users who provide the ConfigMap are unaffected.
* Installations that do not provide the ConfigMap no longer contain a mandatory dependency on a missing resource.
* Current runtime behavior remains unchanged because the volume is not mounted.

## Alternative considered

The volume could be removed entirely.

`db-schema-config-volume` has no corresponding `volumeMount` anywhere in the chart and, based on the chart history, has not had one since at least version 3.59. It therefore appears to be dead wiring.

I chose `optional: true` as the more conservative fix, but I am happy to remove the volume instead if the maintainers prefer.

## How is the PR tested?

* Ran `helm template` before and after the change.
* Confirmed that the rendered output is identical apart from the added `optional: true` field.
* Confirmed that `db-schema-config-volume` occurs exactly once in `filer-statefulset.yaml`, in the volume declaration.
* Confirmed that no container mounts the volume, so the change does not alter current rendered or runtime behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Filer pods can now start successfully even when the optional database schema configuration is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->