### PR TITLE
shell: volume.delete and volume.move accept a -timeout

### DIFF
--- a/weed/shell/command_volume_delete.go
+++ b/weed/shell/command_volume_delete.go
@@ -24,8 +24,10 @@ func (c *commandVolumeDelete) Help() string {
 	return `delete a live volume from one volume server
 
 	volume.delete -node <volume server host:port> -volumeId <volume id>
+	volume.delete -node <volume server host:port> -volumeId <volume id> -timeout 30s
 
 	This command deletes a volume from one volume server.
+	The option "-timeout" fails the command if the volume server does not respond in time.
 
 `
 }
@@ -39,6 +41,7 @@ func (c *commandVolumeDelete) Do(args []string, commandEnv *CommandEnv, writer i
 	volDeleteCommand := flag.NewFlagSet(c.Name(), flag.ContinueOnError)
 	volumeIdInt := volDeleteCommand.Int("volumeId", 0, "the volume id")
 	nodeStr := volDeleteCommand.String("node", "", "the volume server <host>:<port>")
+	timeout := volDeleteCommand.Duration("timeout", 0, "wall-clock cap on the deletion; 0 = no timeout")
 	if err = volDeleteCommand.Parse(args); err != nil {
 		return nil
 	}
@@ -51,6 +54,13 @@ func (c *commandVolumeDelete) Do(args []string, commandEnv *CommandEnv, writer i
 
 	volumeId := needle.VolumeId(*volumeIdInt)
 
-	return deleteVolume(context.Background(), commandEnv.option.GrpcDialOption, volumeId, sourceVolumeServer, false, false)
+	ctx := context.Background()
+	if *timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, *timeout)
+		defer cancel()
+	}
+
+	return deleteVolume(ctx, commandEnv.option.GrpcDialOption, volumeId, sourceVolumeServer, false, false)
 
 }

--- a/weed/shell/command_volume_move.go
+++ b/weed/shell/command_volume_move.go
@@ -45,6 +45,7 @@ func (c *commandVolumeMove) Help() string {
 	4. This command asks the source volume server to delete the source volume.
 
 	The option "-disk [hdd|ssd|<tag>]" can be used to change the volume disk type.
+	The option "-timeout" fails the whole move if it does not finish in time.
 
 `
 }
@@ -61,6 +62,7 @@ func (c *commandVolumeMove) Do(args []string, commandEnv *CommandEnv, writer io.
 	targetNodeStr := volMoveCommand.String("target", "", "the target volume server <host>:<port>")
 	diskTypeStr := volMoveCommand.String("disk", "", "[hdd|ssd|<tag>] hard drive or solid state drive or any tag")
 	ioBytePerSecond := volMoveCommand.Int64("ioBytePerSecond", 0, "limit the speed of move")
+	timeout := volMoveCommand.Duration("timeout", 0, "wall-clock cap on the whole move; 0 = no timeout")
 	noLock := volMoveCommand.Bool("noLock", false, "do not lock the admin shell at one's own risk")
 
 	if err = volMoveCommand.Parse(args); err != nil {
@@ -83,7 +85,14 @@ func (c *commandVolumeMove) Do(args []string, commandEnv *CommandEnv, writer io.
 		return fmt.Errorf("source and target volume servers are the same!")
 	}
 
-	return LiveMoveVolume(context.Background(), commandEnv.option.GrpcDialOption, writer, volumeId, sourceVolumeServer, targetVolumeServer, 5*time.Second, *diskTypeStr, *ioBytePerSecond, false)
+	ctx := context.Background()
+	if *timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, *timeout)
+		defer cancel()
+	}
+
+	return LiveMoveVolume(ctx, commandEnv.option.GrpcDialOption, writer, volumeId, sourceVolumeServer, targetVolumeServer, 5*time.Second, *diskTypeStr, *ioBytePerSecond, false)
 }
 
 // LiveMoveVolume moves one volume from one source volume server to one target volume server, with idleTimeout to drain the incoming requests.


### PR DESCRIPTION
Fixes #10690

`volume.delete` and `volume.move` issue their gRPC calls on a bare `context.Background()`, so a hung or unreachable volume server blocks the shell forever. Both commands now take an opt-in `-timeout` that caps the whole operation; the default 0 keeps today's wait-forever behavior.

The context plumbing through `deleteVolume`/`copyVolume`/`markVolumeWritable` already exists, so this only wires a deadline into it. A move that times out mid-copy still restores the source volume's writability, which already runs on its own detached context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `-timeout` controls to `volume.delete` and `volume.move`.
  * Positive timeout values cancel the operation when the limit is reached.
  * Leaving the timeout at zero preserves unlimited execution time.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->