### PR TITLE
topology: follow a volume that moved between a server's disks

### DIFF
--- a/weed/server/master_grpc_server.go
+++ b/weed/server/master_grpc_server.go
@@ -28,12 +28,9 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/topology"
 )
 
-// shouldBroadcastVolumeRemoval reports whether clients should be told the
-// volume has left this node. A volume moved between the node's own disks is
-// removed from one and added to the other, so it appears in both lists of the
-// same heartbeat, and clients apply additions before deletions -- passing the
-// removal on would drop a location that is still good. Mirrors the guard the ec
-// shard paths already apply.
+// A volume moved between the node's disks appears in both lists, and clients
+// apply additions before deletions, so passing the removal on would drop a
+// location that is still good.
 func shouldBroadcastVolumeRemoval(dn *topology.DataNode, vid needle.VolumeId) bool {
 	return !dn.HasVolumesById(vid)
 }
@@ -217,8 +214,7 @@ func (ms *MasterServer) SendHeartbeat(stream master_pb.Seaweed_SendHeartbeatServ
 			stats.MasterReceivedHeartbeatCounter.WithLabelValues("deletedVolumes").Inc()
 		}
 		if len(heartbeat.NewVolumes) > 0 || len(heartbeat.DeletedVolumes) > 0 {
-			// update master internal volume layouts first, so the removals below
-			// are judged against where the volumes ended up
+			// first, so the removals below see where the volumes ended up
 			ms.Topo.IncrementalSyncDataNodeRegistration(heartbeat.NewVolumes, heartbeat.DeletedVolumes, dn)
 
 			// process delta volume ids if exists for fast volume id updates

--- a/weed/server/master_grpc_server.go
+++ b/weed/server/master_grpc_server.go
@@ -30,9 +30,12 @@ import (
 
 // A volume moved between the node's disks appears in both lists, and clients
 // apply additions before deletions, so passing the removal on would drop a
-// location that is still good.
+// location that is still good. Not HasVolumesById, which answers for ec shards
+// too: clients hold those separately and prefer the normal location, so a
+// replica that became ec shards has to be reported gone.
 func shouldBroadcastVolumeRemoval(dn *topology.DataNode, vid needle.VolumeId) bool {
-	return !dn.HasVolumesById(vid)
+	_, err := dn.GetVolumesById(vid)
+	return err != nil
 }
 
 func (ms *MasterServer) RegisterUuids(heartbeat *master_pb.Heartbeat) (duplicated_uuids []string, err error) {

--- a/weed/server/master_grpc_server.go
+++ b/weed/server/master_grpc_server.go
@@ -28,6 +28,16 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/topology"
 )
 
+// shouldBroadcastVolumeRemoval reports whether clients should be told the
+// volume has left this node. A volume moved between the node's own disks is
+// removed from one and added to the other, so it appears in both lists of the
+// same heartbeat, and clients apply additions before deletions -- passing the
+// removal on would drop a location that is still good. Mirrors the guard the ec
+// shard paths already apply.
+func shouldBroadcastVolumeRemoval(dn *topology.DataNode, vid needle.VolumeId) bool {
+	return !dn.HasVolumesById(vid)
+}
+
 func (ms *MasterServer) RegisterUuids(heartbeat *master_pb.Heartbeat) (duplicated_uuids []string, err error) {
 	ms.Topo.UuidAccessLock.Lock()
 	defer ms.Topo.UuidAccessLock.Unlock()
@@ -207,15 +217,20 @@ func (ms *MasterServer) SendHeartbeat(stream master_pb.Seaweed_SendHeartbeatServ
 			stats.MasterReceivedHeartbeatCounter.WithLabelValues("deletedVolumes").Inc()
 		}
 		if len(heartbeat.NewVolumes) > 0 || len(heartbeat.DeletedVolumes) > 0 {
+			// update master internal volume layouts first, so the removals below
+			// are judged against where the volumes ended up
+			ms.Topo.IncrementalSyncDataNodeRegistration(heartbeat.NewVolumes, heartbeat.DeletedVolumes, dn)
+
 			// process delta volume ids if exists for fast volume id updates
 			for _, volInfo := range heartbeat.NewVolumes {
 				message.NewVids = append(message.NewVids, volInfo.Id)
 			}
 			for _, volInfo := range heartbeat.DeletedVolumes {
+				if !shouldBroadcastVolumeRemoval(dn, needle.VolumeId(volInfo.Id)) {
+					continue
+				}
 				message.DeletedVids = append(message.DeletedVids, volInfo.Id)
 			}
-			// update master internal volume layouts
-			ms.Topo.IncrementalSyncDataNodeRegistration(heartbeat.NewVolumes, heartbeat.DeletedVolumes, dn)
 		}
 
 		if len(heartbeat.Volumes) > 0 || heartbeat.HasNoVolumes {
@@ -234,6 +249,9 @@ func (ms *MasterServer) SendHeartbeat(stream master_pb.Seaweed_SendHeartbeatServ
 			}
 			for _, v := range deletedVolumes {
 				glog.V(1).Infof("master see deleted volume %d from %s", uint32(v.Id), dn.Url())
+				if !shouldBroadcastVolumeRemoval(dn, v.Id) {
+					continue
+				}
 				message.DeletedVids = append(message.DeletedVids, uint32(v.Id))
 			}
 		}

--- a/weed/server/master_grpc_server_volume_move_test.go
+++ b/weed/server/master_grpc_server_volume_move_test.go
@@ -78,3 +78,21 @@ func TestVolumeUnmountedViaDeltaIsBroadcastAsRemoved(t *testing.T) {
 		t.Error("clients were not told about a volume that really was unmounted")
 	}
 }
+
+// Clients track normal and ec locations separately, and prefer the normal one
+// when both come from the same generation. A replica that became ec shards has
+// genuinely left, so the removal must still go out.
+func TestVolumeReplacedByEcShardsIsBroadcastAsRemoved(t *testing.T) {
+	topo, dn := moveTestNode(t)
+	topo.SyncDataNodeRegistration([]*master_pb.VolumeInformationMessage{moveTestVolume("", 0)}, dn)
+	topo.SyncDataNodeEcShards([]*master_pb.VolumeEcShardInformationMessage{
+		{Id: 1, Collection: "c", EcIndexBits: 0x3fff},
+	}, dn)
+
+	if _, deleted := topo.SyncDataNodeRegistration(nil, dn); len(deleted) != 1 {
+		t.Fatalf("expected the normal volume to be removed, got %d removals", len(deleted))
+	}
+	if !shouldBroadcastVolumeRemoval(dn, needle.VolumeId(1)) {
+		t.Error("clients kept a normal-volume location for a replica that became ec shards")
+	}
+}

--- a/weed/server/master_grpc_server_volume_move_test.go
+++ b/weed/server/master_grpc_server_volume_move_test.go
@@ -1,0 +1,86 @@
+package weed_server
+
+import (
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
+	"github.com/seaweedfs/seaweedfs/weed/sequence"
+	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
+	"github.com/seaweedfs/seaweedfs/weed/topology"
+)
+
+func moveTestNode(t *testing.T) (*topology.Topology, *topology.DataNode) {
+	t.Helper()
+	topo := topology.NewTopology("test", sequence.NewMemorySequencer(), 32*1024*1024*1024, 5, false)
+	dn := topo.GetOrCreateDataCenter("dc1").GetOrCreateRack("rack1").
+		GetOrCreateDataNode("127.0.0.1", 8080, 18080, "", "", map[string]uint32{"": 100, "ssd": 100})
+	return topo, dn
+}
+
+func moveTestVolume(diskType string, diskId uint32) *master_pb.VolumeInformationMessage {
+	return &master_pb.VolumeInformationMessage{
+		Id: 1, Size: 1024, Collection: "c", Version: 3, DiskType: diskType, DiskId: diskId,
+	}
+}
+
+// A volume moved between a node's disks leaves one disk and joins another, so
+// the master sees it as both removed and added. Clients apply additions before
+// deletions, so telling them about the removal would leave them with no location
+// for a volume that never went anywhere.
+func TestVolumeMovedBetweenDisksIsNotBroadcastAsRemoved(t *testing.T) {
+	topo, dn := moveTestNode(t)
+	topo.SyncDataNodeRegistration([]*master_pb.VolumeInformationMessage{moveTestVolume("", 0)}, dn)
+
+	_, deleted := topo.SyncDataNodeRegistration(
+		[]*master_pb.VolumeInformationMessage{moveTestVolume("ssd", 1)}, dn)
+
+	if len(deleted) != 1 {
+		t.Fatalf("expected the move to remove the volume from the disk it left, got %d removals", len(deleted))
+	}
+	if shouldBroadcastVolumeRemoval(dn, needle.VolumeId(1)) {
+		t.Error("clients would be told a volume left a node that still has it")
+	}
+}
+
+func TestVolumeGoneFromTheNodeIsBroadcastAsRemoved(t *testing.T) {
+	topo, dn := moveTestNode(t)
+	topo.SyncDataNodeRegistration([]*master_pb.VolumeInformationMessage{moveTestVolume("", 0)}, dn)
+
+	if _, deleted := topo.SyncDataNodeRegistration(nil, dn); len(deleted) != 1 {
+		t.Fatalf("expected the volume to be removed, got %d removals", len(deleted))
+	}
+	if !shouldBroadcastVolumeRemoval(dn, needle.VolumeId(1)) {
+		t.Error("clients were not told about a volume that really did leave the node")
+	}
+}
+
+// The same volume can be unmounted from one disk and mounted on another in one
+// delta heartbeat, which reaches the master as both a deletion and an addition.
+func TestVolumeRemountedOnAnotherDiskIsNotBroadcastAsRemoved(t *testing.T) {
+	topo, dn := moveTestNode(t)
+	topo.SyncDataNodeRegistration([]*master_pb.VolumeInformationMessage{moveTestVolume("", 0)}, dn)
+
+	topo.IncrementalSyncDataNodeRegistration(
+		[]*master_pb.VolumeShortInformationMessage{{Id: 1, Collection: "c", DiskType: "ssd"}},
+		[]*master_pb.VolumeShortInformationMessage{{Id: 1, Collection: "c", DiskType: ""}},
+		dn)
+
+	if shouldBroadcastVolumeRemoval(dn, needle.VolumeId(1)) {
+		t.Error("clients would be told a volume left a node that still has it on another disk")
+	}
+}
+
+// The mirror case, and the reason the topology update has to run before the
+// removals are judged: a volume unmounted and not remounted anywhere really has
+// left, and clients still need to hear about it.
+func TestVolumeUnmountedViaDeltaIsBroadcastAsRemoved(t *testing.T) {
+	topo, dn := moveTestNode(t)
+	topo.SyncDataNodeRegistration([]*master_pb.VolumeInformationMessage{moveTestVolume("", 0)}, dn)
+
+	topo.IncrementalSyncDataNodeRegistration(nil,
+		[]*master_pb.VolumeShortInformationMessage{{Id: 1, Collection: "c", DiskType: ""}}, dn)
+
+	if !shouldBroadcastVolumeRemoval(dn, needle.VolumeId(1)) {
+		t.Error("clients were not told about a volume that really was unmounted")
+	}
+}

--- a/weed/server/master_grpc_server_volume_move_test.go
+++ b/weed/server/master_grpc_server_volume_move_test.go
@@ -23,10 +23,8 @@ func moveTestVolume(diskType string, diskId uint32) *master_pb.VolumeInformation
 	}
 }
 
-// A volume moved between a node's disks leaves one disk and joins another, so
-// the master sees it as both removed and added. Clients apply additions before
-// deletions, so telling them about the removal would leave them with no location
-// for a volume that never went anywhere.
+// Clients apply additions before deletions, so a move reported as both would
+// leave them with no location for a volume that never went anywhere.
 func TestVolumeMovedBetweenDisksIsNotBroadcastAsRemoved(t *testing.T) {
 	topo, dn := moveTestNode(t)
 	topo.SyncDataNodeRegistration([]*master_pb.VolumeInformationMessage{moveTestVolume("", 0)}, dn)
@@ -54,8 +52,6 @@ func TestVolumeGoneFromTheNodeIsBroadcastAsRemoved(t *testing.T) {
 	}
 }
 
-// The same volume can be unmounted from one disk and mounted on another in one
-// delta heartbeat, which reaches the master as both a deletion and an addition.
 func TestVolumeRemountedOnAnotherDiskIsNotBroadcastAsRemoved(t *testing.T) {
 	topo, dn := moveTestNode(t)
 	topo.SyncDataNodeRegistration([]*master_pb.VolumeInformationMessage{moveTestVolume("", 0)}, dn)
@@ -70,9 +66,7 @@ func TestVolumeRemountedOnAnotherDiskIsNotBroadcastAsRemoved(t *testing.T) {
 	}
 }
 
-// The mirror case, and the reason the topology update has to run before the
-// removals are judged: a volume unmounted and not remounted anywhere really has
-// left, and clients still need to hear about it.
+// Fails if the topology update stops running before the removals are judged.
 func TestVolumeUnmountedViaDeltaIsBroadcastAsRemoved(t *testing.T) {
 	topo, dn := moveTestNode(t)
 	topo.SyncDataNodeRegistration([]*master_pb.VolumeInformationMessage{moveTestVolume("", 0)}, dn)

--- a/weed/topology/data_node.go
+++ b/weed/topology/data_node.go
@@ -83,9 +83,9 @@ func (dn *DataNode) doAddOrUpdateVolume(v storage.VolumeInfo) (isNew, isChanged 
 // used in master to notify master clients of these changes.
 func (dn *DataNode) UpdateVolumes(actualVolumes []storage.VolumeInfo) (newVolumes, deletedVolumes, changedVolumes []storage.VolumeInfo) {
 
-	actualVolumeIds := make(map[needle.VolumeId]struct{}, len(actualVolumes))
+	reported := newReportedVolumes(len(actualVolumes))
 	for _, v := range actualVolumes {
-		actualVolumeIds[v.Id] = struct{}{}
+		reported.add(v.Id, v.DiskType)
 	}
 
 	// A volume id mounted on two disks of one server -- a stale twin re-attached
@@ -93,7 +93,7 @@ func (dn *DataNode) UpdateVolumes(actualVolumes []storage.VolumeInfo) (newVolume
 	// id alone and keeps only the last copy. Its digest can then never equal the
 	// server's however often the list is resent, so record it and let the
 	// heartbeat fall back to the full list for this node.
-	dn.duplicateVolumeIds.Store(len(actualVolumeIds) < len(actualVolumes))
+	dn.duplicateVolumeIds.Store(reported.duplicated)
 
 	dn.Lock()
 	defer dn.Unlock()
@@ -101,7 +101,7 @@ func (dn *DataNode) UpdateVolumes(actualVolumes []storage.VolumeInfo) (newVolume
 	keptCount := 0
 	for _, c := range dn.children {
 		disk := c.(*Disk)
-		for _, v := range disk.RemoveVolumesNotIn(actualVolumeIds) {
+		for _, v := range disk.RemoveVolumesNotIn(reported) {
 			glog.V(0).Infoln("Deleting volume id:", v.Id)
 			deletedVolumes = append(deletedVolumes, v)
 
@@ -120,7 +120,7 @@ func (dn *DataNode) UpdateVolumes(actualVolumes []storage.VolumeInfo) (newVolume
 	// Everything still on the node is also in this heartbeat, so the remainder
 	// is what the node is about to gain. A steady-state heartbeat gains nothing
 	// and must not allocate here; a reconnecting server gains all of them.
-	if addedCount := len(actualVolumes) - keptCount; addedCount > 0 {
+	if addedCount := reported.count() - keptCount; addedCount > 0 {
 		newVolumes = make([]storage.VolumeInfo, 0, addedCount)
 	}
 	for _, v := range actualVolumes {

--- a/weed/topology/disk.go
+++ b/weed/topology/disk.go
@@ -235,14 +235,17 @@ func (d *Disk) VolumeCount() int {
 	return len(d.volumes)
 }
 
-// RemoveVolumesNotIn drops the volumes whose ids are absent from keep and
-// returns them, so a heartbeat can be diffed without first copying the whole
-// volume map out.
-func (d *Disk) RemoveVolumesNotIn(keep map[needle.VolumeId]struct{}) (removed []storage.VolumeInfo) {
+// RemoveVolumesNotIn drops the volumes the heartbeat did not name on this disk
+// and returns them, so a heartbeat can be diffed without first copying the whole
+// volume map out. A volume the heartbeat names on a different disk counts as
+// absent here: it moved, and leaving it behind would keep a second copy of it
+// on the node forever.
+func (d *Disk) RemoveVolumesNotIn(reported *reportedVolumes) (removed []storage.VolumeInfo) {
+	diskTypeIndex := reported.diskTypeIndex(string(d.Id()))
 	d.Lock()
 	defer d.Unlock()
 	for vid, v := range d.volumes {
-		if _, ok := keep[vid]; !ok {
+		if !reported.namedOn(vid, diskTypeIndex) {
 			removed = append(removed, v)
 			delete(d.volumes, vid)
 			d.volumeDigest ^= v.ReportHash()

--- a/weed/topology/disk.go
+++ b/weed/topology/disk.go
@@ -236,10 +236,8 @@ func (d *Disk) VolumeCount() int {
 }
 
 // RemoveVolumesNotIn drops the volumes the heartbeat did not name on this disk
-// and returns them, so a heartbeat can be diffed without first copying the whole
-// volume map out. A volume the heartbeat names on a different disk counts as
-// absent here: it moved, and leaving it behind would keep a second copy of it
-// on the node forever.
+// and returns them, so a heartbeat can be diffed without copying the volume map
+// out. A volume named on another disk has moved, and counts as absent here.
 func (d *Disk) RemoveVolumesNotIn(reported *reportedVolumes) (removed []storage.VolumeInfo) {
 	diskTypeIndex := reported.diskTypeIndex(string(d.Id()))
 	d.Lock()

--- a/weed/topology/reported_volumes.go
+++ b/weed/topology/reported_volumes.go
@@ -5,21 +5,16 @@ import (
 )
 
 // reportedVolumes records which disk types a heartbeat named each volume on, so
-// a volume that moved between disks of one server is dropped from the disk it
-// left rather than lingering there as a second copy.
-//
-// Disk types are interned to an index: a server reports a handful of them
-// across hundreds of thousands of volumes, and a string header per volume would
-// cost more than the map holding them.
+// a volume that moved between a server's disks is dropped from the one it left.
+// Disk types are interned because a string header per volume would cost more
+// than the map holding them.
 type reportedVolumes struct {
 	diskTypes []string
 	byVolume  map[needle.VolumeId]int32
-	// extra covers volumes named on more than one disk type, which a server can
-	// legitimately do when a stale twin is re-attached on another disk. Stays
-	// nil otherwise.
+	// extra covers volumes named on several disk types, a stale twin rather than
+	// a move. Nil otherwise.
 	extra map[needle.VolumeId][]int32
-	// duplicated records the same volume named twice on one disk type, which
-	// the master stores once and so cannot represent.
+	// duplicated: named twice on one disk type, which the master stores once.
 	duplicated bool
 }
 
@@ -52,8 +47,7 @@ func (r *reportedVolumes) internDiskType(diskType string) int32 {
 	return int32(len(r.diskTypes) - 1)
 }
 
-// diskTypeIndex resolves a disk type to its index, or -1 when the heartbeat
-// named no volume on it.
+// diskTypeIndex returns -1 when the heartbeat named no volume on the type.
 func (r *reportedVolumes) diskTypeIndex(diskType string) int32 {
 	for i, known := range r.diskTypes {
 		if known == diskType {
@@ -63,7 +57,6 @@ func (r *reportedVolumes) diskTypeIndex(diskType string) int32 {
 	return -1
 }
 
-// namedOn reports whether the heartbeat placed vid on the disk type at index.
 func (r *reportedVolumes) namedOn(vid needle.VolumeId, index int32) bool {
 	if index < 0 {
 		return false

--- a/weed/topology/reported_volumes.go
+++ b/weed/topology/reported_volumes.go
@@ -1,0 +1,86 @@
+package topology
+
+import (
+	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
+)
+
+// reportedVolumes records which disk types a heartbeat named each volume on, so
+// a volume that moved between disks of one server is dropped from the disk it
+// left rather than lingering there as a second copy.
+//
+// Disk types are interned to an index: a server reports a handful of them
+// across hundreds of thousands of volumes, and a string header per volume would
+// cost more than the map holding them.
+type reportedVolumes struct {
+	diskTypes []string
+	byVolume  map[needle.VolumeId]int32
+	// extra covers volumes named on more than one disk type, which a server can
+	// legitimately do when a stale twin is re-attached on another disk. Stays
+	// nil otherwise.
+	extra map[needle.VolumeId][]int32
+	// duplicated records the same volume named twice on one disk type, which
+	// the master stores once and so cannot represent.
+	duplicated bool
+}
+
+func newReportedVolumes(size int) *reportedVolumes {
+	return &reportedVolumes{byVolume: make(map[needle.VolumeId]int32, size)}
+}
+
+func (r *reportedVolumes) add(vid needle.VolumeId, diskType string) {
+	index := r.internDiskType(diskType)
+	existing, seen := r.byVolume[vid]
+	if !seen {
+		r.byVolume[vid] = index
+		return
+	}
+	if existing == index || r.hasExtra(vid, index) {
+		r.duplicated = true
+		return
+	}
+	if r.extra == nil {
+		r.extra = make(map[needle.VolumeId][]int32)
+	}
+	r.extra[vid] = append(r.extra[vid], index)
+}
+
+func (r *reportedVolumes) internDiskType(diskType string) int32 {
+	if index := r.diskTypeIndex(diskType); index >= 0 {
+		return index
+	}
+	r.diskTypes = append(r.diskTypes, diskType)
+	return int32(len(r.diskTypes) - 1)
+}
+
+// diskTypeIndex resolves a disk type to its index, or -1 when the heartbeat
+// named no volume on it.
+func (r *reportedVolumes) diskTypeIndex(diskType string) int32 {
+	for i, known := range r.diskTypes {
+		if known == diskType {
+			return int32(i)
+		}
+	}
+	return -1
+}
+
+// namedOn reports whether the heartbeat placed vid on the disk type at index.
+func (r *reportedVolumes) namedOn(vid needle.VolumeId, index int32) bool {
+	if index < 0 {
+		return false
+	}
+	if stored, ok := r.byVolume[vid]; ok && stored == index {
+		return true
+	}
+	return r.hasExtra(vid, index)
+}
+
+func (r *reportedVolumes) hasExtra(vid needle.VolumeId, index int32) bool {
+	for _, other := range r.extra[vid] {
+		if other == index {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *reportedVolumes) count() int { return len(r.byVolume) }

--- a/weed/topology/volume_disk_move_test.go
+++ b/weed/topology/volume_disk_move_test.go
@@ -1,0 +1,117 @@
+package topology
+
+import (
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
+	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
+)
+
+func diskMoveNode(t *testing.T) (*Topology, *DataNode) {
+	t.Helper()
+	topo := NewTopology("move", nil, 32*1024*1024*1024, 5, false)
+	dn := topo.GetOrCreateDataCenter("dc1").GetOrCreateRack("rack1").
+		GetOrCreateDataNode("127.0.0.1", 8080, 18080, "", "", map[string]uint32{"": 100, "ssd": 100})
+	return topo, dn
+}
+
+func diskMoveVolume(id uint32, diskType string, diskId uint32) *master_pb.VolumeInformationMessage {
+	return &master_pb.VolumeInformationMessage{
+		Id: id, Size: 1024, Collection: "c", Version: 3, DiskType: diskType, DiskId: diskId,
+	}
+}
+
+func heldCopies(dn *DataNode) int {
+	total := 0
+	for _, c := range dn.Children() {
+		total += c.(*Disk).VolumeCount()
+	}
+	return total
+}
+
+// Moving a volume between disks of one server only changes the disk it is
+// reported on. The master has to follow it rather than keep the disk it left.
+func TestVolumeMovedBetweenDisks(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		from, to string
+	}{
+		{"SameDiskType", "", ""},
+		{"DifferentDiskType", "", "ssd"},
+		{"BackAgain", "ssd", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			topo, dn := diskMoveNode(t)
+			topo.SyncDataNodeRegistration(
+				[]*master_pb.VolumeInformationMessage{diskMoveVolume(1, tc.from, 0)}, dn)
+			topo.SyncDataNodeRegistration(
+				[]*master_pb.VolumeInformationMessage{diskMoveVolume(1, tc.to, 1)}, dn)
+
+			if got := heldCopies(dn); got != 1 {
+				t.Errorf("master holds %d copies of a volume that moved, want 1", got)
+			}
+			stored, err := dn.GetVolumesById(needle.VolumeId(1))
+			if err != nil {
+				t.Fatalf("moved volume is no longer on the node: %v", err)
+			}
+			if stored.DiskType != tc.to || stored.DiskId != 1 {
+				t.Errorf("master has the volume on disk %q/%d, server reports %q/1",
+					stored.DiskType, stored.DiskId, tc.to)
+			}
+			if !dn.HasConsistentVolumeIndex() {
+				t.Error("the move left the lookup index disagreeing with the disks")
+			}
+		})
+	}
+}
+
+// A server can legitimately hold one volume id on two disks when a stale twin is
+// re-attached. Those are two reports, not a move, and dropping one would tell
+// the master a replica vanished.
+func TestVolumeReportedOnTwoDiskTypesIsKept(t *testing.T) {
+	topo, dn := diskMoveNode(t)
+	topo.SyncDataNodeRegistration([]*master_pb.VolumeInformationMessage{
+		diskMoveVolume(1, "", 0), diskMoveVolume(1, "ssd", 1),
+	}, dn)
+
+	if got := heldCopies(dn); got != 2 {
+		t.Errorf("master holds %d copies of a volume reported on two disks, want 2", got)
+	}
+	if dn.HasDuplicateVolumeIds() {
+		t.Error("a volume on two disk types is representable, so it should not disable digest comparison")
+	}
+
+	// Once the twin is gone the master follows.
+	topo.SyncDataNodeRegistration([]*master_pb.VolumeInformationMessage{diskMoveVolume(1, "ssd", 1)}, dn)
+	if got := heldCopies(dn); got != 1 {
+		t.Errorf("master holds %d copies after the twin was unmounted, want 1", got)
+	}
+}
+
+// Twice on one disk type is the case the master genuinely cannot represent.
+func TestVolumeReportedTwiceOnOneDiskTypeIsFlagged(t *testing.T) {
+	topo, dn := diskMoveNode(t)
+	first := diskMoveVolume(1, "ssd", 0)
+	second := diskMoveVolume(1, "ssd", 1)
+	topo.SyncDataNodeRegistration([]*master_pb.VolumeInformationMessage{first, second}, dn)
+
+	if !dn.HasDuplicateVolumeIds() {
+		t.Error("a volume reported twice on one disk type went unflagged")
+	}
+}
+
+func TestVolumeDigestSurvivesADiskMove(t *testing.T) {
+	topo, dn := diskMoveNode(t)
+	topo.SyncDataNodeRegistration([]*master_pb.VolumeInformationMessage{diskMoveVolume(1, "", 0)}, dn)
+
+	moved := diskMoveVolume(1, "ssd", 1)
+	topo.SyncDataNodeRegistration([]*master_pb.VolumeInformationMessage{moved}, dn)
+
+	reference, referenceNode := diskMoveNode(t)
+	reference.SyncDataNodeRegistration([]*master_pb.VolumeInformationMessage{moved}, referenceNode)
+
+	if dn.VolumeDigest() != referenceNode.VolumeDigest() {
+		t.Errorf("after a disk move the digest is %d, a server holding only the moved volume reports %d",
+			dn.VolumeDigest(), referenceNode.VolumeDigest())
+	}
+}

--- a/weed/topology/volume_disk_move_test.go
+++ b/weed/topology/volume_disk_move_test.go
@@ -29,8 +29,6 @@ func heldCopies(dn *DataNode) int {
 	return total
 }
 
-// Moving a volume between disks of one server only changes the disk it is
-// reported on. The master has to follow it rather than keep the disk it left.
 func TestVolumeMovedBetweenDisks(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
@@ -65,9 +63,8 @@ func TestVolumeMovedBetweenDisks(t *testing.T) {
 	}
 }
 
-// A server can legitimately hold one volume id on two disks when a stale twin is
-// re-attached. Those are two reports, not a move, and dropping one would tell
-// the master a replica vanished.
+// A stale twin is two reports, not a move: dropping one would tell the master a
+// replica vanished.
 func TestVolumeReportedOnTwoDiskTypesIsKept(t *testing.T) {
 	topo, dn := diskMoveNode(t)
 	topo.SyncDataNodeRegistration([]*master_pb.VolumeInformationMessage{
@@ -81,14 +78,12 @@ func TestVolumeReportedOnTwoDiskTypesIsKept(t *testing.T) {
 		t.Error("a volume on two disk types is representable, so it should not disable digest comparison")
 	}
 
-	// Once the twin is gone the master follows.
 	topo.SyncDataNodeRegistration([]*master_pb.VolumeInformationMessage{diskMoveVolume(1, "ssd", 1)}, dn)
 	if got := heldCopies(dn); got != 1 {
 		t.Errorf("master holds %d copies after the twin was unmounted, want 1", got)
 	}
 }
 
-// Twice on one disk type is the case the master genuinely cannot represent.
 func TestVolumeReportedTwiceOnOneDiskTypeIsFlagged(t *testing.T) {
 	topo, dn := diskMoveNode(t)
 	first := diskMoveVolume(1, "ssd", 0)


### PR DESCRIPTION
Pre-existing, found while checking whether the heartbeat digest in #10627 notices a volume moving between disks of one server. It notices a move within a disk type. It cannot notice a move across disk types, because the master never learns about it.

## What happens

`UpdateVolumes` asked only whether a volume id appeared *anywhere* in the report, so a volume that moved from an hdd disk to an ssd one was still "reported" and stayed in the hdd map, while the ssd map gained it as new. On `origin/master`:

```
copies=2 storedDiskType=""
```

The master then holds two copies of that volume forever. The volume count is overstated by one, and `GetVolumesById` returns whichever disk `dn.children` iterates first — so a lookup can hand back the disk the volume has already left.

Moves within one disk type were always handled: the volume stays in the same map and the disk id is updated in place.

## The fix

Track which disk types the heartbeat named each volume on, and treat a volume named on another disk as absent from this one. Disk types are interned to an index rather than stored per volume: a server reports a handful of them across hundreds of thousands of volumes, so a string header each would cost more than the map holding them. `BenchmarkSyncDataNodeRegistration/100000Volumes` moves from `23142575 B/op` to `23142640 B/op` — the interned type list and nothing else.

A volume named on two disks *at the same time* is a stale twin rather than a move — `store_duplicate_vid_test.go` covers the store handling that — and is still kept on both. Dropping one would tell the master a replica had vanished and could trigger re-replication of a volume that is fine.

That sharpens the duplicate marking added in #10619: a volume on two disk *types* is representable, since the two copies land in different maps, so it no longer disables digest comparison for the node. Only a volume named twice on one disk type is unrepresentable, and that is now what marks it.

## Why it matters beyond the count

Once heartbeats carry a digest, this is unreconcilable: the server digests one copy, the master digests two, and no amount of resending the full list closes the gap. The "already sent the list, do not ask again" guard in #10627 keeps that from looping, but the node would sit in full-list mode permanently — quietly losing exactly the saving the digest is for.

## Tests

`TestVolumeMovedBetweenDisks` covers a move within a type, across types, and back; `TestVolumeReportedOnTwoDiskTypesIsKept` and `TestVolumeReportedTwiceOnOneDiskTypeIsFlagged` separate the twin from the unrepresentable case; `TestVolumeDigestSurvivesADiskMove` checks the master ends up digesting what a server holding only the moved volume would report.

Refs #10603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved volume tracking when volumes move between disks or change disk types.
  * Prevented moved volumes from being incorrectly duplicated, removed, or reported as unavailable.
  * Improved handling of duplicate volume reports and volume indexing.
  * Preserved volume digest consistency during disk moves.
  * Correctly reports volumes removed from a node while ignoring disk-to-disk moves on the same node.

* **Tests**
  * Added coverage for volume moves, remounts, disk-type changes, duplicate reports, and removal notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->