### PR TITLE
Helm: Add support for schedulerName

### DIFF
--- a/k8s/charts/seaweedfs/templates/admin/admin-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/admin/admin-statefulset.yaml
@@ -69,6 +69,9 @@ spec:
       {{- if .Values.admin.priorityClassName }}
       priorityClassName: {{ .Values.admin.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.admin.schedulerName }}
+      schedulerName: {{ .Values.admin.schedulerName | quote }}
+      {{- end }}
       enableServiceLinks: false
       {{- if .Values.admin.serviceAccountName }}
       serviceAccountName: {{ .Values.admin.serviceAccountName | quote }}

--- a/k8s/charts/seaweedfs/templates/all-in-one/all-in-one-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/all-in-one/all-in-one-deployment.yaml
@@ -64,6 +64,9 @@ spec:
       {{- if .Values.allInOne.priorityClassName }}
       priorityClassName: {{ .Values.allInOne.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.allInOne.schedulerName }}
+      schedulerName: {{ .Values.allInOne.schedulerName | quote }}
+      {{- end }}
       {{- if .Values.allInOne.serviceAccountName }}
       serviceAccountName: {{ .Values.allInOne.serviceAccountName | quote }}
       {{- end }}

--- a/k8s/charts/seaweedfs/templates/cosi/cosi-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/cosi/cosi-deployment.yaml
@@ -57,6 +57,9 @@ spec:
       {{- if .Values.cosi.priorityClassName }}
       priorityClassName: {{ .Values.cosi.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.cosi.schedulerName }}
+      schedulerName: {{ .Values.cosi.schedulerName | quote }}
+      {{- end }}
       enableServiceLinks: false
       serviceAccountName: {{ include "seaweedfs.componentName" (list . "objectstorage-provisioner") }}
       {{- if .Values.cosi.initContainers }}

--- a/k8s/charts/seaweedfs/templates/filer/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer/filer-statefulset.yaml
@@ -76,6 +76,9 @@ spec:
       {{- if .Values.filer.priorityClassName }}
       priorityClassName: {{ .Values.filer.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.filer.schedulerName }}
+      schedulerName: {{ .Values.filer.schedulerName | quote }}
+      {{- end }}
       enableServiceLinks: false
       {{- if .Values.filer.initContainers }}
       initContainers:

--- a/k8s/charts/seaweedfs/templates/master/master-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/master/master-statefulset.yaml
@@ -69,6 +69,9 @@ spec:
       {{- if .Values.master.priorityClassName }}
       priorityClassName: {{ .Values.master.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.master.schedulerName }}
+      schedulerName: {{ .Values.master.schedulerName | quote }}
+      {{- end }}
       enableServiceLinks: false
       serviceAccountName: {{ .Values.master.serviceAccountName | default (include "seaweedfs.serviceAccountName" .) | quote }} # for deleting statefulset pods after migration
       {{- if .Values.master.initContainers }}

--- a/k8s/charts/seaweedfs/templates/s3/s3-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/s3/s3-deployment.yaml
@@ -61,6 +61,9 @@ spec:
       {{- if .Values.s3.priorityClassName }}
       priorityClassName: {{ .Values.s3.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.s3.schedulerName }}
+      schedulerName: {{ .Values.s3.schedulerName | quote }}
+      {{- end }}
       enableServiceLinks: false
       {{- if .Values.s3.serviceAccountName }}
       serviceAccountName: {{ .Values.s3.serviceAccountName | quote }}

--- a/k8s/charts/seaweedfs/templates/sftp/sftp-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/sftp/sftp-deployment.yaml
@@ -61,6 +61,9 @@ spec:
       {{- if .Values.sftp.priorityClassName }}
       priorityClassName: {{ .Values.sftp.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.sftp.schedulerName }}
+      schedulerName: {{ .Values.sftp.schedulerName | quote }}
+      {{- end }}
       enableServiceLinks: false
       {{- if .Values.sftp.serviceAccountName }}
       serviceAccountName: {{ .Values.sftp.serviceAccountName | quote }}

--- a/k8s/charts/seaweedfs/templates/volume/volume-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/volume/volume-statefulset.yaml
@@ -73,6 +73,9 @@ spec:
       {{- if $volume.priorityClassName }}
       priorityClassName: {{ $volume.priorityClassName | quote }}
       {{- end }}
+      {{- if $volume.schedulerName }}
+      schedulerName: {{ $volume.schedulerName | quote }}
+      {{- end }}
       enableServiceLinks: false
       serviceAccountName: {{ $volume.serviceAccountName | default (include "seaweedfs.serviceAccountName" $) | quote }} # for deleting statefulset pods after migration
       {{- $initContainers_exists := include "seaweedfs.volume.initContainers_exists" $ -}}

--- a/k8s/charts/seaweedfs/templates/worker/worker-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/worker/worker-deployment.yaml
@@ -64,6 +64,9 @@ spec:
       {{- if .Values.worker.priorityClassName }}
       priorityClassName: {{ .Values.worker.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.worker.schedulerName }}
+      schedulerName: {{ .Values.worker.schedulerName | quote }}
+      {{- end }}
       enableServiceLinks: false
       {{- if .Values.worker.serviceAccountName }}
       serviceAccountName: {{ .Values.worker.serviceAccountName | quote }}

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -242,6 +242,10 @@ master:
   # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   priorityClassName: ""
 
+  # used to specify a custom scheduler for master pods
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/
+  schedulerName: ""
+
   # used to assign a service account.
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
   serviceAccountName: ""
@@ -535,6 +539,10 @@ volume:
   # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   priorityClassName: ""
 
+  # used to specify a custom scheduler for volume pods
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/
+  schedulerName: ""
+
   # used to assign a service account.
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
   serviceAccountName: ""
@@ -815,6 +823,10 @@ filer:
   # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   priorityClassName: ""
 
+  # used to specify a custom scheduler for filer pods
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/
+  schedulerName: ""
+
   # used to assign a service account.
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
   serviceAccountName: ""
@@ -1074,6 +1086,10 @@ s3:
   # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   priorityClassName: ""
 
+  # used to assign a custom scheduler to server pods
+  # ref: https://kubernetes.io/docs/tasks/extend-kubernetes/configure-multiple-schedulers/
+  schedulerName: ""
+
   # used to assign a service account.
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
   serviceAccountName: ""
@@ -1227,6 +1243,7 @@ sftp:
   tolerations: ""
   nodeSelector: ""
   priorityClassName: ""
+  schedulerName: ""
   serviceAccountName: ""
   podSecurityContext: {}
   containerSecurityContext: {}
@@ -1351,6 +1368,7 @@ admin:
   tolerations: ""
   nodeSelector: ""
   priorityClassName: ""
+  schedulerName: ""
   serviceAccountName: ""
   podSecurityContext: {}
   containerSecurityContext: {}
@@ -1493,6 +1511,7 @@ worker:
   tolerations: ""
   nodeSelector: ""
   priorityClassName: ""
+  schedulerName: ""
   serviceAccountName: ""
   podSecurityContext: {}
   containerSecurityContext: {}
@@ -1732,6 +1751,10 @@ allInOne:
   # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   priorityClassName: ""
 
+  # Used to assign a custom scheduler to pods
+  # ref: https://kubernetes.io/docs/tasks/extend-kubernetes/configure-multiple-schedulers/
+  schedulerName: ""
+
   # Used to assign a service account.
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
   serviceAccountName: ""
@@ -1793,6 +1816,10 @@ cosi:
 
   podSecurityContext: {}
   containerSecurityContext: {}
+
+  # used to assign a custom scheduler to cosi pods
+  # ref: https://kubernetes.io/docs/tasks/extend-kubernetes/configure-multiple-schedulers/
+  schedulerName: ""
 
   extraVolumes: ""
   extraVolumeMounts: ""


### PR DESCRIPTION
# What problem are we solving?
I can not change the volume scheduler for any pod


# How are we solving the problem?
Add an option to configure the scheduler name for each pod

# How is the PR tested?
Locally deployed to a cluster


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable Kubernetes scheduler settings for master, volume, filer, S3, SFTP, admin, worker, all-in-one, and COSI components.
  * Deployments and stateful services now use the specified scheduler when configured, while retaining default scheduling behavior otherwise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->