### PR TITLE
perf(weed/storage/super_block): intern the byte-encoded replica placements

### DIFF
--- a/weed/storage/super_block/replica_placement.go
+++ b/weed/storage/super_block/replica_placement.go
@@ -43,8 +43,26 @@ func NewReplicaPlacementFromString(t string) (*ReplicaPlacement, error) {
 	return rp, nil
 }
 
+// replicaPlacementsByByte is one 6KB pointer-free array covering every encoding
+// a byte can hold. The master decodes one per volume in every volume server
+// heartbeat and keeps it for the volume's lifetime, so handing out a shared
+// element keeps that path off fmt and off the heap entirely.
+//
+// Elements are immutable. Callers must not write through the returned pointer.
+var replicaPlacementsByByte [256]ReplicaPlacement
+
+func init() {
+	for b := range replicaPlacementsByByte {
+		replicaPlacementsByByte[b] = ReplicaPlacement{
+			DiffDataCenterCount: b / 100,
+			DiffRackCount:       b / 10 % 10,
+			SameRackCount:       b % 10,
+		}
+	}
+}
+
 func NewReplicaPlacementFromByte(b byte) (*ReplicaPlacement, error) {
-	return NewReplicaPlacementFromString(fmt.Sprintf("%03d", b))
+	return &replicaPlacementsByByte[b], nil
 }
 
 func (rp *ReplicaPlacement) HasReplication() bool {

--- a/weed/storage/super_block/replica_placement_test.go
+++ b/weed/storage/super_block/replica_placement_test.go
@@ -1,8 +1,28 @@
 package super_block
 
 import (
+	"fmt"
 	"testing"
 )
+
+func TestReplicaPlacementFromByteMatchesString(t *testing.T) {
+	for b := 0; b < 256; b++ {
+		want, err := NewReplicaPlacementFromString(fmt.Sprintf("%03d", b))
+		if err != nil {
+			t.Fatalf("byte %d: %v", b, err)
+		}
+		got, err := NewReplicaPlacementFromByte(byte(b))
+		if err != nil {
+			t.Fatalf("byte %d: %v", b, err)
+		}
+		if !got.Equals(want) {
+			t.Errorf("byte %d: got %+v, want %+v", b, got, want)
+		}
+		if got.Byte() != byte(b) {
+			t.Errorf("byte %d: round trip gave %d", b, got.Byte())
+		}
+	}
+}
 
 func TestReplicaPlacementSerialDeserial(t *testing.T) {
 	rp, _ := NewReplicaPlacementFromString("001")


### PR DESCRIPTION
Part of the series cutting the master's allocation churn at large volume counts.

`NewReplicaPlacementFromByte` did `NewReplicaPlacementFromString(fmt.Sprintf("%03d", b))` — it formatted the byte into a string only to parse the digits back out. The master calls it once per volume in every volume server heartbeat (`storage.NewVolumeInfo`), so at 550k volumes per server that is 550k `Sprintf` calls every 5 seconds.

It also keeps the resulting pointer for the lifetime of the volume, so a cluster with 1.6M volume replicas holds 1.6M separate `ReplicaPlacement` objects where only 256 distinct values are possible. Interning collapses those into 256, which is 1.6M fewer objects for the GC to mark on every cycle.

A `byte` always decodes to a valid placement (`dc*100 + rack*10 + same` for a byte is the byte itself, so the >255 check can never fire), so the table is total and the error return stays nil for compatibility with the existing call sites. `TestReplicaPlacementFromByteMatchesString` asserts the table matches the old string-derived result for all 256 inputs.

Entries are shared, so they must be treated as immutable — noted in the comment. I checked every caller: the only writes to these fields are inside `NewReplicaPlacementFromString` on a freshly allocated struct.

```
BenchmarkSyncDataNodeRegistration/100000Volumes
master   199670102 B/op   500601 allocs/op
after    196946129 B/op   300589 allocs/op
```

(`BenchmarkSyncDataNodeRegistration` comes from #10607; measured here with that benchmark applied on top. Two allocations per volume disappear — the format string and the struct.)

Refs #10603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved replica placement processing for faster conversion from encoded placement values.

* **Bug Fixes**
  * Ensured byte-based replica placement conversion consistently matches string-based conversion.
  * Added validation for all supported placement values and round-trip conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->