### PR TITLE
master: stop copying the cluster to name it

### DIFF
--- a/weed/server/master_grpc_server.go
+++ b/weed/server/master_grpc_server.go
@@ -474,7 +474,10 @@ func (ms *MasterServer) KeepConnected(stream master_pb.Seaweed_KeepConnectedServ
 		select {
 		case message := <-messageChan:
 			if err := stream.Send(message); err != nil {
-				glog.V(0).Infof("=> client %v: %+v", clientName, message)
+				// The error, not the message: it carries every volume id on a
+				// newly connected node, and formatting a proto that size to
+				// say a client went away costs more than the send did.
+				glog.V(0).Infof("=> client %v: %v", clientName, err)
 				return err
 			}
 		case <-ticker.C:

--- a/weed/topology/data_node.go
+++ b/weed/topology/data_node.go
@@ -219,6 +219,17 @@ func (dn *DataNode) AdjustDiskUsageBytes(diskTotalBytes, diskFreeBytes map[strin
 	}
 }
 
+// AppendVolumeIds appends the ids of this node's volumes to dst, without
+// copying the volume records to read them.
+func (dn *DataNode) AppendVolumeIds(dst []uint32) []uint32 {
+	dn.RLock()
+	defer dn.RUnlock()
+	for _, c := range dn.children {
+		dst = c.(*Disk).AppendVolumeIds(dst)
+	}
+	return dst
+}
+
 func (dn *DataNode) GetVolumes() (ret []storage.VolumeInfo) {
 	dn.RLock()
 	defer dn.RUnlock()

--- a/weed/topology/disk.go
+++ b/weed/topology/disk.go
@@ -274,6 +274,18 @@ func (d *Disk) GetVolumes() []storage.VolumeInfo {
 	return d.AppendVolumes(make([]storage.VolumeInfo, 0, d.VolumeCount()))
 }
 
+// AppendVolumeIds appends the ids of the disk's volumes to dst. Callers that
+// only need to name volumes use this rather than AppendVolumes, which copies
+// a whole record per volume to be read for four bytes of it.
+func (d *Disk) AppendVolumeIds(dst []uint32) []uint32 {
+	d.RLock()
+	defer d.RUnlock()
+	for id := range d.volumes {
+		dst = append(dst, uint32(id))
+	}
+	return dst
+}
+
 // AppendVolumes appends the disk's volumes to dst, so a caller gathering
 // several disks fills one slice instead of concatenating a copy per disk.
 func (d *Disk) AppendVolumes(dst []storage.VolumeInfo) []storage.VolumeInfo {

--- a/weed/topology/topology_info.go
+++ b/weed/topology/topology_info.go
@@ -100,11 +100,7 @@ func (t *Topology) ToVolumeLocations() (volumeLocations []*master_pb.VolumeLocat
 					DataCenter: dn.GetDataCenterId(),
 					GrpcPort:   uint32(dn.GrpcPort),
 				}
-				dnVolumes := dn.GetVolumes()
-				volumeLocation.NewVids = make([]uint32, 0, len(dnVolumes))
-				for _, v := range dnVolumes {
-					volumeLocation.NewVids = append(volumeLocation.NewVids, uint32(v.Id))
-				}
+				volumeLocation.NewVids = dn.AppendVolumeIds(nil)
 				// A single EC volume's shards can live on multiple disks of
 				// one DataNode, so GetEcShards returns per-(vid,disk) entries.
 				// Dedupe so the snapshot carries each vid once.


### PR DESCRIPTION
Two things from the memory profile @giftz posted on #10603, which is the first real one we have had for this.

## `Disk.GetVolumes` — 1656MB, the largest entry in that profile

`ToVolumeLocations` reads one volume id off every volume in the cluster, and reaches them through `GetVolumes`, which copies a whole `storage.VolumeInfo` per volume — 120 bytes materialised to be read for four bytes of it. Every client that connects to `KeepConnected` asks for this, so the cost is per connecting filer, not per cluster.

```
800k volumes, naming them all
  via GetVolumes (whole records)     94.6 MB
  ids only                           16.0 MB
```

16MB is the ids themselves, so what is left is the answer rather than the walk.

## `prototext.MarshalOptions.Format` — 646MB cumulative

```go
if err := stream.Send(message); err != nil {
    glog.V(0).Infof("=> client %v: %+v", clientName, message)
```

The message a client gets on connect carries every volume id on the node, and this formats a protobuf that size into text to report that the client went away — at `V(0)`, which is always on. It also logs the payload and drops `err`, which is the part worth having. Now it logs the error.

Two commits, one each.

Refs #10603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved efficiency when collecting volume information, reducing unnecessary data processing.
  * Enhanced topology-related operations for faster volume location updates.

* **Reliability**
  * Improved error handling when streaming responses to connected clients, with clearer diagnostics and reduced overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->