### PR TITLE
reload filer config on local metadata updates

### DIFF
--- a/weed/filer/filer_notify.go
+++ b/weed/filer/filer_notify.go
@@ -71,9 +71,7 @@ func (f *Filer) notifyUpdateEvent(ctx context.Context, oldEntry, newEntry *Entry
 		sink.Record(event)
 	}
 
-	// Trigger empty folder cleanup for local events
-	// Remote events are handled via MetaAggregator.onMetadataChangeEvent
-	f.triggerLocalEmptyFolderCleanup(oldEntry, newEntry)
+	f.onMetadataChangeEvent(event)
 
 	return event
 }
@@ -119,41 +117,6 @@ func (f *Filer) logMetaEvent(ctx context.Context, event *filer_pb.SubscribeMetad
 		glog.Errorf("failed to add data to log buffer for %s: %v", event.Directory, err)
 	}
 
-}
-
-// triggerLocalEmptyFolderCleanup triggers empty folder cleanup for local events
-// This is needed because onMetadataChangeEvent is only called for remote peer events
-func (f *Filer) triggerLocalEmptyFolderCleanup(oldEntry, newEntry *Entry) {
-	if f.EmptyFolderCleaner == nil || !f.EmptyFolderCleaner.IsEnabled() {
-		return
-	}
-
-	eventTime := time.Now()
-
-	// Handle delete events (oldEntry exists, newEntry is nil)
-	if oldEntry != nil && newEntry == nil {
-		dir, name := oldEntry.FullPath.DirAndName()
-		f.EmptyFolderCleaner.OnDeleteEvent(dir, name, oldEntry.IsDirectory(), eventTime)
-	}
-
-	// Handle create events (oldEntry is nil, newEntry exists)
-	if oldEntry == nil && newEntry != nil {
-		dir, name := newEntry.FullPath.DirAndName()
-		f.EmptyFolderCleaner.OnCreateEvent(dir, name, newEntry.IsDirectory())
-	}
-
-	// Handle rename/move events (both exist but paths differ)
-	if oldEntry != nil && newEntry != nil {
-		oldDir, oldName := oldEntry.FullPath.DirAndName()
-		newDir, newName := newEntry.FullPath.DirAndName()
-
-		if oldDir != newDir || oldName != newName {
-			// Treat old location as delete
-			f.EmptyFolderCleaner.OnDeleteEvent(oldDir, oldName, oldEntry.IsDirectory(), eventTime)
-			// Treat new location as create
-			f.EmptyFolderCleaner.OnCreateEvent(newDir, newName, newEntry.IsDirectory())
-		}
-	}
 }
 
 // metadataLogUploadLimit is the piece size a metadata log flush starts with. A

--- a/weed/filer/metadata_event_sink_test.go
+++ b/weed/filer/metadata_event_sink_test.go
@@ -1,10 +1,12 @@
 package filer
 
 import (
+	"bytes"
 	"context"
 	"testing"
 	"time"
 
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/util"
 	"github.com/seaweedfs/seaweedfs/weed/util/log_buffer"
 )
@@ -39,5 +41,47 @@ func TestNotifyUpdateEventRecordsRequestMetadataEvent(t *testing.T) {
 	}
 	if event.TsNs == 0 {
 		t.Fatal("expected event timestamp to be set")
+	}
+}
+
+func TestNotifyUpdateEventReloadsLocalFilerConfiguration(t *testing.T) {
+	f := &Filer{
+		Signature: 42,
+		FilerConf: NewFilerConf(),
+		LocalMetaLogBuffer: log_buffer.NewLogBuffer(
+			"test",
+			time.Hour,
+			func(*log_buffer.LogBuffer, time.Time, time.Time, []byte, int64, int64) {},
+			nil,
+			nil,
+		),
+	}
+
+	updatedConf := NewFilerConf()
+	if err := updatedConf.SetLocationConf(&filer_pb.FilerConf_PathConf{
+		LocationPrefix: "/data/",
+		Collection:     "hot",
+	}); err != nil {
+		t.Fatalf("set location conf: %v", err)
+	}
+	var content bytes.Buffer
+	if err := updatedConf.ToText(&content); err != nil {
+		t.Fatalf("serialize filer conf: %v", err)
+	}
+
+	f.NotifyUpdateEvent(context.Background(), nil, &Entry{
+		FullPath: util.NewFullPath(DirectoryEtcSeaweedFS, FilerConfName),
+		Attr: Attr{
+			FileSize: uint64(content.Len()),
+		},
+		Content: content.Bytes(),
+	}, false, false, nil)
+
+	locConf, found := f.FilerConf.GetLocationConf("/data/")
+	if !found {
+		t.Fatal("expected local filer configuration to reload /data/ rule")
+	}
+	if locConf.Collection != "hot" {
+		t.Fatalf("collection = %q, want hot", locConf.Collection)
 	}
 }


### PR DESCRIPTION
Fixes #10620.

## What changed

Local metadata updates now run through the same `Filer.onMetadataChangeEvent()` hook that peer-subscription updates already use. This makes local writes to `/etc/seaweedfs/filer.conf` reload the in-memory `FilerConf` immediately, matching the behavior remote filers already get after receiving the metadata event.

The old local-only empty-folder cleanup shim was removed because `onMetadataChangeEvent()` already dispatches empty-folder cleanup events as part of the shared metadata side-effect path.

## Why

`fs.configure -apply` persists `/etc/seaweedfs/filer.conf` through the filer entry write path, but before this change the local filer only logged the metadata event. The reload hook was only reached by peer filers in the remote metadata subscription path.

## Tests

- `GOCACHE=... GOMODCACHE=... go test ./weed/filer`
- `GOCACHE=... GOMODCACHE=... go test ./weed/server -run 'TestFilerGrpcServerObjectTxnTtl|TestOnBucketEvents|TestNotifyUpdateEvent'` (compiled, no matching tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of local metadata events, including file deletions, creations, and moves.
  * Filer instances now reload local configuration when configuration updates are received through metadata events.
  * Preserved collection mapping rules, such as routing `/data/` to the `hot` collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->