### PR TITLE
rust: stop quarantining v2 volumes, load a disk's volumes concurrently

### DIFF
--- a/seaweed-volume/src/storage/disk_location.rs
+++ b/seaweed-volume/src/storage/disk_location.rs
@@ -122,8 +122,11 @@ impl DiskLocation {
         // Scan for .dat files
         let entries = fs::read_dir(&self.directory)?;
         let mut dat_files: Vec<(String, VolumeId)> = Vec::new();
-        let mut to_load: Vec<(String, VolumeId)> = Vec::new();
-        let mut queued: HashSet<VolumeId> = HashSet::new();
+        // One entry per volume id, holding every collection name that claims it
+        // in scan order -- the loader tries them in turn and keeps the first
+        // that opens, so a corrupt candidate does not shadow a good one.
+        let mut to_load: Vec<(VolumeId, Vec<String>)> = Vec::new();
+        let mut queued: HashMap<VolumeId, usize> = HashMap::new();
         let mut seen = HashSet::new();
 
         for entry in entries {
@@ -203,11 +206,6 @@ impl DiskLocation {
                 continue;
             }
 
-            // Skip volumes already queued under a different collection name for
-            // the same id -- the loader below keys results by id.
-            if !queued.insert(vid) {
-                continue;
-            }
 
             // Load existing data only; never create a phantom `.dat`. A lone
             // `.vif`/`.idx` (e.g. an EC sidecar whose `.ecx` is on a sibling
@@ -229,7 +227,13 @@ impl DiskLocation {
                 continue;
             }
 
-            to_load.push((collection, vid));
+            match queued.get(&vid) {
+                Some(&i) => to_load[i].1.push(collection),
+                None => {
+                    queued.insert(vid, to_load.len());
+                    to_load.push((vid, vec![collection]));
+                }
+            }
         }
 
         for (collection, vid, v) in self.open_volumes(to_load, needle_map_kind) {
@@ -257,9 +261,13 @@ impl DiskLocation {
     /// serial index reads to come up. Mirrors Go's concurrentLoadingVolumes,
     /// including its max(cores, 10) worker count -- the work is IO-bound, so
     /// the floor keeps a small-core box from loading one volume at a time.
+    ///
+    /// Each id carries every collection name that claims it, tried in scan
+    /// order until one opens: an id is only spoken for once a volume actually
+    /// loads, so a corrupt `colA_5.dat` still leaves `colB_5.dat` a chance.
     fn open_volumes(
         &self,
-        to_load: Vec<(String, VolumeId)>,
+        to_load: Vec<(VolumeId, Vec<String>)>,
         needle_map_kind: NeedleMapKind,
     ) -> Vec<(String, VolumeId, Volume)> {
         if to_load.is_empty() {
@@ -277,26 +285,29 @@ impl DiskLocation {
             for _ in 0..workers {
                 scope.spawn(|| loop {
                     let i = next.fetch_add(1, Ordering::Relaxed);
-                    let Some((collection, vid)) = to_load.get(i) else {
+                    let Some((vid, collections)) = to_load.get(i) else {
                         return;
                     };
-                    match Volume::new(
-                        &self.directory,
-                        &self.idx_directory,
-                        collection,
-                        *vid,
-                        needle_map_kind,
-                        None, // replica placement read from superblock
-                        None, // TTL read from superblock
-                        0,    // no preallocate on load
-                        Version::current(),
-                    ) {
-                        Ok(mut v) => {
-                            v.location_disk_space_low = self.is_disk_space_low.clone();
-                            opened.lock().unwrap().push((collection.clone(), *vid, v));
-                        }
-                        Err(e) => {
-                            warn!(volume_id = vid.0, error = %e, "failed to load volume");
+                    for collection in collections {
+                        match Volume::new(
+                            &self.directory,
+                            &self.idx_directory,
+                            collection,
+                            *vid,
+                            needle_map_kind,
+                            None, // replica placement read from superblock
+                            None, // TTL read from superblock
+                            0,    // no preallocate on load
+                            Version::current(),
+                        ) {
+                            Ok(mut v) => {
+                                v.location_disk_space_low = self.is_disk_space_low.clone();
+                                opened.lock().unwrap().push((collection.clone(), *vid, v));
+                                break;
+                            }
+                            Err(e) => {
+                                warn!(volume_id = vid.0, error = %e, "failed to load volume");
+                            }
                         }
                     }
                 });
@@ -1539,6 +1550,62 @@ mod tests {
         let ids = loc.volume_ids();
         assert!(ids.contains(&VolumeId(1)));
         assert!(ids.contains(&VolumeId(2)));
+    }
+
+    // Two collections can name the same volume id on one disk. The id is only
+    // spoken for once a volume actually opens, so a candidate that fails to
+    // load must not shadow a good one behind it.
+    #[test]
+    fn test_open_volumes_falls_back_past_a_corrupt_candidate() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().to_str().unwrap();
+
+        {
+            let mut loc = DiskLocation::new(
+                dir,
+                dir,
+                10,
+                DiskType::HardDrive,
+                MinFreeSpace::Percent(1.0),
+                Vec::new(),
+            )
+            .unwrap();
+            loc.create_volume(
+                VolumeId(9),
+                "good",
+                NeedleMapKind::InMemory,
+                None,
+                None,
+                0,
+                Version::current(),
+            )
+            .unwrap();
+            loc.close();
+        }
+
+        // Same id under another collection, with a superblock this build
+        // cannot read -- Volume::new fails on it.
+        let mut bad = vec![0u8; 16];
+        bad[0] = 9; // unsupported version
+        std::fs::write(format!("{}/bad_9.dat", dir), &bad).unwrap();
+
+        let loc = DiskLocation::new(
+            dir,
+            dir,
+            10,
+            DiskType::HardDrive,
+            MinFreeSpace::Percent(1.0),
+            Vec::new(),
+        )
+        .unwrap();
+        let opened = loc.open_volumes(
+            vec![(VolumeId(9), vec!["bad".to_string(), "good".to_string()])],
+            NeedleMapKind::InMemory,
+        );
+
+        assert_eq!(opened.len(), 1, "the good candidate should still open");
+        assert_eq!(opened[0].0, "good");
+        assert_eq!(opened[0].1, VolumeId(9));
     }
 
     #[test]

--- a/seaweed-volume/src/storage/disk_location.rs
+++ b/seaweed-volume/src/storage/disk_location.rs
@@ -7,8 +7,8 @@
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io;
-use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 
 use tracing::warn;
 
@@ -122,6 +122,8 @@ impl DiskLocation {
         // Scan for .dat files
         let entries = fs::read_dir(&self.directory)?;
         let mut dat_files: Vec<(String, VolumeId)> = Vec::new();
+        let mut to_load: Vec<(String, VolumeId)> = Vec::new();
+        let mut queued: HashSet<VolumeId> = HashSet::new();
         let mut seen = HashSet::new();
 
         for entry in entries {
@@ -201,6 +203,12 @@ impl DiskLocation {
                 continue;
             }
 
+            // Skip volumes already queued under a different collection name for
+            // the same id -- the loader below keys results by id.
+            if !queued.insert(vid) {
+                continue;
+            }
+
             // Load existing data only; never create a phantom `.dat`. A lone
             // `.vif`/`.idx` (e.g. an EC sidecar whose `.ecx` is on a sibling
             // disk) would otherwise have Volume::new write an 8-byte stub that
@@ -221,28 +229,14 @@ impl DiskLocation {
                 continue;
             }
 
-            match Volume::new(
-                &self.directory,
-                &self.idx_directory,
-                &collection,
-                vid,
-                needle_map_kind,
-                None, // replica placement read from superblock
-                None, // TTL read from superblock
-                0,    // no preallocate on load
-                Version::current(),
-            ) {
-                Ok(mut v) => {
-                    v.location_disk_space_low = self.is_disk_space_low.clone();
-                    crate::metrics::VOLUME_GAUGE
-                        .with_label_values(&[&collection, "volume"])
-                        .inc();
-                    self.volumes.insert(vid, v);
-                }
-                Err(e) => {
-                    warn!(volume_id = vid.0, error = %e, "failed to load volume");
-                }
-            }
+            to_load.push((collection, vid));
+        }
+
+        for (collection, vid, v) in self.open_volumes(to_load, needle_map_kind) {
+            crate::metrics::VOLUME_GAUGE
+                .with_label_values(&[&collection, "volume"])
+                .inc();
+            self.volumes.insert(vid, v);
         }
 
         // After regular volumes, auto-discover EC shards on disk so a
@@ -255,6 +249,60 @@ impl DiskLocation {
         }
 
         Ok(())
+    }
+
+    /// Open the volumes the directory scan selected, on a pool of worker
+    /// threads. Opening a volume is dominated by reading its .idx into the
+    /// needle map, so a disk holding thousands of them takes thousands of
+    /// serial index reads to come up. Mirrors Go's concurrentLoadingVolumes,
+    /// including its max(cores, 10) worker count -- the work is IO-bound, so
+    /// the floor keeps a small-core box from loading one volume at a time.
+    fn open_volumes(
+        &self,
+        to_load: Vec<(String, VolumeId)>,
+        needle_map_kind: NeedleMapKind,
+    ) -> Vec<(String, VolumeId, Volume)> {
+        if to_load.is_empty() {
+            return Vec::new();
+        }
+        let workers = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1)
+            .max(10)
+            .min(to_load.len());
+
+        let next = AtomicUsize::new(0);
+        let opened = Mutex::new(Vec::with_capacity(to_load.len()));
+        std::thread::scope(|scope| {
+            for _ in 0..workers {
+                scope.spawn(|| loop {
+                    let i = next.fetch_add(1, Ordering::Relaxed);
+                    let Some((collection, vid)) = to_load.get(i) else {
+                        return;
+                    };
+                    match Volume::new(
+                        &self.directory,
+                        &self.idx_directory,
+                        collection,
+                        *vid,
+                        needle_map_kind,
+                        None, // replica placement read from superblock
+                        None, // TTL read from superblock
+                        0,    // no preallocate on load
+                        Version::current(),
+                    ) {
+                        Ok(mut v) => {
+                            v.location_disk_space_low = self.is_disk_space_low.clone();
+                            opened.lock().unwrap().push((collection.clone(), *vid, v));
+                        }
+                        Err(e) => {
+                            warn!(volume_id = vid.0, error = %e, "failed to load volume");
+                        }
+                    }
+                });
+            }
+        });
+        opened.into_inner().unwrap_or_else(|e| e.into_inner())
     }
 
     /// Directory pre-pass that recovers interrupted compaction commits. Collects

--- a/seaweed-volume/src/storage/disk_location.rs
+++ b/seaweed-volume/src/storage/disk_location.rs
@@ -122,9 +122,8 @@ impl DiskLocation {
         // Scan for .dat files
         let entries = fs::read_dir(&self.directory)?;
         let mut dat_files: Vec<(String, VolumeId)> = Vec::new();
-        // One entry per volume id, holding every collection name that claims it
-        // in scan order -- the loader tries them in turn and keeps the first
-        // that opens, so a corrupt candidate does not shadow a good one.
+        // Every collection claiming an id, in scan order; open_volumes keeps
+        // the first that opens.
         let mut to_load: Vec<(VolumeId, Vec<String>)> = Vec::new();
         let mut queued: HashMap<VolumeId, usize> = HashMap::new();
         let mut seen = HashSet::new();
@@ -255,16 +254,14 @@ impl DiskLocation {
         Ok(())
     }
 
-    /// Open the volumes the directory scan selected, on a pool of worker
-    /// threads. Opening a volume is dominated by reading its .idx into the
-    /// needle map, so a disk holding thousands of them takes thousands of
-    /// serial index reads to come up. Mirrors Go's concurrentLoadingVolumes,
-    /// including its max(cores, 10) worker count -- the work is IO-bound, so
-    /// the floor keeps a small-core box from loading one volume at a time.
+    /// Open the volumes the directory scan selected. Opening one is dominated
+    /// by reading its .idx into the needle map, so a disk holding thousands
+    /// takes thousands of serial index reads to come up; mirrors Go's
+    /// concurrentLoadingVolumes down to the max(cores, 10) worker count, whose
+    /// floor keeps a small-core box off one-at-a-time on IO-bound work.
     ///
-    /// Each id carries every collection name that claims it, tried in scan
-    /// order until one opens: an id is only spoken for once a volume actually
-    /// loads, so a corrupt `colA_5.dat` still leaves `colB_5.dat` a chance.
+    /// An id is only spoken for once a volume actually loads, so a corrupt
+    /// `colA_5.dat` still leaves `colB_5.dat` a chance.
     fn open_volumes(
         &self,
         to_load: Vec<(VolumeId, Vec<String>)>,
@@ -1552,9 +1549,8 @@ mod tests {
         assert!(ids.contains(&VolumeId(2)));
     }
 
-    // Two collections can name the same volume id on one disk. The id is only
-    // spoken for once a volume actually opens, so a candidate that fails to
-    // load must not shadow a good one behind it.
+    // Two collections can name the same volume id on one disk; a candidate
+    // that fails to open must not shadow a good one behind it.
     #[test]
     fn test_open_volumes_falls_back_past_a_corrupt_candidate() {
         let tmp = TempDir::new().unwrap();
@@ -1583,8 +1579,7 @@ mod tests {
             loc.close();
         }
 
-        // Same id under another collection, with a superblock this build
-        // cannot read -- Volume::new fails on it.
+        // Same id under another collection, unopenable.
         let mut bad = vec![0u8; 16];
         bad[0] = 9; // unsupported version
         std::fs::write(format!("{}/bad_9.dat", dir), &bad).unwrap();

--- a/seaweed-volume/src/storage/volume.rs
+++ b/seaweed-volume/src/storage/volume.rs
@@ -1974,11 +1974,9 @@ impl Volume {
     /// Extra bytes mean an unindexed trailing record (a torn append);
     /// appending after one would place the next needle at an offset the
     /// 8-byte .idx encoding may not represent, so the volume is quarantined
-    /// read-only instead. Mirrors Go's verifyNeedleIntegrity, including its
-    /// v3-only tail check: v1/v2 volumes predate the append timestamp the
-    /// check rides along with, and Go serves them read-write regardless, so
-    /// checking them here would flip a whole legacy cluster read-only the
-    /// first time it boots on this server.
+    /// read-only instead. Mirrors Go's verifyNeedleIntegrity, whose tail
+    /// check is v3-only -- a v1/v2 volume Go serves read-write must not go
+    /// read-only here.
     fn verify_needle_integrity(
         &mut self,
         actual_offset: i64,
@@ -4120,10 +4118,9 @@ mod tests {
         );
     }
 
-    // Go only compares the .dat tail on v3 volumes -- the comparison rides
-    // along with the v3 append-timestamp read -- so it serves a v1/v2 volume
-    // with an unindexed tail read-write. Checking it here anyway flipped every
-    // such volume read-only, which on a legacy cluster is the whole disk.
+    // Go's tail check is v3-only, so it serves a v1/v2 volume with an
+    // unindexed tail read-write. Checking it here flipped whole legacy disks
+    // read-only on their first boot under this server.
     #[test]
     fn test_integrity_skips_dat_tail_check_before_v3() {
         let tmp = TempDir::new().unwrap();

--- a/seaweed-volume/src/storage/volume.rs
+++ b/seaweed-volume/src/storage/volume.rs
@@ -1970,11 +1970,15 @@ impl Volume {
     }
 
     /// Verify the live needle at the .dat tail: its header must match the
-    /// .idx entry and the .dat must end exactly at its on-disk end. Extra
-    /// bytes mean an unindexed trailing record (a torn append); appending
-    /// after one would place the next needle at an offset the 8-byte .idx
-    /// encoding may not represent, so the volume is quarantined read-only
-    /// instead. Mirrors Go's verifyNeedleIntegrity.
+    /// .idx entry and, on v3, the .dat must end exactly at its on-disk end.
+    /// Extra bytes mean an unindexed trailing record (a torn append);
+    /// appending after one would place the next needle at an offset the
+    /// 8-byte .idx encoding may not represent, so the volume is quarantined
+    /// read-only instead. Mirrors Go's verifyNeedleIntegrity, including its
+    /// v3-only tail check: v1/v2 volumes predate the append timestamp the
+    /// check rides along with, and Go serves them read-write regardless, so
+    /// checking them here would flip a whole legacy cluster read-only the
+    /// first time it boots on this server.
     fn verify_needle_integrity(
         &mut self,
         actual_offset: i64,
@@ -2013,15 +2017,16 @@ impl Volume {
             )));
         }
 
-        if version == VERSION_3 {
-            let ts_offset =
-                checked_offset as u64 + NEEDLE_HEADER_SIZE as u64 + size.0 as u64 + 4; // skip checksum
-            let mut ts_buf = [0u8; 8];
-            self.read_exact_at_backend(&mut ts_buf, ts_offset)?;
-            let ts = u64::from_be_bytes(ts_buf);
-            if ts > 0 {
-                self.last_append_at_ns = ts;
-            }
+        if version != VERSION_3 {
+            return Ok(());
+        }
+
+        let ts_offset = checked_offset as u64 + NEEDLE_HEADER_SIZE as u64 + size.0 as u64 + 4; // skip checksum
+        let mut ts_buf = [0u8; 8];
+        self.read_exact_at_backend(&mut ts_buf, ts_offset)?;
+        let ts = u64::from_be_bytes(ts_buf);
+        if ts > 0 {
+            self.last_append_at_ns = ts;
         }
 
         self.verify_dat_ends_at(checked_offset + get_actual_size(size, version))
@@ -4112,6 +4117,55 @@ mod tests {
         assert!(
             v.is_no_write_or_delete(),
             "volume with unindexed .dat tail must load read-only"
+        );
+    }
+
+    // Go only compares the .dat tail on v3 volumes -- the comparison rides
+    // along with the v3 append-timestamp read -- so it serves a v1/v2 volume
+    // with an unindexed tail read-write. Checking it here anyway flipped every
+    // such volume read-only, which on a legacy cluster is the whole disk.
+    #[test]
+    fn test_integrity_skips_dat_tail_check_before_v3() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().to_str().unwrap();
+        {
+            let mut v = Volume::new(
+                dir,
+                dir,
+                "",
+                VolumeId(1),
+                NeedleMapKind::InMemory,
+                None,
+                None,
+                0,
+                VERSION_2,
+            )
+            .unwrap();
+            for i in 1..=3u64 {
+                let data = format!("data {}", i);
+                let mut n = Needle {
+                    id: NeedleId(i),
+                    cookie: Cookie(i as u32),
+                    data: data.as_bytes().to_vec(),
+                    data_size: data.len() as u32,
+                    ..Needle::default()
+                };
+                v.write_needle(&mut n, true).unwrap();
+            }
+            v.sync_to_disk().unwrap();
+        }
+
+        let dat_path = volume_file_name(dir, "", VolumeId(1)) + ".dat";
+        let mut f = OpenOptions::new().append(true).open(&dat_path).unwrap();
+        f.write_all(&[0xFFu8; 96]).unwrap();
+        f.sync_all().unwrap();
+        drop(f);
+
+        let v = reload_volume(dir);
+        assert_eq!(v.version(), VERSION_2, "volume should reload as v2");
+        assert!(
+            !v.is_no_write_or_delete(),
+            "v2 volume with unindexed .dat tail must stay writable, as in Go"
         );
     }
 


### PR DESCRIPTION
Fixes #10600, where booting the Rust volume server on volumes a Go server wrote
flooded the log with `data file N.dat actual X bytes expected Y bytes` and took a
long time to come up. Two independent causes.

### v2 volumes were quarantined where Go serves them

Go's `verifyNeedleIntegrity` does the ".dat ends exactly at the last indexed
needle" comparison *inside* its `if v == needle.Version3` branch -- it rides
along with the v3 append-timestamp read. So a v1/v2 volume carrying an unindexed
trailing record loads read-write and silent under Go. The Rust check ran at every
version, so a legacy cluster warned on and flipped read-only volumes the Go
server had been serving happily. Gated on v3 to match.

`verifyDeletedNeedleIntegrity` (trailing tombstone) checks the tail
unconditionally in both, and stays that way.

Building the same torn tail at both versions -- write a volume, then truncate the
.idx by one `NeedleMapEntrySize` -- and running both servers over it:

| | Go | Rust before | Rust after |
| --- | --- | --- | --- |
| v2, unindexed tail | silent, writable | `actual 3296 expected 2960` + read-only | silent, writable |
| v3, unindexed tail | warns + read-only | warns + read-only | warns + read-only |

The reporter's numbers fit: their 6,291,816-byte gap is exactly 262,159 x 24, and
24 bytes is the v2 tombstone record size (v3's is 32).

### volumes were opened one at a time

Opening a volume is dominated by reading its .idx into the needle map, and the
loader did them serially, so a disk holding thousands of volumes needed thousands
of serial index reads before the server came up. Go's `concurrentLoadingVolumes`
spreads the same work over max(NumCPU, 10) workers; this does the same, keeping
the directory pre-pass and the map insert serial so only the open is parallel.

Cross-disk parallelism (Go does that too, in `NewStore`) is still serial here and
only matters for a process configured with several `-dir`s.

### testing

- 120 volumes with 150k-needle indexes: load 0.44-0.60s -> 0.10-0.11s, same 120
  volumes with the same ids registered either way.
- 60 files written through a Go volume server all read back through the fixed
  Rust server, zero warnings.
- New regression test `test_integrity_skips_dat_tail_check_before_v3`; full lib
  suite passes with and without `--no-default-features` (392 tests each).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved volume startup by loading eligible volumes concurrently.
  * Avoided duplicate volume loading when volumes are found under multiple collection names.

* **Bug Fixes**
  * Improved recovery when a volume candidate is corrupt by trying valid alternatives.
  * Preserved disk-space state while loading volumes and improved failure handling.
  * Fixed compatibility checks so version 1 and 2 volumes with unindexed trailing data remain writable.
  * Added regression coverage for fallback loading and writable version 2 volumes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->