### PR TITLE
fix(redis2): remove orphaned directory index members on listing

### DIFF
--- a/weed/filer/redis2/universal_redis_store.go
+++ b/weed/filer/redis2/universal_redis_store.go
@@ -205,6 +205,7 @@ func (store *UniversalRedis2Store) ListDirectoryEntries(ctx context.Context, dir
 		if err != nil {
 			glog.V(0).InfofCtx(ctx, "list %s : %v", path, err)
 			if err == filer_pb.ErrNotFound {
+				store.Client.ZRem(ctx, dirListKey, fileName).Result()
 				err = nil
 				continue
 			}

--- a/weed/filer/redis2/universal_redis_store.go
+++ b/weed/filer/redis2/universal_redis_store.go
@@ -205,7 +205,7 @@ func (store *UniversalRedis2Store) ListDirectoryEntries(ctx context.Context, dir
 		if err != nil {
 			glog.V(0).InfofCtx(ctx, "list %s : %v", path, err)
 			if err == filer_pb.ErrNotFound {
-				store.Client.ZRem(ctx, dirListKey, fileName).Result()
+				store.removeOrphanedDirectoryListMember(ctx, dirListKey, path, fileName)
 				err = nil
 				continue
 			}
@@ -232,6 +232,22 @@ func (store *UniversalRedis2Store) ListDirectoryEntries(ctx context.Context, dir
 	}
 
 	return lastFileName, err
+}
+
+func (store *UniversalRedis2Store) removeOrphanedDirectoryListMember(ctx context.Context, dirListKey string, path util.FullPath, fileName string) {
+	if err := store.Client.ZRem(ctx, dirListKey, fileName).Err(); err != nil {
+		return
+	}
+
+	// InsertEntry writes the value before adding the member, so a value present
+	// again here may belong to an insert that found the member still in place
+	// and whose ZAddNX was therefore a no-op.
+	exists, err := store.Client.Exists(ctx, store.getKey(string(path))).Result()
+	if err == nil && exists == 0 {
+		return
+	}
+
+	store.Client.ZAddNX(ctx, dirListKey, redis.Z{Score: 0, Member: fileName})
 }
 
 func genDirectoryListKey(dir string) (dirList string) {

--- a/weed/filer/redis2/universal_redis_store_test.go
+++ b/weed/filer/redis2/universal_redis_store_test.go
@@ -1,0 +1,126 @@
+package redis2
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+
+	"github.com/seaweedfs/seaweedfs/weed/filer"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+)
+
+func newTestStore(t *testing.T, keyPrefix string) (*UniversalRedis2Store, util.FullPath) {
+	t.Helper()
+
+	if os.Getenv("RUN_REDIS_TESTS") != "1" {
+		t.Skip("redis2 tests are disabled. Start a redis-server and set RUN_REDIS_TESTS=1 to enable, REDIS_ADDR defaults to 127.0.0.1:6379.")
+	}
+
+	addr := os.Getenv("REDIS_ADDR")
+	if addr == "" {
+		addr = "127.0.0.1:6379"
+	}
+
+	ctx := context.Background()
+	client := redis.NewClient(&redis.Options{Addr: addr})
+	if err := client.Ping(ctx).Err(); err != nil {
+		t.Fatalf("connect to redis at %s: %v", addr, err)
+	}
+
+	store := &UniversalRedis2Store{Client: client, keyPrefix: keyPrefix}
+	store.loadSuperLargeDirectories(nil)
+
+	dir := util.FullPath(fmt.Sprintf("/redis2_test_%d", time.Now().UnixNano()))
+	t.Cleanup(func() {
+		store.DeleteFolderChildren(ctx, dir)
+		store.DeleteEntry(ctx, dir)
+		client.Close()
+	})
+
+	return store, dir
+}
+
+func insertTestEntry(t *testing.T, store *UniversalRedis2Store, path util.FullPath, ttlSec int32) {
+	t.Helper()
+
+	now := time.Now()
+	if err := store.InsertEntry(context.Background(), &filer.Entry{
+		FullPath: path,
+		Attr:     filer.Attr{Crtime: now, Mtime: now, Mode: 0644, TtlSec: ttlSec},
+	}); err != nil {
+		t.Fatalf("InsertEntry %s: %v", path, err)
+	}
+}
+
+func listNames(t *testing.T, store *UniversalRedis2Store, dir util.FullPath) []string {
+	t.Helper()
+
+	names := []string{}
+	if _, err := store.ListDirectoryEntries(context.Background(), dir, "", true, 100, func(entry *filer.Entry) (bool, error) {
+		_, name := entry.FullPath.DirAndName()
+		names = append(names, name)
+		return true, nil
+	}); err != nil {
+		t.Fatalf("ListDirectoryEntries %s: %v", dir, err)
+	}
+	return names
+}
+
+func indexMembers(t *testing.T, store *UniversalRedis2Store, dir util.FullPath) []string {
+	t.Helper()
+
+	members, err := store.Client.ZRangeByLex(context.Background(), store.getKey(genDirectoryListKey(string(dir))), &redis.ZRangeBy{Min: "-", Max: "+"}).Result()
+	if err != nil {
+		t.Fatalf("read directory index of %s: %v", dir, err)
+	}
+	return members
+}
+
+func TestListDirectoryEntriesRemovesOrphanedIndexMembers(t *testing.T) {
+	for _, keyPrefix := range []string{"", "sw:"} {
+		t.Run("keyPrefix="+keyPrefix, func(t *testing.T) {
+			store, dir := newTestStore(t, keyPrefix)
+
+			insertTestEntry(t, store, dir.Child("alive"), 0)
+			insertTestEntry(t, store, dir.Child("orphan"), 0)
+
+			if err := store.Client.Del(context.Background(), store.getKey(string(dir.Child("orphan")))).Err(); err != nil {
+				t.Fatalf("drop value key: %v", err)
+			}
+
+			if names := listNames(t, store, dir); len(names) != 1 || names[0] != "alive" {
+				t.Fatalf("listed %v, want [alive]", names)
+			}
+
+			if members := indexMembers(t, store, dir); len(members) != 1 || members[0] != "alive" {
+				t.Fatalf("directory index holds %v, want [alive]", members)
+			}
+		})
+	}
+}
+
+func TestListDirectoryEntriesRemovesIndexMembersExpiredByRedis(t *testing.T) {
+	store, dir := newTestStore(t, "")
+
+	insertTestEntry(t, store, dir.Child("ttl"), 1)
+
+	time.Sleep(1500 * time.Millisecond)
+
+	if exists, err := store.Client.Exists(context.Background(), store.getKey(string(dir.Child("ttl")))).Result(); err != nil {
+		t.Fatalf("check value key: %v", err)
+	} else if exists != 0 {
+		t.Fatal("redis did not expire the value key, the logical expiry path is not being bypassed")
+	}
+
+	if names := listNames(t, store, dir); len(names) != 0 {
+		t.Fatalf("listed %v, want none", names)
+	}
+
+	if members := indexMembers(t, store, dir); len(members) != 0 {
+		t.Fatalf("directory index holds %v, want none", members)
+	}
+}

--- a/weed/filer/redis2/universal_redis_store_test.go
+++ b/weed/filer/redis2/universal_redis_store_test.go
@@ -103,6 +103,23 @@ func TestListDirectoryEntriesRemovesOrphanedIndexMembers(t *testing.T) {
 	}
 }
 
+func TestRemoveOrphanedDirectoryListMemberKeepsRecreatedEntry(t *testing.T) {
+	store, dir := newTestStore(t, "")
+
+	path := dir.Child("recreated")
+	insertTestEntry(t, store, path, 0)
+
+	store.removeOrphanedDirectoryListMember(context.Background(), store.getKey(genDirectoryListKey(string(dir))), path, "recreated")
+
+	if members := indexMembers(t, store, dir); len(members) != 1 || members[0] != "recreated" {
+		t.Fatalf("directory index holds %v, want [recreated]", members)
+	}
+
+	if names := listNames(t, store, dir); len(names) != 1 || names[0] != "recreated" {
+		t.Fatalf("listed %v, want [recreated]", names)
+	}
+}
+
 func TestListDirectoryEntriesRemovesIndexMembersExpiredByRedis(t *testing.T) {
 	store, dir := newTestStore(t, "")
 


### PR DESCRIPTION
# What problem are we solving?

The `redis2` per-directory child index — the ZSET at `<dir>\x00` — accumulates members whose value key no longer exists, and nothing ever removes them.

`ListDirectoryEntries` reads the members, then calls `FindEntry` per member (`weed/filer/redis2/universal_redis_store.go:189-231`). Two outcomes matter:

- the value key is gone → `filer_pb.ErrNotFound` → the loop logs and `continue`s, **leaving the member in the index** (`:205-211` before this change);
- the value key is there but the entry is logically expired (`Crtime + TtlSec < now`) → `DEL` the value **and `ZREM` the member** (`:213-219`).

The second branch is the intended behaviour — the code already means to keep the index consistent. The first branch is the one that actually runs for TTL entries, because the two expiry deadlines are on different clocks:

- `doInsertEntry` writes `SET <key> <value> EX <TtlSec>` (`:86`), so Redis drops the key at `set_time + TtlSec`;
- the filer's logical check is `Crtime + TtlSec < now`.

`Crtime` is stamped before the store write, so `Crtime <= set_time` and the logical deadline is the *earlier* of the two — by the sub-millisecond gap between stamping the attribute and Redis processing the `SET`. The `else` branch can therefore only run if a listing lands inside that gap. Every listing after it finds `GET` returning `redis.Nil` and takes the not-found branch, the one that leaves the member behind. (An entry that is later *updated* re-arms the Redis TTL from the update time while `Crtime` stays put, which is the only case where the working branch is reliably reachable — so the leak is specific to entries created once and never touched again, which is the common TTL case.)

Under a TTL workload the index therefore grows without bound, and two things get worse with it:

- `LIST` costs one `GET` round trip per name *ever created* in that directory, not per live entry;
- the skip logs at `glog.V(0)`, which is on by default, so every listing emits one log line per dead member.

The same orphan is produced by any other route that removes a value key without the matching `ZREM` — an out-of-band `DEL`, `maxmemory` eviction, or a `DeleteEntry` that fails between its `DEL` and its `ZREM` (`:119-143`). TTL is just the one that does it continuously.

# How are we solving the problem?

`ZREM` the member in the not-found branch, mirroring what the expiry branch already does below and against the same `dirListKey` variable — guarded against a concurrent recreate, per the review point below.

Things I checked rather than assumed:

**A member cannot legitimately outlive a missing value.** `InsertEntry` writes the value first and adds the member second (`:56-74`): `doInsertEntry`'s `SET` has returned before `ZAddNX` is issued. So "member present" implies "value was written at some point", and a member returned by `ZRangeByLex` whose value is absent has had that value deleted or expired — it is never an entry mid-creation. The opposite window (value written, member not yet added) does exist, but a listing cannot observe it, because it only iterates members.

**The value can, however, come back before the `ZREM` lands** — which the paragraph above does not cover, and which both review bots caught. If an `InsertEntry` for the same path completes between `FindEntry` returning `ErrNotFound` and the `ZREM`, its `ZAddNX` is a no-op, because the member is still in place; the `ZREM` then strips the index member off a live value. `UpdateEntry` only calls `doInsertEntry` (`:92-95`) and never re-adds the member, so the entry stays invisible to `ListDirectoryEntries` and `DeleteFolderChildren` until another `InsertEntry` hits that exact path. That is a real regression, so the cleanup compensates rather than removing unconditionally: `ZREM`, re-check the value key, and `ZAddNX` the member back when the value is present again or when the check itself failed.

That converges in both interleavings. If the insert's `SET` lands before the re-check, the re-check sees it and restores the member; if it lands after, the insert's own `ZAddNX` is necessarily after our `ZREM` and restores the member itself. Only a positively confirmed absent value leaves the member removed, so the repair still converges for genuine orphans at the cost of one extra `EXISTS` — on the repair path only, which is one-time per orphan.

The remedy both reviews suggested — a Lua script or `MULTI` spanning the value key and the index key — is not available here. `RedisCluster2Store` embeds `UniversalRedis2Store`, and the two keys (`<prefix></dir/name>` and `<prefix></dir>\x00`) carry no hash tag, so a multi-key script would be `CROSSSLOT` under `redis_cluster2`. The compensating form uses only single-key commands and behaves identically on all three transports.

**`keyPrefix`.** `dirListKey` is `store.getKey(genDirectoryListKey(...))` at `:178` — already prefixed — and the new `ZREM` reuses that variable instead of rebuilding the key. Rebuilding it unprefixed would have been a silent no-op for every deployment that sets `keyPrefix`, which is why the test runs both with and without one.

**Transient errors cannot trigger it.** `FindEntry` returns the bare `filer_pb.ErrNotFound` sentinel only for `redis.Nil` (`:99-102`); every other failure is wrapped with `fmt.Errorf`. The branch guard is `err == filer_pb.ErrNotFound` — identity, not `errors.Is` — so a connection blip cannot match it and still breaks out of the loop as before.

**Super-large directories.** `isSuperLargeDirectory` makes `InsertEntry` skip the `ZAdd` and `DeleteEntry` skip the `ZRem`, so the index key does not exist for those directories at all. `ZRangeByLex` returns nothing, the loop body never runs, and the new call is unreachable. The feature is unaffected.

Cleanup failures still do not fail the listing — a failed repair is simply retried on the next one — but the errors are no longer discarded outright, since the restore decision depends on them: a `ZREM` that errors removes nothing and returns, and a re-check that errors restores the member, so the failure modes bias towards a stale member rather than a lost one.

**Deliberately not included:** making the physical TTL a backstop behind the logical one (`SET ... EX TtlSec + grace`) so the logical branch wins the race and performs the clean two-part delete. That changes when data actually disappears from Redis for every `redis2` user, and it would not remove the need for this fix, since the non-TTL routes above produce the same orphan. Happy to raise it separately if you want it.

**Also deliberately not included:** the expiry branch at `:214-219` has a pre-existing instance of the same race, with a worse outcome — a concurrent `InsertEntry` landing between `FindEntry` and the `DEL` loses the freshly written value, not just the index member. Closing it needs a compare-and-delete on the value rather than the compensating restore used here, so it is a separate change and not one I want to smuggle into this one.

# How is the PR tested?

New `weed/filer/redis2/universal_redis_store_test.go`. It needs a live Redis, so it follows the existing convention for store tests that need a server — `tarantool_store_test.go` gating on `RUN_TARANTOOL_TESTS=1`, `foundationdb_store_test.go` skipping when the cluster is absent — and skips unless `RUN_REDIS_TESTS=1`, with `REDIS_ADDR` defaulting to `127.0.0.1:6379`. Each test works inside a uniquely named directory and cleans up after itself, so it is safe against a shared instance.

I did try the in-tree `tempredis` helper used by `redis3/kv_directory_children_test.go` first. It hangs on any current `redis-server`: it blocks waiting for the literal line `The server is now ready to accept connections`, which Redis stopped printing years ago. That helper is only reachable from a `Benchmark` today, so nothing noticed. Worth knowing if anyone tries to build on it.

- `TestListDirectoryEntriesRemovesOrphanedIndexMembers` — two entries, one's value key dropped; asserts the listing returns only the live entry *and* that the index is left holding only the live name. Run with `keyPrefix` empty and set.
- `TestListDirectoryEntriesRemovesIndexMembersExpiredByRedis` — inserts with `TtlSec: 1`, waits past it, asserts Redis has already dropped the value key, then asserts the listing empties the index. This is the reported path end to end.
- `TestRemoveOrphanedDirectoryListMemberKeepsRecreatedEntry` — added for the review point above. It drives the cleanup with the value key present, which is exactly the state a concurrent recreate leaves behind, and asserts the member survives and the entry still lists. Asserted at the helper rather than through `ListDirectoryEntries`, because the window between the `GET` and the `ZREM` cannot be hit deterministically from outside. It fails if the restore is removed.

Against `redis-server 8.2.1`, the first three cases fail on master and pass with the change:

```
--- FAIL: TestListDirectoryEntriesRemovesOrphanedIndexMembers/keyPrefix=
        directory index holds [alive orphan], want [alive]
--- FAIL: TestListDirectoryEntriesRemovesOrphanedIndexMembers/keyPrefix=sw:
        directory index holds [alive orphan], want [alive]
--- FAIL: TestListDirectoryEntriesRemovesIndexMembersExpiredByRedis
        directory index holds [ttl], want none
```

`go build ./weed/...`, `go vet ./weed/filer/redis2/`, `gofmt` all clean, and `go test ./weed/filer/redis2/... -race` passes against a live Redis.

## Note on `redis3`, which I am not touching

`redis3` has the same shape at `universal_redis_store.go:140-166`, and is worse off: its not-found branch removes nothing at all, and its expiry branch calls `ZRem` on `<dir>\x00` — which in `redis3` is a **string** holding the serialised skiplist root (`kv_directory_children.go:43`), not a ZSET. That returns `WRONGTYPE`, the result is discarded, and it has therefore never removed anything.

Flagging rather than fixing, because `weed/filer/redis3/README.md` reads `Desuppported.` and the store has no section in `weed/command/scaffold/filer.toml`, so any fix there would be to a store nobody is being pointed at. Say the word if you would like it repaired anyway.

## Related

#10736 proposes giving lazily-created remote-mount entries a TTL so the filer's existing expiry machinery reclaims them. The two compose: that change makes TTL entries the normal case for a whole class of deployment, and this one is what stops the directory index growing anyway when they expire.

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Directory listings now automatically remove references to missing or expired entries, preventing stale filenames from appearing in results.
  * Recreated entries are preserved when they reappear during cleanup.
  * Improved cleanup works across supported Redis key prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->