### PR TITLE
mount: let the kernel cache directory listings

### DIFF
--- a/weed/mount/weedfs.go
+++ b/weed/mount/weedfs.go
@@ -801,7 +801,31 @@ func (wfs *WFS) onEntryInvalidation(invalidation meta_cache.EntryInvalidation) {
 	if listener != nil {
 		listener(invalidation)
 	}
+	wfs.invalidateKernelDirListing(invalidation.Path)
 	wfs.invalidateOpenFileHandle(invalidation)
+}
+
+// invalidateKernelDirListing drops the kernel's cached listing of the directory
+// holding path. Safe here because invalidations run on their own worker, never
+// on a thread serving a kernel request; notifying from a handler can deadlock
+// against the page it holds, which is why the file paths avoid InodeNotify.
+// A directory the kernel has not looked up has no inode here and nothing
+// cached, so it is skipped.
+func (wfs *WFS) invalidateKernelDirListing(path util.FullPath) {
+	server := wfs.fuseServer
+	if server == nil {
+		return
+	}
+	dir, _ := path.DirAndName()
+	dirInode, found := wfs.inodeToPath.GetInode(util.FullPath(dir))
+	if !found {
+		return
+	}
+	// ENOENT is the kernel not holding the inode, ENOSYS a kernel without the
+	// notify; neither is worth a line.
+	if status := server.InodeNotify(dirInode, 0, -1); status != fuse.OK && status != fuse.ENOENT && status != fuse.ENOSYS {
+		glog.V(4).Infof("invalidate kernel listing of %s: %v", dir, status)
+	}
 }
 
 // MountRoot is the filer path this mount is rooted at. Event paths are absolute

--- a/weed/mount/weedfs_dir_read.go
+++ b/weed/mount/weedfs_dir_read.go
@@ -108,6 +108,12 @@ func (wfs *WFS) OpenDir(cancel <-chan struct{}, input *fuse.OpenIn, out *fuse.Op
 	}
 	dhid, _ := wfs.AcquireDirectoryHandle()
 	out.Fh = uint64(dhid)
+	// Let the kernel keep the listing in the directory's page cache, so
+	// reopening the directory does not reach the mount at all. Local mutations
+	// drop that cache in the kernel; remote ones arrive through the metadata
+	// subscription, which notifies the kernel per changed directory. A kernel
+	// too old for the flag ignores it.
+	out.OpenFlags |= fuse.FOPEN_CACHE_DIR | fuse.FOPEN_KEEP_CACHE
 	return fuse.OK
 }
 

--- a/weed/mount/weedfs_dir_read_cache_flags_test.go
+++ b/weed/mount/weedfs_dir_read_cache_flags_test.go
@@ -1,0 +1,32 @@
+package mount
+
+import (
+	"testing"
+
+	"github.com/seaweedfs/go-fuse/v2/fuse"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+)
+
+// TestOpenDirEnablesKernelListingCache pins the reply flags: without them the
+// kernel calls back for every enumeration, and losing them would silently
+// revert repeat listings to full walks of the mount.
+func TestOpenDirEnablesKernelListingCache(t *testing.T) {
+	dir := util.FullPath("/images")
+	wfs := newBenchWFS(t, dir, 4)
+	dirInode, _ := wfs.inodeToPath.GetInode(dir)
+
+	var out fuse.OpenOut
+	if status := wfs.OpenDir(nil, &fuse.OpenIn{InHeader: fuse.InHeader{NodeId: dirInode}}, &out); status != fuse.OK {
+		t.Fatalf("OpenDir: %v", status)
+	}
+	defer wfs.ReleaseDir(&fuse.ReleaseIn{Fh: out.Fh})
+
+	for _, want := range []struct {
+		name string
+		flag uint32
+	}{{"FOPEN_CACHE_DIR", fuse.FOPEN_CACHE_DIR}, {"FOPEN_KEEP_CACHE", fuse.FOPEN_KEEP_CACHE}} {
+		if out.OpenFlags&want.flag == 0 {
+			t.Errorf("OpenDir reply lacks %s", want.name)
+		}
+	}
+}


### PR DESCRIPTION
Repeat enumerations of a directory re-walked the whole FUSE machinery every
time. The kernel has a cache for exactly this — `FOPEN_CACHE_DIR`, Linux 4.20+ —
and the mount never enabled it. With it, the listing lives in the directory's
page cache and a repeat `ls` never reaches the mount at all.

Two lines carry the feature; the rest is invalidation, and that is the part
that had to be proven rather than assumed:

- Local mutations through the mount already invalidate the kernel's dir cache
  in-kernel.
- Remote mutations arrive through the metadata subscription. The entry
  invalidation worker now also issues `InodeNotify` for the changed entry's
  directory. The worker is the one safe place to do this from: notifying from a
  thread serving a kernel request can deadlock against the page it holds, which
  is why the file-data paths deliberately avoid `InodeNotify` today.
- A kernel too old for the flag ignores it; a kernel without the notify returns
  ENOSYS and is ignored.

Measured end to end in a Linux container (weed server + mount, 20k-entry
directory, `ls -f | wc -l`):

```
                      master     this PR
    warm listing    199-355ms     6-9ms
```

The invalidation was verified live, not by inspection: a file PUT to the filer
from outside the mount appeared in the next listing within one second, and the
listing re-cached afterwards.

Where this sits relative to the other listing work:

- It composes with #10631: the page cache sits above the whole mount, so
  read-through oversized directories get warm listings too — the mount-side
  caches never see those.
- It supersedes the Linux warm-listing case of #10629 at a fraction of the
  size, with the memory in reclaimable page cache instead of the Go heap. What
  #10629 would still uniquely cover is consumers with no kernel above the WFS
  layer and serving stat storms from memory; holding it unmerged.
- The Windows analog is WinFsp's DirInfoTimeout plus the change notifications
  the mount already pushes. Left out here deliberately: I cannot verify on real
  WinFsp that its notify purges the DirInfo cache, and an unverifiable
  staleness window is not worth shipping blind.

Context: #10533, #10020.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory listing cache consistency after metadata changes.
  * Preserved cached directory contents when reopening directories.
  * Reduced errors from expected directory notification conditions while retaining diagnostics for unexpected failures.

* **Tests**
  * Added coverage verifying directory handles retain the expected caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->