### PR TITLE
master: keep disk_id when registering volumes from incremental heartbeats

### DIFF
--- a/weed/storage/volume_info.go
+++ b/weed/storage/volume_info.go
@@ -67,6 +67,7 @@ func NewVolumeInfoFromShort(m *master_pb.VolumeShortInformationMessage) (vi Volu
 		Id:         needle.VolumeId(m.Id),
 		Collection: internVolumeString(m.Collection),
 		Version:    needle.Version(m.Version),
+		DiskId:     m.DiskId,
 	}
 	rp, e := super_block.NewReplicaPlacementFromByte(byte(m.ReplicaPlacement))
 	if e != nil {

--- a/weed/storage/volume_info_test.go
+++ b/weed/storage/volume_info_test.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"testing"
 
+	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
 	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
 )
 
@@ -23,5 +24,19 @@ func TestSortVolumeInfos(t *testing.T) {
 		if vis[i].Id != needle.VolumeId(i+1) {
 			t.Fatal()
 		}
+	}
+}
+
+func TestNewVolumeInfoFromShortKeepsDiskId(t *testing.T) {
+	vi, err := NewVolumeInfoFromShort(&master_pb.VolumeShortInformationMessage{
+		Id:      7,
+		Version: 3,
+		DiskId:  3,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vi.DiskId != 3 {
+		t.Fatalf("DiskId = %d, want 3", vi.DiskId)
 	}
 }


### PR DESCRIPTION
`NewVolumeInfoFromShort` never copied `DiskId` from the `VolumeShortInformationMessage`, even though the volume server sets it on every incremental new-volume report. Every volume registered through that path therefore showed `disk_id 0` at the master until a full volume report arrived — misreporting multi-dir servers in `volume.list` and the per-physical-disk topology views, and (with the report digest covering `disk_id`) leaving the master's copy permanently disagreeing with what the server hashes.

Found by an integration test that judges chunk placement from the master's `VolumeList`: a 3-server × 4-dir cluster showed every freshly grown volume on disk 0 regardless of the directory that actually held it.

One-line fix plus a unit test pinning the field.

https://claude.ai/code/session_01QdTEEPbg4MtcoEGwqbgtZC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved disk identification when volume information is created from a short volume message.
  * Improved consistency of volume metadata across storage operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->