### PR TITLE
telemetry: put the version pie back beside the stacked chart

### DIFF
--- a/telemetry/server/dashboard/dashboard.go
+++ b/telemetry/server/dashboard/dashboard.go
@@ -143,7 +143,9 @@ func (h *Handler) ServeIndex(w http.ResponseWriter, r *http.Request) {
 
             <div class="chart-container">
                 <div class="chart-title">Version Distribution</div>
-                <canvas id="versionChart" width="400" height="200"></canvas>
+                <div style="position: relative; height: 320px;">
+                    <canvas id="versionChart"></canvas>
+                </div>
             </div>
 
             <div class="chart-container">
@@ -156,7 +158,9 @@ func (h *Handler) ServeIndex(w http.ResponseWriter, r *http.Request) {
 
             <div class="chart-container">
                 <div class="chart-title">Operating System Distribution</div>
-                <canvas id="osChart" width="400" height="200"></canvas>
+                <div style="position: relative; height: 320px;">
+                    <canvas id="osChart"></canvas>
+                </div>
             </div>
 
             <div class="chart-container">
@@ -209,13 +213,16 @@ func (h *Handler) ServeIndex(w http.ResponseWriter, r *http.Request) {
                 const versionsResponse = await fetch('/api/versions?days=30&limit=8');
                 const versions = await versionsResponse.json();
 
+                // Show the dashboard before drawing into it: a canvas in a
+                // display:none container measures zero, and a pie sized from
+                // that never grows back.
+                document.getElementById('loading').style.display = 'none';
+                document.getElementById('dashboard').style.display = 'block';
+
                 updateStats(stats);
                 updateCharts(stats);
                 updateVersions(versions);
                 updateClusterSizes(sizes);
-
-                document.getElementById('loading').style.display = 'none';
-                document.getElementById('dashboard').style.display = 'block';
             } catch (error) {
                 console.error('Error loading dashboard:', error);
                 showError('Failed to load telemetry data: ' + error.message);
@@ -259,6 +266,9 @@ func (h *Handler) ServeIndex(w http.ResponseWriter, r *http.Request) {
                 },
                 options: {
                     responsive: true,
+                    // Without this the canvas keeps its 2:1 attribute ratio at
+                    // the card's full width, drawing a pie taller than the card.
+                    maintainAspectRatio: false,
                     plugins: {
                         legend: {
                             position: 'bottom'

--- a/telemetry/server/dashboard/dashboard.go
+++ b/telemetry/server/dashboard/dashboard.go
@@ -143,9 +143,14 @@ func (h *Handler) ServeIndex(w http.ResponseWriter, r *http.Request) {
 
             <div class="chart-container">
                 <div class="chart-title">Version Distribution</div>
-                <div class="chart-subtitle" id="versionTotal"></div>
+                <canvas id="versionChart" width="400" height="200"></canvas>
+            </div>
+
+            <div class="chart-container">
+                <div class="chart-title">Versions Over Time</div>
+                <div class="chart-subtitle" id="versionSeriesTotal"></div>
                 <div style="position: relative; height: 420px;">
-                    <canvas id="versionChart"></canvas>
+                    <canvas id="versionSeriesChart"></canvas>
                 </div>
             </div>
 
@@ -205,7 +210,7 @@ func (h *Handler) ServeIndex(w http.ResponseWriter, r *http.Request) {
                 const versions = await versionsResponse.json();
 
                 updateStats(stats);
-                createPieChart('osChart', stats.os_distribution || {});
+                updateCharts(stats);
                 updateVersions(versions);
                 updateClusterSizes(sizes);
 
@@ -225,7 +230,12 @@ func (h *Handler) ServeIndex(w http.ResponseWriter, r *http.Request) {
             document.getElementById('totalOS').textContent = Object.keys(stats.os_distribution || {}).length;
         }
 
-        function createPieChart(canvasId, data) {
+        function updateCharts(stats) {
+            createPieChart('versionChart', 'Version Distribution', stats.versions || {});
+            createPieChart('osChart', 'Operating System Distribution', stats.os_distribution || {});
+        }
+
+        function createPieChart(canvasId, title, data) {
             const ctx = document.getElementById(canvasId).getContext('2d');
             
             if (charts[canvasId]) {
@@ -309,12 +319,13 @@ func (h *Handler) ServeIndex(w http.ResponseWriter, r *http.Request) {
 
         // One stacked band per version: the band is how many clusters ran that
         // version that day, the top of the stack is the confirmed fleet, so the
-        // chart shows both how it grows and what it upgrades to.
+        // chart shows both how it grows and what it upgrades to. The pie above
+        // it is the same fleet on the last of these days.
         function updateVersions(series) {
             const versions = series.versions || [];
             const dates = series.dates || [];
             const total = series.total_clusters || 0;
-            document.getElementById('versionTotal').textContent =
+            document.getElementById('versionSeriesTotal').textContent =
                 total + ' cluster' + (total === 1 ? '' : 's') + ' on ' + (dates[dates.length - 1] || 'no data');
 
             // Newest release on the floor, oldest on top: the current release
@@ -329,7 +340,7 @@ func (h *Handler) ServeIndex(w http.ResponseWriter, r *http.Request) {
                     '#ffffff', '#9a9a94', 2));
             }
 
-            stackedArea('versionChart', dates, datasets, value => value, { plugins: [bandLabels] });
+            stackedArea('versionSeriesChart', dates, datasets, value => value, { plugins: [bandLabels] });
         }
 
         // Writes each version into its own band, so the chart reads without


### PR DESCRIPTION
Follow-up to #10625, which replaced the Version Distribution pie with the stack. The two answer different questions, and the pie was the better answer to one of them: what the fleet is on right now, at a glance. So it comes back under its old name, and the stack gets its own card as Versions Over Time directly below it — the pie is the last day of the chart under it.

While putting it back I found the pies had never sized correctly: with `responsive: true` and no `maintainAspectRatio`, the canvas kept its tag's 2:1 ratio at the card's full width, so each pie came out around 560px tall and spilled past its card. Both get a height to fill now. The charts are also built after the dashboard is shown rather than before — a canvas in a `display:none` container measures zero, and a pie sized from that never grows back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate dashboard views for version distribution and version trends.
  * Added clearer titles to pie charts.
* **Improvements**
  * Improved chart layout with consistent sizing.
  * Dashboard content now appears before charts are rendered.
  * Version trend visualizations now display trend data independently from other version charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->