### PR TITLE
chore(weed/topology): drop the unused DataNode volume id listing

### DIFF
--- a/weed/topology/data_node.go
+++ b/weed/topology/data_node.go
@@ -2,7 +2,6 @@ package topology
 
 import (
 	"fmt"
-	"slices"
 	"sync/atomic"
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
@@ -387,29 +386,4 @@ func (dn *DataNode) UpdateDiskTags(tags []*master_pb.DiskTag) {
 	dn.Lock()
 	dn.diskMetas = metas
 	dn.Unlock()
-}
-
-// GetVolumeIds returns the human readable volume ids limited to count of max 100.
-func (dn *DataNode) GetVolumeIds() string {
-	dn.RLock()
-	defer dn.RUnlock()
-	existingVolumes := dn.getVolumes()
-	ids := make([]int, 0, len(existingVolumes))
-
-	for k := range existingVolumes {
-		ids = append(ids, int(k))
-	}
-
-	slices.Sort(ids)
-
-	return util.HumanReadableIntsMax(100, ids...)
-}
-
-func (dn *DataNode) getVolumes() []storage.VolumeInfo {
-	var existingVolumes []storage.VolumeInfo
-	for _, c := range dn.children {
-		disk := c.(*Disk)
-		existingVolumes = append(existingVolumes, disk.GetVolumes()...)
-	}
-	return existingVolumes
 }


### PR DESCRIPTION
Noticed while working through #10603.

`DataNode.GetVolumeIds` ranges over a `[]storage.VolumeInfo` and appends `int(k)` — the loop *index*, not the volume id — so it always reports `0-99` regardless of what the node holds. It presumably ranged over a map at some point and was never updated when it became a slice.

It has no callers. `Disk.GetVolumeIds` is the one in use (from `Disk.ToDiskInfo` and `DataNode.ToMap`), it ranges over `d.volumes` which is a map, and it is correct.

Deleting rather than fixing it: there is no caller to want it back, and the disk-level version already covers the need. Its private `getVolumes` helper goes too, since nothing else used it.

Refs #10603