### PR TITLE
[shell] volume.balance io byte per second

### DIFF
--- a/weed/shell/command_volume_balance.go
+++ b/weed/shell/command_volume_balance.go
@@ -512,21 +512,22 @@ func selectVolumesByActive(volumeSize uint64, volumeByActive *bool, volumeSizeLi
 	}
 }
 
-func (c *commandVolumeBalance) balanceSelectedVolume(diskType types.DiskType, volumeReplicas map[uint32][]*VolumeReplica, nodes []*Node, sortCandidatesFn func(volumes []*master_pb.VolumeInformationMessage)) (err error) {
-	if c.maxParallelization > 1 {
-		return c.balanceSelectedVolumeParallel(diskType, volumeReplicas, nodes, sortCandidatesFn)
-	}
-
-	selectedVolumeCount, volumeCapacities := uint64(0), float64(0)
-	var nodesWithCapacity []*Node
-	volumeSizeLimitMb := c.volumeSizeLimitMb
+// planBalance computes the state shared by both the sequential and parallel
+// balancing paths: the nodes that have spare capacity, the density function
+// used to rank them, and the ideal volume ratio this pass is aiming for.
+// ok is false when there is no capacity to balance against (volumeCapacities
+// == 0); callers should return nil without doing any work in that case.
+func (c *commandVolumeBalance) planBalance(diskType types.DiskType, nodes []*Node) (nodesWithCapacity []*Node, capacityFunc DensityFunc, idealVolumeRatio float64, volumeSizeLimitMb uint64, ok bool) {
+	volumeSizeLimitMb = c.volumeSizeLimitMb
 	if volumeSizeLimitMb == 0 {
 		volumeSizeLimitMb = util.VolumeSizeLimitGB * util.KiByte
 	}
-	capacityFunc := capacityByMinVolumeDensity(diskType, volumeSizeLimitMb)
+	capacityFunc = capacityByMinVolumeDensity(diskType, volumeSizeLimitMb)
 	if c.byDiskUsage {
 		capacityFunc = capacityByDiskUsage(diskType, volumeSizeLimitMb, nodes)
 	}
+
+	selectedVolumeCount, volumeCapacities := uint64(0), float64(0)
 	for _, dn := range nodes {
 		capacity, volumeCount := capacityFunc(dn.info)
 		if capacity > 0 {
@@ -536,15 +537,28 @@ func (c *commandVolumeBalance) balanceSelectedVolume(diskType types.DiskType, vo
 		selectedVolumeCount += volumeCount
 	}
 	if volumeCapacities == 0 {
-		return nil
+		return nil, nil, 0, volumeSizeLimitMb, false
 	}
-	idealVolumeRatio := float64(selectedVolumeCount) / volumeCapacities
-
-	hasMoved := true
+	idealVolumeRatio = float64(selectedVolumeCount) / volumeCapacities
 
 	if c.commandEnv != nil && c.commandEnv.verbose {
-		fmt.Fprintf(os.Stdout, "selected nodes %d, volumes:%d, cap:%d, idealVolumeRatio %f\n", len(nodesWithCapacity), selectedVolumeCount, int64(volumeCapacities), idealVolumeRatio*100)
+		fmt.Fprintf(os.Stdout, "selected nodes %d, volumes:%d, cap:%d, idealVolumeRatio %f\n",
+			len(nodesWithCapacity), selectedVolumeCount, int64(volumeCapacities), idealVolumeRatio*100)
 	}
+	return nodesWithCapacity, capacityFunc, idealVolumeRatio, volumeSizeLimitMb, true
+}
+
+func (c *commandVolumeBalance) balanceSelectedVolume(diskType types.DiskType, volumeReplicas map[uint32][]*VolumeReplica, nodes []*Node, sortCandidatesFn func(volumes []*master_pb.VolumeInformationMessage)) (err error) {
+	if c.maxParallelization > 1 {
+		return c.balanceSelectedVolumeParallel(diskType, volumeReplicas, nodes, sortCandidatesFn)
+	}
+
+	nodesWithCapacity, capacityFunc, idealVolumeRatio, volumeSizeLimitMb, ok := c.planBalance(diskType, nodes)
+	if !ok {
+		return nil
+	}
+
+	hasMoved := true
 	for hasMoved {
 		hasMoved = false
 		if c.volumesPerExec > 0 && c.movedCount >= c.volumesPerExec {
@@ -631,33 +645,11 @@ func (c *commandVolumeBalance) balanceSelectedVolume(diskType types.DiskType, vo
 }
 
 func (c *commandVolumeBalance) balanceSelectedVolumeParallel(diskType types.DiskType, volumeReplicas map[uint32][]*VolumeReplica, nodes []*Node, sortCandidatesFn func(volumes []*master_pb.VolumeInformationMessage)) error {
-	selectedVolumeCount, volumeCapacities := uint64(0), float64(0)
-	var nodesWithCapacity []*Node
-	volumeSizeLimitMb := c.volumeSizeLimitMb
-	if volumeSizeLimitMb == 0 {
-		volumeSizeLimitMb = util.VolumeSizeLimitGB * util.KiByte
-	}
-	capacityFunc := capacityByMinVolumeDensity(diskType, volumeSizeLimitMb)
-	if c.byDiskUsage {
-		capacityFunc = capacityByDiskUsage(diskType, volumeSizeLimitMb, nodes)
-	}
-	for _, dn := range nodes {
-		capacity, volumeCount := capacityFunc(dn.info)
-		if capacity > 0 {
-			nodesWithCapacity = append(nodesWithCapacity, dn)
-		}
-		volumeCapacities += capacity
-		selectedVolumeCount += volumeCount
-	}
-	if volumeCapacities == 0 {
+	nodesWithCapacity, capacityFunc, idealVolumeRatio, volumeSizeLimitMb, ok := c.planBalance(diskType, nodes)
+	if !ok {
 		return nil
 	}
-	idealVolumeRatio := float64(selectedVolumeCount) / volumeCapacities
 	failedTargets := make(map[string]struct{})
-
-	if c.commandEnv != nil && c.commandEnv.verbose {
-		fmt.Fprintf(os.Stdout, "selected nodes %d, volumes:%d, cap:%d, idealVolumeRatio %f\n", len(nodesWithCapacity), selectedVolumeCount, int64(volumeCapacities), idealVolumeRatio*100)
-	}
 
 	for {
 		c.balanceMu.Lock()

--- a/weed/shell/command_volume_balance.go
+++ b/weed/shell/command_volume_balance.go
@@ -677,12 +677,10 @@ func nodeByID(nodes []*Node, id string) *Node {
 }
 
 func (c *commandVolumeBalance) printBalancePlan(diskType types.DiskType, plan *volumeBalancePlan, capacityFunc DensityFunc, idealVolumeRatio float64) {
-	fullRatio := plan.source.localVolumeDensityRatio(capacityFunc)
-	emptyNextRatio := plan.target.localVolumeDensityNextRatio(capacityFunc)
-	fmt.Fprintf(os.Stdout, "%s %.2f %.2f:%.2f\t", diskType.ReadableString(), idealVolumeRatio, fullRatio, emptyNextRatio)
 	if c.commandEnv != nil && c.commandEnv.verbose {
-		fmt.Fprintf(os.Stdout, "%s %.1f %.1f:%.1f\t", diskType.ReadableString(), idealVolumeRatio*100,
-			fullRatio*100, emptyNextRatio*100)
+		fullRatio := plan.source.localVolumeDensityRatio(capacityFunc)
+		emptyNextRatio := plan.target.localVolumeDensityNextRatio(capacityFunc)
+		fmt.Fprintf(os.Stdout, "%s %.2f %.2f:%.2f\t", diskType.ReadableString(), idealVolumeRatio, fullRatio, emptyNextRatio)
 	}
 }
 

--- a/weed/shell/command_volume_balance.go
+++ b/weed/shell/command_volume_balance.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/util"
@@ -32,13 +33,15 @@ func init() {
 }
 
 type commandVolumeBalance struct {
-	volumeSizeLimitMb uint64
-	commandEnv        *CommandEnv
-	volumeByActive    *bool
-	applyBalancing    bool
-	volumesPerExec    int
-	movedCount        int
-	byDiskUsage       bool
+	volumeSizeLimitMb  uint64
+	commandEnv         *CommandEnv
+	volumeByActive     *bool
+	applyBalancing     bool
+	volumesPerExec     int
+	maxParallelization int
+	movedCount         int
+	byDiskUsage        bool
+	balanceMu          sync.Mutex
 
 	// diskUsageHighWaterPercent skips a move target whose physical disk used%
 	// is at or above this mark. 0 or >=100 disables the gate.
@@ -52,7 +55,7 @@ func (c *commandVolumeBalance) Name() string {
 func (c *commandVolumeBalance) Help() string {
 	return `balance all volumes among volume servers
 
-	volume.balance [-collection ALL_COLLECTIONS|EACH_COLLECTION|<collection_name>] [-apply] [-dataCenter=<data_center_name>] [-racks=rack_name_one,rack_name_two] [-nodes=192.168.0.1:8080,192.168.0.2:8080] [-volumesPerExec=5] [-byDiskUsage] [-maxDiskUsagePercent=90]
+	volume.balance [-collection ALL_COLLECTIONS|EACH_COLLECTION|<collection_name>] [-apply] [-dataCenter=<data_center_name>] [-racks=rack_name_one,rack_name_two] [-nodes=192.168.0.1:8080,192.168.0.2:8080] [-volumesPerExec=5] [-maxParallelization=1] [-byDiskUsage] [-maxDiskUsagePercent=90]
 
 	The -collection parameter supports:
 	  - ALL_COLLECTIONS: balance across all collections
@@ -65,6 +68,8 @@ func (c *commandVolumeBalance) Help() string {
 	The -volumesPerExec parameter limits the maximum number of volume moves in one command execution.
 	If unset - the command will try to balance all volumes at once.
 	It might be beneficial to set, if your cluster has lots of volumes growing and topology changes faster than balancing can occur.
+	The -maxParallelization parameter limits the number of volume moves running at the same time.
+	The default value of 1 keeps the original sequential behavior.
 
 	The -maxDiskUsagePercent flag (default 90) skips any move target whose physical disk is already used at
 	or above that percentage, using the real filesystem capacity each volume server reports. This is the
@@ -132,6 +137,7 @@ func (c *commandVolumeBalance) Do(args []string, commandEnv *CommandEnv, writer 
 	// TODO: remove this alias
 	applyBalancingAlias := balanceCommand.Bool("force", false, "apply the balancing plan (alias for -apply)")
 	volumesPerExec := balanceCommand.Int("volumesPerExec", 0, "how many volumes to move in one run (default is 0 for unlimited)")
+	maxParallelization := balanceCommand.Int("maxParallelization", 1, "run up to X volume moves in parallel, whenever possible")
 	byDiskUsage := balanceCommand.Bool("byDiskUsage", false, "rank servers by reported physical disk used percent instead of slot density; falls back to sum of volume sizes for all servers when any server does not report disk bytes. Use when maxVolumeCount is set too high for the disk.")
 	maxDiskUsagePercent := balanceCommand.Int("maxDiskUsagePercent", balancer.DefaultMaxDiskUsagePercent, "skip a move target whose physical disk used%% is at/above this; judged per server against its own disk, so heterogeneous disk sizes are fine. 0 or >=100 disables. Auto-skipped for servers that do not report disk bytes.")
 
@@ -155,7 +161,11 @@ func (c *commandVolumeBalance) Do(args []string, commandEnv *CommandEnv, writer 
 	if *volumesPerExec < 0 {
 		return fmt.Errorf("volumesPerExec must be >= 0")
 	}
+	if *maxParallelization < 1 {
+		return fmt.Errorf("maxParallelization must be >= 1")
+	}
 	c.volumesPerExec = *volumesPerExec
+	c.maxParallelization = *maxParallelization
 	c.movedCount = 0
 	c.byDiskUsage = *byDiskUsage
 	c.diskUsageHighWaterPercent = *maxDiskUsagePercent
@@ -320,6 +330,12 @@ type Node struct {
 	selectedVolumes map[uint32]*master_pb.VolumeInformationMessage
 	dc              string
 	rack            string
+}
+
+type volumeBalanceMove struct {
+	volume *master_pb.VolumeInformationMessage
+	source *Node
+	target *Node
 }
 
 type CapacityFunc func(*master_pb.DataNodeInfo) float64
@@ -497,6 +513,10 @@ func selectVolumesByActive(volumeSize uint64, volumeByActive *bool, volumeSizeLi
 }
 
 func (c *commandVolumeBalance) balanceSelectedVolume(diskType types.DiskType, volumeReplicas map[uint32][]*VolumeReplica, nodes []*Node, sortCandidatesFn func(volumes []*master_pb.VolumeInformationMessage)) (err error) {
+	if c.maxParallelization > 1 {
+		return c.balanceSelectedVolumeParallel(diskType, volumeReplicas, nodes, sortCandidatesFn)
+	}
+
 	selectedVolumeCount, volumeCapacities := uint64(0), float64(0)
 	var nodesWithCapacity []*Node
 	volumeSizeLimitMb := c.volumeSizeLimitMb
@@ -608,6 +628,193 @@ func (c *commandVolumeBalance) balanceSelectedVolume(diskType types.DiskType, vo
 		}
 	}
 	return nil
+}
+
+func (c *commandVolumeBalance) balanceSelectedVolumeParallel(diskType types.DiskType, volumeReplicas map[uint32][]*VolumeReplica, nodes []*Node, sortCandidatesFn func(volumes []*master_pb.VolumeInformationMessage)) error {
+	selectedVolumeCount, volumeCapacities := uint64(0), float64(0)
+	var nodesWithCapacity []*Node
+	volumeSizeLimitMb := c.volumeSizeLimitMb
+	if volumeSizeLimitMb == 0 {
+		volumeSizeLimitMb = util.VolumeSizeLimitGB * util.KiByte
+	}
+	capacityFunc := capacityByMinVolumeDensity(diskType, volumeSizeLimitMb)
+	if c.byDiskUsage {
+		capacityFunc = capacityByDiskUsage(diskType, volumeSizeLimitMb, nodes)
+	}
+	for _, dn := range nodes {
+		capacity, volumeCount := capacityFunc(dn.info)
+		if capacity > 0 {
+			nodesWithCapacity = append(nodesWithCapacity, dn)
+		}
+		volumeCapacities += capacity
+		selectedVolumeCount += volumeCount
+	}
+	if volumeCapacities == 0 {
+		return nil
+	}
+	idealVolumeRatio := float64(selectedVolumeCount) / volumeCapacities
+	failedTargets := make(map[string]struct{})
+
+	if c.commandEnv != nil && c.commandEnv.verbose {
+		fmt.Fprintf(os.Stdout, "selected nodes %d, volumes:%d, cap:%d, idealVolumeRatio %f\n", len(nodesWithCapacity), selectedVolumeCount, int64(volumeCapacities), idealVolumeRatio*100)
+	}
+
+	for {
+		c.balanceMu.Lock()
+		moves := make([]volumeBalanceMove, 0, c.maxParallelization)
+		for len(moves) < c.maxParallelization {
+			if c.volumesPerExec > 0 && c.movedCount >= c.volumesPerExec {
+				break
+			}
+			move, ok := c.reserveParallelMove(diskType, volumeReplicas, nodesWithCapacity, sortCandidatesFn, capacityFunc, idealVolumeRatio, volumeSizeLimitMb, failedTargets)
+			if !ok {
+				break
+			}
+			moves = append(moves, *move)
+		}
+		c.balanceMu.Unlock()
+
+		if len(moves) == 0 {
+			return nil
+		}
+
+		ewg := NewErrorWaitGroup(c.maxParallelization)
+		for _, move := range moves {
+			move := move
+			ewg.Add(func() error {
+				return c.executeParallelMove(move, volumeReplicas, failedTargets)
+			})
+		}
+		if err := ewg.Wait(); err != nil {
+			return err
+		}
+	}
+}
+
+func (c *commandVolumeBalance) reserveParallelMove(diskType types.DiskType, volumeReplicas map[uint32][]*VolumeReplica, nodesWithCapacity []*Node, sortCandidatesFn func(volumes []*master_pb.VolumeInformationMessage), capacityFunc DensityFunc, idealVolumeRatio float64, volumeSizeLimitMb uint64, failedTargets map[string]struct{}) (*volumeBalanceMove, bool) {
+	slices.SortFunc(nodesWithCapacity, func(a, b *Node) int {
+		return cmp.Compare(a.localVolumeDensityRatio(capacityFunc), b.localVolumeDensityRatio(capacityFunc))
+	})
+	if len(nodesWithCapacity) == 0 {
+		return nil, false
+	}
+
+	var fullNode *Node
+	var fullNodeIndex int
+	for fullNodeIndex = len(nodesWithCapacity) - 1; fullNodeIndex >= 0; fullNodeIndex-- {
+		fullNode = nodesWithCapacity[fullNodeIndex]
+		if len(fullNode.selectedVolumes) == 0 {
+			continue
+		}
+		if !fullNode.isOneVolumeOnly() {
+			break
+		}
+	}
+	if fullNodeIndex == -1 {
+		return nil, false
+	}
+
+	candidateVolumes := make([]*master_pb.VolumeInformationMessage, 0, len(fullNode.selectedVolumes))
+	for _, v := range fullNode.selectedVolumes {
+		candidateVolumes = append(candidateVolumes, v)
+	}
+	sortCandidatesFn(candidateVolumes)
+
+	for _, emptyNode := range nodesWithCapacity[:fullNodeIndex] {
+		if _, failed := failedTargets[emptyNode.info.Id]; failed {
+			continue
+		}
+		if c.byDiskUsage && !emptyNode.hasFreeVolumeSlot(diskType) {
+			continue
+		}
+		if c.targetDiskTooFull(emptyNode, diskType, volumeSizeLimitMb) {
+			continue
+		}
+		if !(fullNode.localVolumeDensityNextRatio(capacityFunc) > idealVolumeRatio && emptyNode.localVolumeDensityNextRatio(capacityFunc) <= idealVolumeRatio) {
+			break
+		}
+
+		for _, v := range candidateVolumes {
+			if v.RemoteStorageName != "" {
+				continue
+			}
+			if v.ReplicaPlacement > 0 {
+				replicaPlacement, _ := super_block.NewReplicaPlacementFromByte(byte(v.ReplicaPlacement))
+				if !isGoodMove(replicaPlacement, volumeReplicas[v.Id], fullNode, emptyNode) {
+					continue
+				}
+			}
+			if _, found := emptyNode.selectedVolumes[v.Id]; found {
+				continue
+			}
+
+			fmt.Fprintf(os.Stdout, "%s %.2f %.2f:%.2f\t", diskType.ReadableString(), idealVolumeRatio,
+				fullNode.localVolumeDensityRatio(capacityFunc), emptyNode.localVolumeDensityNextRatio(capacityFunc))
+			if c.commandEnv != nil && c.commandEnv.verbose {
+				fmt.Fprintf(os.Stdout, "%s %.1f %.1f:%.1f\t", diskType.ReadableString(), idealVolumeRatio*100,
+					fullNode.localVolumeDensityRatio(capacityFunc)*100, emptyNode.localVolumeDensityNextRatio(capacityFunc)*100)
+			}
+
+			// Reserve the move before releasing the planner lock. This makes the
+			// next reservation observe the updated source, target, replica, and
+			// disk accounting while the network operation runs in parallel.
+			adjustAfterMove(v, volumeReplicas, fullNode, emptyNode)
+			c.movedCount++
+			return &volumeBalanceMove{volume: v, source: fullNode, target: emptyNode}, true
+		}
+	}
+	return nil, false
+}
+
+func (c *commandVolumeBalance) executeParallelMove(move volumeBalanceMove, volumeReplicas map[uint32][]*VolumeReplica, failedTargets map[string]struct{}) error {
+	if !c.commandEnv.isLocked() {
+		c.balanceMu.Lock()
+		rollbackParallelMove(move, volumeReplicas)
+		c.movedCount--
+		c.balanceMu.Unlock()
+		return fmt.Errorf("lock is lost")
+	}
+
+	if err := moveVolume(c.commandEnv, move.volume, move.source, move.target, c.applyBalancing); err != nil {
+		c.balanceMu.Lock()
+		rollbackParallelMove(move, volumeReplicas)
+		c.movedCount--
+		if strings.Contains(err.Error(), util.ErrVolumeNoSpaceLeft) {
+			failedTargets[move.target.info.Id] = struct{}{}
+			c.balanceMu.Unlock()
+			return nil
+		}
+		c.balanceMu.Unlock()
+		return err
+	}
+	return nil
+}
+
+func rollbackParallelMove(move volumeBalanceMove, volumeReplicas map[uint32][]*VolumeReplica) {
+	delete(move.target.selectedVolumes, move.volume.Id)
+	if move.source.selectedVolumes == nil {
+		move.source.selectedVolumes = make(map[uint32]*master_pb.VolumeInformationMessage)
+	}
+	move.source.selectedVolumes[move.volume.Id] = move.volume
+
+	for _, replica := range volumeReplicas[move.volume.Id] {
+		if replica.location.dataNode.Id != move.target.info.Id || replica.location.rack != move.target.rack || replica.location.dc != move.target.dc {
+			continue
+		}
+		loc := newLocation(move.source.dc, move.source.rack, move.source.info)
+		replica.location = &loc
+		if targetDisk, found := move.target.info.DiskInfos[move.volume.DiskType]; found {
+			removeVolumeInfo(targetDisk, move.volume.Id)
+			addVolumeCount(targetDisk, -1)
+			addDiskFreeBytes(targetDisk, int64(move.volume.Size))
+		}
+		if sourceDisk, found := move.source.info.DiskInfos[move.volume.DiskType]; found {
+			sourceDisk.VolumeInfos = append(sourceDisk.VolumeInfos, move.volume)
+			addVolumeCount(sourceDisk, 1)
+			addDiskFreeBytes(sourceDisk, -int64(move.volume.Size))
+		}
+		return
+	}
 }
 
 func attemptToMoveOneVolume(commandEnv *CommandEnv, volumeReplicas map[uint32][]*VolumeReplica, fullNode *Node, candidateVolumes []*master_pb.VolumeInformationMessage, emptyNode *Node, applyBalancing bool) (hasMoved bool, err error) {

--- a/weed/shell/command_volume_balance.go
+++ b/weed/shell/command_volume_balance.go
@@ -38,6 +38,7 @@ type commandVolumeBalance struct {
 	volumeByActive     *bool
 	applyBalancing     bool
 	volumesPerExec     int
+	ioBytePerSecond    int64
 	maxParallelization int
 	movedCount         int
 	byDiskUsage        bool
@@ -132,6 +133,7 @@ func (c *commandVolumeBalance) Do(args []string, commandEnv *CommandEnv, writer 
 	dc := balanceCommand.String("dataCenter", "", "only apply the balancing for this dataCenter")
 	racks := balanceCommand.String("racks", "", "only apply the balancing for this racks")
 	nodes := balanceCommand.String("nodes", "", "only apply the balancing for this nodes")
+	ioBytePerSecond := balanceCommand.Int64("ioBytePerSecond", 0, "limit the speed of move")
 	noLock := balanceCommand.Bool("noLock", false, "do not lock the admin shell at one's own risk")
 	applyBalancing := balanceCommand.Bool("apply", false, "apply the balancing plan.")
 	// TODO: remove this alias
@@ -164,6 +166,7 @@ func (c *commandVolumeBalance) Do(args []string, commandEnv *CommandEnv, writer 
 	if *maxParallelization < 1 {
 		return fmt.Errorf("maxParallelization must be >= 1")
 	}
+	c.ioBytePerSecond = *ioBytePerSecond
 	c.volumesPerExec = *volumesPerExec
 	c.maxParallelization = *maxParallelization
 	c.movedCount = 0
@@ -721,7 +724,7 @@ func (c *commandVolumeBalance) balanceSelectedVolume(diskType types.DiskType, vo
 
 		c.printBalancePlan(diskType, plan, capacityFunc, idealVolumeRatio)
 		hasMoved, err = attemptToMoveOneVolume(c.commandEnv, volumeReplicas, plan.source,
-			plan.candidateVolumes, plan.target, c.applyBalancing)
+			plan.candidateVolumes, plan.target, c.ioBytePerSecond, c.applyBalancing)
 		if err != nil {
 			if c.commandEnv != nil && c.commandEnv.verbose {
 				fmt.Fprintf(os.Stdout, "attempt to move one volume error %+v\n", err)
@@ -803,7 +806,7 @@ func (c *commandVolumeBalance) executeParallelMove(move volumeBalanceMove, volum
 		return fmt.Errorf("lock is lost")
 	}
 
-	if err := moveVolume(c.commandEnv, move.volume, move.source, move.target, c.applyBalancing); err != nil {
+	if err := moveVolume(c.commandEnv, move.volume, move.source, move.target, c.ioBytePerSecond, c.applyBalancing); err != nil {
 		if c.commandEnv != nil && c.commandEnv.verbose {
 			fmt.Fprintf(os.Stdout, "attempt to parallel move volume error %+v\n", err)
 		}
@@ -848,10 +851,10 @@ func rollbackParallelMove(move volumeBalanceMove, volumeReplicas map[uint32][]*V
 	}
 }
 
-func attemptToMoveOneVolume(commandEnv *CommandEnv, volumeReplicas map[uint32][]*VolumeReplica, fullNode *Node, candidateVolumes []*master_pb.VolumeInformationMessage, emptyNode *Node, applyBalancing bool) (hasMoved bool, err error) {
+func attemptToMoveOneVolume(commandEnv *CommandEnv, volumeReplicas map[uint32][]*VolumeReplica, fullNode *Node, candidateVolumes []*master_pb.VolumeInformationMessage, emptyNode *Node, ioBytePerSecond int64, applyBalancing bool) (hasMoved bool, err error) {
 
 	for _, v := range candidateVolumes {
-		hasMoved, err = maybeMoveOneVolume(commandEnv, volumeReplicas, fullNode, v, emptyNode, applyBalancing)
+		hasMoved, err = maybeMoveOneVolume(commandEnv, volumeReplicas, fullNode, v, emptyNode, ioBytePerSecond, applyBalancing)
 		if err != nil {
 			return
 		}
@@ -862,7 +865,7 @@ func attemptToMoveOneVolume(commandEnv *CommandEnv, volumeReplicas map[uint32][]
 	return
 }
 
-func maybeMoveOneVolume(commandEnv *CommandEnv, volumeReplicas map[uint32][]*VolumeReplica, fullNode *Node, candidateVolume *master_pb.VolumeInformationMessage, emptyNode *Node, applyChange bool) (hasMoved bool, err error) {
+func maybeMoveOneVolume(commandEnv *CommandEnv, volumeReplicas map[uint32][]*VolumeReplica, fullNode *Node, candidateVolume *master_pb.VolumeInformationMessage, emptyNode *Node, ioBytePerSecond int64, applyChange bool) (hasMoved bool, err error) {
 	if !commandEnv.isLocked() {
 		return false, fmt.Errorf("lock is lost")
 	}
@@ -878,7 +881,7 @@ func maybeMoveOneVolume(commandEnv *CommandEnv, volumeReplicas map[uint32][]*Vol
 		}
 	}
 	if _, found := emptyNode.selectedVolumes[candidateVolume.Id]; !found {
-		if err = moveVolume(commandEnv, candidateVolume, fullNode, emptyNode, applyChange); err == nil {
+		if err = moveVolume(commandEnv, candidateVolume, fullNode, emptyNode, ioBytePerSecond, applyChange); err == nil {
 			adjustAfterMove(candidateVolume, volumeReplicas, fullNode, emptyNode)
 			return true, nil
 		} else {
@@ -888,14 +891,14 @@ func maybeMoveOneVolume(commandEnv *CommandEnv, volumeReplicas map[uint32][]*Vol
 	return
 }
 
-func moveVolume(commandEnv *CommandEnv, v *master_pb.VolumeInformationMessage, fullNode *Node, emptyNode *Node, applyChange bool) error {
+func moveVolume(commandEnv *CommandEnv, v *master_pb.VolumeInformationMessage, fullNode *Node, emptyNode *Node, ioBytePerSecond int64, applyChange bool) error {
 	collectionPrefix := v.Collection + "_"
 	if v.Collection == "" {
 		collectionPrefix = ""
 	}
 	fmt.Fprintf(os.Stdout, "  moving %s volume %s%d %s => %s\n", v.DiskType, collectionPrefix, v.Id, fullNode.info.Id, emptyNode.info.Id)
 	if applyChange {
-		return LiveMoveVolume(context.Background(), commandEnv.option.GrpcDialOption, os.Stderr, needle.VolumeId(v.Id), pb.NewServerAddressFromDataNode(fullNode.info), pb.NewServerAddressFromDataNode(emptyNode.info), 5*time.Second, v.DiskType, 0, v.ReadOnly)
+		return LiveMoveVolume(context.Background(), commandEnv.option.GrpcDialOption, os.Stderr, needle.VolumeId(v.Id), pb.NewServerAddressFromDataNode(fullNode.info), pb.NewServerAddressFromDataNode(emptyNode.info), 5*time.Second, v.DiskType, ioBytePerSecond, v.ReadOnly)
 	}
 	return nil
 }

--- a/weed/shell/command_volume_balance.go
+++ b/weed/shell/command_volume_balance.go
@@ -776,6 +776,9 @@ func (c *commandVolumeBalance) executeParallelMove(move volumeBalanceMove, volum
 	}
 
 	if err := moveVolume(c.commandEnv, move.volume, move.source, move.target, c.applyBalancing); err != nil {
+		if c.commandEnv != nil && c.commandEnv.verbose {
+			fmt.Fprintf(os.Stdout, "attempt to parallel move volume error %+v\n", err)
+		}
 		c.balanceMu.Lock()
 		rollbackParallelMove(move, volumeReplicas)
 		c.movedCount--

--- a/weed/shell/command_volume_balance.go
+++ b/weed/shell/command_volume_balance.go
@@ -338,6 +338,16 @@ type volumeBalanceMove struct {
 	target *Node
 }
 
+// volumeBalancePlan is the common source/target decision used by sequential
+// and parallel execution. The caller decides when to mutate the in-memory
+// topology: sequential execution updates it after a successful RPC, while
+// parallel execution reserves it before starting the RPC.
+type volumeBalancePlan struct {
+	source           *Node
+	target           *Node
+	candidateVolumes []*master_pb.VolumeInformationMessage
+}
+
 type CapacityFunc func(*master_pb.DataNodeInfo) float64
 type DensityFunc func(*master_pb.DataNodeInfo) (float64, uint64)
 
@@ -548,6 +558,134 @@ func (c *commandVolumeBalance) planBalance(diskType types.DiskType, nodes []*Nod
 	return nodesWithCapacity, capacityFunc, idealVolumeRatio, volumeSizeLimitMb, true
 }
 
+// planBalanceMove applies the same source, target, and replica-placement
+// policy for both execution modes. It only reads the current planner state;
+// reserveParallelMove is the caller that turns the returned move into a
+// reservation before starting a concurrent RPC.
+//
+// sourceFound distinguishes "all eligible nodes contain only one volume" from
+// "there is a source, but no eligible target/volume pair" so the sequential
+// path can retain its existing diagnostic output.
+func (c *commandVolumeBalance) planBalanceMove(diskType types.DiskType, volumeReplicas map[uint32][]*VolumeReplica, nodesWithCapacity []*Node, sortCandidatesFn func(volumes []*master_pb.VolumeInformationMessage), capacityFunc DensityFunc, idealVolumeRatio float64, volumeSizeLimitMb uint64, failedTargets map[string]struct{}) (plan *volumeBalancePlan, sourceFound bool) {
+	if len(nodesWithCapacity) == 0 {
+		return nil, false
+	}
+
+	sourceCandidates := make([]balancer.NodeLoad, 0, len(nodesWithCapacity))
+	for _, node := range nodesWithCapacity {
+		if len(node.selectedVolumes) == 0 || node.isOneVolumeOnly() {
+			continue
+		}
+		sourceCandidates = append(sourceCandidates, balancer.NodeLoad{
+			ID:    node.info.Id,
+			Score: node.localVolumeDensityRatio(capacityFunc),
+		})
+	}
+	if len(sourceCandidates) == 0 {
+		return nil, false
+	}
+	sourceIndex := balancer.PickMostLoaded(sourceCandidates)
+	source := nodeByID(nodesWithCapacity, sourceCandidates[sourceIndex].ID)
+	if source == nil {
+		return nil, false
+	}
+	if source.localVolumeDensityNextRatio(capacityFunc) <= idealVolumeRatio {
+		return nil, true
+	}
+
+	candidateVolumes := make([]*master_pb.VolumeInformationMessage, 0, len(source.selectedVolumes))
+	for _, volume := range source.selectedVolumes {
+		if volume.RemoteStorageName != "" {
+			continue
+		}
+		candidateVolumes = append(candidateVolumes, volume)
+	}
+	sortCandidatesFn(candidateVolumes)
+
+	targetCandidates := make([]balancer.NodeLoad, 0, len(nodesWithCapacity))
+	volumesByTarget := make(map[string][]*master_pb.VolumeInformationMessage)
+	for _, target := range nodesWithCapacity {
+		if target.info.Id == source.info.Id {
+			continue
+		}
+		if _, failed := failedTargets[target.info.Id]; failed {
+			continue
+		}
+		// In byte-usage mode the ranking ignores volume slots, so skip targets
+		// that are already at MaxVolumeCount so balancing never exceeds the
+		// slot limit.
+		if c.byDiskUsage && !target.hasFreeVolumeSlot(diskType) {
+			continue
+		}
+		// Never move onto a server whose physical disk is already near full,
+		// even if the density metric ranks it as the emptiest node.
+		if c.targetDiskTooFull(target, diskType, volumeSizeLimitMb) {
+			if c.commandEnv != nil && c.commandEnv.verbose {
+				fmt.Fprintf(os.Stdout, "skip target %s: disk used%% >= %d%%\n", target.info.Id, c.diskUsageHighWaterPercent)
+			}
+			continue
+		}
+		if target.localVolumeDensityNextRatio(capacityFunc) > idealVolumeRatio {
+			continue
+		}
+
+		eligibleVolumes := make([]*master_pb.VolumeInformationMessage, 0, len(candidateVolumes))
+		for _, volume := range candidateVolumes {
+			if _, found := target.selectedVolumes[volume.Id]; found {
+				continue
+			}
+			if volume.ReplicaPlacement > 0 {
+				replicaPlacement, _ := super_block.NewReplicaPlacementFromByte(byte(volume.ReplicaPlacement))
+				if !isGoodMove(replicaPlacement, volumeReplicas[volume.Id], source, target) {
+					continue
+				}
+			}
+			eligibleVolumes = append(eligibleVolumes, volume)
+		}
+		if len(eligibleVolumes) == 0 {
+			continue
+		}
+		targetCandidates = append(targetCandidates, balancer.NodeLoad{
+			ID:    target.info.Id,
+			Score: target.localVolumeDensityRatio(capacityFunc),
+		})
+		volumesByTarget[target.info.Id] = eligibleVolumes
+	}
+
+	targetIndex := balancer.PickLeastLoaded(targetCandidates)
+	if targetIndex < 0 {
+		return nil, true
+	}
+	target := nodeByID(nodesWithCapacity, targetCandidates[targetIndex].ID)
+	if target == nil {
+		return nil, true
+	}
+	return &volumeBalancePlan{
+		source:           source,
+		target:           target,
+		candidateVolumes: volumesByTarget[target.info.Id],
+	}, true
+}
+
+func nodeByID(nodes []*Node, id string) *Node {
+	for _, node := range nodes {
+		if node.info.Id == id {
+			return node
+		}
+	}
+	return nil
+}
+
+func (c *commandVolumeBalance) printBalancePlan(diskType types.DiskType, plan *volumeBalancePlan, capacityFunc DensityFunc, idealVolumeRatio float64) {
+	fullRatio := plan.source.localVolumeDensityRatio(capacityFunc)
+	emptyNextRatio := plan.target.localVolumeDensityNextRatio(capacityFunc)
+	fmt.Fprintf(os.Stdout, "%s %.2f %.2f:%.2f\t", diskType.ReadableString(), idealVolumeRatio, fullRatio, emptyNextRatio)
+	if c.commandEnv != nil && c.commandEnv.verbose {
+		fmt.Fprintf(os.Stdout, "%s %.1f %.1f:%.1f\t", diskType.ReadableString(), idealVolumeRatio*100,
+			fullRatio*100, emptyNextRatio*100)
+	}
+}
+
 func (c *commandVolumeBalance) balanceSelectedVolume(diskType types.DiskType, volumeReplicas map[uint32][]*VolumeReplica, nodes []*Node, sortCandidatesFn func(volumes []*master_pb.VolumeInformationMessage)) (err error) {
 	if c.maxParallelization > 1 {
 		return c.balanceSelectedVolumeParallel(diskType, volumeReplicas, nodes, sortCandidatesFn)
@@ -564,9 +702,6 @@ func (c *commandVolumeBalance) balanceSelectedVolume(diskType types.DiskType, vo
 		if c.volumesPerExec > 0 && c.movedCount >= c.volumesPerExec {
 			break
 		}
-		slices.SortFunc(nodesWithCapacity, func(a, b *Node) int {
-			return cmp.Compare(a.localVolumeDensityRatio(capacityFunc), b.localVolumeDensityRatio(capacityFunc))
-		})
 		if len(nodesWithCapacity) == 0 {
 			if c.commandEnv != nil && c.commandEnv.verbose {
 				fmt.Fprintf(os.Stdout, "no volume server found with capacity for %s", diskType.ReadableString())
@@ -574,71 +709,32 @@ func (c *commandVolumeBalance) balanceSelectedVolume(diskType types.DiskType, vo
 			return nil
 		}
 
-		var fullNode *Node
-		var fullNodeIndex int
-		for fullNodeIndex = len(nodesWithCapacity) - 1; fullNodeIndex >= 0; fullNodeIndex-- {
-			fullNode = nodesWithCapacity[fullNodeIndex]
-			if len(fullNode.selectedVolumes) == 0 {
-				continue
-			}
-			if !fullNode.isOneVolumeOnly() {
-				break
-			}
-		}
-		var candidateVolumes []*master_pb.VolumeInformationMessage
-		for _, v := range fullNode.selectedVolumes {
-			candidateVolumes = append(candidateVolumes, v)
-		}
-		if fullNodeIndex == -1 {
+		plan, sourceFound := c.planBalanceMove(diskType, volumeReplicas, nodesWithCapacity, sortCandidatesFn,
+			capacityFunc, idealVolumeRatio, volumeSizeLimitMb, nil)
+		if !sourceFound {
 			if c.commandEnv != nil && c.commandEnv.verbose {
 				fmt.Fprintf(os.Stdout, "no nodes with capacity found for %s, nodes %d", diskType.ReadableString(), len(nodesWithCapacity))
 			}
 			return nil
 		}
-		sortCandidatesFn(candidateVolumes)
-		for _, emptyNode := range nodesWithCapacity[:fullNodeIndex] {
-			// In byte-usage mode the ranking ignores volume slots, so skip targets
-			// that are already at MaxVolumeCount so balancing never exceeds the
-			// slot limit.
-			if c.byDiskUsage && !emptyNode.hasFreeVolumeSlot(diskType) {
-				continue
-			}
-			// Never move onto a server whose physical disk is already near full,
-			// even if the slot-density metric ranks it as the emptiest node. This is
-			// the root-cause guard for an over-configured maxVolumeCount making a
-			// full disk look empty; it is judged per server against its own disk.
-			if c.targetDiskTooFull(emptyNode, diskType, volumeSizeLimitMb) {
-				if c.commandEnv != nil && c.commandEnv.verbose {
-					fmt.Fprintf(os.Stdout, "skip target %s: disk used%% >= %d%%\n", emptyNode.info.Id, c.diskUsageHighWaterPercent)
-				}
-				continue
-			}
-			if !(fullNode.localVolumeDensityNextRatio(capacityFunc) > idealVolumeRatio && emptyNode.localVolumeDensityNextRatio(capacityFunc) <= idealVolumeRatio) {
-				if c.commandEnv != nil && c.commandEnv.verbose {
-					fmt.Printf("no more volume servers with empty slots %s, idealVolumeRatio %f\n", emptyNode.info.Id, idealVolumeRatio)
-				}
-				break
-			}
-			fmt.Fprintf(os.Stdout, "%s %.2f %.2f:%.2f\t", diskType.ReadableString(), idealVolumeRatio,
-				fullNode.localVolumeDensityRatio(capacityFunc), emptyNode.localVolumeDensityNextRatio(capacityFunc))
+		if plan == nil {
+			return nil
+		}
+
+		c.printBalancePlan(diskType, plan, capacityFunc, idealVolumeRatio)
+		hasMoved, err = attemptToMoveOneVolume(c.commandEnv, volumeReplicas, plan.source,
+			plan.candidateVolumes, plan.target, c.applyBalancing)
+		if err != nil {
 			if c.commandEnv != nil && c.commandEnv.verbose {
-				fmt.Fprintf(os.Stdout, "%s %.1f %.1f:%.1f\t", diskType.ReadableString(), idealVolumeRatio*100,
-					fullNode.localVolumeDensityRatio(capacityFunc)*100, emptyNode.localVolumeDensityNextRatio(capacityFunc)*100)
+				fmt.Fprintf(os.Stdout, "attempt to move one volume error %+v\n", err)
 			}
-			hasMoved, err = attemptToMoveOneVolume(c.commandEnv, volumeReplicas, fullNode, candidateVolumes, emptyNode, c.applyBalancing)
-			if err != nil {
-				if c.commandEnv != nil && c.commandEnv.verbose {
-					fmt.Fprintf(os.Stdout, "attempt to move one volume error %+v\n", err)
-				}
-				if strings.Contains(err.Error(), util.ErrVolumeNoSpaceLeft) {
-					continue
-				}
-				return
+			if strings.Contains(err.Error(), util.ErrVolumeNoSpaceLeft) {
+				continue
 			}
-			if hasMoved {
-				c.movedCount++
-				break
-			}
+			return
+		}
+		if hasMoved {
+			c.movedCount++
 		}
 	}
 	return nil
@@ -684,78 +780,20 @@ func (c *commandVolumeBalance) balanceSelectedVolumeParallel(diskType types.Disk
 }
 
 func (c *commandVolumeBalance) reserveParallelMove(diskType types.DiskType, volumeReplicas map[uint32][]*VolumeReplica, nodesWithCapacity []*Node, sortCandidatesFn func(volumes []*master_pb.VolumeInformationMessage), capacityFunc DensityFunc, idealVolumeRatio float64, volumeSizeLimitMb uint64, failedTargets map[string]struct{}) (*volumeBalanceMove, bool) {
-	slices.SortFunc(nodesWithCapacity, func(a, b *Node) int {
-		return cmp.Compare(a.localVolumeDensityRatio(capacityFunc), b.localVolumeDensityRatio(capacityFunc))
-	})
-	if len(nodesWithCapacity) == 0 {
+	plan, _ := c.planBalanceMove(diskType, volumeReplicas, nodesWithCapacity, sortCandidatesFn,
+		capacityFunc, idealVolumeRatio, volumeSizeLimitMb, failedTargets)
+	if plan == nil || len(plan.candidateVolumes) == 0 {
 		return nil, false
 	}
 
-	var fullNode *Node
-	var fullNodeIndex int
-	for fullNodeIndex = len(nodesWithCapacity) - 1; fullNodeIndex >= 0; fullNodeIndex-- {
-		fullNode = nodesWithCapacity[fullNodeIndex]
-		if len(fullNode.selectedVolumes) == 0 {
-			continue
-		}
-		if !fullNode.isOneVolumeOnly() {
-			break
-		}
-	}
-	if fullNodeIndex == -1 {
-		return nil, false
-	}
-
-	candidateVolumes := make([]*master_pb.VolumeInformationMessage, 0, len(fullNode.selectedVolumes))
-	for _, v := range fullNode.selectedVolumes {
-		candidateVolumes = append(candidateVolumes, v)
-	}
-	sortCandidatesFn(candidateVolumes)
-
-	for _, emptyNode := range nodesWithCapacity[:fullNodeIndex] {
-		if _, failed := failedTargets[emptyNode.info.Id]; failed {
-			continue
-		}
-		if c.byDiskUsage && !emptyNode.hasFreeVolumeSlot(diskType) {
-			continue
-		}
-		if c.targetDiskTooFull(emptyNode, diskType, volumeSizeLimitMb) {
-			continue
-		}
-		if !(fullNode.localVolumeDensityNextRatio(capacityFunc) > idealVolumeRatio && emptyNode.localVolumeDensityNextRatio(capacityFunc) <= idealVolumeRatio) {
-			break
-		}
-
-		for _, v := range candidateVolumes {
-			if v.RemoteStorageName != "" {
-				continue
-			}
-			if v.ReplicaPlacement > 0 {
-				replicaPlacement, _ := super_block.NewReplicaPlacementFromByte(byte(v.ReplicaPlacement))
-				if !isGoodMove(replicaPlacement, volumeReplicas[v.Id], fullNode, emptyNode) {
-					continue
-				}
-			}
-			if _, found := emptyNode.selectedVolumes[v.Id]; found {
-				continue
-			}
-
-			fmt.Fprintf(os.Stdout, "%s %.2f %.2f:%.2f\t", diskType.ReadableString(), idealVolumeRatio,
-				fullNode.localVolumeDensityRatio(capacityFunc), emptyNode.localVolumeDensityNextRatio(capacityFunc))
-			if c.commandEnv != nil && c.commandEnv.verbose {
-				fmt.Fprintf(os.Stdout, "%s %.1f %.1f:%.1f\t", diskType.ReadableString(), idealVolumeRatio*100,
-					fullNode.localVolumeDensityRatio(capacityFunc)*100, emptyNode.localVolumeDensityNextRatio(capacityFunc)*100)
-			}
-
-			// Reserve the move before releasing the planner lock. This makes the
-			// next reservation observe the updated source, target, replica, and
-			// disk accounting while the network operation runs in parallel.
-			adjustAfterMove(v, volumeReplicas, fullNode, emptyNode)
-			c.movedCount++
-			return &volumeBalanceMove{volume: v, source: fullNode, target: emptyNode}, true
-		}
-	}
-	return nil, false
+	c.printBalancePlan(diskType, plan, capacityFunc, idealVolumeRatio)
+	volume := plan.candidateVolumes[0]
+	// Reserve the move before releasing the planner lock. This makes the next
+	// reservation observe the updated source, target, replica, and disk
+	// accounting while the network operation runs in parallel.
+	adjustAfterMove(volume, volumeReplicas, plan.source, plan.target)
+	c.movedCount++
+	return &volumeBalanceMove{volume: volume, source: plan.source, target: plan.target}, true
 }
 
 func (c *commandVolumeBalance) executeParallelMove(move volumeBalanceMove, volumeReplicas map[uint32][]*VolumeReplica, failedTargets map[string]struct{}) error {

--- a/weed/shell/command_volume_balance_test.go
+++ b/weed/shell/command_volume_balance_test.go
@@ -297,6 +297,59 @@ func TestBalance(t *testing.T) {
 
 }
 
+func TestBalanceParallel(t *testing.T) {
+	const mb = 1024 * 1024
+	volumeSizeLimitMb := uint64(100)
+
+	volumes := make([]*master_pb.VolumeInformationMessage, 0, 8)
+	for id := uint32(1); id <= 8; id++ {
+		volumes = append(volumes, &master_pb.VolumeInformationMessage{Id: id, Size: 95 * mb})
+	}
+	fullNode := &Node{
+		info: &master_pb.DataNodeInfo{
+			Id: "full",
+			DiskInfos: map[string]*master_pb.DiskInfo{
+				"": {MaxVolumeCount: 10, VolumeCount: int64(len(volumes)), VolumeInfos: volumes},
+			},
+		},
+		dc: "dc1", rack: "rack1",
+	}
+	emptyNode := &Node{
+		info: &master_pb.DataNodeInfo{
+			Id: "empty",
+			DiskInfos: map[string]*master_pb.DiskInfo{
+				"": {MaxVolumeCount: 10},
+			},
+		},
+		dc: "dc1", rack: "rack1",
+	}
+
+	c := &commandVolumeBalance{
+		volumeSizeLimitMb:  volumeSizeLimitMb,
+		maxParallelization: 3,
+	}
+	runBalance(t, c, []*Node{fullNode, emptyNode})
+
+	if c.movedCount == 0 {
+		t.Fatal("expected parallel balance to move at least one volume")
+	}
+	if diff := len(fullNode.info.DiskInfos[""].VolumeInfos) - len(emptyNode.info.DiskInfos[""].VolumeInfos); diff > 1 || diff < -1 {
+		t.Fatalf("expected balanced distribution, got full=%d empty=%d", len(fullNode.info.DiskInfos[""].VolumeInfos), len(emptyNode.info.DiskInfos[""].VolumeInfos))
+	}
+
+	seen := make(map[uint32]int)
+	for _, node := range []*Node{fullNode, emptyNode} {
+		for _, volume := range node.info.DiskInfos[""].VolumeInfos {
+			seen[volume.Id]++
+		}
+	}
+	for id, count := range seen {
+		if count != 1 {
+			t.Fatalf("volume %d appears %d times after parallel balance", id, count)
+		}
+	}
+}
+
 // Regression test: a freshly added empty volume server must end up sharing the
 // data roughly evenly, not having every volume drained onto it. Before the fix,
 // adjustAfterMove never updated the per-disk VolumeInfos that the density-based

--- a/weed/shell/command_volume_server_evacuate.go
+++ b/weed/shell/command_volume_server_evacuate.go
@@ -280,7 +280,7 @@ func moveAwayOneNormalVolume(commandEnv *CommandEnv, volumeReplicas map[uint32][
 		if freeVolumeCountfn(emptyNode.info) <= 0 {
 			continue
 		}
-		hasMoved, err = maybeMoveOneVolume(commandEnv, volumeReplicas, thisNode, vol, emptyNode, applyChange)
+		hasMoved, err = maybeMoveOneVolume(commandEnv, volumeReplicas, thisNode, vol, emptyNode, 0, applyChange)
 		if err != nil {
 			return
 		}

--- a/weed/storage/erasure_coding/ecbalancer/balancer.go
+++ b/weed/storage/erasure_coding/ecbalancer/balancer.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/seaweedfs/seaweedfs/weed/storage/erasure_coding"
 	"github.com/seaweedfs/seaweedfs/weed/storage/super_block"
+	"github.com/seaweedfs/seaweedfs/weed/topology/balancer"
 )
 
 // Topology is a snapshot of EC shard placement to plan against. Build it with
@@ -457,8 +458,7 @@ func pickNodeInRack(r *rack, vk volKey, rp *super_block.ReplicaPlacement) *Node 
 // pickBestNodeForVolume returns the node with the fewest shards of the volume that
 // has a free slot and is under the SameRackCount cap, or nil.
 func pickBestNodeForVolume(nodes []*Node, vk volKey, rp *super_block.ReplicaPlacement) *Node {
-	var best *Node
-	bestCount := -1
+	candidates := make([]balancer.NodeLoad, 0, len(nodes))
 	for _, node := range nodes {
 		if node.freeSlots <= 0 {
 			continue
@@ -467,11 +467,16 @@ func pickBestNodeForVolume(nodes []*Node, vk volKey, rp *super_block.ReplicaPlac
 		if rp != nil && rp.SameRackCount > 0 && count >= rp.SameRackCount {
 			continue
 		}
-		if best == nil || count < bestCount {
-			best, bestCount = node, count
+		candidates = append(candidates, balancer.NodeLoad{ID: node.id, Score: float64(count)})
+	}
+	if index := balancer.PickLeastLoaded(candidates); index >= 0 {
+		for _, node := range nodes {
+			if node.id == candidates[index].ID {
+				return node
+			}
 		}
 	}
-	return best
+	return nil
 }
 
 // detectWithinRackImbalance spreads a volume's shards within each rack, data then
@@ -731,10 +736,7 @@ func detectGlobalImbalance(nodes map[string]*Node, racks map[string]*rack, diskT
 			iterations = totalShards
 		}
 		for i := 0; i < iterations; i++ {
-			var minNode, maxNode *Node
-			minUtil := math.Inf(1)
-			maxUtil := -1.0
-			var minCount, maxCount int
+			var sourceCandidates, targetCandidates []balancer.NodeLoad
 			for _, nodeID := range sortedNodeKeys(r.nodes) {
 				count := nodeShardCounts[nodeID]
 				node := r.nodes[nodeID]
@@ -743,16 +745,20 @@ func detectGlobalImbalance(nodes map[string]*Node, racks map[string]*rack, diskT
 					continue
 				}
 				util := float64(count) / float64(capacity)
-				if util < minUtil && node.freeSlots > 0 {
-					minUtil, minCount, minNode = util, count, node
-				}
-				if util > maxUtil {
-					maxUtil, maxCount, maxNode = util, count, node
+				sourceCandidates = append(sourceCandidates, balancer.NodeLoad{ID: nodeID, Score: util})
+				if node.freeSlots > 0 {
+					targetCandidates = append(targetCandidates, balancer.NodeLoad{ID: nodeID, Score: util})
 				}
 			}
-			if maxNode == nil || minNode == nil || maxNode.id == minNode.id {
+			sourceIndex := balancer.PickMostLoaded(sourceCandidates)
+			targetIndex := balancer.PickLeastLoaded(targetCandidates)
+			if sourceIndex < 0 || targetIndex < 0 || sourceCandidates[sourceIndex].ID == targetCandidates[targetIndex].ID {
 				break
 			}
+			maxNode := r.nodes[sourceCandidates[sourceIndex].ID]
+			minNode := r.nodes[targetCandidates[targetIndex].ID]
+			maxCount := nodeShardCounts[maxNode.id]
+			minCount := nodeShardCounts[minNode.id]
 
 			maxCap := nodeCapacity[maxNode.id]
 			minCap := nodeCapacity[minNode.id]
@@ -868,8 +874,7 @@ func shardsByGroup(vk volKey, nodes map[string]*Node, dataShards int, key func(*
 // key order, so selection is deterministic.
 func pickTarget(candidates []string, shardsPerTarget map[string][]int, maxPerTarget int, antiAffinity map[string]bool, hasFreeSlots, withinLimit func(string) bool) (string, bool) {
 	try := func(skipAnti bool) (string, bool) {
-		best := ""
-		bestCount := maxPerTarget + 1
+		eligible := make([]balancer.NodeLoad, 0, len(candidates))
 		for _, c := range candidates {
 			if skipAnti && antiAffinity[c] {
 				continue
@@ -883,11 +888,12 @@ func pickTarget(candidates []string, shardsPerTarget map[string][]int, maxPerTar
 			if !withinLimit(c) {
 				continue
 			}
-			if cnt := len(shardsPerTarget[c]); cnt < bestCount {
-				best, bestCount = c, cnt
-			}
+			eligible = append(eligible, balancer.NodeLoad{ID: c, Score: float64(len(shardsPerTarget[c]))})
 		}
-		return best, best != ""
+		if index := balancer.PickLeastLoaded(eligible); index >= 0 {
+			return eligible[index].ID, true
+		}
+		return "", false
 	}
 	if len(antiAffinity) > 0 {
 		if t, ok := try(true); ok {

--- a/weed/topology/balancer/load.go
+++ b/weed/topology/balancer/load.go
@@ -1,0 +1,37 @@
+package balancer
+
+// NodeLoad is the load score used when selecting a source or target node.
+// Callers decide which nodes are eligible and provide the score appropriate to
+// their balancing policy (for example, volume density or EC shard fullness).
+type NodeLoad struct {
+	ID    string
+	Score float64
+}
+
+// PickMostLoaded returns the index of the highest-scored node. Ties are broken
+// by node id so callers get the same plan regardless of map iteration order.
+// It returns -1 when nodes is empty.
+func PickMostLoaded(nodes []NodeLoad) int {
+	best := -1
+	for i, node := range nodes {
+		if best < 0 || node.Score > nodes[best].Score ||
+			(node.Score == nodes[best].Score && node.ID < nodes[best].ID) {
+			best = i
+		}
+	}
+	return best
+}
+
+// PickLeastLoaded returns the index of the lowest-scored node. Ties are broken
+// by node id so callers get the same plan regardless of map iteration order.
+// It returns -1 when nodes is empty.
+func PickLeastLoaded(nodes []NodeLoad) int {
+	best := -1
+	for i, node := range nodes {
+		if best < 0 || node.Score < nodes[best].Score ||
+			(node.Score == nodes[best].Score && node.ID < nodes[best].ID) {
+			best = i
+		}
+	}
+	return best
+}


### PR DESCRIPTION
# What problem are we solving?

To avoid 100% disk utilization,

# How are we solving the problem?

We limit the data transfer limit when moving

# How is the PR tested?

reuse option from volume.move

# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Volume balancing now supports configurable parallel operations and I/O bandwidth limits.
  * Balancing more evenly distributes volumes while preserving replica placement and preventing unsafe disk usage.
  * Improved handling of failed moves and rollback during balancing.

* **Bug Fixes**
  * Enhanced volume selection and load balancing for more predictable results.
  * Improved erasure-coded data balancing across nodes and racks.

* **Tests**
  * Added coverage verifying parallel balancing preserves all volumes and achieves an even distribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->