### PR TITLE
topology: mark a volume crowded only if it can take writes

### DIFF
--- a/weed/topology/crowded_writable_test.go
+++ b/weed/topology/crowded_writable_test.go
@@ -28,21 +28,23 @@ func TestCrowdedVolumesAreOnesThatCanTakeWrites(t *testing.T) {
 	// The channels are unbuffered and normally drained by the writable-refresh
 	// loop, which is not running here.
 	crowded := map[needle.VolumeId]bool{}
-	collected := make(chan struct{})
+	stop, done := make(chan struct{}), make(chan struct{})
 	go func() {
+		defer close(done)
 		for {
 			select {
 			case v := <-topo.chanCrowdedVolumes:
 				crowded[v.Id] = true
 			case <-topo.chanFullVolumes:
-			case <-collected:
+			case <-stop:
 				return
 			}
 		}
 	}()
 	topo.CollectDeadNodeAndFullVolumes(time.Now().Unix()-1, topo.volumeSizeLimit, 0.9)
 	time.Sleep(50 * time.Millisecond)
-	close(collected)
+	close(stop)
+	<-done // the collector owns the map until it returns
 
 	if !crowded[needle.VolumeId(1)] {
 		t.Error("a writable volume past the threshold was not reported crowded")

--- a/weed/topology/crowded_writable_test.go
+++ b/weed/topology/crowded_writable_test.go
@@ -41,8 +41,9 @@ func TestCrowdedVolumesAreOnesThatCanTakeWrites(t *testing.T) {
 			}
 		}
 	}()
+	// The channels are unbuffered, so every send has been received by the time
+	// this returns; waiting for the collector to finish covers the recording.
 	topo.CollectDeadNodeAndFullVolumes(time.Now().Unix()-1, topo.volumeSizeLimit, 0.9)
-	time.Sleep(50 * time.Millisecond)
 	close(stop)
 	<-done // the collector owns the map until it returns
 

--- a/weed/topology/crowded_writable_test.go
+++ b/weed/topology/crowded_writable_test.go
@@ -1,0 +1,72 @@
+package topology
+
+import (
+	"testing"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
+	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
+	"github.com/seaweedfs/seaweedfs/weed/storage/super_block"
+	"github.com/seaweedfs/seaweedfs/weed/storage/types"
+)
+
+// Crowding asks for more room to write into, so a read-only volume has nothing
+// to say about it. Growth already discounts them by intersecting with the
+// writable list, so an entry for one is weight and nothing else.
+func TestCrowdedVolumesAreOnesThatCanTakeWrites(t *testing.T) {
+	topo := NewTopology("crowd", nil, 10000, 5, false)
+	dn := topo.GetOrCreateDataCenter("dc1").GetOrCreateRack("rack1").
+		GetOrCreateDataNode("127.0.0.1", 8080, 18080, "", "", map[string]uint32{"": 100})
+
+	// Both are past the growth threshold; only one can be written to.
+	topo.SyncDataNodeRegistration([]*master_pb.VolumeInformationMessage{
+		{Id: 1, Size: 9500, Collection: "c", Version: 3},
+		{Id: 2, Size: 9500, Collection: "c", Version: 3, ReadOnly: true},
+	}, dn)
+	dn.LastSeen = time.Now().Unix()
+
+	// The channels are unbuffered and normally drained by the writable-refresh
+	// loop, which is not running here.
+	crowded := map[needle.VolumeId]bool{}
+	collected := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case v := <-topo.chanCrowdedVolumes:
+				crowded[v.Id] = true
+			case <-topo.chanFullVolumes:
+			case <-collected:
+				return
+			}
+		}
+	}()
+	topo.CollectDeadNodeAndFullVolumes(time.Now().Unix()-1, topo.volumeSizeLimit, 0.9)
+	time.Sleep(50 * time.Millisecond)
+	close(collected)
+
+	if !crowded[needle.VolumeId(1)] {
+		t.Error("a writable volume past the threshold was not reported crowded")
+	}
+	if crowded[needle.VolumeId(2)] {
+		t.Error("a read-only volume was reported crowded, which only adds an entry growth then discounts")
+	}
+}
+
+// The count growth decides on has to be unchanged by this.
+func TestCrowdedCountStillMatchesWritables(t *testing.T) {
+	topo := NewTopology("crowd", nil, 10000, 5, false)
+	dn := topo.GetOrCreateDataCenter("dc1").GetOrCreateRack("rack1").
+		GetOrCreateDataNode("127.0.0.1", 8080, 18080, "", "", map[string]uint32{"": 100})
+	topo.SyncDataNodeRegistration([]*master_pb.VolumeInformationMessage{
+		{Id: 1, Size: 9500, Collection: "c", Version: 3},
+	}, dn)
+
+	rp, _ := super_block.NewReplicaPlacementFromString("000")
+	vl := topo.GetVolumeLayout("c", rp, needle.EMPTY_TTL, types.HardDriveType)
+	vl.SetVolumeCrowded(needle.VolumeId(1))
+
+	writable, crowded := vl.GetWritableVolumeCount()
+	if writable != 1 || crowded != 1 {
+		t.Errorf("writable=%d crowded=%d, want 1 and 1", writable, crowded)
+	}
+}

--- a/weed/topology/node.go
+++ b/weed/topology/node.go
@@ -514,7 +514,11 @@ func (n *NodeImpl) CollectDeadNodeAndFullVolumes(freshThreshHoldUnixTime int64, 
 						//fmt.Println("volume",v.Id,"size",v.Size,">",volumeSizeLimit)
 						topo.chanFullVolumes <- v
 					}
-				} else if float64(v.Size) > float64(volumeSizeLimit)*growThreshold {
+				} else if !v.ReadOnly && float64(v.Size) > float64(volumeSizeLimit)*growThreshold {
+					// Crowding asks for more room to write into, which a
+					// read-only volume can never provide. Growth already
+					// discounts them by intersecting with the writable list, so
+					// marking one only costs the entry.
 					topo.chanCrowdedVolumes <- v
 				}
 				copyCount := v.ReplicaPlacement.GetCopyCount()


### PR DESCRIPTION
Last of three trimming the master's resident volume layout for #10603. Independent of #10653 and #10654.

The writable-volume refresh loop feeds `chanCrowdedVolumes` for any volume past the growth threshold, with no check that writes can land there. In a tiered cluster the read-only volumes sit near the size limit — that is usually why they were tiered — so nearly every volume ends up in the crowded set.

Those entries change no decision. `GetWritableVolumeCount` already reports crowded as its intersection with the writable list, from #10522, precisely because a crowded set that outgrows writables demanded growth forever. So a read-only volume in there is discounted at every read and only takes space.

## Why here rather than at the map

The other feeder, `UpdateVolumeSize`, stops before the threshold check for read-only volumes once #10653 lands, which is what leaves this path as the one that still adds them. Gating `setVolumeCrowded` itself would mean testing membership of `writables`, which is a slice — an O(writables) scan per crowded volume per pass. The source has the volume in hand and the check is free.

Insertion is what is gated, not removal: #7793 deliberately stopped removing entries when a volume becomes unwritable, to keep transient flips from flapping the set, and that is untouched. A volume that was crowded while writable keeps its entry.

## Tests

`TestCrowdedVolumesAreOnesThatCanTakeWrites` puts a writable and a read-only volume both past the threshold and asserts only the first is reported; it fails against the previous version. `TestCrowdedCountStillMatchesWritables` checks the count growth actually decides on is unchanged.

The refresh loop's channels are unbuffered and normally drained by a goroutine `StartRefreshWritableVolumes` owns, so the test drains them itself.

Refs #10603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Crowded-volume reporting now includes only writable volumes that exceed the growth threshold.
  * Read-only volumes are excluded from crowded-volume results, preventing them from being considered available for additional writes.
  * Improved consistency between crowded-volume totals and writable-volume counts.

* **Tests**
  * Added coverage verifying writable and read-only volume handling.
  * Added checks confirming crowded-volume counts remain accurate across topology changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->