### PR TITLE
perf(weed/topology): preallocate the disk volume snapshot

### DIFF
--- a/weed/topology/disk.go
+++ b/weed/topology/disk.go
@@ -204,6 +204,7 @@ func (d *Disk) doAddOrUpdateVolume(v storage.VolumeInfo) (isNew, isChanged bool)
 
 func (d *Disk) GetVolumes() (ret []storage.VolumeInfo) {
 	d.RLock()
+	ret = make([]storage.VolumeInfo, 0, len(d.volumes))
 	for _, v := range d.volumes {
 		ret = append(ret, v)
 	}


### PR DESCRIPTION
Part of the series cutting the master's allocation churn at large volume counts.

`Disk.GetVolumes` copies the disk's whole volume map into a fresh slice, growing it from nil. Since `storage.VolumeInfo` is 152 bytes, the doubling reallocations copy roughly twice the final size on every call — about 60MB of garbage per call at 100k volumes on a disk.

It is on every path that walks a node's volumes:

- `NodeImpl.CollectDeadNodeAndFullVolumes`, which runs every `pulse`..`2*pulse` seconds over every volume in the cluster
- `Disk.ToDiskInfo`, so once per disk per `VolumeList`
- `Topology.ToVolumeMap` and `ToVolumeLocations`
- the telemetry collector
- `Topology.UnRegisterDataNode` and the heartbeat diff in `DataNode.UpdateVolumes`

`len(d.volumes)` is known under the lock we already hold.

```
BenchmarkSyncDataNodeRegistration/100000Volumes
master   199670102 B/op   500601 allocs/op
after    137728051 B/op   500571 allocs/op
```

(`BenchmarkSyncDataNodeRegistration` comes from #10607; measured here with that benchmark applied on top.)

I looked at replacing the copy with a `ForEachVolume` callback for the callers that only iterate, which would drop the allocation entirely. It is not safe as-is: `VolumeLayout.RegisterVolume` holds `vl.accessLock` and calls `dn.GetVolumesById`, establishing a VolumeLayout-then-Disk lock order, while several of these callers take `vl.accessLock` inside the loop. Holding the disk read lock across the callback would invert that. Left alone.

Refs #10603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved internal efficiency when collecting disk volume information, with no changes to user-visible behavior or APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->