### PR TITLE
topology: build the volume list without copying the volume map first

### DIFF
--- a/weed/topology/disk.go
+++ b/weed/topology/disk.go
@@ -371,13 +371,23 @@ func (d *Disk) FreeSpace() int64 {
 func (d *Disk) ToDiskInfo() *master_pb.DiskInfo {
 	diskUsage := d.diskUsages.getOrCreateDisk(types.ToDiskType(string(d.Id())))
 
-	// Get disk ID from first volume or EC shard
+	// Built while holding the read lock rather than from a copy of the volume
+	// map: the copy was the same size as the messages themselves and thrown
+	// away immediately. Nothing here reaches back into the topology, so the
+	// lock cannot be held against anything that wants it.
+	d.RLock()
+	volumeInfos := make([]*master_pb.VolumeInformationMessage, 0, len(d.volumes))
 	var diskId uint32
-	volumes := d.GetVolumes()
+	for _, v := range d.volumes {
+		if len(volumeInfos) == 0 {
+			diskId = v.DiskId
+		}
+		volumeInfos = append(volumeInfos, v.ToVolumeInformationMessage())
+	}
+	d.RUnlock()
+
 	ecShards := d.GetEcShards()
-	if len(volumes) > 0 {
-		diskId = volumes[0].DiskId
-	} else if len(ecShards) > 0 {
+	if len(volumeInfos) == 0 && len(ecShards) > 0 {
 		diskId = ecShards[0].DiskId
 	}
 
@@ -392,10 +402,7 @@ func (d *Disk) ToDiskInfo() *master_pb.DiskInfo {
 		DiskTotalBytes:    uint64(max(0, diskUsage.diskTotalBytes)),
 		DiskFreeBytes:     uint64(max(0, diskUsage.diskFreeBytes)),
 	}
-	m.VolumeInfos = make([]*master_pb.VolumeInformationMessage, 0, len(volumes))
-	for _, v := range volumes {
-		m.VolumeInfos = append(m.VolumeInfos, v.ToVolumeInformationMessage())
-	}
+	m.VolumeInfos = volumeInfos
 	m.EcShardInfos = make([]*master_pb.VolumeEcShardInformationMessage, 0, len(ecShards))
 	for _, ecv := range ecShards {
 		m.EcShardInfos = append(m.EcShardInfos, ecv.ToVolumeEcShardInformationMessage())

--- a/weed/topology/disk.go
+++ b/weed/topology/disk.go
@@ -371,10 +371,8 @@ func (d *Disk) FreeSpace() int64 {
 func (d *Disk) ToDiskInfo() *master_pb.DiskInfo {
 	diskUsage := d.diskUsages.getOrCreateDisk(types.ToDiskType(string(d.Id())))
 
-	// Built while holding the read lock rather than from a copy of the volume
-	// map: the copy was the same size as the messages themselves and thrown
-	// away immediately. Nothing here reaches back into the topology, so the
-	// lock cannot be held against anything that wants it.
+	// Built under the read lock rather than from a copy as large as the
+	// messages it fed. Nothing here re-enters the topology, so the hold is safe.
 	d.RLock()
 	volumeInfos := make([]*master_pb.VolumeInformationMessage, 0, len(d.volumes))
 	var diskId uint32

--- a/weed/topology/disk_info_test.go
+++ b/weed/topology/disk_info_test.go
@@ -6,8 +6,6 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
 )
 
-// ToDiskInfo is what VolumeList reports, and it is built straight from the
-// volume map rather than from a copy of it.
 func TestDiskInfoReportsEveryVolume(t *testing.T) {
 	topo := NewTopology("diskinfo", nil, 32*1024*1024*1024, 5, false)
 	dn := topo.GetOrCreateDataCenter("dc1").GetOrCreateRack("rack1").
@@ -51,7 +49,6 @@ func TestDiskInfoReportsEveryVolume(t *testing.T) {
 	}
 }
 
-// A disk holding only ec shards still has to report which disk it is.
 func TestDiskInfoReportsTheDiskIdOfEcOnlyDisks(t *testing.T) {
 	topo := NewTopology("diskinfo", nil, 32*1024*1024*1024, 5, false)
 	dn := topo.GetOrCreateDataCenter("dc1").GetOrCreateRack("rack1").

--- a/weed/topology/disk_info_test.go
+++ b/weed/topology/disk_info_test.go
@@ -1,0 +1,72 @@
+package topology
+
+import (
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
+)
+
+// ToDiskInfo is what VolumeList reports, and it is built straight from the
+// volume map rather than from a copy of it.
+func TestDiskInfoReportsEveryVolume(t *testing.T) {
+	topo := NewTopology("diskinfo", nil, 32*1024*1024*1024, 5, false)
+	dn := topo.GetOrCreateDataCenter("dc1").GetOrCreateRack("rack1").
+		GetOrCreateDataNode("10.0.0.1", 8080, 18080, "", "", map[string]uint32{"": 100})
+
+	volumes := []*master_pb.VolumeInformationMessage{
+		{Id: 1, Collection: "c", Size: 1000, FileCount: 10, Version: 3, DiskId: 2},
+		{Id: 2, Collection: "c", Size: 2000, FileCount: 20, Version: 3, DiskId: 2},
+		{Id: 3, Collection: "other", Size: 3000, FileCount: 30, Version: 3, DiskId: 2},
+	}
+	topo.SyncDataNodeRegistration(volumes, dn)
+	topo.SyncDataNodeEcShards([]*master_pb.VolumeEcShardInformationMessage{
+		{Id: 9, Collection: "c", EcIndexBits: 0x3fff, DiskId: 2},
+	}, dn)
+
+	var info *master_pb.DiskInfo
+	for _, c := range dn.Children() {
+		info = c.(*Disk).ToDiskInfo()
+	}
+	if info == nil {
+		t.Fatal("the node reported no disk")
+	}
+	if len(info.VolumeInfos) != len(volumes) {
+		t.Fatalf("reported %d volumes, want %d", len(info.VolumeInfos), len(volumes))
+	}
+	if len(info.EcShardInfos) != 1 {
+		t.Fatalf("reported %d ec volumes, want 1", len(info.EcShardInfos))
+	}
+	if info.DiskId != 2 {
+		t.Errorf("reported disk id %d, want the one its volumes are on", info.DiskId)
+	}
+
+	bySize := map[uint32]uint64{}
+	for _, v := range info.VolumeInfos {
+		bySize[v.Id] = v.Size
+	}
+	for _, want := range volumes {
+		if got := bySize[want.Id]; got != want.Size {
+			t.Errorf("volume %d reported size %d, want %d", want.Id, got, want.Size)
+		}
+	}
+}
+
+// A disk holding only ec shards still has to report which disk it is.
+func TestDiskInfoReportsTheDiskIdOfEcOnlyDisks(t *testing.T) {
+	topo := NewTopology("diskinfo", nil, 32*1024*1024*1024, 5, false)
+	dn := topo.GetOrCreateDataCenter("dc1").GetOrCreateRack("rack1").
+		GetOrCreateDataNode("10.0.0.1", 8080, 18080, "", "", map[string]uint32{"": 100})
+	topo.SyncDataNodeEcShards([]*master_pb.VolumeEcShardInformationMessage{
+		{Id: 9, Collection: "c", EcIndexBits: 0x3fff, DiskId: 5},
+	}, dn)
+
+	for _, c := range dn.Children() {
+		info := c.(*Disk).ToDiskInfo()
+		if len(info.VolumeInfos) != 0 {
+			t.Fatalf("expected no regular volumes, got %d", len(info.VolumeInfos))
+		}
+		if info.DiskId != 5 {
+			t.Errorf("reported disk id %d, want the one its shards are on", info.DiskId)
+		}
+	}
+}


### PR DESCRIPTION
Continuing Phase 3 for #10603. #10664 removed the periodic caller of `VolumeList`; this makes the call itself cheaper for the ones that remain — the admin dashboard on every page load, the maintenance scanner every 30 minutes, and several shell commands.

`Disk.ToDiskInfo` copied every `VolumeInfo` on the disk into a fresh slice, walked it to build a protobuf message for each, then discarded the copy. At 152 bytes per volume the copy was about as large as the messages it produced.

```
ToTopologyInfo over 550k volumes
before   193617502 B/op   550029 allocs/op   52.7 ms
after    110011017 B/op   550029 allocs/op   47.9 ms
```

43% less, and faster for not making the copy. The allocation count is unchanged because what went away was one large slice, not many objects.

## The trade

It now holds the disk's read lock across the walk rather than just across the copy, so a heartbeat updating that disk waits behind it — roughly 48ms at 550k volumes, against a few for the copy alone. It is a read lock, so concurrent readers are unaffected, and since #10640 heartbeats mostly carry only what changed. On a call that is now infrequent that seemed the better side of the trade, but it is a real change rather than a free win.

Nothing inside the walk reaches back into the topology: `ToVolumeInformationMessage` is a plain conversion on `storage.VolumeInfo`, and the ec shards are read after the lock is released, so the hold cannot block on anything that wants it.

## Tests

`ToDiskInfo` had no direct coverage. `TestDiskInfoReportsEveryVolume` checks every volume and ec volume is reported with its size, and `TestDiskInfoReportsTheDiskIdOfEcOnlyDisks` covers the branch that only runs when a disk holds shards and nothing else.

Refs #10603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Disk information now consistently reports all regular volumes and erasure-coded shards.
  * Preserves volume sizes and accurately identifies the disk associated with reported data.
  * Correctly supports disks containing only erasure-coded shards, including cases with no regular volumes.
  * Improves the reliability and completeness of disk status information across different storage configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->