### PR TITLE
perf(weed/topology): preallocate the heartbeat volume conversion slice

### DIFF
--- a/weed/topology/topology.go
+++ b/weed/topology/topology.go
@@ -587,7 +587,7 @@ func (t *Topology) ListDCAndRacks() (dcs map[NodeId][]NodeId) {
 
 func (t *Topology) SyncDataNodeRegistration(volumes []*master_pb.VolumeInformationMessage, dn *DataNode) (newVolumes, deletedVolumes []storage.VolumeInfo) {
 	// convert into in memory struct storage.VolumeInfo
-	var volumeInfos []storage.VolumeInfo
+	volumeInfos := make([]storage.VolumeInfo, 0, len(volumes))
 	for _, v := range volumes {
 		if vi, err := storage.NewVolumeInfo(v); err == nil {
 			volumeInfos = append(volumeInfos, vi)

--- a/weed/topology/topology_heartbeat_bench_test.go
+++ b/weed/topology/topology_heartbeat_bench_test.go
@@ -1,0 +1,52 @@
+package topology
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
+)
+
+func benchHeartbeatMessages(count int) []*master_pb.VolumeInformationMessage {
+	messages := make([]*master_pb.VolumeInformationMessage, 0, count)
+	for i := 0; i < count; i++ {
+		messages = append(messages, &master_pb.VolumeInformationMessage{
+			Id:               uint32(i),
+			Size:             1024 * 1024,
+			Collection:       "benchcollection",
+			FileCount:        100,
+			DeleteCount:      1,
+			DeletedByteCount: 1024,
+			ReplicaPlacement: 0,
+			Version:          3,
+			CompactRevision:  1,
+			ModifiedAtSecond: 1700000000,
+		})
+	}
+	return messages
+}
+
+// A volume server re-sends its whole volume list on every heartbeat, so this is
+// the master's steady-state cost per volume server every VolumePulsePeriod.
+func benchSyncDataNodeRegistration(b *testing.B, count int) {
+	topo := NewTopology("bench", nil, 32*1024*1024*1024, 5, false)
+	dn := topo.GetOrCreateDataCenter("dc1").GetOrCreateRack("rack1").
+		GetOrCreateDataNode("127.0.0.1", 8080, 18080, "", "", map[string]uint32{"": uint32(count) * 2})
+	topo.SyncDataNodeRegistration(benchHeartbeatMessages(count), dn)
+
+	messages := benchHeartbeatMessages(count)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		topo.SyncDataNodeRegistration(messages, dn)
+	}
+}
+
+func BenchmarkSyncDataNodeRegistration(b *testing.B) {
+	for _, count := range []int{1000, 100000} {
+		b.Run(fmt.Sprintf("%dVolumes", count), func(b *testing.B) {
+			benchSyncDataNodeRegistration(b, count)
+		})
+	}
+}


### PR DESCRIPTION
First of a series cutting the master's per-heartbeat allocation churn at large volume counts.

A volume server re-sends its whole volume list on every heartbeat (`VolumePulsePeriod`, 5s), so `SyncDataNodeRegistration` runs once per volume server every 5 seconds with every volume in the message. It converts the protobuf messages into `[]storage.VolumeInfo` through an append on a nil slice, so the doubling reallocations copy the whole (152-byte-element) slice about twice over. The final length is `len(volumes)`.

Also adds `BenchmarkSyncDataNodeRegistration` so this path has allocation coverage; the rest of the series uses it too.

```
BenchmarkSyncDataNodeRegistration/100000Volumes
before   199670102 B/op   500601 allocs/op
after    137725872 B/op   500565 allocs/op
```

Context: on a cluster with 800k volume ids across 3 volume servers (~550k volumes each), the master allocates ~1.26 GB per full heartbeat against a ~514 MB live topology — roughly 760 MB/s of churn, which is what drives it into an OOM kill under an 8 GB limit rather than the footprint itself.

Refs #10603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved synchronization efficiency when processing data nodes with many reported volumes.

* **Tests**
  * Added benchmarks covering synchronization scenarios with 1,000 and 100,000 volumes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->