### PR TITLE
test: let the vacuum shell session outlive the vacuum

### DIFF
--- a/test/vacuum/vacuum_integration_test.go
+++ b/test/vacuum/vacuum_integration_test.go
@@ -315,10 +315,15 @@ func TestVacuumIntegration(t *testing.T) {
 		}
 		commandEnv := shell.NewCommandEnv(options)
 
-		shellCtx, shellCancel := context.WithTimeout(context.Background(), 60*time.Second)
+		// The session context outlives the vacuum command: a deadline here
+		// closes the master connection mid-command on a slow runner, and the
+		// leaked lock renewal then spins until the test binary's timeout.
+		shellCtx, shellCancel := context.WithCancel(context.Background())
 		defer shellCancel()
 		go commandEnv.MasterClient.KeepConnectedToMaster(shellCtx)
-		commandEnv.MasterClient.WaitUntilConnected(shellCtx)
+		connectCtx, connectCancel := context.WithTimeout(shellCtx, 30*time.Second)
+		commandEnv.MasterClient.WaitUntilConnected(connectCtx)
+		connectCancel()
 		time.Sleep(2 * time.Second)
 
 		// Acquire lock (required by shell commands)


### PR DESCRIPTION
The vacuum integration test ran its whole shell session — connect, lock, vacuum — under one 60-second context. The vacuum itself takes ~32s on a fast machine, so a slow runner crosses the deadline mid-command: the master connection closes under the in-flight RPC ("grpc: the client connection is closing"), and the orphaned lock renewal then spins in WaitUntilConnected until the test binary's 10-minute timeout turns one failed subtest into a goroutine-dump job failure.

The session context is now cancel-only and scoped to the subtest, with the 30-second bound kept just for the initial connect; the command duration is governed by the test timeout, as elsewhere.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vacuum operation reliability during longer-running processes.
  * Prevented the master connection from expiring while slow vacuum tasks are in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->