### PR TITLE
topology: provisional volume update must not erase the reported disk id

### DIFF
--- a/weed/topology/disk.go
+++ b/weed/topology/disk.go
@@ -230,6 +230,14 @@ func (d *Disk) doAddOrUpdateVolume(v storage.VolumeInfo, fromReport bool) (isNew
 		d.UpAdjustDiskUsageDelta(types.ToDiskType(v.DiskType), deltaDiskUsage)
 		isNew = true
 	} else {
+		if !fromReport && v.DiskId == 0 && oldV.DiskId != 0 {
+			// A provisional (grow-time) record carries no disk id -- the
+			// master cannot know which directory the server chose. Keep the
+			// one the server's report already named, before the digest below
+			// is computed, or the stored record would drift from what the
+			// server keeps reporting.
+			v.DiskId = oldV.DiskId
+		}
 		if oldV.IsRemote() != v.IsRemote() {
 			if v.IsRemote() {
 				deltaDiskUsage.remoteVolumeCount = 1

--- a/weed/topology/disk_provisional_disk_id_test.go
+++ b/weed/topology/disk_provisional_disk_id_test.go
@@ -1,0 +1,33 @@
+package topology
+
+import (
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/storage"
+	"github.com/seaweedfs/seaweedfs/weed/storage/types"
+)
+
+// A provisional (grow-time) registration carries no disk id; when it lands
+// after the server's own report -- the server pushes its report during the
+// AllocateVolume RPC, so either order happens -- it must not erase the disk id
+// the report recorded.
+func TestProvisionalUpdateKeepsReportedDiskId(t *testing.T) {
+	disk := NewDisk(types.HardDriveType.String())
+
+	disk.AddOrUpdateVolume(storage.VolumeInfo{Id: 1, DiskId: 2})
+	disk.AddProvisionalVolume(storage.VolumeInfo{Id: 1})
+
+	v, err := disk.GetVolumesById(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.DiskId != 2 {
+		t.Fatalf("DiskId = %d, want 2 (provisional update clobbered the reported value)", v.DiskId)
+	}
+
+	// A later server report naming a different disk still wins.
+	disk.AddOrUpdateVolume(storage.VolumeInfo{Id: 1, DiskId: 1})
+	if v, _ = disk.GetVolumesById(1); v.DiskId != 1 {
+		t.Fatalf("DiskId = %d, want 1 (a real report must override)", v.DiskId)
+	}
+}


### PR DESCRIPTION
Volume growth registers a provisional `VolumeInfo` before it can know which directory the server chose (`AllocateVolume` doesn't return one), while the server's own report — pushed to `NewVolumesChan` during the AllocateVolume RPC — carries the real `disk_id`. `doAddOrUpdateVolume` is last-writer-wins, so whichever lands second sticks: fresh volumes on multi-dir servers nondeterministically showed disk 0 (the same cluster showing correct per-disk spread on one run and everything on disk 0 the next).

Fix: when a provisional update carries no disk id and the record already has one from a report, keep the reported value — applied before the report digest is recomputed, so the stored record stays consistent with what the server keeps hashing. A real report naming a different disk still wins, and a follow-up could return the chosen disk id in `AllocateVolumeResponse` to remove the provisional blind spot entirely.

Companion to the incremental-heartbeat fix in #10686; together they make the master's per-volume disk view trustworthy for fresh volumes.

https://claude.ai/code/session_01QdTEEPbg4MtcoEGwqbgtZC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved volume metadata consistency when provisional updates omit disk identifiers.
  * Existing disk identifiers are now preserved until a later definitive report provides updated information.
  * Prevented discrepancies between stored volume metadata and generated report digests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->