### PR TITLE
perf(weed/storage/needle): intern the stored ttl values

### DIFF
--- a/weed/storage/needle/volume_ttl.go
+++ b/weed/storage/needle/volume_ttl.go
@@ -88,20 +88,39 @@ func fitTtlCount(count int, unit byte) *TTL {
 	return EMPTY_TTL
 }
 
-// read stored bytes to a ttl
-func LoadTTLFromBytes(input []byte) (t *TTL) {
-	if input[0] == 0 && input[1] == 0 {
+// storedTTLs interns every count paired with a defined unit. The master decodes
+// one per volume in every heartbeat and keeps it for the volume's lifetime, so
+// sharing spares a cluster with millions of volume replicas a distinct two-byte
+// object for each.
+//
+// Entries are immutable. Callers must not write through the returned pointer.
+var storedTTLs = func() (table [256][Year + 1]TTL) {
+	for count := range table {
+		for unit := range table[count] {
+			table[count][unit] = TTL{Count: byte(count), Unit: byte(unit)}
+		}
+	}
+	return table
+}()
+
+func loadTTL(count, unit byte) *TTL {
+	if count == 0 && unit == 0 {
 		return EMPTY_TTL
 	}
-	return &TTL{Count: input[0], Unit: input[1]}
+	if unit <= Year {
+		return &storedTTLs[count][unit]
+	}
+	return &TTL{Count: count, Unit: unit}
+}
+
+// read stored bytes to a ttl
+func LoadTTLFromBytes(input []byte) (t *TTL) {
+	return loadTTL(input[0], input[1])
 }
 
 // read stored bytes to a ttl
 func LoadTTLFromUint32(ttl uint32) (t *TTL) {
-	input := make([]byte, 2)
-	input[1] = byte(ttl)
-	input[0] = byte(ttl >> 8)
-	return LoadTTLFromBytes(input)
+	return loadTTL(byte(ttl>>8), byte(ttl))
 }
 
 // save stored bytes to an output with 2 bytes

--- a/weed/storage/needle/volume_ttl_test.go
+++ b/weed/storage/needle/volume_ttl_test.go
@@ -73,3 +73,26 @@ func TestTTLReadWrite(t *testing.T) {
 	}
 
 }
+
+func TestLoadTTLIsInterned(t *testing.T) {
+	for count := 0; count < 256; count++ {
+		for unit := 0; unit < 256; unit++ {
+			got := LoadTTLFromBytes([]byte{byte(count), byte(unit)})
+			if got.Count != byte(count) || got.Unit != byte(unit) {
+				if count == 0 && unit == 0 {
+					continue
+				}
+				t.Fatalf("count %d unit %d: got %+v", count, unit, got)
+			}
+			if fromUint32 := LoadTTLFromUint32(got.ToUint32()); count != 0 && *fromUint32 != *got {
+				t.Fatalf("count %d unit %d: uint32 round trip gave %+v", count, unit, fromUint32)
+			}
+		}
+	}
+	if LoadTTLFromBytes([]byte{3, Day}) != LoadTTLFromBytes([]byte{3, Day}) {
+		t.Error("expected repeated loads of the same stored ttl to share one value")
+	}
+	if LoadTTLFromBytes([]byte{0, 0}) != EMPTY_TTL {
+		t.Error("expected a zero ttl to stay EMPTY_TTL")
+	}
+}


### PR DESCRIPTION
Part of the series cutting the master's allocation churn at large volume counts. Same shape as #10610, for TTL.

`LoadTTLFromUint32` staged the two stored bytes through a fresh `[]byte` and then allocated a `TTL` for them. The master calls it once per volume in every volume server heartbeat and holds the pointer for the volume's lifetime, so a cluster that uses TTLs carries one distinct two-byte object per volume replica — 1.6M of them at the scale in #10603 — where only 256 counts times 7 defined units are possible.

`storedTTLs` interns that space; a unit outside the defined range still allocates, so no encoding is lost. `LoadTTLFromUint32` now decodes the two bytes directly rather than round-tripping through a slice.

Most of those 1792 combinations are never used by a real cluster, so the table holds values rather than pointers: an unused entry costs two bytes of static data and nothing at init. That is 3584 bytes for the whole table, against 14336 bytes of pointers plus 1791 init allocations had each entry been its own object.

Clusters that set no TTL see no change: that path already returned the shared `EMPTY_TTL`.

```
BenchmarkSyncDataNodeRegistration/100000Volumes, volumes carrying a ttl
master   199990684 B/op   600600 allocs/op
after    199669148 B/op   500597 allocs/op
```

(`BenchmarkSyncDataNodeRegistration` comes from #10607, with `Ttl` set on the messages; measured here with that benchmark applied on top. Exactly one allocation per volume disappears.)

Entries are shared, so they must be treated as immutable — noted in the comment. No caller writes to `TTL.Count` or `TTL.Unit`; the only mutation site is `ToBytes`, which writes into the caller's buffer.

Refs #10603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TTL value decoding for consistent handling of defined, zero, and unknown units.
  * Preserved zero-value TTL behavior while improving repeated TTL loading consistency.
  * Ensured TTL values remain accurate when converted between supported representations.

* **Tests**
  * Added coverage for TTL decoding, round-trip conversion, repeated value reuse, and zero-value handling.
  * Expanded validation across defined time units and uncommon TTL values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
