### PR TITLE
storage: order VolumeInfo by alignment

### DIFF
--- a/weed/storage/volume_info.go
+++ b/weed/storage/volume_info.go
@@ -10,23 +10,32 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/storage/super_block"
 )
 
+// VolumeInfo is held for every volume replica in the cluster, so its field
+// order is grouped by alignment rather than by meaning: strings and pointers
+// first, then the eight-byte counters, then the small fields last. Interleaved,
+// each one-byte field rounds up to a whole word and the struct grows by 16
+// bytes it does not use.
 type VolumeInfo struct {
-	Id                needle.VolumeId
-	Size              uint64
-	ReplicaPlacement  *super_block.ReplicaPlacement
-	Ttl               *needle.TTL
-	DiskType          string
-	DiskId            uint32
 	Collection        string
-	Version           needle.Version
-	FileCount         int
-	DeleteCount       int
-	DeletedByteCount  uint64
-	ReadOnly          bool
-	CompactRevision   uint32
-	ModifiedAtSecond  int64
+	DiskType          string
 	RemoteStorageName string
 	RemoteStorageKey  string
+
+	ReplicaPlacement *super_block.ReplicaPlacement
+	Ttl              *needle.TTL
+
+	Size             uint64
+	FileCount        int
+	DeleteCount      int
+	DeletedByteCount uint64
+	ModifiedAtSecond int64
+
+	Id              needle.VolumeId
+	DiskId          uint32
+	CompactRevision uint32
+
+	Version  needle.Version
+	ReadOnly bool
 }
 
 func NewVolumeInfo(m *master_pb.VolumeInformationMessage) (vi VolumeInfo, err error) {

--- a/weed/storage/volume_info.go
+++ b/weed/storage/volume_info.go
@@ -10,11 +10,8 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/storage/super_block"
 )
 
-// VolumeInfo is held for every volume replica in the cluster, so its field
-// order is grouped by alignment rather than by meaning: strings and pointers
-// first, then the eight-byte counters, then the small fields last. Interleaved,
-// each one-byte field rounds up to a whole word and the struct grows by 16
-// bytes it does not use.
+// Held for every volume replica, so the fields are grouped by size rather than
+// by meaning: interleaved, each one-byte field rounds up to a whole word.
 type VolumeInfo struct {
 	Collection        string
 	DiskType          string

--- a/weed/storage/volume_info_layout_test.go
+++ b/weed/storage/volume_info_layout_test.go
@@ -6,10 +6,8 @@ import (
 	"unsafe"
 )
 
-// VolumeInfo is held for every volume replica in the cluster, so padding in it
-// is multiplied by however many volumes a master tracks. Field order is the
-// only thing keeping it down, and nothing else in the package would notice if
-// someone grouped the fields by meaning again.
+// Nothing else in the package would notice if someone grouped the fields by
+// meaning again, and the padding is multiplied by every volume a master holds.
 func TestVolumeInfoHasNoInteriorPadding(t *testing.T) {
 	typ := reflect.TypeOf(VolumeInfo{})
 

--- a/weed/storage/volume_info_layout_test.go
+++ b/weed/storage/volume_info_layout_test.go
@@ -1,0 +1,36 @@
+package storage
+
+import (
+	"reflect"
+	"testing"
+	"unsafe"
+)
+
+// VolumeInfo is held for every volume replica in the cluster, so padding in it
+// is multiplied by however many volumes a master tracks. Field order is the
+// only thing keeping it down, and nothing else in the package would notice if
+// someone grouped the fields by meaning again.
+func TestVolumeInfoHasNoInteriorPadding(t *testing.T) {
+	typ := reflect.TypeOf(VolumeInfo{})
+
+	var used, interior uintptr
+	prevEnd := uintptr(0)
+	for i := 0; i < typ.NumField(); i++ {
+		f := typ.Field(i)
+		if gap := f.Offset - prevEnd; gap > 0 {
+			t.Errorf("%d bytes of padding before %s, at offset %d: order the fields by size so they pack",
+				gap, f.Name, prevEnd)
+			interior += gap
+		}
+		used += f.Type.Size()
+		prevEnd = f.Offset + f.Type.Size()
+	}
+
+	size := unsafe.Sizeof(VolumeInfo{})
+	if tail := size - prevEnd; tail > 7 {
+		t.Errorf("%d bytes of padding at the end, more than alignment requires", tail)
+	}
+	if interior == 0 {
+		t.Logf("%d bytes of fields in a %d byte struct", used, size)
+	}
+}


### PR DESCRIPTION
Continuing Phase 3 for #10603, on the master's largest remaining structure.

`storage.VolumeInfo` is held for every volume replica a master tracks, so padding inside it is multiplied by the volume count. It had 18 bytes of it in 152:

```
offset  72   Version   1 byte,  then 7 bytes of padding
offset 104   ReadOnly  1 byte,  then 3 bytes of padding
offset   4             4 bytes of padding after Id
offset  52             4 bytes of padding after DiskId
```

Two single-byte fields each sat at the head of a word and left the rest of it empty — ten of the eighteen bytes. Grouping the fields by size rather than by meaning packs them:

```
152 bytes, 18 padding  ->  136 bytes, 2 padding
```

The map holding them shrinks with it, because a Go map's per-entry slack scales with the size of the value, so the saving is larger than the 16 bytes off the struct:

```
800k volumes, registered from a heartbeat that has been over the wire
  plain     211 -> 195 B/volume
  tiered    214 -> 198 B/volume
```

At the 1.6M replicas in #10603 that is about 26MB.

## Why this is safe

Field order is not observable outside the struct. Go accesses fields by name, `VolumeInfo` is never binary or gob encoded, and it reaches the wire only by being converted field-by-field into `VolumeInformationMessage`. I checked for unkeyed struct literals, which would have silently taken the new order; there are none — the matches that look like them are slice literals holding a variable.

## Keeping it packed

Nothing else in the package would notice if someone grouped the fields by meaning again, so `TestVolumeInfoHasNoInteriorPadding` walks the field offsets and fails with the offending field named and a note to order by size. It reports the fields occupy 134 bytes of the 136.

Refs #10603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the efficiency of volume information handling without changing available fields, values, or behavior.
  * Added clearer alignment documentation to support consistent operation.

* **Tests**
  * Added automated checks to help prevent inefficient data layouts and maintain reliability in future updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->