### PR TITLE
mount: keep hot directories cached

### DIFF
--- a/weed/mount/filehandle_read_remote_test.go
+++ b/weed/mount/filehandle_read_remote_test.go
@@ -110,7 +110,6 @@ func TestReadUncachedRemoteEntryDoesNotDeadlock(t *testing.T) {
 			lock := wfs.fhLockTable.AcquireLock("invalidateFunc", fh.fh, util.ExclusiveLock)
 			wfs.fhLockTable.ReleaseLock(fh.fh, lock)
 		},
-		nil,
 	)
 	wfs.inodeToPath.MarkChildrenCached(root)
 	wfs.inodeToPath.Lookup(util.FullPath("/dir"), time.Now().Unix(), true, false, 0, false)

--- a/weed/mount/inode_to_path.go
+++ b/weed/mount/inode_to_path.go
@@ -34,8 +34,6 @@ type dirState struct {
 	cachedExpiresTime time.Time
 	lastAccess        time.Time
 	lastRefresh       time.Time
-	updateWindowStart time.Time
-	updateCount       int
 	subdirCount       int32 // tracked in-memory for POSIX directory nlink
 }
 
@@ -43,8 +41,6 @@ func (d *dirState) resetCacheState() {
 	d.isChildrenCached = false
 	d.readDirDirect = false
 	d.cachedExpiresTime = time.Time{}
-	d.updateCount = 0
-	d.updateWindowStart = time.Time{}
 }
 
 func (ie *InodeEntry) removeOnePath(p util.FullPath) bool {
@@ -245,8 +241,6 @@ func (i *InodeToPath) MarkChildrenCached(fullpath util.FullPath) {
 	now := time.Now()
 	d.lastAccess = now
 	d.lastRefresh = now
-	d.updateCount = 0
-	d.updateWindowStart = time.Time{}
 	if i.cacheMetaTtlSec > 0 {
 		d.cachedExpiresTime = now.Add(i.cacheMetaTtlSec)
 	}
@@ -376,41 +370,7 @@ func (i *InodeToPath) MarkDirectoryReadThrough(fullpath util.FullPath, now time.
 	d.cachedExpiresTime = time.Time{}
 	d.lastAccess = now
 	d.lastRefresh = time.Time{}
-	d.updateCount = 0
-	d.updateWindowStart = time.Time{}
 	return true
-}
-
-func (i *InodeToPath) RecordDirectoryUpdate(fullpath util.FullPath, now time.Time, window time.Duration, threshold int) bool {
-	if threshold <= 0 || window <= 0 {
-		return false
-	}
-	i.Lock()
-	defer i.Unlock()
-	inode, found := i.path2inode[fullpath]
-	if !found {
-		return false
-	}
-	d := i.dirStates[inode]
-	if d == nil || !d.isChildrenCached {
-		return false
-	}
-	if d.updateWindowStart.IsZero() || now.Sub(d.updateWindowStart) > window {
-		d.updateWindowStart = now
-		d.updateCount = 0
-	}
-	d.updateCount++
-	if d.updateCount >= threshold {
-		d.isChildrenCached = false
-		d.readDirDirect = true
-		d.cachedExpiresTime = time.Time{}
-		d.lastAccess = now
-		d.lastRefresh = time.Time{}
-		d.updateCount = 0
-		d.updateWindowStart = time.Time{}
-		return true
-	}
-	return false
 }
 
 func (i *InodeToPath) ShouldReadDirectoryDirect(fullpath util.FullPath) bool {
@@ -441,8 +401,6 @@ func (i *InodeToPath) MarkDirectoryRefreshed(fullpath util.FullPath, now time.Ti
 	d.lastRefresh = now
 	d.lastAccess = now
 	d.readDirDirect = false
-	d.updateCount = 0
-	d.updateWindowStart = time.Time{}
 	if i.cacheMetaTtlSec > 0 {
 		d.cachedExpiresTime = now.Add(i.cacheMetaTtlSec)
 	}

--- a/weed/mount/inode_to_path_test.go
+++ b/weed/mount/inode_to_path_test.go
@@ -126,26 +126,6 @@ func TestOnlyDirectoriesGetDirState(t *testing.T) {
 	}
 }
 
-func TestRecordDirectoryUpdateSwitchesDirectoryToReadThrough(t *testing.T) {
-	root := util.FullPath("/")
-	dir := util.FullPath("/data")
-
-	inodeToPath := NewInodeToPath(root, 60)
-	inodeToPath.Lookup(dir, time.Now().Unix(), true, false, 0, true)
-	inodeToPath.MarkChildrenCached(dir)
-
-	now := time.Now()
-	if !inodeToPath.RecordDirectoryUpdate(dir, now, time.Second, 1) {
-		t.Fatal("expected directory to switch to read-through mode")
-	}
-	if inodeToPath.IsChildrenCached(dir) {
-		t.Fatal("directory should no longer be marked cached")
-	}
-	if !inodeToPath.ShouldReadDirectoryDirect(dir) {
-		t.Fatal("directory should be served via direct reads after hot invalidation")
-	}
-}
-
 func TestMarkChildrenCachedClearsReadThroughMode(t *testing.T) {
 	root := util.FullPath("/")
 	dir := util.FullPath("/data")

--- a/weed/mount/meta_cache/meta_cache.go
+++ b/weed/mount/meta_cache/meta_cache.go
@@ -32,7 +32,6 @@ type MetaCache struct {
 	markCachedFn         func(fullpath util.FullPath)
 	isCachedFn           func(fullpath util.FullPath) bool
 	invalidateFunc       func(EntryInvalidation)
-	onDirectoryUpdate    func(dir util.FullPath)
 	pinnedChildFn        func(*filer.Entry) bool // a child a rebuild must not drop (local-only, not yet on the filer); nil disables
 	visitGroup           singleflight.Group      // deduplicates concurrent EnsureVisited calls for the same path
 	applyCh              chan metadataApplyRequest
@@ -64,16 +63,12 @@ type MetaCache struct {
 var errMetaCacheClosed = errors.New("metadata cache is shut down")
 
 type MetadataResponseApplyOptions struct {
-	NotifyDirectories bool
 	InvalidateEntries bool
 }
 
 var (
-	LocalMetadataResponseApplyOptions = MetadataResponseApplyOptions{
-		NotifyDirectories: true,
-	}
+	LocalMetadataResponseApplyOptions      = MetadataResponseApplyOptions{}
 	SubscriberMetadataResponseApplyOptions = MetadataResponseApplyOptions{
-		NotifyDirectories: true,
 		InvalidateEntries: true,
 	}
 )
@@ -107,7 +102,7 @@ type metadataApplyRequest struct {
 }
 
 func NewMetaCache(dbFolder string, uidGidMapper *UidGidMapper, root util.FullPath, includeSystemEntries bool,
-	markCachedFn func(path util.FullPath), isCachedFn func(path util.FullPath) bool, invalidateFunc func(EntryInvalidation), onDirectoryUpdate func(dir util.FullPath)) *MetaCache {
+	markCachedFn func(path util.FullPath), isCachedFn func(path util.FullPath) bool, invalidateFunc func(EntryInvalidation)) *MetaCache {
 	leveldbStore, virtualStore := openMetaStore(dbFolder)
 	mc := &MetaCache{
 		root:                 root,
@@ -116,7 +111,6 @@ func NewMetaCache(dbFolder string, uidGidMapper *UidGidMapper, root util.FullPat
 		markCachedFn:         markCachedFn,
 		isCachedFn:           isCachedFn,
 		uidGidMapper:         uidGidMapper,
-		onDirectoryUpdate:    onDirectoryUpdate,
 		includeSystemEntries: includeSystemEntries,
 		invalidateFunc:       invalidateFunc,
 		applyCh:              make(chan metadataApplyRequest, 128),
@@ -714,12 +708,6 @@ func (mc *MetaCache) IsDirectoryCached(dirPath util.FullPath) bool {
 	return mc.isCachedFn(dirPath)
 }
 
-func (mc *MetaCache) noteDirectoryUpdate(dirPath util.FullPath) {
-	if mc.onDirectoryUpdate != nil {
-		mc.onDirectoryUpdate(dirPath)
-	}
-}
-
 func (mc *MetaCache) enqueueAndWait(ctx context.Context, req metadataApplyRequest) error {
 	if ctx == nil {
 		ctx = context.Background()
@@ -821,11 +809,6 @@ type EntryInvalidation struct {
 	WasDirectory bool
 }
 
-type metadataResponseSideEffects struct {
-	dirsToNotify  []util.FullPath
-	invalidations []EntryInvalidation
-}
-
 func (mc *MetaCache) applyMetadataResponseNow(ctx context.Context, resp *filer_pb.SubscribeMetadataResponse, options MetadataResponseApplyOptions) error {
 	if mc.shouldSkipDuplicateEvent(resp) {
 		return nil
@@ -841,11 +824,7 @@ func (mc *MetaCache) applyMetadataResponseNow(ctx context.Context, resp *filer_p
 			return err
 		}
 	}
-	// Apply side effects but skip directory notifications for dirs that are
-	// currently being built. Notifying a building dir can trigger
-	// markDirectoryReadThrough → DeleteFolderChildren, wiping entries that
-	// EnsureVisited already inserted, leaving an incomplete cache.
-	mc.applyMetadataSideEffectsSkippingBuildingDirs(resp, options)
+	mc.applyMetadataSideEffects(resp, options)
 	for buildDir, events := range bufferedEvents {
 		state := mc.buildingDirs[buildDir]
 		if state == nil {
@@ -857,7 +836,7 @@ func (mc *MetaCache) applyMetadataResponseNow(ctx context.Context, resp *filer_p
 }
 
 func (mc *MetaCache) applyMetadataResponseDirect(ctx context.Context, resp *filer_pb.SubscribeMetadataResponse, options MetadataResponseApplyOptions, allowUncachedInsert bool) error {
-	if _, err := mc.applyMetadataResponseLocked(ctx, resp, options, allowUncachedInsert); err != nil {
+	if err := mc.applyMetadataResponseLocked(ctx, resp, options, allowUncachedInsert); err != nil {
 		return err
 	}
 	mc.applyMetadataSideEffects(resp, options)
@@ -865,36 +844,9 @@ func (mc *MetaCache) applyMetadataResponseDirect(ctx context.Context, resp *file
 }
 
 func (mc *MetaCache) applyMetadataSideEffects(resp *filer_pb.SubscribeMetadataResponse, options MetadataResponseApplyOptions) {
-	sideEffects := metadataResponseSideEffects{}
-	if options.NotifyDirectories {
-		sideEffects.dirsToNotify = collectDirectoryNotifications(resp)
-	}
 	if options.InvalidateEntries {
-		sideEffects.invalidations = collectEntryInvalidations(resp)
+		mc.invalidateWorker.Enqueue(collectEntryInvalidations(resp)...)
 	}
-	for _, dirPath := range sideEffects.dirsToNotify {
-		mc.noteDirectoryUpdate(dirPath)
-	}
-	mc.invalidateWorker.Enqueue(sideEffects.invalidations...)
-}
-
-// applyMetadataSideEffectsSkippingBuildingDirs is like applyMetadataSideEffects
-// but suppresses directory notifications for dirs currently in buildingDirs.
-// This prevents markDirectoryReadThrough from wiping entries mid-build.
-func (mc *MetaCache) applyMetadataSideEffectsSkippingBuildingDirs(resp *filer_pb.SubscribeMetadataResponse, options MetadataResponseApplyOptions) {
-	sideEffects := metadataResponseSideEffects{}
-	if options.NotifyDirectories {
-		sideEffects.dirsToNotify = collectDirectoryNotifications(resp)
-	}
-	if options.InvalidateEntries {
-		sideEffects.invalidations = collectEntryInvalidations(resp)
-	}
-	for _, dirPath := range sideEffects.dirsToNotify {
-		if _, building := mc.buildingDirs[dirPath]; !building {
-			mc.noteDirectoryUpdate(dirPath)
-		}
-	}
-	mc.invalidateWorker.Enqueue(sideEffects.invalidations...)
 }
 
 // WaitForEntryInvalidations blocks until every invalidation enqueued so far
@@ -904,10 +856,10 @@ func (mc *MetaCache) WaitForEntryInvalidations() {
 	mc.invalidateWorker.Drain()
 }
 
-func (mc *MetaCache) applyMetadataResponseLocked(ctx context.Context, resp *filer_pb.SubscribeMetadataResponse, options MetadataResponseApplyOptions, allowUncachedInsert bool) (metadataResponseSideEffects, error) {
+func (mc *MetaCache) applyMetadataResponseLocked(ctx context.Context, resp *filer_pb.SubscribeMetadataResponse, options MetadataResponseApplyOptions, allowUncachedInsert bool) error {
 	message := resp.GetEventNotification()
 	if message == nil {
-		return metadataResponseSideEffects{}, nil
+		return nil
 	}
 
 	var oldPath util.FullPath
@@ -960,10 +912,7 @@ func (mc *MetaCache) applyMetadataResponseLocked(ctx context.Context, resp *file
 		}
 	}
 	mc.Unlock()
-	if err != nil {
-		return metadataResponseSideEffects{}, err
-	}
-	return metadataResponseSideEffects{}, nil
+	return err
 }
 
 func (mc *MetaCache) beginDirectoryBuildNow(dirPath util.FullPath) error {
@@ -1214,47 +1163,6 @@ func (r *dedupRingBuffer) Add(key string) bool {
 	r.set[key] = struct{}{}
 	r.head = (r.head + 1) % recentEventDedupWindow
 	return true // new entry
-}
-
-func collectDirectoryNotifications(resp *filer_pb.SubscribeMetadataResponse) []util.FullPath {
-	message := resp.GetEventNotification()
-	if message == nil {
-		return nil
-	}
-
-	// At most 3 dirs: old parent, new parent, new child (if directory).
-	// Use a fixed slice with linear dedup to avoid map allocation.
-	var dirs [3]util.FullPath
-	n := 0
-	addUnique := func(p util.FullPath) {
-		for i := 0; i < n; i++ {
-			if dirs[i] == p {
-				return
-			}
-		}
-		dirs[n] = p
-		n++
-	}
-
-	if message.OldEntry != nil {
-		oldPath := util.NewFullPath(resp.Directory, message.OldEntry.Name)
-		parent, _ := oldPath.DirAndName()
-		addUnique(util.FullPath(parent))
-	}
-	if message.NewEntry != nil {
-		newDir := resp.Directory
-		if message.NewParentPath != "" {
-			newDir = message.NewParentPath
-		}
-		newPath := util.NewFullPath(newDir, message.NewEntry.Name)
-		parent, _ := newPath.DirAndName()
-		addUnique(util.FullPath(parent))
-		if message.NewEntry.IsDirectory {
-			addUnique(newPath)
-		}
-	}
-
-	return dirs[:n]
 }
 
 func collectEntryInvalidations(resp *filer_pb.SubscribeMetadataResponse) []EntryInvalidation {

--- a/weed/mount/meta_cache/meta_cache_apply_test.go
+++ b/weed/mount/meta_cache/meta_cache_apply_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestApplyMetadataResponseAppliesEventsInOrder(t *testing.T) {
-	mc, _, notifications, invalidations := newTestMetaCache(t, map[util.FullPath]bool{
+	mc, _, invalidations := newTestMetaCache(t, map[util.FullPath]bool{
 		"/":    true,
 		"/dir": true,
 	})
@@ -97,9 +97,6 @@ func TestApplyMetadataResponseAppliesEventsInOrder(t *testing.T) {
 		t.Fatalf("deleted entry still cached: %+v", entry)
 	}
 
-	if got := countPath(notifications.paths(), util.FullPath("/dir")); got != 3 {
-		t.Fatalf("directory notifications for /dir = %d, want 3", got)
-	}
 	mc.WaitForEntryInvalidations()
 	if got := countPath(invalidations.paths(), util.FullPath("/dir/file.txt")); got != 3 {
 		t.Fatalf("invalidations for /dir/file.txt = %d, want 3 (create + update + delete)", got)
@@ -107,7 +104,7 @@ func TestApplyMetadataResponseAppliesEventsInOrder(t *testing.T) {
 }
 
 func TestApplyMetadataResponseRenamesAcrossCachedDirectories(t *testing.T) {
-	mc, _, notifications, invalidations := newTestMetaCache(t, map[util.FullPath]bool{
+	mc, _, invalidations := newTestMetaCache(t, map[util.FullPath]bool{
 		"/":    true,
 		"/src": true,
 		"/dst": true,
@@ -165,12 +162,6 @@ func TestApplyMetadataResponseRenamesAcrossCachedDirectories(t *testing.T) {
 		t.Fatalf("renamed file size = %d, want 41", newEntry.FileSize)
 	}
 
-	if got := countPath(notifications.paths(), util.FullPath("/src")); got != 1 {
-		t.Fatalf("directory notifications for /src = %d, want 1", got)
-	}
-	if got := countPath(notifications.paths(), util.FullPath("/dst")); got != 1 {
-		t.Fatalf("directory notifications for /dst = %d, want 1", got)
-	}
 	mc.WaitForEntryInvalidations()
 	if got := countPath(invalidations.paths(), util.FullPath("/src/file.tmp")); got != 1 {
 		t.Fatalf("invalidations for /src/file.tmp = %d, want 1", got)
@@ -181,7 +172,7 @@ func TestApplyMetadataResponseRenamesAcrossCachedDirectories(t *testing.T) {
 }
 
 func TestApplyMetadataResponseLocalOptionsSkipInvalidations(t *testing.T) {
-	mc, _, notifications, invalidations := newTestMetaCache(t, map[util.FullPath]bool{
+	mc, _, invalidations := newTestMetaCache(t, map[util.FullPath]bool{
 		"/":    true,
 		"/dir": true,
 	})
@@ -229,9 +220,6 @@ func TestApplyMetadataResponseLocalOptionsSkipInvalidations(t *testing.T) {
 	if entry.FileSize != 17 {
 		t.Fatalf("updated file size = %d, want 17", entry.FileSize)
 	}
-	if got := countPath(notifications.paths(), util.FullPath("/dir")); got != 1 {
-		t.Fatalf("directory notifications for /dir = %d, want 1", got)
-	}
 	mc.WaitForEntryInvalidations()
 	if got := len(invalidations.paths()); got != 0 {
 		t.Fatalf("invalidations = %d, want 0", got)
@@ -239,7 +227,7 @@ func TestApplyMetadataResponseLocalOptionsSkipInvalidations(t *testing.T) {
 }
 
 func TestApplyMetadataResponseDeduplicatesRepeatedFilerEvent(t *testing.T) {
-	mc, _, notifications, invalidations := newTestMetaCache(t, map[util.FullPath]bool{
+	mc, _, invalidations := newTestMetaCache(t, map[util.FullPath]bool{
 		"/":    true,
 		"/dir": true,
 	})
@@ -292,9 +280,6 @@ func TestApplyMetadataResponseDeduplicatesRepeatedFilerEvent(t *testing.T) {
 	if entry.FileSize != 15 {
 		t.Fatalf("updated file size = %d, want 15", entry.FileSize)
 	}
-	if got := countPath(notifications.paths(), util.FullPath("/dir")); got != 1 {
-		t.Fatalf("directory notifications for /dir = %d, want 1", got)
-	}
 	mc.WaitForEntryInvalidations()
 	if got := countPath(invalidations.paths(), util.FullPath("/dir/file.txt")); got != 1 {
 		t.Fatalf("invalidations for /dir/file.txt = %d, want 1", got)
@@ -302,7 +287,7 @@ func TestApplyMetadataResponseDeduplicatesRepeatedFilerEvent(t *testing.T) {
 }
 
 func TestApplyMetadataResponseSkipsHiddenSystemEntryWhenDisabled(t *testing.T) {
-	mc, _, _, _ := newTestMetaCache(t, map[util.FullPath]bool{
+	mc, _, _ := newTestMetaCache(t, map[util.FullPath]bool{
 		"/": true,
 	})
 	defer mc.Shutdown()
@@ -336,7 +321,7 @@ func TestApplyMetadataResponseSkipsHiddenSystemEntryWhenDisabled(t *testing.T) {
 }
 
 func TestApplyMetadataResponsePurgesHiddenDestinationPath(t *testing.T) {
-	mc, _, _, _ := newTestMetaCache(t, map[util.FullPath]bool{
+	mc, _, _ := newTestMetaCache(t, map[util.FullPath]bool{
 		"/":    true,
 		"/src": true,
 	})
@@ -473,7 +458,7 @@ func TestCollectEntryInvalidationsCarryAuthoritativeEntries(t *testing.T) {
 	}
 }
 
-func newTestMetaCache(t *testing.T, cached map[util.FullPath]bool) (*MetaCache, map[util.FullPath]bool, *recordedPaths, *recordedPaths) {
+func newTestMetaCache(t *testing.T, cached map[util.FullPath]bool) (*MetaCache, map[util.FullPath]bool, *recordedPaths) {
 	t.Helper()
 
 	mapper, err := NewUidGidMapper("", "")
@@ -482,7 +467,6 @@ func newTestMetaCache(t *testing.T, cached map[util.FullPath]bool) (*MetaCache, 
 	}
 
 	var cachedMu sync.Mutex
-	notifications := &recordedPaths{}
 	invalidations := &recordedPaths{}
 
 	mc := NewMetaCache(
@@ -503,12 +487,9 @@ func newTestMetaCache(t *testing.T, cached map[util.FullPath]bool) (*MetaCache, 
 		func(inv EntryInvalidation) {
 			invalidations.record(inv.Path)
 		},
-		func(dir util.FullPath) {
-			notifications.record(dir)
-		},
 	)
 
-	return mc, cached, notifications, invalidations
+	return mc, cached, invalidations
 }
 
 type recordedPaths struct {
@@ -542,7 +523,7 @@ func countPath(paths []util.FullPath, target util.FullPath) int {
 // claim no longer describes it and must be cleared — keeping it would fence
 // out events correcting the unversioned state.
 func TestUnversionedWriteClearsEntryVersion(t *testing.T) {
-	mc, _, _, _ := newTestMetaCache(t, map[util.FullPath]bool{
+	mc, _, _ := newTestMetaCache(t, map[util.FullPath]bool{
 		"/":    true,
 		"/dir": true,
 	})
@@ -587,7 +568,7 @@ func TestUnversionedWriteClearsEntryVersion(t *testing.T) {
 // incarnations left behind, or valid events below the stale claim are
 // rejected.
 func TestUnversionedRebuildClearsStaleVersions(t *testing.T) {
-	mc, _, _, _ := newTestMetaCache(t, map[util.FullPath]bool{
+	mc, _, _ := newTestMetaCache(t, map[util.FullPath]bool{
 		"/":    true,
 		"/dir": true,
 	})
@@ -635,7 +616,7 @@ func TestUnversionedRebuildClearsStaleVersions(t *testing.T) {
 // protects; an uncached parent never serves from the store nor applies the
 // resurrecting insert, so a tombstone there would only accumulate.
 func TestTombstonesScopedToCachedDirectories(t *testing.T) {
-	mc, _, _, _ := newTestMetaCache(t, map[util.FullPath]bool{
+	mc, _, _ := newTestMetaCache(t, map[util.FullPath]bool{
 		"/":       true,
 		"/cached": true,
 	})
@@ -670,7 +651,7 @@ func TestTombstonesScopedToCachedDirectories(t *testing.T) {
 // A completed listing's absence floor supersedes the direct-child tombstones
 // at or below its snapshot; newer tombstones survive.
 func TestBuildCompletionPrunesSupersededTombstones(t *testing.T) {
-	mc, _, _, _ := newTestMetaCache(t, map[util.FullPath]bool{
+	mc, _, _ := newTestMetaCache(t, map[util.FullPath]bool{
 		"/":    true,
 		"/dir": true,
 	})
@@ -737,7 +718,7 @@ func TestBuildCompletionPrunesSupersededTombstones(t *testing.T) {
 // tombstone) so they cannot accumulate for the lifetime of a long-running
 // mount.
 func TestDirectoryEvictionClearsVersionRecords(t *testing.T) {
-	mc, _, _, _ := newTestMetaCache(t, map[util.FullPath]bool{
+	mc, _, _ := newTestMetaCache(t, map[util.FullPath]bool{
 		"/":    true,
 		"/dir": true,
 	})
@@ -786,7 +767,7 @@ func TestDirectoryEvictionClearsVersionRecords(t *testing.T) {
 // than a version record per child, and the floor fences exactly as per-child
 // records did.
 func TestBuildFloorVersionsChildrenWithoutPerChildRecords(t *testing.T) {
-	mc, _, _, _ := newTestMetaCache(t, map[util.FullPath]bool{
+	mc, _, _ := newTestMetaCache(t, map[util.FullPath]bool{
 		"/":    true,
 		"/dir": true,
 	})
@@ -843,7 +824,7 @@ func TestBuildFloorVersionsChildrenWithoutPerChildRecords(t *testing.T) {
 // logically-expired entry is judged by its directory's floor rather than by
 // the stale version record it still carries.
 func TestExpiredEntryIsJudgedByDirectoryFloor(t *testing.T) {
-	mc, _, _, _ := newTestMetaCache(t, map[util.FullPath]bool{
+	mc, _, _ := newTestMetaCache(t, map[util.FullPath]bool{
 		"/":    true,
 		"/dir": true,
 	})
@@ -880,7 +861,7 @@ func TestExpiredEntryIsJudgedByDirectoryFloor(t *testing.T) {
 // must not inherit the directory's listing floor — that would fence the very
 // events needed to correct it.
 func TestUnversionedWriteDoesNotInheritDirectoryFloor(t *testing.T) {
-	mc, _, _, _ := newTestMetaCache(t, map[util.FullPath]bool{
+	mc, _, _ := newTestMetaCache(t, map[util.FullPath]bool{
 		"/":    true,
 		"/dir": true,
 	})

--- a/weed/mount/meta_cache/meta_cache_build_test.go
+++ b/weed/mount/meta_cache/meta_cache_build_test.go
@@ -68,7 +68,7 @@ func (a *buildFilerAccessor) AdjustedUrl(*filer_pb.Location) string { return "" 
 func (a *buildFilerAccessor) GetDataCenter() string                 { return "" }
 
 func TestEnsureVisitedReplaysBufferedEventsAfterSnapshot(t *testing.T) {
-	mc, _, _, _ := newTestMetaCache(t, map[util.FullPath]bool{
+	mc, _, _ := newTestMetaCache(t, map[util.FullPath]bool{
 		"/": true,
 	})
 	defer mc.Shutdown()
@@ -137,13 +137,11 @@ func TestEnsureVisitedReplaysBufferedEventsAfterSnapshot(t *testing.T) {
 	}
 }
 
-// TestDirectoryNotificationsSuppressedDuringBuild verifies that metadata events
-// targeting a directory under active build do NOT fire onDirectoryUpdate for
-// that directory. In production, onDirectoryUpdate can trigger
-// markDirectoryReadThrough → DeleteFolderChildren, which would wipe entries
-// that EnsureVisited already inserted mid-build.
-func TestDirectoryNotificationsSuppressedDuringBuild(t *testing.T) {
-	mc, _, notifications, _ := newTestMetaCache(t, map[util.FullPath]bool{
+// TestEventsDuringBuildKeepInsertedEntries verifies that metadata events
+// targeting a directory under active build do not disturb entries the build
+// already inserted, and are replayed once the build completes.
+func TestEventsDuringBuildKeepInsertedEntries(t *testing.T) {
+	mc, _, _ := newTestMetaCache(t, map[util.FullPath]bool{
 		"/": true,
 	})
 	defer mc.Shutdown()
@@ -167,8 +165,7 @@ func TestDirectoryNotificationsSuppressedDuringBuild(t *testing.T) {
 	}
 
 	// Simulate multiple metadata events arriving for /dir while the build
-	// is in progress. Each event would normally call noteDirectoryUpdate,
-	// which in production can trigger markDirectoryReadThrough and wipe entries.
+	// is in progress.
 	for i := 0; i < 5; i++ {
 		resp := &filer_pb.SubscribeMetadataResponse{
 			Directory: "/dir",
@@ -187,14 +184,6 @@ func TestDirectoryNotificationsSuppressedDuringBuild(t *testing.T) {
 		}
 		if err := mc.ApplyMetadataResponse(context.Background(), resp, SubscriberMetadataResponseApplyOptions); err != nil {
 			t.Fatalf("apply event %d: %v", i, err)
-		}
-	}
-
-	// The building directory /dir must NOT have received any notifications.
-	// If it did, markDirectoryReadThrough would wipe the cache mid-build.
-	for _, p := range notifications.paths() {
-		if p == util.FullPath("/dir") {
-			t.Fatal("onDirectoryUpdate was called for /dir during build; this would cause markDirectoryReadThrough to wipe entries mid-build")
 		}
 	}
 
@@ -240,7 +229,7 @@ func TestDirectoryNotificationsSuppressedDuringBuild(t *testing.T) {
 // without any TsNs filtering. This prevents clock-skew between client and
 // filer from dropping legitimate mutations.
 func TestEmptyDirectoryBuildReplaysAllBufferedEvents(t *testing.T) {
-	mc, _, _, _ := newTestMetaCache(t, map[util.FullPath]bool{
+	mc, _, _ := newTestMetaCache(t, map[util.FullPath]bool{
 		"/": true,
 	})
 	defer mc.Shutdown()
@@ -300,7 +289,7 @@ func TestEmptyDirectoryBuildReplaysAllBufferedEvents(t *testing.T) {
 // prevent the build from completing. The apply loop uses context.Background()
 // internally, so the operation finishes even if the caller gives up waiting.
 func TestBuildCompletionSurvivesCallerCancellation(t *testing.T) {
-	mc, _, _, _ := newTestMetaCache(t, map[util.FullPath]bool{
+	mc, _, _ := newTestMetaCache(t, map[util.FullPath]bool{
 		"/": true,
 	})
 	defer mc.Shutdown()
@@ -383,7 +372,7 @@ func TestBuildCompletionSurvivesCallerCancellation(t *testing.T) {
 }
 
 func TestBufferedRenameUpdatesOtherDirectoryBeforeBuildCompletes(t *testing.T) {
-	mc, _, _, _ := newTestMetaCache(t, map[util.FullPath]bool{
+	mc, _, _ := newTestMetaCache(t, map[util.FullPath]bool{
 		"/":    true,
 		"/src": true,
 	})
@@ -470,7 +459,7 @@ func TestBufferedRenameUpdatesOtherDirectoryBeforeBuildCompletes(t *testing.T) {
 // authoritatively cached (markCachedFn). The local entry vanishes although the
 // client created it: lookupEntry then returns an authoritative ENOENT for it.
 func TestEnsureVisitedPreservesLocalOnlyEntry(t *testing.T) {
-	mc, _, _, _ := newTestMetaCache(t, map[util.FullPath]bool{"/": true})
+	mc, _, _ := newTestMetaCache(t, map[util.FullPath]bool{"/": true})
 	defer mc.Shutdown()
 
 	// The mount pins the un-flushed create (open dirty handle / pending flush),
@@ -527,7 +516,7 @@ func TestEnsureVisitedPreservesLocalOnlyEntry(t *testing.T) {
 // a cached child the filer listing no longer returns and that is NOT pinned must
 // still be wiped, so the rebuild can't resurrect a deleted/renamed entry.
 func TestEnsureVisitedDropsUnpinnedStaleEntry(t *testing.T) {
-	mc, _, _, _ := newTestMetaCache(t, map[util.FullPath]bool{"/": true})
+	mc, _, _ := newTestMetaCache(t, map[util.FullPath]bool{"/": true})
 	defer mc.Shutdown()
 
 	mc.SetPinnedChildFn(func(*filer.Entry) bool { return false })
@@ -583,7 +572,7 @@ func (c *sequencedListClient) ListEntries(ctx context.Context, in *filer_pb.List
 // listing comes back empty must re-read and cache the real entries, not strand
 // the directory cached over an empty store (the ConcurrentReadWrite ENOENT flake).
 func TestEnsureVisitedConfirmsTransientEmptyListing(t *testing.T) {
-	mc, _, _, _ := newTestMetaCache(t, map[util.FullPath]bool{"/": true})
+	mc, _, _ := newTestMetaCache(t, map[util.FullPath]bool{"/": true})
 	defer mc.Shutdown()
 
 	entry := &filer_pb.Entry{
@@ -611,7 +600,7 @@ func TestEnsureVisitedConfirmsTransientEmptyListing(t *testing.T) {
 // TestEnsureVisitedCachesGenuinelyEmptyDirectory: a really-empty directory lists
 // empty on every confirm and must still end up cached.
 func TestEnsureVisitedCachesGenuinelyEmptyDirectory(t *testing.T) {
-	mc, _, _, _ := newTestMetaCache(t, map[util.FullPath]bool{"/": true})
+	mc, _, _ := newTestMetaCache(t, map[util.FullPath]bool{"/": true})
 	defer mc.Shutdown()
 
 	client := &sequencedListClient{

--- a/weed/mount/meta_cache/meta_cache_deadlock_test.go
+++ b/weed/mount/meta_cache/meta_cache_deadlock_test.go
@@ -65,7 +65,6 @@ func TestApplyLoopInvalidateDoesNotDeadlockWithLockHoldingEnqueuer(t *testing.T)
 			lock := fhLockTable.AcquireLock("invalidateFunc", fhKey, util.ExclusiveLock)
 			fhLockTable.ReleaseLock(fhKey, lock)
 		},
-		func(dir util.FullPath) {},
 	)
 	defer func() {
 		// Only safe to shut down once the apply loop is unwedged.

--- a/weed/mount/meta_cache/meta_cache_purge_test.go
+++ b/weed/mount/meta_cache/meta_cache_purge_test.go
@@ -42,7 +42,7 @@ func barrier(t *testing.T, mc *MetaCache) {
 // store, and every file in it vanishes from the mount though it is safe on the
 // filer.
 func TestPurgeSkippedWhileDirectoryBuilding(t *testing.T) {
-	mc, _, _, _ := newTestMetaCache(t, map[util.FullPath]bool{"/": true})
+	mc, _, _ := newTestMetaCache(t, map[util.FullPath]bool{"/": true})
 	defer mc.Shutdown()
 
 	dir := util.FullPath("/dir")
@@ -79,7 +79,7 @@ func TestPurgeSkippedWhileDirectoryBuilding(t *testing.T) {
 // apply loop: with no build in flight, the purge resets the cached flag and
 // wipes the store.
 func TestPurgeClearsWhenNotBuilding(t *testing.T) {
-	mc, _, _, _ := newTestMetaCache(t, map[util.FullPath]bool{"/": true, "/dir": true})
+	mc, _, _ := newTestMetaCache(t, map[util.FullPath]bool{"/": true, "/dir": true})
 	defer mc.Shutdown()
 
 	dir := util.FullPath("/dir")

--- a/weed/mount/meta_cache/oversized_dir_test.go
+++ b/weed/mount/meta_cache/oversized_dir_test.go
@@ -32,7 +32,7 @@ func listResponses(n int) []*filer_pb.ListEntriesResponse {
 // limit is not cached, that the refusal is remembered, and that the partial
 // build leaves nothing behind in the local store.
 func TestEnsureVisitedRefusesOversizedDirectory(t *testing.T) {
-	mc, _, _, _ := newTestMetaCache(t, map[util.FullPath]bool{"/": true})
+	mc, _, _ := newTestMetaCache(t, map[util.FullPath]bool{"/": true})
 	defer mc.Shutdown()
 
 	accessor := &buildFilerAccessor{client: &buildListClient{responses: listResponses(10)}}
@@ -69,7 +69,7 @@ func TestEnsureVisitedRefusesOversizedDirectory(t *testing.T) {
 // TestEnsureVisitedStepsOverOversizedAncestor checks a huge ancestor does not
 // wedge the caching of its subdirectories.
 func TestEnsureVisitedStepsOverOversizedAncestor(t *testing.T) {
-	mc, _, _, _ := newTestMetaCache(t, map[util.FullPath]bool{"/": true})
+	mc, _, _ := newTestMetaCache(t, map[util.FullPath]bool{"/": true})
 	defer mc.Shutdown()
 	mc.markOversized(util.FullPath("/huge"))
 
@@ -88,7 +88,7 @@ func TestEnsureVisitedStepsOverOversizedAncestor(t *testing.T) {
 // TestEnsureVisitedUnderTheLimitStillCaches pins that the gate does not change
 // behaviour for ordinary directories.
 func TestEnsureVisitedUnderTheLimitStillCaches(t *testing.T) {
-	mc, _, _, _ := newTestMetaCache(t, map[util.FullPath]bool{"/": true})
+	mc, _, _ := newTestMetaCache(t, map[util.FullPath]bool{"/": true})
 	defer mc.Shutdown()
 
 	accessor := &buildFilerAccessor{client: &buildListClient{responses: listResponses(5)}}
@@ -115,7 +115,7 @@ func (c *pathListClient) ListEntries(ctx context.Context, in *filer_pb.ListEntri
 // the ancestor's refusal must neither cancel the descendant's build nor be
 // reported as the descendant's own.
 func TestEnsureVisitedAncestorFoundOversizedMidVisit(t *testing.T) {
-	mc, _, _, _ := newTestMetaCache(t, map[util.FullPath]bool{"/": true})
+	mc, _, _ := newTestMetaCache(t, map[util.FullPath]bool{"/": true})
 	defer mc.Shutdown()
 
 	accessor := &buildFilerAccessor{client: &pathListClient{perDir: map[string][]*filer_pb.ListEntriesResponse{

--- a/weed/mount/weedfs.go
+++ b/weed/mount/weedfs.go
@@ -308,7 +308,7 @@ func NewSeaweedFileSystem(option *Option) *WFS {
 			wfs.inodeToPath.MarkChildrenCached(path)
 		}, func(path util.FullPath) bool {
 			return wfs.inodeToPath.IsChildrenCached(path)
-		}, wfs.onEntryInvalidation, nil)
+		}, wfs.onEntryInvalidation)
 	wfs.metaCache.SetPinnedChildFn(wfs.isLocalOnlyEntry)
 	grace.OnInterrupt(func() {
 		// grace calls os.Exit(0) after all hooks, so WaitForAsyncFlush

--- a/weed/mount/weedfs.go
+++ b/weed/mount/weedfs.go
@@ -179,8 +179,6 @@ type WFS struct {
 	dirMtimeMap           map[uint64]time.Time // inode -> mtime/ctime, in-memory overlay for dirs
 	entryValidSec         uint64               // kernel FUSE entry cache TTL in seconds
 	attrValidSec          uint64               // kernel FUSE attr cache TTL in seconds
-	dirHotWindow          time.Duration
-	dirHotThreshold       int
 	dirIdleEvict          time.Duration
 
 	// openMtimeCache maps inode -> [mtime_sec, mtime_ns] from the last Open.
@@ -222,11 +220,7 @@ type WFS struct {
 	lockClient *cluster.LockClient
 }
 
-const (
-	defaultDirHotWindow    = 2 * time.Second
-	defaultDirHotThreshold = 64
-	defaultDirIdleEvict    = 10 * time.Minute
-)
+const defaultDirIdleEvict = 10 * time.Minute
 
 func NewSeaweedFileSystem(option *Option) *WFS {
 	// Only create FilerClient for direct volume access modes
@@ -251,8 +245,6 @@ func NewSeaweedFileSystem(option *Option) *WFS {
 		)
 	}
 
-	dirHotWindow := defaultDirHotWindow
-	dirHotThreshold := defaultDirHotThreshold
 	dirIdleEvict := defaultDirIdleEvict
 	if option.DirIdleEvictSec != 0 {
 		dirIdleEvict = time.Duration(option.DirIdleEvictSec) * time.Second
@@ -281,8 +273,6 @@ func NewSeaweedFileSystem(option *Option) *WFS {
 		dirMtimeMap:       make(map[uint64]time.Time, 1024),
 		entryValidSec:     1,
 		attrValidSec:      1,
-		dirHotWindow:      dirHotWindow,
-		dirHotThreshold:   dirHotThreshold,
 		dirIdleEvict:      dirIdleEvict,
 	}
 
@@ -318,11 +308,7 @@ func NewSeaweedFileSystem(option *Option) *WFS {
 			wfs.inodeToPath.MarkChildrenCached(path)
 		}, func(path util.FullPath) bool {
 			return wfs.inodeToPath.IsChildrenCached(path)
-		}, wfs.onEntryInvalidation, func(dirPath util.FullPath) {
-			if wfs.inodeToPath.RecordDirectoryUpdate(dirPath, time.Now(), wfs.dirHotWindow, wfs.dirHotThreshold) {
-				wfs.markDirectoryReadThrough(dirPath)
-			}
-		})
+		}, wfs.onEntryInvalidation, nil)
 	wfs.metaCache.SetPinnedChildFn(wfs.isLocalOnlyEntry)
 	grace.OnInterrupt(func() {
 		// grace calls os.Exit(0) after all hooks, so WaitForAsyncFlush
@@ -689,8 +675,7 @@ func (wfs *WFS) lookupEntry(fullpath util.FullPath) (*filer.Entry, entryVersion,
 						glog.V(4).Infof("lookupEntry found deferred entry in local cache %s", fullpath)
 						return localEntry, entryVersion{tsNs: localVersionTsNs}, fuse.OK
 					}
-					// Creating many files at once can push the directory past
-					// the hot threshold and evict it, which drops the local
+					// Cache eviction (idle, kernel Forget) can drop the local
 					// placeholder a deferred create left behind. The handle
 					// still holding the unflushed entry is authoritative for
 					// it, so read it from there rather than reporting a file
@@ -986,18 +971,6 @@ func (wfs *WFS) ClearCacheDir() {
 	wfs.metaCache.Shutdown()
 	os.RemoveAll(wfs.option.getUniqueCacheDirForWrite())
 	os.RemoveAll(wfs.option.getUniqueCacheDirForRead())
-}
-
-// markDirectoryReadThrough drops a hot directory's cached listing. Only safe
-// from the apply loop (onDirectoryUpdate), where it serializes with a build's
-// markCachedFn; off-loop callers must use purgeDirectoryCache.
-func (wfs *WFS) markDirectoryReadThrough(dirPath util.FullPath) {
-	if !wfs.inodeToPath.MarkDirectoryReadThrough(dirPath, time.Now()) {
-		return
-	}
-	if err := wfs.metaCache.DeleteFolderChildren(context.Background(), dirPath); err != nil {
-		glog.V(2).Infof("clear dir cache %s: %v", dirPath, err)
-	}
 }
 
 // purgeDirectoryCache drops a directory's cached listing from off the apply loop

--- a/weed/mount/weedfs_dir_read_bench_test.go
+++ b/weed/mount/weedfs_dir_read_bench_test.go
@@ -109,7 +109,6 @@ func newBenchWFS(tb testing.TB, dir util.FullPath, n int) *WFS {
 		func(path util.FullPath) { wfs.inodeToPath.MarkChildrenCached(path) },
 		func(path util.FullPath) bool { return wfs.inodeToPath.IsChildrenCached(path) },
 		func(meta_cache.EntryInvalidation) {},
-		nil,
 	)
 	tb.Cleanup(wfs.metaCache.Shutdown)
 

--- a/weed/mount/weedfs_dir_read_pagination_test.go
+++ b/weed/mount/weedfs_dir_read_pagination_test.go
@@ -62,7 +62,7 @@ func newPagingWFS(tb testing.TB, dir util.FullPath, names []string, ttlSec int32
 		filepath.Join(tb.TempDir(), "meta"), uidGidMapper, root, false,
 		func(p util.FullPath) { wfs.inodeToPath.MarkChildrenCached(p) },
 		func(p util.FullPath) bool { return wfs.inodeToPath.IsChildrenCached(p) },
-		func(meta_cache.EntryInvalidation) {}, nil,
+		func(meta_cache.EntryInvalidation) {},
 	)
 	tb.Cleanup(wfs.metaCache.Shutdown)
 

--- a/weed/mount/weedfs_file_copy_range_test.go
+++ b/weed/mount/weedfs_file_copy_range_test.go
@@ -347,7 +347,6 @@ func newCopyRangeTestWFSWithMetaCache(t *testing.T) *WFS {
 			return wfs.inodeToPath.IsChildrenCached(path)
 		},
 		func(meta_cache.EntryInvalidation) {},
-		nil,
 	)
 	t.Cleanup(func() {
 		wfs.metaCache.Shutdown()

--- a/weed/mount/weedfs_file_mkrm_test.go
+++ b/weed/mount/weedfs_file_mkrm_test.go
@@ -129,7 +129,6 @@ func newCreateTestWFS(t *testing.T) (*WFS, *createEntryTestServer) {
 			return wfs.inodeToPath.IsChildrenCached(path)
 		},
 		func(meta_cache.EntryInvalidation) {},
-		nil,
 	)
 	wfs.inodeToPath.MarkChildrenCached(root)
 	t.Cleanup(func() {

--- a/weed/mount/weedfs_invalidate_open_handle_test.go
+++ b/weed/mount/weedfs_invalidate_open_handle_test.go
@@ -61,7 +61,6 @@ func newInvalidateTestWFS(t *testing.T) *WFS {
 		func(path util.FullPath) { wfs.inodeToPath.MarkChildrenCached(path) },
 		func(path util.FullPath) bool { return wfs.inodeToPath.IsChildrenCached(path) },
 		wfs.invalidateOpenFileHandle,
-		nil,
 	)
 	t.Cleanup(wfs.metaCache.Shutdown)
 

--- a/weed/mount/weedfs_rename_test.go
+++ b/weed/mount/weedfs_rename_test.go
@@ -31,7 +31,6 @@ func TestHandleRenameResponseLeavesUncachedTargetOutOfCache(t *testing.T) {
 			return inodeToPath.IsChildrenCached(path)
 		},
 		func(meta_cache.EntryInvalidation) {},
-		nil,
 	)
 	defer mc.Shutdown()
 


### PR DESCRIPTION
Addresses the analysis in #10708: browsing a directory while another client keeps writing into it drives sustained CPU on the mount, because the cached listing keeps getting discarded and re-fetched.

The per-event handling was already incremental: the apply loop inserts or removes just the changed entry, versioned so late or duplicate events cannot roll the cache back. But the hot-directory heuristic sat on top of it, wiping the whole cached listing after 64 events within 2s and flipping the directory to read-through. With a continuous writer the directory cycles forever through wipe, full direct listing, full rebuild, and every sibling lookup in between falls through to the filer as its own LookupEntry call. The writer's own events also count toward the threshold, so a local untar evicts its own directory (the deferred-create fallback in lookupEntry papered over exactly that).

Since events keep a cached directory coherent, churn is no reason to discard it. This removes the churn wipe; idle eviction (-dirIdleEvictSec) and kernel Forget still bound memory, and directories over -cacheDirMaxEntries still read through as before. The second commit removes the directory-notification plumbing that existed only to drive the wipe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory metadata-cache behavior by removing burst-based hotness tracking.
  * Directory caching now relies on idle eviction and explicit purge or read-through operations.
  * Preserved entry invalidation and cache consistency during metadata updates and directory builds.

* **Tests**
  * Updated coverage for cache invalidation, eviction, pagination, purging, renaming, and remote reads.
  * Removed obsolete directory-notification expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->