### PR TITLE
storage: fix corrupted leveldb detection in DoOffsetLoading

### DIFF
--- a/weed/storage/needle_map_leveldb.go
+++ b/weed/storage/needle_map_leveldb.go
@@ -359,7 +359,7 @@ func (m *LevelDbNeedleMap) DoOffsetLoading(v *Volume, indexFile *os.File, startF
 
 	}()
 	if dbErr != nil {
-		if errors.IsCorrupted(err) {
+		if errors.IsCorrupted(dbErr) {
 			db, dbErr = leveldb.RecoverFile(dbFileName, nil)
 		}
 		if dbErr != nil {


### PR DESCRIPTION
# What problem are we solving?

In `DoOffsetLoading` (weed/storage/needle_map_leveldb.go), when `leveldb.OpenFile` fails, the code checks `errors.IsCorrupted(err)` to decide whether to attempt recovery via `leveldb.RecoverFile`. However, `err` is the function's named return value, which is still `nil` at that point — the actual open error is stored in `dbErr`. As a result, `errors.IsCorrupted` always receives `nil` and the corruption-recovery path is never taken; a corrupted `.cpldb` index file just returns the open error immediately instead of being recovered.

# How are we solving the problem?

Check `errors.IsCorrupted(dbErr)` instead of `errors.IsCorrupted(err)`, matching the same pattern already used correctly elsewhere in this file (e.g. `NewLevelDbNeedleMap`).

# How is the PR tested?

`go build ./weed/storage/...` passes. This is a one-line variable fix with no behavior change to the non-error path.

# Checks
- [x] I have added unit tests if possible. (N/A — one-line variable fix, no new behavior to unit test beyond existing coverage)
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LevelDB storage recovery by correctly detecting database corruption when opening the database fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->