### PR TITLE
perf(weed/topology): log writable-state changes, not every check

### DIFF
--- a/weed/topology/volume_layout.go
+++ b/weed/topology/volume_layout.go
@@ -355,7 +355,7 @@ func (vl *VolumeLayout) ensureCorrectWritables(vid needle.VolumeId) {
 		glog.V(0).Infof("volume %d does not have enough copies", vid)
 	}
 	if !isAllWritable {
-		glog.V(0).Infof("volume %d are not all writable", vid)
+		glog.V(0).Infof("volume %d is not fully writable", vid)
 	}
 	if isOversizedVolume {
 		glog.V(0).Infof("volume %d is oversized", vid)

--- a/weed/topology/volume_layout.go
+++ b/weed/topology/volume_layout.go
@@ -343,18 +343,22 @@ func (vl *VolumeLayout) ensureCorrectWritables(vid needle.VolumeId) {
 	isOversizedVolume := vl.oversizedVolumes.IsTrue(vid)
 	if isEnoughCopies && isAllWritable && !isOversizedVolume {
 		vl.setVolumeWritable(vid)
-	} else {
-		if !isEnoughCopies {
-			glog.V(0).Infof("volume %d does not have enough copies", vid)
-		}
-		if !isAllWritable {
-			glog.V(0).Infof("volume %d are not all writable", vid)
-		}
-		if isOversizedVolume {
-			glog.V(1).Infof("volume %d are oversized", vid)
-		}
-		glog.V(0).Infof("volume %d remove from writable", vid)
-		vl.removeFromWritable(vid)
+		return
+	}
+	// removeFromWritable reports the transition itself, and only when there is
+	// one. Explain it only then: every heartbeat re-runs this for every volume,
+	// so a volume that is simply staying read-only must not log.
+	if !vl.removeFromWritable(vid) {
+		return
+	}
+	if !isEnoughCopies {
+		glog.V(0).Infof("volume %d does not have enough copies", vid)
+	}
+	if !isAllWritable {
+		glog.V(0).Infof("volume %d are not all writable", vid)
+	}
+	if isOversizedVolume {
+		glog.V(0).Infof("volume %d is oversized", vid)
 	}
 }
 


### PR DESCRIPTION
Part of the series cutting the master's allocation churn at large volume counts.

`ensureCorrectWritables` emitted its three diagnostics every time it was called, regardless of whether the volume's writable state actually changed. `removeFromWritable`, right below them, already logs `Volume N becomes unwritable` and already does so only on the transition — so the lines above it were level-triggered duplicates of an edge-triggered event.

That is cheap when most volumes are writable. It is not when they are not: a volume server reconnecting with 550k read-only volumes makes the master format over a million log lines before it can serve anything, at exactly the moment it is already at its memory peak rebuilding the topology. In a master that is OOM-crash-looping, this is part of what it restarts into.

Now the diagnostics run only when `removeFromWritable` reports it actually removed the volume, so the reason for a transition is still logged, once, when it happens. Also dropped the separate `volume N remove from writable` line, which carried nothing `Volume N becomes unwritable` does not, and raised the oversized line to V(0) to match its two siblings now that it can no longer repeat.

```
BenchmarkRegisterReadOnlyVolumes, 100k read-only volumes registered
master   285791480 B/op   1902069 allocs/op   395104569 ns/op
after    234592088 B/op   1302572 allocs/op   153772569 ns/op
```

(Six allocations per volume go away — two log lines at three each. Measured with glog's output discarded, so the write syscalls are on top of this.)

Refs #10603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved volume writability handling to stop processing after a volume is successfully made writable.
  * Reduced repetitive heartbeat logging when volumes are already excluded from the writable list.
  * Updated messaging for oversized volumes, including its severity and wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->