### PR TITLE
perf(weed/topology): preallocate the client-facing topology snapshots

### DIFF
--- a/weed/topology/topology_info.go
+++ b/weed/topology/topology_info.go
@@ -72,8 +72,9 @@ func (t *Topology) ToVolumeMap() interface{} {
 			dataNodes := make(map[NodeId]interface{})
 			for _, d := range rack.Children() {
 				dn := d.(*DataNode)
-				var volumes []interface{}
-				for _, v := range dn.GetVolumes() {
+				dnVolumes := dn.GetVolumes()
+				volumes := make([]interface{}, 0, len(dnVolumes))
+				for _, v := range dnVolumes {
 					volumes = append(volumes, v)
 				}
 				dataNodes[d.Id()] = volumes

--- a/weed/topology/topology_info.go
+++ b/weed/topology/topology_info.go
@@ -100,7 +100,9 @@ func (t *Topology) ToVolumeLocations() (volumeLocations []*master_pb.VolumeLocat
 					DataCenter: dn.GetDataCenterId(),
 					GrpcPort:   uint32(dn.GrpcPort),
 				}
-				for _, v := range dn.GetVolumes() {
+				dnVolumes := dn.GetVolumes()
+				volumeLocation.NewVids = make([]uint32, 0, len(dnVolumes))
+				for _, v := range dnVolumes {
 					volumeLocation.NewVids = append(volumeLocation.NewVids, uint32(v.Id))
 				}
 				// A single EC volume's shards can live on multiple disks of


### PR DESCRIPTION
Follow-up to the #10607..#10612 series. Two snapshot builders in `topology_info.go` that walk a data node's whole volume list into a slice grown from nil, one commit each.

- `ToVolumeMap` (`/dir/status`) boxes every volume into an `[]interface{}`, so the slice reallocates its way up on top of the per-volume boxing.
- `ToVolumeLocations` builds the volume id list handed to every filer, s3 gateway, and mount that connects to the master. At 550k volumes on a node that is a 2.2MB `[]uint32` reached by copying about twice that.

Both counts are known from `dn.GetVolumes()`, which is already being called.

I left `NewEcVids` alone deliberately. A single EC volume's shards can live on several disks of one node, so `GetEcShards` returns per-(vid, disk) entries and the loop dedupes them — the shard count is an upper bound on the deduped vid count, not the count. On a node where shards span 8 disks, preallocating to the shard count would waste more than the doubling it replaces.

No measurable change in the `VolumeList` harness, which exercises `ToTopologyInfo` rather than these two; the win is on `/dir/status` and on client connect.

Refs #10603