### PR TITLE
shell: volume.move cleans up when aborted after the copy phase

### DIFF
--- a/weed/shell/command_volume_copy.go
+++ b/weed/shell/command_volume_copy.go
@@ -61,6 +61,6 @@ func (c *commandVolumeCopy) Do(args []string, commandEnv *CommandEnv, writer io.
 		return fmt.Errorf("source and target volume servers are the same!")
 	}
 
-	_, err = copyVolume(context.Background(), commandEnv.option.GrpcDialOption, writer, volumeId, sourceVolumeServer, targetVolumeServer, "", 0, true)
+	_, _, err = copyVolume(context.Background(), commandEnv.option.GrpcDialOption, writer, volumeId, sourceVolumeServer, targetVolumeServer, "", 0, true)
 	return
 }

--- a/weed/shell/command_volume_merge.go
+++ b/weed/shell/command_volume_merge.go
@@ -187,7 +187,7 @@ func (c *commandVolumeMerge) Do(args []string, commandEnv *CommandEnv, writer io
 
 	for i, replica := range replicas {
 		sourceServer := pb.NewServerAddressFromDataNode(replica.location.dataNode)
-		if _, err = copyVolume(context.Background(), commandEnv.option.GrpcDialOption, writer, volumeId, targetServer, sourceServer, "", 0, false); err != nil {
+		if _, _, err = copyVolume(context.Background(), commandEnv.option.GrpcDialOption, writer, volumeId, targetServer, sourceServer, "", 0, false); err != nil {
 			return fmt.Errorf("rebuild replica %d/%d on %s from merged volume %d: %w; merged copy kept on %s, re-run to finish", i+1, len(replicas), sourceServer, volumeId, err, targetServer)
 		}
 	}

--- a/weed/shell/command_volume_move.go
+++ b/weed/shell/command_volume_move.go
@@ -106,12 +106,20 @@ func LiveMoveVolume(ctx context.Context, grpcDialOption grpc.DialOption, writer 
 
 	// A move aborted after the copy must restore the source writability, or
 	// the source volume is left permanently readonly.
+	var sourceDeleteStarted bool
 	defer func() {
 		if err == nil || !leftReadonly {
 			return
 		}
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 		defer cleanupCancel()
+		if !sourceDeleteStarted {
+			// The target copy may be missing tailed entries; remove it so the
+			// restored source stays the only replica.
+			if dErr := deleteVolume(cleanupCtx, grpcDialOption, volumeId, targetVolumeServer, false, true); dErr != nil {
+				log.Printf("failed to delete the incomplete copy of volume %d on %s: %v", volumeId, targetVolumeServer, dErr)
+			}
+		}
 		if wErr := markVolumeWritable(cleanupCtx, grpcDialOption, volumeId, sourceVolumeServer, true, false); wErr != nil {
 			log.Printf("failed to restore volume %d writable on %s: %v", volumeId, sourceVolumeServer, wErr)
 		}
@@ -127,6 +135,7 @@ func LiveMoveVolume(ctx context.Context, grpcDialOption grpc.DialOption, writer 
 	}
 
 	log.Printf("deleting volume %d from %s", volumeId, sourceVolumeServer)
+	sourceDeleteStarted = true
 	if err = deleteVolume(ctx, grpcDialOption, volumeId, sourceVolumeServer, false, true); err != nil {
 		return fmt.Errorf("delete volume %d from %s: %v", volumeId, sourceVolumeServer, err)
 	}

--- a/weed/shell/command_volume_move.go
+++ b/weed/shell/command_volume_move.go
@@ -99,10 +99,23 @@ func (c *commandVolumeMove) Do(args []string, commandEnv *CommandEnv, writer io.
 func LiveMoveVolume(ctx context.Context, grpcDialOption grpc.DialOption, writer io.Writer, volumeId needle.VolumeId, sourceVolumeServer, targetVolumeServer pb.ServerAddress, idleTimeout time.Duration, diskType string, ioBytePerSecond int64, skipTailError bool) (err error) {
 
 	log.Printf("copying volume %d from %s to %s", volumeId, sourceVolumeServer, targetVolumeServer)
-	lastAppendAtNs, err := copyVolume(ctx, grpcDialOption, writer, volumeId, sourceVolumeServer, targetVolumeServer, diskType, ioBytePerSecond, false)
+	lastAppendAtNs, leftReadonly, err := copyVolume(ctx, grpcDialOption, writer, volumeId, sourceVolumeServer, targetVolumeServer, diskType, ioBytePerSecond, false)
 	if err != nil {
 		return fmt.Errorf("copy volume %d from %s to %s: %v", volumeId, sourceVolumeServer, targetVolumeServer, err)
 	}
+
+	// A move aborted after the copy must restore the source writability, or
+	// the source volume is left permanently readonly.
+	defer func() {
+		if err == nil || !leftReadonly {
+			return
+		}
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cleanupCancel()
+		if wErr := markVolumeWritable(cleanupCtx, grpcDialOption, volumeId, sourceVolumeServer, true, false); wErr != nil {
+			log.Printf("failed to restore volume %d writable on %s: %v", volumeId, sourceVolumeServer, wErr)
+		}
+	}()
 
 	log.Printf("tailing volume %d from %s to %s", volumeId, sourceVolumeServer, targetVolumeServer)
 	if err = tailVolume(ctx, grpcDialOption, volumeId, sourceVolumeServer, targetVolumeServer, lastAppendAtNs, idleTimeout); err != nil {
@@ -122,7 +135,7 @@ func LiveMoveVolume(ctx context.Context, grpcDialOption grpc.DialOption, writer 
 	return nil
 }
 
-func copyVolume(ctx context.Context, grpcDialOption grpc.DialOption, writer io.Writer, volumeId needle.VolumeId, sourceVolumeServer, targetVolumeServer pb.ServerAddress, diskType string, ioBytePerSecond int64, restoreWritable bool) (lastAppendAtNs uint64, err error) {
+func copyVolume(ctx context.Context, grpcDialOption grpc.DialOption, writer io.Writer, volumeId needle.VolumeId, sourceVolumeServer, targetVolumeServer pb.ServerAddress, diskType string, ioBytePerSecond int64, restoreWritable bool) (lastAppendAtNs uint64, leftReadonly bool, err error) {
 
 	// check to see if the volume is already read-only and if its not then we need
 	// to mark it as read-only and then before we return we need to undo what we
@@ -133,6 +146,7 @@ func copyVolume(ctx context.Context, grpcDialOption grpc.DialOption, writer io.W
 			return
 		}
 		if !restoreWritable && err == nil {
+			leftReadonly = true
 			return
 		}
 

--- a/weed/shell/command_volume_move.go
+++ b/weed/shell/command_volume_move.go
@@ -111,16 +111,18 @@ func LiveMoveVolume(ctx context.Context, grpcDialOption grpc.DialOption, writer 
 		if err == nil || !leftReadonly {
 			return
 		}
-		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
-		defer cleanupCancel()
 		if !sourceDeleteStarted {
 			// The target copy may be missing tailed entries; remove it so the
 			// restored source stays the only replica.
-			if dErr := deleteVolume(cleanupCtx, grpcDialOption, volumeId, targetVolumeServer, false, true); dErr != nil {
+			deleteCtx, deleteCancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+			defer deleteCancel()
+			if dErr := deleteVolume(deleteCtx, grpcDialOption, volumeId, targetVolumeServer, false, true); dErr != nil {
 				log.Printf("failed to delete the incomplete copy of volume %d on %s: %v", volumeId, targetVolumeServer, dErr)
 			}
 		}
-		if wErr := markVolumeWritable(cleanupCtx, grpcDialOption, volumeId, sourceVolumeServer, true, false); wErr != nil {
+		restoreCtx, restoreCancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer restoreCancel()
+		if wErr := markVolumeWritable(restoreCtx, grpcDialOption, volumeId, sourceVolumeServer, true, false); wErr != nil {
 			log.Printf("failed to restore volume %d writable on %s: %v", volumeId, sourceVolumeServer, wErr)
 		}
 	}()


### PR DESCRIPTION
Fixes #10691.

The copy-phase restore is already covered: the copyVolume defer marks the source writable on a context.WithoutCancel context. But a move cancelled after the copy succeeds — during the tail or the source delete — returned with the source volume still readonly, forever, and with a stale writable copy mounted on the target. The -timeout flag makes this easy to hit: the tail phase drains for idleTimeout seconds, so a timeout expiring there aborts the move between the copy and the delete.

Two changes:

- LiveMoveVolume restores the source writability when the move fails after copyVolume marked the source readonly, using a context that survives the cancellation. copyVolume now reports whether it left the source readonly, so an already-readonly volume is not made writable.
- If the abort happens before the source delete began, the cleanup also deletes the target copy, which may be missing tailed entries. Leaving it would make the volume over-replicated, and volume.fix.replication could resolve that by keeping the stale copy and deleting the source. If the abort happens during the source delete, the target is kept since it may be the only complete copy.

Reproduced on a 2-server cluster: volume.move -timeout 3s on a 5MB volume aborts mid-tail (the tail drains for 5s). Before the fix the source stayed readonly and the target kept a writable stale copy. After the fix the target copy is removed, the source is writable again, and the data is readable. A normal move is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved volume move recovery when an operation is interrupted or cancelled.
  - Incomplete destination copies are now cleaned up when appropriate.
  - Source volumes are restored to writable status after an aborted move.
  - Improved handling of volume copy and replica rebuild operations to preserve consistent error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->