### PR TITLE
perf(weed/topology): diff a heartbeat without copying the volume map

### DIFF
--- a/weed/topology/data_node.go
+++ b/weed/topology/data_node.go
@@ -78,9 +78,9 @@ func (dn *DataNode) doAddOrUpdateVolume(v storage.VolumeInfo) (isNew, isChanged 
 // used in master to notify master clients of these changes.
 func (dn *DataNode) UpdateVolumes(actualVolumes []storage.VolumeInfo) (newVolumes, deletedVolumes, changedVolumes []storage.VolumeInfo) {
 
-	actualVolumeMap := make(map[needle.VolumeId]storage.VolumeInfo)
+	actualVolumeIds := make(map[needle.VolumeId]struct{}, len(actualVolumes))
 	for _, v := range actualVolumes {
-		actualVolumeMap[v.Id] = v
+		actualVolumeIds[v.Id] = struct{}{}
 	}
 
 	dn.Lock()
@@ -90,7 +90,7 @@ func (dn *DataNode) UpdateVolumes(actualVolumes []storage.VolumeInfo) (newVolume
 
 	for _, v := range existingVolumes {
 		vid := v.Id
-		if _, ok := actualVolumeMap[vid]; !ok {
+		if _, ok := actualVolumeIds[vid]; !ok {
 			glog.V(0).Infoln("Deleting volume id:", vid)
 			disk := dn.getOrCreateDisk(v.DiskType)
 			disk.DeleteVolumeById(vid)

--- a/weed/topology/data_node.go
+++ b/weed/topology/data_node.go
@@ -86,14 +86,10 @@ func (dn *DataNode) UpdateVolumes(actualVolumes []storage.VolumeInfo) (newVolume
 	dn.Lock()
 	defer dn.Unlock()
 
-	existingVolumes := dn.getVolumes()
-
-	for _, v := range existingVolumes {
-		vid := v.Id
-		if _, ok := actualVolumeIds[vid]; !ok {
-			glog.V(0).Infoln("Deleting volume id:", vid)
-			disk := dn.getOrCreateDisk(v.DiskType)
-			disk.DeleteVolumeById(vid)
+	for _, c := range dn.children {
+		disk := c.(*Disk)
+		for _, v := range disk.RemoveVolumesNotIn(actualVolumeIds) {
+			glog.V(0).Infoln("Deleting volume id:", v.Id)
 			deletedVolumes = append(deletedVolumes, v)
 
 			deltaDiskUsage := &DiskUsageCounts{}

--- a/weed/topology/disk.go
+++ b/weed/topology/disk.go
@@ -211,6 +211,21 @@ func (d *Disk) GetVolumes() (ret []storage.VolumeInfo) {
 	return ret
 }
 
+// RemoveVolumesNotIn drops the volumes whose ids are absent from keep and
+// returns them, so a heartbeat can be diffed without first copying the whole
+// volume map out.
+func (d *Disk) RemoveVolumesNotIn(keep map[needle.VolumeId]struct{}) (removed []storage.VolumeInfo) {
+	d.Lock()
+	defer d.Unlock()
+	for vid, v := range d.volumes {
+		if _, ok := keep[vid]; !ok {
+			removed = append(removed, v)
+			delete(d.volumes, vid)
+		}
+	}
+	return removed
+}
+
 func (d *Disk) GetVolumesById(id needle.VolumeId) (storage.VolumeInfo, error) {
 	d.RLock()
 	defer d.RUnlock()


### PR DESCRIPTION
Part of the series cutting the master's per-heartbeat allocation churn at large volume counts.

`DataNode.UpdateVolumes` runs once per volume server every `VolumePulsePeriod` (5s) with the server's entire volume list, and builds two full copies of that list before doing any work:

- `actualVolumeMap` copied the whole 152-byte `VolumeInfo` for every volume in the heartbeat, but is only ever used for `if _, ok := ...; !ok` — a membership test. It is now a `map[needle.VolumeId]struct{}`, presized.
- `existingVolumes := dn.getVolumes()` copied every `VolumeInfo` already on the node into a fresh slice purely to find the ones the heartbeat no longer mentions — usually none. `Disk.RemoveVolumesNotIn` now scans the disk map in place under one write lock and returns only what it removed.

Lock ordering is unchanged (DataNode then Disk), and deletion now happens on the disk that actually holds the volume rather than on a `getOrCreateDisk(v.DiskType)` re-lookup.

```
BenchmarkSyncDataNodeRegistration/100000Volumes
master   199670102 B/op   500601 allocs/op
after    87806436 B/op    400294 allocs/op
```

(`BenchmarkSyncDataNodeRegistration` comes from #10607; measured here with that benchmark applied on top.)

Context: on a cluster with 800k volume ids across 3 volume servers (~550k volumes each), the master allocates ~1.26 GB per full heartbeat against a ~514 MB live topology — roughly 760 MB/s of churn, which is what drives it into an OOM kill under an 8 GB limit rather than the footprint itself.

Refs #10603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved volume synchronization so missing volumes are removed directly from their associated disks.
  * Preserved accurate deleted-volume reporting and disk usage updates during synchronization.
  * Reduced the risk of inconsistent disk state when volumes are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->