### PR TITLE
mount: absorb the WinFsp metadata cache window in the concurrent-reader test

### DIFF
--- a/test/winfsp/semantics_test.go
+++ b/test/winfsp/semantics_test.go
@@ -352,6 +352,21 @@ func TestConcurrentReaders(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 
+	// WriteFile's own existence probe ran while the file did not exist, and
+	// WinFsp may serve that answer from its metadata cache for up to the
+	// mount's FileInfoTimeout. Establish visibility once before racing the
+	// readers, so the race exercises concurrent reading rather than the
+	// cache window.
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if _, err := os.Stat(path); err == nil {
+			break
+		} else if time.Now().After(deadline) {
+			t.Fatalf("file never became visible: %v", err)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
 	var wg sync.WaitGroup
 	errs := make(chan error, 8)
 	for r := 0; r < 8; r++ {


### PR DESCRIPTION
`TestConcurrentReaders` failed once on the #10634 branch with
`open ...\read-me: The system cannot find the file specified` — a just-written
file invisible to a racing reader.

Not a regression from that PR: the Windows path is provably untouched by it
(`fuseServer` is nil on Windows so the new notify is gated off, and the WinFsp
adapter never reads the new `OpenFlags` bits), and the merged code passed this
workflow twice on master immediately after. First failure in the workflow's
run history.

The window is real, though: the mount sets WinFsp's `FileInfoTimeout` to one
second, `os.WriteFile`'s own existence probe runs while the file does not
exist, and WinFsp may serve that cached not-found to an open for up to the
window. The test now establishes visibility once, with a bounded retry, before
racing the readers — so it fails loudly if the file genuinely never appears,
and exercises concurrent reading rather than the cache window it was
accidentally also testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrent file-reading tests by waiting until newly written files are visible before reading them.
  * Reduced intermittent failures caused by filesystem metadata visibility timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->