### PR TITLE
wdclient: keep the location of a volume reported added and removed at once

### DIFF
--- a/weed/wdclient/masterclient.go
+++ b/weed/wdclient/masterclient.go
@@ -351,6 +351,22 @@ func (mc *MasterClient) tryConnectToMaster(ctx context.Context, master pb.Server
 	return nextHintedLeader
 }
 
+// addedVids indexes added ids that are also being removed. A volume moved
+// between a server's disks is reported both ways in one message, and the server
+// still has it -- acting on the removal would drop a good location, whichever
+// order the two lists happen to be applied in. Empty unless both lists are
+// non-empty, so the full id list a client gets on connect costs nothing.
+func addedVids(added, removed []uint32) map[uint32]struct{} {
+	if len(added) == 0 || len(removed) == 0 {
+		return nil
+	}
+	index := make(map[uint32]struct{}, len(added))
+	for _, vid := range added {
+		index[vid] = struct{}{}
+	}
+	return index
+}
+
 func (mc *MasterClient) updateVidMap(resp *master_pb.KeepConnectedResponse) {
 	if resp.VolumeLocation.IsEmptyUrl() {
 		glog.V(0).Infof("updateVidMap ignore short heartbeat: %+v", resp)
@@ -363,19 +379,27 @@ func (mc *MasterClient) updateVidMap(resp *master_pb.KeepConnectedResponse) {
 		DataCenter: resp.VolumeLocation.DataCenter,
 		GrpcPort:   int(resp.VolumeLocation.GrpcPort),
 	}
+	stillOnServer := addedVids(resp.VolumeLocation.NewVids, resp.VolumeLocation.DeletedVids)
 	for _, newVid := range resp.VolumeLocation.NewVids {
 		glog.V(2).Infof("%s.%s: %s masterClient adds volume %d", mc.FilerGroup, mc.clientType, loc.Url, newVid)
 		mc.addLocation(newVid, loc)
 	}
 	for _, deletedVid := range resp.VolumeLocation.DeletedVids {
+		if _, moved := stillOnServer[deletedVid]; moved {
+			continue
+		}
 		glog.V(2).Infof("%s.%s: %s masterClient removes volume %d", mc.FilerGroup, mc.clientType, loc.Url, deletedVid)
 		mc.deleteLocation(deletedVid, loc)
 	}
+	stillOnServerEc := addedVids(resp.VolumeLocation.NewEcVids, resp.VolumeLocation.DeletedEcVids)
 	for _, newEcVid := range resp.VolumeLocation.NewEcVids {
 		glog.V(2).Infof("%s.%s: %s masterClient adds ec volume %d", mc.FilerGroup, mc.clientType, loc.Url, newEcVid)
 		mc.addEcLocation(newEcVid, loc)
 	}
 	for _, deletedEcVid := range resp.VolumeLocation.DeletedEcVids {
+		if _, moved := stillOnServerEc[deletedEcVid]; moved {
+			continue
+		}
 		glog.V(2).Infof("%s.%s: %s masterClient removes ec volume %d", mc.FilerGroup, mc.clientType, loc.Url, deletedEcVid)
 		mc.deleteEcLocation(deletedEcVid, loc)
 	}

--- a/weed/wdclient/masterclient_move_test.go
+++ b/weed/wdclient/masterclient_move_test.go
@@ -1,0 +1,68 @@
+package wdclient
+
+import (
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
+)
+
+func moveClient() *MasterClient {
+	return &MasterClient{vidMapClient: newVidMapClient(nil, "", 0)}
+}
+
+func moveResponse(newVids, deletedVids []uint32) *master_pb.KeepConnectedResponse {
+	return &master_pb.KeepConnectedResponse{VolumeLocation: &master_pb.VolumeLocation{
+		Url: "server:8080", PublicUrl: "server:8080", NewVids: newVids, DeletedVids: deletedVids,
+	}}
+}
+
+// A volume moved between a server's disks arrives added and removed at once,
+// and the server still has it.
+func TestMovedVolumeKeepsItsLocation(t *testing.T) {
+	mc := moveClient()
+	mc.updateVidMap(moveResponse([]uint32{1}, nil))
+	mc.updateVidMap(moveResponse([]uint32{1}, []uint32{1}))
+
+	locations, found := mc.GetLocations(1)
+	if !found || len(locations) != 1 {
+		t.Errorf("a volume that moved between its server's disks lost its location: found=%v %v", found, locations)
+	}
+}
+
+func TestRemovedVolumeLosesItsLocation(t *testing.T) {
+	mc := moveClient()
+	mc.updateVidMap(moveResponse([]uint32{1}, nil))
+	mc.updateVidMap(moveResponse(nil, []uint32{1}))
+
+	if locations, found := mc.GetLocations(1); found && len(locations) > 0 {
+		t.Errorf("a volume that left the server kept its location: %v", locations)
+	}
+}
+
+// Removals of other volumes in the same message must still apply.
+func TestRemovalsAlongsideAMoveStillApply(t *testing.T) {
+	mc := moveClient()
+	mc.updateVidMap(moveResponse([]uint32{1, 2}, nil))
+	mc.updateVidMap(moveResponse([]uint32{1}, []uint32{1, 2}))
+
+	if locations, found := mc.GetLocations(1); !found || len(locations) != 1 {
+		t.Errorf("the moved volume lost its location: found=%v %v", found, locations)
+	}
+	if locations, found := mc.GetLocations(2); found && len(locations) > 0 {
+		t.Errorf("a volume that left the server kept its location: %v", locations)
+	}
+}
+
+func TestEcVolumeMovedKeepsItsLocation(t *testing.T) {
+	mc := moveClient()
+	resp := &master_pb.KeepConnectedResponse{VolumeLocation: &master_pb.VolumeLocation{
+		Url: "server:8080", PublicUrl: "server:8080", NewEcVids: []uint32{7},
+	}}
+	mc.updateVidMap(resp)
+	resp.VolumeLocation.DeletedEcVids = []uint32{7}
+	mc.updateVidMap(resp)
+
+	if locations, found := mc.GetLocations(7); !found || len(locations) != 1 {
+		t.Errorf("an ec volume reported both ways lost its location: found=%v %v", found, locations)
+	}
+}

--- a/weed/wdclient/masterclient_move_test.go
+++ b/weed/wdclient/masterclient_move_test.go
@@ -53,16 +53,28 @@ func TestRemovalsAlongsideAMoveStillApply(t *testing.T) {
 	}
 }
 
+func moveEcResponse(newEcVids, deletedEcVids []uint32) *master_pb.KeepConnectedResponse {
+	return &master_pb.KeepConnectedResponse{VolumeLocation: &master_pb.VolumeLocation{
+		Url: "server:8080", PublicUrl: "server:8080", NewEcVids: newEcVids, DeletedEcVids: deletedEcVids,
+	}}
+}
+
 func TestEcVolumeMovedKeepsItsLocation(t *testing.T) {
 	mc := moveClient()
-	resp := &master_pb.KeepConnectedResponse{VolumeLocation: &master_pb.VolumeLocation{
-		Url: "server:8080", PublicUrl: "server:8080", NewEcVids: []uint32{7},
-	}}
-	mc.updateVidMap(resp)
-	resp.VolumeLocation.DeletedEcVids = []uint32{7}
-	mc.updateVidMap(resp)
+	mc.updateVidMap(moveEcResponse([]uint32{7}, nil))
+	mc.updateVidMap(moveEcResponse([]uint32{7}, []uint32{7}))
 
 	if locations, found := mc.GetLocations(7); !found || len(locations) != 1 {
 		t.Errorf("an ec volume reported both ways lost its location: found=%v %v", found, locations)
+	}
+}
+
+func TestEcVolumeRemovedLosesItsLocation(t *testing.T) {
+	mc := moveClient()
+	mc.updateVidMap(moveEcResponse([]uint32{7}, nil))
+	mc.updateVidMap(moveEcResponse(nil, []uint32{7}))
+
+	if locations, found := mc.GetLocations(7); found && len(locations) > 0 {
+		t.Errorf("an ec volume that left the server kept its location: %v", locations)
 	}
 }


### PR DESCRIPTION
Hardening on the client side of the same problem as #10628, which fixes it on the master side.

A `VolumeLocation` message is about one server, so a volume id appearing in both `NewVids` and `DeletedVids` can only mean it moved between that server's own disks — it is still there. `updateVidMap` applied additions before removals, so the removal won and the client ended up with no location for a volume that never went anywhere.

Reachable today without #10628: a volume server that unmounts and remounts a volume within one delta batch produces exactly that pair.

## Not reordering

Applying removals first would give the right end state, but `addLocation` and `deleteLocation` take the lock separately, so it opens a window where the volume resolves nowhere — trading a wrong answer for an intermittent one, which is harder to diagnose.

Skipping the removal for ids that are also being added has no window and does not depend on the order the two lists happen to be applied in. Same for the ec lists, which have the same shape.

The index is only built when both lists are non-empty, so the full id list a client receives on connect — hundreds of thousands of ids with no removals — costs nothing.

## Why both sides

#10628 stops the master emitting the contradiction, which is the real fix and the only one that helps the clients already deployed. This one means a client is not at the mercy of the master getting that right, including against masters that predate it.

Four tests: a moved volume keeps its location, one that really left loses it, removals alongside a move still apply, and the ec path behaves the same.

Refs #10603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved volume tracking during disk moves so relocated volumes retain their server location.
  * Prevented volumes from being incorrectly removed when move and deletion notifications occur together.
  * Applied the same protection to erasure-coded volumes.
  * Ensured genuinely removed volumes are no longer listed.

* **Tests**
  * Added coverage for regular and erasure-coded volume moves, removals, and mixed move/removal updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->