### PR TITLE
shell: keep the source readonly when the incomplete target copy cannot be deleted

### DIFF
--- a/weed/shell/command_volume_move.go
+++ b/weed/shell/command_volume_move.go
@@ -117,7 +117,10 @@ func LiveMoveVolume(ctx context.Context, grpcDialOption grpc.DialOption, writer 
 			deleteCtx, deleteCancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 			defer deleteCancel()
 			if dErr := deleteVolume(deleteCtx, grpcDialOption, volumeId, targetVolumeServer, false, true); dErr != nil {
-				log.Printf("failed to delete the incomplete copy of volume %d on %s: %v", volumeId, targetVolumeServer, dErr)
+				// Restoring the source while the stale target stays mounted
+				// risks divergent replicas; re-running the move recovers both.
+				log.Printf("volume %d is left readonly on %s: failed to delete the incomplete copy on %s: %v; re-run volume.move to recover", volumeId, sourceVolumeServer, targetVolumeServer, dErr)
+				return
 			}
 		}
 		restoreCtx, restoreCancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)


### PR DESCRIPTION
Follow-up to #10704.

When a move aborts after the copy and the cleanup fails to delete the incomplete target copy, restoring the source writability would leave two reachable replicas — the target possibly missing tailed entries — and replication repair could keep the stale one. Keep the source readonly instead and say so: re-running volume.move recovers, since VolumeCopy replaces the pre-existing target replica.

Verified on a 2-server cluster by killing the target mid-tail: the cleanup logs the readonly state with the recovery hint, and re-running volume.move after restarting the target completes the move with the data intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging when volume move cleanup fails.
  * Clarifies that the source remains read-only, identifies the affected servers, and provides recovery guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->