### PR TITLE
perf(weed/topology): gather a node's volumes into one slice

### DIFF
--- a/weed/topology/data_node.go
+++ b/weed/topology/data_node.go
@@ -207,7 +207,7 @@ func (dn *DataNode) GetVolumes() (ret []storage.VolumeInfo) {
 	}
 	ret = make([]storage.VolumeInfo, 0, total)
 	for _, c := range dn.children {
-		ret = append(ret, c.(*Disk).GetVolumes()...)
+		ret = c.(*Disk).AppendVolumes(ret)
 	}
 	return ret
 }

--- a/weed/topology/data_node.go
+++ b/weed/topology/data_node.go
@@ -200,11 +200,15 @@ func (dn *DataNode) AdjustDiskUsageBytes(diskTotalBytes, diskFreeBytes map[strin
 
 func (dn *DataNode) GetVolumes() (ret []storage.VolumeInfo) {
 	dn.RLock()
+	defer dn.RUnlock()
+	total := 0
 	for _, c := range dn.children {
-		disk := c.(*Disk)
-		ret = append(ret, disk.GetVolumes()...)
+		total += c.(*Disk).VolumeCount()
 	}
-	dn.RUnlock()
+	ret = make([]storage.VolumeInfo, 0, total)
+	for _, c := range dn.children {
+		ret = append(ret, c.(*Disk).GetVolumes()...)
+	}
 	return ret
 }
 

--- a/weed/topology/disk.go
+++ b/weed/topology/disk.go
@@ -202,14 +202,19 @@ func (d *Disk) doAddOrUpdateVolume(v storage.VolumeInfo) (isNew, isChanged bool)
 	return
 }
 
-func (d *Disk) GetVolumes() (ret []storage.VolumeInfo) {
+func (d *Disk) GetVolumes() []storage.VolumeInfo {
+	return d.AppendVolumes(make([]storage.VolumeInfo, 0, d.VolumeCount()))
+}
+
+// AppendVolumes appends the disk's volumes to dst, so a caller gathering
+// several disks fills one slice instead of concatenating a copy per disk.
+func (d *Disk) AppendVolumes(dst []storage.VolumeInfo) []storage.VolumeInfo {
 	d.RLock()
-	ret = make([]storage.VolumeInfo, 0, len(d.volumes))
+	defer d.RUnlock()
 	for _, v := range d.volumes {
-		ret = append(ret, v)
+		dst = append(dst, v)
 	}
-	d.RUnlock()
-	return ret
+	return dst
 }
 
 func (d *Disk) VolumeCount() int {


### PR DESCRIPTION
Follow-up to the #10607..#10614 series, on `DataNode.GetVolumes`. Two commits.

`NodeImpl.CollectDeadNodeAndFullVolumes` calls this for every data node every `pulse`..`2*pulse` seconds, and it is also behind `ToVolumeMap`, `ToVolumeLocations`, the telemetry collector, and node unregistration.

**1. Preallocate the concatenation.** The node gathered each disk's volumes and appended them to a slice grown from nil, so a server with several disks realloc-and-copied its way up. `Disk.VolumeCount` gives the total up front.

**2. Fill one slice instead of copying twice.** Even after that, each disk built its own right-sized copy that was immediately copied again into the combined slice. `Disk.AppendVolumes(dst)` appends straight into the caller's slice, so it is one allocation regardless of disk count — which halves the single-disk case too, where the prealloc alone changed nothing.

```
BenchmarkDataNodeGetVolumes, 400k volumes on the node
                 master                  after (1)               after (2)
1Disks   121602326 B/op  2 allocs  121602350 B/op  2 allocs   60801314 B/op  1 alloc
8Disks   322551844 B/op 15 allocs  121602326 B/op  9 allocs   60801024 B/op  1 alloc
```

The second commit goes past "preallocate the append" — happy to drop it if you'd rather keep this to the sizing fix, though it is the larger win of the two for the common single-disk server.

`DataNode.getVolumes` has the same unpreallocated loop and is deliberately untouched: its only caller is `DataNode.GetVolumeIds`, which is dead and returns slice indices rather than volume ids. Removing both is a separate PR.

Refs #10603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved volume collection efficiency by reducing temporary allocations.
  * Preserved existing volume results while making repeated collection operations more efficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->