### PR TITLE
perf(weed/topology): preallocate the per-disk VolumeList payload

### DIFF
--- a/weed/topology/disk.go
+++ b/weed/topology/disk.go
@@ -305,9 +305,11 @@ func (d *Disk) ToDiskInfo() *master_pb.DiskInfo {
 		DiskTotalBytes:    uint64(max(0, diskUsage.diskTotalBytes)),
 		DiskFreeBytes:     uint64(max(0, diskUsage.diskFreeBytes)),
 	}
+	m.VolumeInfos = make([]*master_pb.VolumeInformationMessage, 0, len(volumes))
 	for _, v := range volumes {
 		m.VolumeInfos = append(m.VolumeInfos, v.ToVolumeInformationMessage())
 	}
+	m.EcShardInfos = make([]*master_pb.VolumeEcShardInformationMessage, 0, len(ecShards))
 	for _, ecv := range ecShards {
 		m.EcShardInfos = append(m.EcShardInfos, ecv.ToVolumeEcShardInformationMessage())
 	}


### PR DESCRIPTION
Follow-up to the #10607..#10612 series, on the `VolumeList` path.

`Disk.ToDiskInfo` builds one protobuf message per volume and per EC shard on the disk and appends each to a nil slice, so both lists realloc-and-copy their way up. `len(volumes)` and `len(ecShards)` are already in hand two lines above.

This runs for every disk in the cluster on every `VolumeList`, and `VolumeList` has a lot of callers: the admin dashboard, the plugin worker's volume metrics, `weed shell` ec/balance/collection commands, and the s3 gateway's bucket-size metrics loop, which pulls the whole list once a minute.

```
ToTopologyInfo() over 550k volumes, one VolumeList call
before   202.2 MB allocated, 550063 objects
after    184.6 MB allocated, 550029 objects
```

The remaining 184.6 MB is the protobuf messages themselves, which is inherent to shipping the full topology in one response — bounding that needs pagination or streaming on `VolumeListRequest`, not a prealloc.

Refs #10603