### PR TITLE
shell: send read jwt when downloading chunks in fs.mergeVolumes and fs.distributeChunks

### DIFF
--- a/weed/shell/command_fs_distribute_chunks.go
+++ b/weed/shell/command_fs_distribute_chunks.go
@@ -692,6 +692,7 @@ func executeChunkMoves(
 			var resp *http.Response
 			var reader io.ReadCloser
 			var readErr error
+			readJwt := filer.JwtForVolumeServer(oldFidStr)
 			for _, serverURL := range downloadURLs {
 				var dlReq *http.Request
 				dlReq, readErr = http.NewRequestWithContext(dlCtx, http.MethodGet, fmt.Sprintf("http://%s/%s", serverURL, oldFidStr), nil)
@@ -699,6 +700,9 @@ func executeChunkMoves(
 					continue
 				}
 				dlReq.Header.Add("Accept-Encoding", "gzip")
+				if readJwt != "" {
+					dlReq.Header.Set("Authorization", security.BearerPrefix+readJwt)
+				}
 				resp, readErr = util_http.GetGlobalHttpClient().Do(dlReq)
 				if readErr == nil && resp.StatusCode >= 400 {
 					util_http.CloseResponse(resp)

--- a/weed/shell/command_fs_merge_volumes.go
+++ b/weed/shell/command_fs_merge_volumes.go
@@ -823,7 +823,7 @@ func moveChunk(chunk *filer_pb.FileChunk, toVolumeId needle.VolumeId, masterClie
 	}
 	uploadURL := fmt.Sprintf("http://%s/%s", uploadURLs[0], toFid.String())
 
-	resp, reader, err := readUrl(downloadURL)
+	resp, reader, err := readUrl(downloadURL, filer.JwtForVolumeServer(fromFid.String()))
 	if err != nil {
 		return err
 	}
@@ -877,13 +877,16 @@ func moveChunk(chunk *filer_pb.FileChunk, toVolumeId needle.VolumeId, masterClie
 	return nil
 }
 
-func readUrl(fileUrl string) (*http.Response, io.ReadCloser, error) {
+func readUrl(fileUrl string, jwt string) (*http.Response, io.ReadCloser, error) {
 
 	req, err := http.NewRequest(http.MethodGet, fileUrl, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 	req.Header.Add("Accept-Encoding", "gzip")
+	if jwt != "" {
+		req.Header.Set("Authorization", security.BearerPrefix+jwt)
+	}
 
 	r, err := util_http.GetGlobalHttpClient().Do(req)
 	if err != nil {


### PR DESCRIPTION
fs.mergeVolumes downloads the source needle with readDeleted=true but never attaches a read jwt, so any cluster with jwt.signing.read configured gets 401 "wrong jwt" on every move. fs.distributeChunks has the same gap in its download loop.

Both now sign the download with filer.JwtForVolumeServer, same as the filer read path. Verified on a local cluster with jwt.signing and jwt.signing.read keys: before, every move fails with 401; after, chunks move and read back with matching md5.

Fixes #10715

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Secured chunk and volume downloads with Bearer token authentication when credentials are available.
  * Preserved existing behavior for unauthenticated requests, retries, response handling, and uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->