### PR TITLE
telemetry: count erasure-coded volumes in the reported totals

### DIFF
--- a/weed/telemetry/collector.go
+++ b/weed/telemetry/collector.go
@@ -6,6 +6,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/telemetry/proto"
 	"github.com/seaweedfs/seaweedfs/weed/cluster"
 	"github.com/seaweedfs/seaweedfs/weed/glog"
+	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
 	"github.com/seaweedfs/seaweedfs/weed/topology"
 )
 
@@ -152,6 +153,7 @@ func (c *Collector) countVolumeServers() int {
 func (c *Collector) collectVolumeStats() (uint64, int) {
 	var totalDiskBytes uint64
 	var totalVolumeCount int
+	ecVolumeIds := make(map[needle.VolumeId]struct{})
 
 	for _, dcNode := range c.topo.Children() {
 		dc := dcNode.(*topology.DataCenter)
@@ -164,11 +166,21 @@ func (c *Collector) collectVolumeStats() (uint64, int) {
 					totalVolumeCount++
 					totalDiskBytes += volumeInfo.Size
 				}
+				// An encoded volume leaves GetVolumes and is reported as
+				// shards, so without this a cluster reports none of the
+				// bytes it erasure-coded. Every shard copy counts, parity
+				// included, the way a replicated volume counts every replica.
+				for _, ecInfo := range dn.GetEcShards() {
+					totalDiskBytes += uint64(ecInfo.ShardsInfo.TotalSize())
+					// One volume's shards are spread over many nodes, so
+					// count the volume once rather than once per holder.
+					ecVolumeIds[ecInfo.VolumeId] = struct{}{}
+				}
 			}
 		}
 	}
 
-	return totalDiskBytes, totalVolumeCount
+	return totalDiskBytes, totalVolumeCount + len(ecVolumeIds)
 }
 
 // countFilers counts the number of active filer servers across all groups

--- a/weed/telemetry/collector_test.go
+++ b/weed/telemetry/collector_test.go
@@ -1,0 +1,66 @@
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
+	"github.com/seaweedfs/seaweedfs/weed/sequence"
+	"github.com/seaweedfs/seaweedfs/weed/storage/erasure_coding"
+	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
+	"github.com/seaweedfs/seaweedfs/weed/topology"
+)
+
+// ecShardMessage builds a heartbeat message for the given shard ids, each
+// sized (id+1)*sizeUnit bytes.
+func ecShardMessage(vid uint32, sizeUnit int, shardIds ...erasure_coding.ShardId) *master_pb.VolumeEcShardInformationMessage {
+	shards := erasure_coding.NewShardsInfo()
+	for _, id := range shardIds {
+		shards.Set(erasure_coding.NewShardInfo(id, erasure_coding.ShardSize((int(id)+1)*sizeUnit)))
+	}
+	return &master_pb.VolumeEcShardInformationMessage{
+		Id:          vid,
+		EcIndexBits: shards.Bitmap(),
+		ShardSizes:  shards.SizesInt64(),
+	}
+}
+
+func TestCollectVolumeStatsCountsEcShards(t *testing.T) {
+	topo := topology.NewTopology("weedfs", sequence.NewMemorySequencer(), 32*1024, 5, false)
+
+	rack := topo.GetOrCreateDataCenter("dc1").GetOrCreateRack("rack1")
+	maxVolumeCounts := map[string]uint32{"": 25}
+	dn1 := rack.GetOrCreateDataNode("127.0.0.1", 34534, 0, "127.0.0.1", "", maxVolumeCounts)
+	dn2 := rack.GetOrCreateDataNode("127.0.0.2", 34534, 0, "127.0.0.2", "", maxVolumeCounts)
+
+	topo.SyncDataNodeRegistration([]*master_pb.VolumeInformationMessage{
+		{Id: 1, Size: 1000, FileCount: 10, Version: uint32(needle.GetCurrentVersion())},
+		{Id: 2, Size: 2000, FileCount: 20, Version: uint32(needle.GetCurrentVersion())},
+	}, dn1)
+
+	// Volume 10's shards span both nodes, with a second copy of shard 0 on
+	// dn2; volume 20 sits entirely on dn1.
+	topo.SyncDataNodeEcShards([]*master_pb.VolumeEcShardInformationMessage{
+		ecShardMessage(10, 100, 0, 1, 2, 3, 4, 5, 6),
+		ecShardMessage(20, 10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13),
+	}, dn1)
+	topo.SyncDataNodeEcShards([]*master_pb.VolumeEcShardInformationMessage{
+		ecShardMessage(10, 100, 0, 7, 8, 9, 10, 11, 12, 13),
+	}, dn2)
+
+	collector := NewCollector(nil, topo, nil)
+	diskBytes, volumeCount := collector.collectVolumeStats()
+
+	// 3000 from the two regular volumes, plus every shard copy of volume 10
+	// sized (id+1)*100 — 100..700 on dn1, and 800..1400 plus the second copy
+	// of shard 0 on dn2 — and volume 20's 14 shards at (id+1)*10.
+	const expectedDiskBytes = 3000 + 2800 + (7700 + 100) + 1050
+	if diskBytes != expectedDiskBytes {
+		t.Errorf("Expected %d total disk bytes, got %d", expectedDiskBytes, diskBytes)
+	}
+
+	// 2 regular volumes plus EC volumes 10 and 20 — volume 10 counts once
+	// even though two nodes hold its shards.
+	if volumeCount != 4 {
+		t.Errorf("Expected 4 volumes, got %d", volumeCount)
+	}
+}


### PR DESCRIPTION
### The bug

`collectVolumeStats` walks `DataNode.GetVolumes()`, which resolves to `Disk.GetVolumes()` → `d.volumes`. EC shards are held in a **separate** map (`weed/topology/disk.go:27`) reachable only through `DataNode.GetEcShards()`, which the collector never called.

So both reported fields silently excluded all erasure-coded data:

- `total_disk_bytes` — EC'd bytes contributed nothing
- `total_volume_count` — EC volumes weren't counted at all

A cluster that encoded everything reported **zero bytes and zero volumes** while still counting as a volume server. Since erasure coding correlates with cluster size and maturity, the aggregate under-reports precisely the largest deployments, and also skews bytes-per-server downward.

The new test shows the scale on a small fixture: before the fix it reports 3000 of 14650 bytes and 2 of 4 volumes.

### The fix

Sum each holder's `ShardsInfo.TotalSize()` into the byte total. Every shard copy counts, parity included — matching how a replicated volume's used size counts every replica, and how `Topology.CollectionEcVolumeStats` (`weed/topology/topology_ec.go:190`) already reports EC footprint for `/dir/status`. `total_disk_bytes` is raw physical size elsewhere too (it doesn't subtract `DeletedByteCount`), so this keeps the field's existing meaning.

The part worth reviewing: **counting volume ids, not shard entries**. One volume's shards are spread across ~14 nodes, and `GetEcShards` returns an entry per (volume, disk) — so incrementing per entry would multiply the EC volume count by the number of holders, turning an undercount into a larger overcount. Deduping through a `needle.VolumeId` set is what keeps volume 10 counted once in the test despite living on two nodes.

### Test

`TestCollectVolumeStatsCountsEcShards` builds a topology with two regular volumes and two EC volumes, one spanning both nodes with a duplicated shard 0 (the over-replication a shard move produces), and asserts both totals. Confirmed failing before the fix and passing after.

`go build ./weed/...` clean; `weed/telemetry` and `weed/topology` tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved volume statistics to include storage used by erasure-coded shard copies, including parity and replicas.
  * Corrected volume counts so erasure-coded volumes are counted once rather than once per shard.

* **Tests**
  * Added coverage verifying accurate storage usage and volume counts for erasure-coded and regular volumes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->