### PR TITLE
topology: keep the volume map's values out of its slots

### DIFF
--- a/weed/topology/disk.go
+++ b/weed/topology/disk.go
@@ -19,7 +19,7 @@ import (
 
 type Disk struct {
 	NodeImpl
-	volumes map[needle.VolumeId]storage.VolumeInfo
+	volumes map[needle.VolumeId]*storage.VolumeInfo
 	// ecShards is nested so the same volume can retain separate entries per
 	// physical disk id. A single topology Disk represents one DiskType on a
 	// DataNode and may front multiple physical disks of that type, so EC
@@ -61,7 +61,7 @@ func NewDisk(diskType string) *Disk {
 	s.id = NodeId(diskType)
 	s.nodeType = "Disk"
 	s.diskUsages = newDiskUsages()
-	s.volumes = make(map[needle.VolumeId]storage.VolumeInfo, 2)
+	s.volumes = make(map[needle.VolumeId]*storage.VolumeInfo, 2)
 	s.volumeAddedAt = make(map[needle.VolumeId]time.Time, 2)
 	s.ecShards = make(map[needle.VolumeId]map[types.DiskId]*erasure_coding.EcVolumeInfo, 2)
 	s.NodeImpl.value = s
@@ -213,7 +213,8 @@ func (d *Disk) AddProvisionalVolume(v storage.VolumeInfo) (isNew, isChanged bool
 func (d *Disk) doAddOrUpdateVolume(v storage.VolumeInfo, fromReport bool) (isNew, isChanged bool) {
 	deltaDiskUsage := &DiskUsageCounts{}
 	if oldV, ok := d.volumes[v.Id]; !ok {
-		d.volumes[v.Id] = v
+		stored := v
+		d.volumes[v.Id] = &stored
 		if !fromReport {
 			d.volumeAddedAt[v.Id] = time.Now()
 		}
@@ -251,7 +252,7 @@ func (d *Disk) doAddOrUpdateVolume(v storage.VolumeInfo, fromReport bool) (isNew
 		if fromReport {
 			delete(d.volumeAddedAt, v.Id)
 		}
-		isChanged = d.volumes[v.Id].ReadOnly != v.ReadOnly
+		isChanged = oldV.ReadOnly != v.ReadOnly
 		if isChanged {
 			// Adjust active volume count when ReadOnly status changes
 			// Use a separate delta object to avoid affecting other metric adjustments
@@ -265,7 +266,9 @@ func (d *Disk) doAddOrUpdateVolume(v storage.VolumeInfo, fromReport bool) (isNew
 			}
 			d.UpAdjustDiskUsageDelta(types.ToDiskType(v.DiskType), readOnlyDelta)
 		}
-		d.volumes[v.Id] = v
+		// Written through the pointer the map already holds, and only after
+		// everything above has read the old value off it.
+		*oldV = v
 	}
 	return
 }
@@ -280,7 +283,7 @@ func (d *Disk) AppendVolumes(dst []storage.VolumeInfo) []storage.VolumeInfo {
 	d.RLock()
 	defer d.RUnlock()
 	for _, v := range d.volumes {
-		dst = append(dst, v)
+		dst = append(dst, *v)
 	}
 	return dst
 }
@@ -313,7 +316,7 @@ func (d *Disk) RemoveVolumesNotIn(reported *reportedVolumes) (removed []storage.
 		if addedAt, unconfirmed := d.volumeAddedAt[vid]; unconfirmed && now.Sub(addedAt) < volumeRemovalGracePeriod {
 			continue
 		}
-		removed = append(removed, v)
+		removed = append(removed, *v)
 		delete(d.volumes, vid)
 		delete(d.volumeAddedAt, vid)
 		d.volumeDigest ^= v.ReportHash()
@@ -327,7 +330,7 @@ func (d *Disk) GetVolumesById(id needle.VolumeId) (storage.VolumeInfo, error) {
 	defer d.RUnlock()
 	vInfo, ok := d.volumes[id]
 	if ok {
-		return vInfo, nil
+		return *vInfo, nil
 	} else {
 		return storage.VolumeInfo{}, fmt.Errorf("volumeInfo not found")
 	}


### PR DESCRIPTION
Found while benchmarking the master against pre-#10603 to total up what the work has saved. It turned out one of my own merged changes made things worse, and this puts it right and then some.

## What happened

Go stores a map value inline in the map's slots once it fits in 128 bytes, and indirectly — a pointer in the slot, the value allocated separately — above that. Slots are allocated to *capacity*, not to occupancy, so an inline value is paid for on every slot the map has, used or not.

`storage.VolumeInfo` was 152 bytes and comfortably indirect. #10669 took it to 136, still indirect, and saved what you would expect. Then #10672 took it to 120 and crossed the line, moving 1.6M volume records into the slots themselves:

```
                                    VolumeInfo   resident topology
2ff3dda7c (before this work)        152 bytes            644.3 MB
#10669, alignment                   136 bytes            571.1 MB
#10672, remote key removed          120 bytes            705.3 MB   <-- worse
```

The map alone went from 283MB to 432MB while each record in it got smaller. I confirmed the mechanism by padding `VolumeInfo` back to 136 on current master: resident drops to 571.1MB. Making the struct *bigger* saves 134MB.

None of this shows up as a struct that got larger, which is why it survived review — including mine, in a PR whose entire claim was memory.

## The fix

Hold `*storage.VolumeInfo`, so how big a volume record is stops deciding how it is stored.

The naive version of that costs churn: `d.volumes[v.Id] = &v` allocates on every update, and a full heartbeat of 533k volumes went from 111.6MB to 176.7MB. Go was not doing that when the struct was above the threshold — on overwrite it writes into the element already allocated. So updates here go through the pointer the map already holds, which is also why the assignment stays at the end of `doAddOrUpdateVolume`: the digest and the read-only comparison above it still need the old value.

```
                        resident    heartbeat
master                   705.3 MB    111.6 MB
this PR                  546.6 MB    111.6 MB
```

Against `2ff3dda7c`, resident is now 644.3 -> 546.6MB rather than 644.3 -> 705.3.

Refs #10603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved disk volume state handling to ensure updates, retrieval, iteration, and removal operate consistently.
  * Prevented unintended changes to stored volume information when adding volumes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->