### PR TITLE
filer: drain pending log chunk refs when the metadata stream ends

### DIFF
--- a/weed/pb/filer_pb_tail.go
+++ b/weed/pb/filer_pb_tail.go
@@ -135,10 +135,38 @@ func makeSubscribeMetadataFunc(option *MetadataFollowOption, processEventFn Proc
 
 		var pendingRefs []*filer_pb.LogFileChunkRef
 
+		// drainPendingRefs reads whatever chunk refs have accumulated. The server
+		// sends refs in their own responses, so they can only be read once
+		// something tells us the run of refs has ended — either a normal event, or
+		// the end of the stream. A bounded subscription (StopTsNs set, range
+		// already in the past) may get nothing but refs and then EOF, so draining
+		// only on the former silently returns no events at all.
+		drainPendingRefs := func() error {
+			if len(pendingRefs) == 0 || option.LogFileReaderFn == nil {
+				return nil
+			}
+			lastTs, readErr := ReadLogFileRefs(pendingRefs, option.LogFileReaderFn,
+				option.StartTsNs, option.StopTsNs,
+				PathFilter{
+					PathPrefix:             option.PathPrefix,
+					AdditionalPathPrefixes: option.AdditionalPathPrefixes,
+					DirectoriesToWatch:     option.DirectoriesToWatch,
+				},
+				processEventFn)
+			if readErr != nil {
+				return fmt.Errorf("read log file refs: %w", readErr)
+			}
+			if lastTs > 0 {
+				option.StartTsNs = lastTs
+			}
+			pendingRefs = nil
+			return nil
+		}
+
 		for {
 			resp, listenErr := stream.Recv()
 			if listenErr == io.EOF {
-				return nil
+				return drainPendingRefs()
 			}
 			if listenErr != nil {
 				return listenErr
@@ -151,22 +179,8 @@ func makeSubscribeMetadataFunc(option *MetadataFollowOption, processEventFn Proc
 			}
 
 			// Process accumulated refs before handling normal events (transition point)
-			if len(pendingRefs) > 0 && option.LogFileReaderFn != nil {
-				lastTs, readErr := ReadLogFileRefs(pendingRefs, option.LogFileReaderFn,
-					option.StartTsNs, option.StopTsNs,
-					PathFilter{
-						PathPrefix:             option.PathPrefix,
-						AdditionalPathPrefixes: option.AdditionalPathPrefixes,
-						DirectoriesToWatch:     option.DirectoriesToWatch,
-					},
-					processEventFn)
-				if readErr != nil {
-					return fmt.Errorf("read log file refs: %w", readErr)
-				}
-				if lastTs > 0 {
-					option.StartTsNs = lastTs
-				}
-				pendingRefs = nil
+			if err := drainPendingRefs(); err != nil {
+				return err
 			}
 
 			// Process the envelope event (top-level fields) and any batched tail.


### PR DESCRIPTION
In metadata chunks mode (`MetadataFollowOption.LogFileReaderFn` set) the server sends log file refs in responses of their own, and the client can only read them once it knows the run of refs has ended. That was inferred **solely** from a normal event arriving afterwards:

```go
for {
    resp, listenErr := stream.Recv()
    if listenErr == io.EOF {
        return nil                       // pending refs dropped here
    }
    if len(resp.LogFileRefs) > 0 {
        pendingRefs = append(pendingRefs, resp.LogFileRefs...)
        continue
    }
    if len(pendingRefs) > 0 { ...ReadLogFileRefs... }   // only reachable via a normal event
    ...
}
```

So refs still pending when the stream ends are discarded, and the subscription returns **no events and no error**.

A follower never trips this: it runs forever, so a live event always arrives to close the run. That is why the only current user of the mode — the mount metadata cache — is unaffected.

A **bounded** subscription is a different story. With `StopTsNs` set over a range that is already in the past, the server can send refs for the whole range and then close the stream, with no normal event in between. The client then reports that nothing happened. For anything auditing a path that is the worst possible outcome, because an empty result is indistinguishable from a genuinely quiet period — it produces a confident wrong answer rather than an error.

The fix hoists the read into a small closure and calls it on EOF as well as at the transition point.

## How it was found

Chasing a support case, running a bounded scan over a two-day window four days in the past. It returned instantly with zero changes; the same range read through the filer returned the events. The window ending in the past is what makes it reproducible — a window running to `now` picks up in-memory events that close the ref run and mask it.

## Scope

`weed/pb/filer_pb_tail.go` only, no behaviour change for followers. Split out of #10645 (which adds a command that uses bounded metadata-chunks subscriptions and is what surfaced this); that PR is stacked on this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pending log-file references are now processed reliably before normal events and when subscriptions reach the end.
  * Bounded subscriptions containing only pending references now complete correctly instead of ending prematurely.
  * Subscription start timestamps are updated consistently after pending references are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->