### PR TITLE
perf(weed/topology): size the new-volume list from the actual delta

### DIFF
--- a/weed/topology/data_node.go
+++ b/weed/topology/data_node.go
@@ -86,6 +86,7 @@ func (dn *DataNode) UpdateVolumes(actualVolumes []storage.VolumeInfo) (newVolume
 	dn.Lock()
 	defer dn.Unlock()
 
+	keptCount := 0
 	for _, c := range dn.children {
 		disk := c.(*Disk)
 		for _, v := range disk.RemoveVolumesNotIn(actualVolumeIds) {
@@ -102,6 +103,13 @@ func (dn *DataNode) UpdateVolumes(actualVolumes []storage.VolumeInfo) (newVolume
 			}
 			disk.UpAdjustDiskUsageDelta(types.ToDiskType(v.DiskType), deltaDiskUsage)
 		}
+		keptCount += disk.VolumeCount()
+	}
+	// Everything still on the node is also in this heartbeat, so the remainder
+	// is what the node is about to gain. A steady-state heartbeat gains nothing
+	// and must not allocate here; a reconnecting server gains all of them.
+	if addedCount := len(actualVolumes) - keptCount; addedCount > 0 {
+		newVolumes = make([]storage.VolumeInfo, 0, addedCount)
 	}
 	for _, v := range actualVolumes {
 		isNew, isChanged := dn.doAddOrUpdateVolume(v)

--- a/weed/topology/disk.go
+++ b/weed/topology/disk.go
@@ -212,6 +212,12 @@ func (d *Disk) GetVolumes() (ret []storage.VolumeInfo) {
 	return ret
 }
 
+func (d *Disk) VolumeCount() int {
+	d.RLock()
+	defer d.RUnlock()
+	return len(d.volumes)
+}
+
 // RemoveVolumesNotIn drops the volumes whose ids are absent from keep and
 // returns them, so a heartbeat can be diffed without first copying the whole
 // volume map out.


### PR DESCRIPTION
Follow-up to the #10607..#10612 series, on the path a master takes when it restarts or a volume server reconnects.

`UpdateVolumes` returns the volumes it saw appear, and grows that list from nil. In steady state nothing is new, so it never allocates. On a reconnect *everything* is new, so it reallocates and copies its way up to one 152-byte entry per volume — about 167MB of copying for a 550k-volume server, at the moment the master is already at its memory peak rebuilding the topology.

Sizing it to `len(actualVolumes)` would fix the reconnect and wreck the steady state, allocating the whole list on every heartbeat to hold nothing.

The exact delta is available for free: the deletion pass just above has already dropped everything the heartbeat no longer mentions, so every volume still on the node is also in this heartbeat. `len(actualVolumes) - keptCount` is therefore precisely what the node is about to gain — all of them on a reconnect, zero in steady state, and the true count for the ordinary case of a few new volumes. It stays a hint: a volume moving between disk types reports as new without changing the total, and `append` handles that.

`deletedVolumes` and `changedVolumes` stay nil-initialized; both are sparse in every case, including reconnect.

```
first registration of 550k read-only volumes
before   1041.7 MB
after     667.4 MB
```

Steady-state heartbeat, resident topology, and `ToTopologyInfo` are all unchanged, verified against the same harness.

Refs #10603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved volume update handling to reduce unnecessary memory allocation during routine heartbeats.
  - Optimized reconnect processing by reserving capacity for incoming volumes.
- **Reliability**
  - Added thread-safe volume counting to improve tracking of volumes associated with disks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->