### PR TITLE
chore(weed/s3api/policy_engine): prune dead code

### DIFF
--- a/weed/s3api/policy_engine/engine.go
+++ b/weed/s3api/policy_engine/engine.go
@@ -26,7 +26,6 @@ type PolicyEvaluationContext struct {
 	bucketName string
 	policy     *CompiledPolicy
 	cache      *PolicyCache
-	mutex      sync.RWMutex
 }
 
 // PolicyEngine is the main policy evaluation engine

--- a/weed/s3api/policy_engine/types.go
+++ b/weed/s3api/policy_engine/types.go
@@ -7,7 +7,6 @@ import (
 	"slices"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	s3const "github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
@@ -320,8 +319,7 @@ type PolicyEvaluationArgs struct {
 
 // PolicyCache for caching compiled policies
 type PolicyCache struct {
-	policies   map[string]*CompiledPolicy
-	lastUpdate time.Time
+	policies map[string]*CompiledPolicy
 }
 
 // CompiledPolicy represents a policy that has been compiled for efficient evaluation


### PR DESCRIPTION
This prunes some unused fields from type structs in `weed/s3api/policy_engine`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal policy evaluation and caching components by removing unused state.
  * No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->