### PR TITLE
topology: clamp the deleted-vs-total subtractions in volume stats

### DIFF
--- a/weed/shell/command_fs_merge_volumes.go
+++ b/weed/shell/command_fs_merge_volumes.go
@@ -465,7 +465,12 @@ func (c *commandFsMergeVolumes) getVolumeSizeBasedOnPlan(plan map[needle.VolumeI
 	return size
 }
 
+// getVolumeSize is the volume's live data size, clamped since
+// DeletedByteCount can transiently exceed Size.
 func (c *commandFsMergeVolumes) getVolumeSize(volume *master_pb.VolumeInformationMessage) uint64 {
+	if volume.Size < volume.DeletedByteCount {
+		return 0
+	}
 	return volume.Size - volume.DeletedByteCount
 }
 

--- a/weed/shell/command_fs_merge_volumes_test.go
+++ b/weed/shell/command_fs_merge_volumes_test.go
@@ -123,3 +123,18 @@ func TestCreateMergePlan_DirectedRejectsIneligible(t *testing.T) {
 		})
 	}
 }
+
+// A volume reporting more deleted bytes than it holds must read as empty.
+func TestGetVolumeSize_ClampsDeletedOverSize(t *testing.T) {
+	c := newMergeCmd(250000)
+
+	overDeleted := &master_pb.VolumeInformationMessage{Id: 1, Size: 1000, DeletedByteCount: 4000}
+	if got := c.getVolumeSize(overDeleted); got != 0 {
+		t.Errorf("expected 0 for a volume with more deleted than stored, got %d", got)
+	}
+
+	healthy := &master_pb.VolumeInformationMessage{Id: 2, Size: 3000, DeletedByteCount: 1000}
+	if got := c.getVolumeSize(healthy); got != 2000 {
+		t.Errorf("expected 2000, got %d", got)
+	}
+}

--- a/weed/topology/topology_stats_test.go
+++ b/weed/topology/topology_stats_test.go
@@ -111,3 +111,25 @@ func TestCollectionVolumeStatsWithEcVolumes(t *testing.T) {
 		t.Errorf("ec stats query should not create a phantom collection")
 	}
 }
+
+func TestCollectionVolumeStatsClampsDeletedOverTotals(t *testing.T) {
+	topo := NewTopology("weedfs", sequence.NewMemorySequencer(), 32*1024, 5, false)
+
+	rack := topo.GetOrCreateDataCenter("dc1").GetOrCreateRack("rack1")
+	dn := rack.GetOrCreateDataNode("127.0.0.1", 34534, 0, "127.0.0.1", "", map[string]uint32{"": 25})
+
+	// Volume 1 reports more deleted than it holds, on both counters.
+	topo.SyncDataNodeRegistration([]*master_pb.VolumeInformationMessage{
+		{Id: 1, Size: 1000, FileCount: 10, DeletedByteCount: 4000, DeleteCount: 40, Version: uint32(needle.GetCurrentVersion())},
+		{Id: 2, Size: 3000, FileCount: 30, DeletedByteCount: 1000, DeleteCount: 10, Version: uint32(needle.GetCurrentVersion())},
+	}, dn)
+
+	// VolumeLocationList.Stats only counts nodes connected for over a minute
+	dn.LastSeen = time.Now().Unix() - 61
+
+	stats := topo.CollectionVolumeStats("")
+	// Volume 1 contributes nothing rather than wrapping.
+	assert(t, "used size", int(stats.UsedSize), 2000)
+	assert(t, "logical used size", int(stats.LogicalUsedSize), 2000)
+	assert(t, "file count", int(stats.FileCount), 20)
+}

--- a/weed/topology/volume_location_list.go
+++ b/weed/topology/volume_location_list.go
@@ -96,13 +96,21 @@ func (dnll *VolumeLocationList) Refresh(freshThreshHold int64) {
 	}
 }
 
-// Stats returns logic size and count
+// Stats returns logic size and count. Both subtractions are clamped: the
+// deleted counters are maintained apart from the totals they come off and can
+// transiently exceed them.
 func (dnll *VolumeLocationList) Stats(vid needle.VolumeId, freshThreshHold int64) (size uint64, fileCount int) {
 	for _, dnl := range dnll.list {
 		if dnl.LastSeen < freshThreshHold {
 			vinfo, err := dnl.GetVolumesById(vid)
 			if err == nil {
-				return (vinfo.Size - vinfo.DeletedByteCount), vinfo.FileCount - vinfo.DeleteCount
+				if vinfo.Size > vinfo.DeletedByteCount {
+					size = vinfo.Size - vinfo.DeletedByteCount
+				}
+				if vinfo.FileCount > vinfo.DeleteCount {
+					fileCount = vinfo.FileCount - vinfo.DeleteCount
+				}
+				return size, fileCount
 			}
 		}
 	}


### PR DESCRIPTION
`VolumeLocationList.Stats` subtracts the deleted figures from the totals to report live size and needle count:

```go
return (vinfo.Size - vinfo.DeletedByteCount), vinfo.FileCount - vinfo.DeleteCount
```

Both deleted figures come from counters (`FileCounter`/`DeletionCounter`, `FileByteCounter`/`DeletionByteCounter` in `needle_map_metric.go`) maintained independently of the totals they're subtracted from, so either can transiently exceed its total. Neither subtraction was clamped.

- **Size** is `uint64` — it wraps to ~16 EB.
- **Count** is signed, so it merely goes negative — but `VolumeLayout.Stats` does `ret.FileCount += uint64(fileCount)` (`volume_layout.go:1013`), turning it into ~1.8e19 just the same.

Either one swamps the cluster totals behind `/dir/status`, `/vol/status` and `Topology.CollectionVolumeStats`.

`commandFsMergeVolumes.getVolumeSize` had the same unclamped subtraction, where a wrapped size reads as a volume far too large to take part in any merge plan.

Both are clamped to zero, matching the guards already present in `CollectionInfo.LogicalSize` (`s3api/bucket_size_metrics.go:43`, `shell/command_collection_list.go:44`) and the admin server's logical-size accumulator (`admin/dash/admin_server.go:1951`) — that last one guards this exact per-volume `uint64` case, so this just brings the remaining two call sites in line.

### Tests

Both were confirmed failing before the fix:

- `TestCollectionVolumeStatsClampsDeletedOverTotals` — a volume over-reporting on both counters alongside a healthy one. Unfixed, used size comes out `-1000` instead of `2000`.
- `TestGetVolumeSize_ClampsDeletedOverSize` — unfixed, returns `18446744073709548616`.

The two clamps are independently necessary: with only the size clamp applied, the same topology test still fails on file count (`-10` vs `20`).

### Notes

I have not reproduced per-volume `DeletedByteCount > Size` on a live cluster — the argument here is the inconsistency with the three call sites that already guard it, plus the size of the blast radius when it does happen. The change is a pure clamp, so it can only affect the path where the numbers are already nonsense.

Not touched: `cluster_volumes_templ.go` and `volume_details_templ.go` do the same subtraction, but they're generated files and display-only, so they'd want the fix in the `.templ` sources instead.

`go build ./weed/...` clean; `weed/topology` and `weed/shell` tests pass. `go vet ./weed/shell/` reports a pre-existing lock-copy warning in `command_volume_delete_empty_test.go` that is present on master and unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected volume size calculations when deleted data exceeds recorded totals.
  - Prevented invalid negative or oversized storage and file statistics.
  - Preserved accurate remaining usage and file counts for healthy volumes.

- **Tests**
  - Added coverage for oversized deleted-byte and deleted-file counters.
  - Verified valid calculations remain unchanged for healthy volumes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->