### PR TITLE
redis: remove orphaned directory index members on listing

### DIFF
--- a/weed/filer/redis/universal_redis_store.go
+++ b/weed/filer/redis/universal_redis_store.go
@@ -182,6 +182,7 @@ func (store *UniversalRedisStore) ListDirectoryEntries(ctx context.Context, dirP
 		if err != nil {
 			glog.V(0).InfofCtx(ctx, "list %s : %v", path, err)
 			if err == filer_pb.ErrNotFound {
+				store.removeOrphanedDirectoryListMember(ctx, dirPath, fileName)
 				err = nil
 				continue
 			}
@@ -207,6 +208,32 @@ func (store *UniversalRedisStore) ListDirectoryEntries(ctx context.Context, dirP
 	}
 
 	return lastFileName, err
+}
+
+func (store *UniversalRedisStore) removeOrphanedDirectoryListMember(ctx context.Context, dirPath util.FullPath, fileName string) {
+	// survive the listing request being canceled mid-repair
+	ctx = context.WithoutCancel(ctx)
+
+	dirListKey := genDirectoryListKey(string(dirPath))
+	path := util.NewFullPath(string(dirPath), fileName)
+
+	if _, err := store.Client.SRem(ctx, dirListKey, fileName).Result(); err != nil {
+		return
+	}
+
+	// a value present again here belongs to a concurrent recreate whose SAdd raced our SRem
+	exists, err := store.Client.Exists(ctx, string(path)).Result()
+	if err == nil && exists == 0 {
+		// empty sets self-delete, so a present child index holds children a recursive delete still needs to reach
+		children, childrenErr := store.Client.Exists(ctx, genDirectoryListKey(string(path))).Result()
+		if childrenErr == nil && children == 0 {
+			return
+		}
+	}
+
+	if err := store.Client.SAdd(ctx, dirListKey, fileName).Err(); err != nil {
+		glog.V(0).InfofCtx(ctx, "restore %s in %s: %v", fileName, dirPath, err)
+	}
 }
 
 func genDirectoryListKey(dir string) (dirList string) {

--- a/weed/filer/redis/universal_redis_store_test.go
+++ b/weed/filer/redis/universal_redis_store_test.go
@@ -1,0 +1,143 @@
+package redis
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+
+	"github.com/seaweedfs/seaweedfs/weed/filer"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+)
+
+func newTestStore(t *testing.T) (*UniversalRedisStore, util.FullPath) {
+	t.Helper()
+
+	if os.Getenv("RUN_REDIS_TESTS") != "1" {
+		t.Skip("redis tests are disabled. Start a redis-server and set RUN_REDIS_TESTS=1 to enable, REDIS_ADDR defaults to 127.0.0.1:6379.")
+	}
+
+	addr := os.Getenv("REDIS_ADDR")
+	if addr == "" {
+		addr = "127.0.0.1:6379"
+	}
+
+	ctx := context.Background()
+	client := redis.NewClient(&redis.Options{Addr: addr})
+	t.Cleanup(func() { client.Close() })
+	if err := client.Ping(ctx).Err(); err != nil {
+		t.Fatalf("connect to redis at %s: %v", addr, err)
+	}
+
+	store := &UniversalRedisStore{Client: client}
+
+	dir := util.FullPath(fmt.Sprintf("/redis_test_%d", time.Now().UnixNano()))
+	t.Cleanup(func() {
+		store.DeleteFolderChildren(ctx, dir)
+		store.DeleteEntry(ctx, dir)
+	})
+
+	return store, dir
+}
+
+func insertTestEntry(t *testing.T, store *UniversalRedisStore, path util.FullPath) {
+	t.Helper()
+
+	now := time.Now()
+	if err := store.InsertEntry(context.Background(), &filer.Entry{
+		FullPath: path,
+		Attr:     filer.Attr{Crtime: now, Mtime: now, Mode: 0644},
+	}); err != nil {
+		t.Fatalf("InsertEntry %s: %v", path, err)
+	}
+}
+
+func listNames(t *testing.T, store *UniversalRedisStore, dir util.FullPath) []string {
+	t.Helper()
+
+	names := []string{}
+	if _, err := store.ListDirectoryEntries(context.Background(), dir, "", true, 100, func(entry *filer.Entry) (bool, error) {
+		_, name := entry.FullPath.DirAndName()
+		names = append(names, name)
+		return true, nil
+	}); err != nil {
+		t.Fatalf("ListDirectoryEntries %s: %v", dir, err)
+	}
+	return names
+}
+
+func indexMembers(t *testing.T, store *UniversalRedisStore, dir util.FullPath) []string {
+	t.Helper()
+
+	members, err := store.Client.SMembers(context.Background(), genDirectoryListKey(string(dir))).Result()
+	if err != nil {
+		t.Fatalf("read directory index of %s: %v", dir, err)
+	}
+	slices.Sort(members)
+	return members
+}
+
+func TestListDirectoryEntriesRemovesOrphanedIndexMembers(t *testing.T) {
+	store, dir := newTestStore(t)
+
+	insertTestEntry(t, store, dir.Child("alive"))
+	insertTestEntry(t, store, dir.Child("orphan"))
+
+	if err := store.Client.Del(context.Background(), string(dir.Child("orphan"))).Err(); err != nil {
+		t.Fatalf("drop value key: %v", err)
+	}
+
+	if names := listNames(t, store, dir); len(names) != 1 || names[0] != "alive" {
+		t.Fatalf("listed %v, want [alive]", names)
+	}
+
+	if members := indexMembers(t, store, dir); len(members) != 1 || members[0] != "alive" {
+		t.Fatalf("directory index holds %v, want [alive]", members)
+	}
+}
+
+func TestRemoveOrphanedDirectoryListMemberKeepsRecreatedEntry(t *testing.T) {
+	store, dir := newTestStore(t)
+
+	insertTestEntry(t, store, dir.Child("recreated"))
+
+	store.removeOrphanedDirectoryListMember(context.Background(), dir, "recreated")
+
+	if members := indexMembers(t, store, dir); len(members) != 1 || members[0] != "recreated" {
+		t.Fatalf("directory index holds %v, want [recreated]", members)
+	}
+
+	if names := listNames(t, store, dir); len(names) != 1 || names[0] != "recreated" {
+		t.Fatalf("listed %v, want [recreated]", names)
+	}
+}
+
+func TestRemoveOrphanedDirectoryListMemberKeepsDirectoryWithChildren(t *testing.T) {
+	store, dir := newTestStore(t)
+
+	sub := dir.Child("sub")
+	insertTestEntry(t, store, sub)
+	insertTestEntry(t, store, sub.Child("kid"))
+	defer store.DeleteFolderChildren(context.Background(), sub)
+
+	// evict the directory's own value while its child index is live
+	if err := store.Client.Del(context.Background(), string(sub)).Err(); err != nil {
+		t.Fatalf("drop value key: %v", err)
+	}
+
+	if names := listNames(t, store, dir); len(names) != 0 {
+		t.Fatalf("listed %v, want none", names)
+	}
+
+	if members := indexMembers(t, store, dir); len(members) != 1 || members[0] != "sub" {
+		t.Fatalf("directory index holds %v, want [sub]", members)
+	}
+
+	if exists, err := store.Client.Exists(context.Background(), string(sub.Child("kid"))).Result(); err != nil || exists != 1 {
+		t.Fatalf("child value key exists=%d err=%v, want it kept", exists, err)
+	}
+}

--- a/weed/filer/redis/universal_redis_store_test.go
+++ b/weed/filer/redis/universal_redis_store_test.go
@@ -28,7 +28,11 @@ func newTestStore(t *testing.T) (*UniversalRedisStore, util.FullPath) {
 
 	ctx := context.Background()
 	client := redis.NewClient(&redis.Options{Addr: addr})
-	t.Cleanup(func() { client.Close() })
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("close redis client: %v", err)
+		}
+	})
 	if err := client.Ping(ctx).Err(); err != nil {
 		t.Fatalf("connect to redis at %s: %v", addr, err)
 	}
@@ -37,8 +41,12 @@ func newTestStore(t *testing.T) (*UniversalRedisStore, util.FullPath) {
 
 	dir := util.FullPath(fmt.Sprintf("/redis_test_%d", time.Now().UnixNano()))
 	t.Cleanup(func() {
-		store.DeleteFolderChildren(ctx, dir)
-		store.DeleteEntry(ctx, dir)
+		if err := store.DeleteFolderChildren(ctx, dir); err != nil {
+			t.Errorf("cleanup %s children: %v", dir, err)
+		}
+		if err := store.DeleteEntry(ctx, dir); err != nil {
+			t.Errorf("cleanup %s: %v", dir, err)
+		}
 	})
 
 	return store, dir
@@ -61,7 +69,7 @@ func listNames(t *testing.T, store *UniversalRedisStore, dir util.FullPath) []st
 
 	names := []string{}
 	if _, err := store.ListDirectoryEntries(context.Background(), dir, "", true, 100, func(entry *filer.Entry) (bool, error) {
-		_, name := entry.FullPath.DirAndName()
+		_, name := entry.DirAndName()
 		names = append(names, name)
 		return true, nil
 	}); err != nil {
@@ -122,7 +130,11 @@ func TestRemoveOrphanedDirectoryListMemberKeepsDirectoryWithChildren(t *testing.
 	sub := dir.Child("sub")
 	insertTestEntry(t, store, sub)
 	insertTestEntry(t, store, sub.Child("kid"))
-	defer store.DeleteFolderChildren(context.Background(), sub)
+	defer func() {
+		if err := store.DeleteFolderChildren(context.Background(), sub); err != nil {
+			t.Errorf("cleanup %s children: %v", sub, err)
+		}
+	}()
 
 	// evict the directory's own value while its child index is live
 	if err := store.Client.Del(context.Background(), string(sub)).Err(); err != nil {


### PR DESCRIPTION
# What problem are we solving?

The `redis` (v1) store has the same defect #10735 fixes in `redis2`: the listing's not-found branch logs and continues without removing the directory-index member, so a member whose value key is gone — TTL expiry, eviction, an out-of-band `DEL` — stays in the parent's SET forever. v1 is worse off than redis2 here, because `ListDirectoryEntries` loads the whole member set with no pagination, so every dead member inflates every single listing of that directory.

# How are we solving the problem?

Same shape as the redis2 fix, with the sharp edges found in its review already filed off:

- `SRem` the member, re-check the value key, and `SAdd` it back when the value is present again — a concurrent recreate's `SAdd` can land before our `SRem`, and this is what keeps that entry listed. Converges in both interleavings for the same reason as in #10735: `InsertEntry` writes the value before the member.
- A member whose value is gone but whose own child index still exists is kept, not stripped: empty sets self-delete in Redis, so a present index means live children, and detaching it would leave the subtree unreachable to a later recursive delete.
- The repair runs on `context.WithoutCancel` so a client disconnect mid-listing cannot tear it half-done, and a failed restore is logged instead of discarded.

Single-key commands only, so behavior is identical on all `UniversalClient` transports.

# How is the PR tested?

`weed/filer/redis/universal_redis_store_test.go`, gated on `RUN_REDIS_TESTS=1` like the redis2 suite (`REDIS_ADDR` defaults to `127.0.0.1:6379`): orphan removal through the listing, a recreated entry surviving the repair, and a directory with live children keeping its member. All pass with `-race` against redis-server 8 (docker `redis:7` as well); the orphan test fails on master.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Directory listings now automatically remove stale entries when the referenced file or directory no longer exists.
  * Entries recreated during cleanup are preserved.
  * Directories containing nested content are protected from accidental removal, preventing valid data from disappearing.

* **Tests**
  * Added coverage for stale-entry cleanup, recreated entries, and directories with children to verify safe directory listing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->