### PR TITLE
iceberg: route unprefixed requests to the first table bucket

### DIFF
--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -1344,6 +1344,10 @@ func runMini(cmd *Command, args []string) bool {
 	tableBucketSpec := *miniTableBucket
 	if tableBucketSpec == "" {
 		tableBucketSpec = os.Getenv("S3_TABLE_BUCKET")
+	} else if os.Getenv("S3_TABLE_BUCKET") == "" {
+		// The catalog routes unprefixed requests to the first S3_TABLE_BUCKET
+		// entry; let the -tableBucket flag mean the same thing.
+		os.Setenv("S3_TABLE_BUCKET", tableBucketSpec)
 	}
 	if err := ensureMiniTableBuckets(tableBucketSpec); err != nil {
 		glog.Warningf("failed to ensure table buckets %q: %v", tableBucketSpec, err)

--- a/weed/s3api/iceberg/iceberg_issue_9103_test.go
+++ b/weed/s3api/iceberg/iceberg_issue_9103_test.go
@@ -81,3 +81,25 @@ func TestBuildFileIOConfig(t *testing.T) {
 		}
 	})
 }
+
+func TestGetBucketFromPrefix_TableBucketEnvFallback(t *testing.T) {
+	r := httptest.NewRequest("GET", "/v1/namespaces", nil)
+
+	t.Setenv("S3_TABLE_BUCKET", " ,analytics, other")
+	if got := getBucketFromPrefix(r); got != "analytics" {
+		t.Fatalf("first S3_TABLE_BUCKET entry: got %q, want analytics", got)
+	}
+
+	// The explicit default still wins over the table bucket list.
+	t.Setenv("S3TABLES_DEFAULT_BUCKET", "explicit")
+	if got := getBucketFromPrefix(r); got != "explicit" {
+		t.Fatalf("S3TABLES_DEFAULT_BUCKET override: got %q, want explicit", got)
+	}
+
+	// A prefixless value with neither env set falls through to the default.
+	t.Setenv("S3TABLES_DEFAULT_BUCKET", "")
+	t.Setenv("S3_TABLE_BUCKET", " , ")
+	if got := getBucketFromPrefix(r); got != "warehouse" {
+		t.Fatalf("empty specs: got %q, want warehouse", got)
+	}
+}

--- a/weed/s3api/iceberg/utils.go
+++ b/weed/s3api/iceberg/utils.go
@@ -236,6 +236,14 @@ func getBucketFromPrefix(r *http.Request) string {
 	if bucket := os.Getenv("S3TABLES_DEFAULT_BUCKET"); bucket != "" {
 		return bucket
 	}
+	// Some writers commit to the unprefixed path even though their reads
+	// honor the /v1/config prefix; the deployment's first table bucket is
+	// where those commits belong.
+	for _, name := range strings.Split(os.Getenv("S3_TABLE_BUCKET"), ",") {
+		if name = strings.TrimSpace(name); name != "" {
+			return name
+		}
+	}
 	// Default bucket if no prefix - use "warehouse" for Iceberg
 	return "warehouse"
 }


### PR DESCRIPTION
Some Iceberg writers commit to the unprefixed catalog path even though their reads honor the /v1/config prefix: ClickHouse's experimental insert posts its metadata update to /v1/namespaces/... while every read goes to /v1/<bucket>/namespaces/.... Without a default bucket the commit 404s and the writer rolls the whole insert back.

Rather than ask operators to set the undocumented S3TABLES_DEFAULT_BUCKET, the catalog now falls back to the first entry of S3_TABLE_BUCKET — the documented variable that already names the deployment's table buckets — and weed mini exports it when the value came from the -tableBucket flag. S3TABLES_DEFAULT_BUCKET keeps working as the explicit override; it has shipped since 4.13.

Resolution order: URL prefix, ?warehouse=, S3TABLES_DEFAULT_BUCKET, first of S3_TABLE_BUCKET, then the literal "warehouse" bucket. Verified end to end: weed mini -tableBucket=analytics with no other configuration, ClickHouse INSERT commits and reads back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Table-bucket setup now automatically uses the first specified bucket as the default when no default bucket is configured.
  * Bucket selection now supports fallback through configured table-bucket settings, with a warehouse fallback when no usable bucket is available.

* **Bug Fixes**
  * Preserves existing default bucket configurations during table-bucket creation.
  * Applies the correct precedence when multiple bucket settings are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->