### PR TITLE
redis2: harden the orphaned index member cleanup

### DIFF
--- a/weed/filer/redis2/universal_redis_store.go
+++ b/weed/filer/redis2/universal_redis_store.go
@@ -235,6 +235,11 @@ func (store *UniversalRedis2Store) ListDirectoryEntries(ctx context.Context, dir
 }
 
 func (store *UniversalRedis2Store) removeOrphanedDirectoryListMember(ctx context.Context, dirPath util.FullPath, fileName string) {
+	// a directory converted to super large after accumulating members still has a legacy index
+	if store.isSuperLargeDirectory(string(dirPath)) {
+		return
+	}
+
 	dirListKey := store.getKey(genDirectoryListKey(string(dirPath)))
 	path := util.NewFullPath(string(dirPath), fileName)
 

--- a/weed/filer/redis2/universal_redis_store.go
+++ b/weed/filer/redis2/universal_redis_store.go
@@ -255,7 +255,12 @@ func (store *UniversalRedis2Store) removeOrphanedDirectoryListMember(ctx context
 	// and whose ZAddNX was therefore a no-op.
 	exists, err := store.Client.Exists(ctx, store.getKey(string(path))).Result()
 	if err == nil && exists == 0 {
-		return
+		// an evicted directory may still have a live child index; empty zsets self-delete,
+		// so a present index holds children a recursive delete still needs to reach
+		children, childrenErr := store.Client.Exists(ctx, store.getKey(genDirectoryListKey(string(path)))).Result()
+		if childrenErr == nil && children == 0 {
+			return
+		}
 	}
 
 	if err := store.Client.ZAddNX(ctx, dirListKey, redis.Z{Score: 0, Member: fileName}).Err(); err != nil {

--- a/weed/filer/redis2/universal_redis_store.go
+++ b/weed/filer/redis2/universal_redis_store.go
@@ -240,6 +240,9 @@ func (store *UniversalRedis2Store) removeOrphanedDirectoryListMember(ctx context
 		return
 	}
 
+	// survive the listing request being canceled mid-repair
+	ctx = context.WithoutCancel(ctx)
+
 	dirListKey := store.getKey(genDirectoryListKey(string(dirPath)))
 	path := util.NewFullPath(string(dirPath), fileName)
 
@@ -255,7 +258,9 @@ func (store *UniversalRedis2Store) removeOrphanedDirectoryListMember(ctx context
 		return
 	}
 
-	store.Client.ZAddNX(ctx, dirListKey, redis.Z{Score: 0, Member: fileName})
+	if err := store.Client.ZAddNX(ctx, dirListKey, redis.Z{Score: 0, Member: fileName}).Err(); err != nil {
+		glog.V(0).InfofCtx(ctx, "restore %s in %s: %v", fileName, dirPath, err)
+	}
 }
 
 func genDirectoryListKey(dir string) (dirList string) {

--- a/weed/filer/redis2/universal_redis_store.go
+++ b/weed/filer/redis2/universal_redis_store.go
@@ -205,7 +205,7 @@ func (store *UniversalRedis2Store) ListDirectoryEntries(ctx context.Context, dir
 		if err != nil {
 			glog.V(0).InfofCtx(ctx, "list %s : %v", path, err)
 			if err == filer_pb.ErrNotFound {
-				store.removeOrphanedDirectoryListMember(ctx, dirListKey, path, fileName)
+				store.removeOrphanedDirectoryListMember(ctx, dirPath, fileName)
 				err = nil
 				continue
 			}
@@ -234,7 +234,10 @@ func (store *UniversalRedis2Store) ListDirectoryEntries(ctx context.Context, dir
 	return lastFileName, err
 }
 
-func (store *UniversalRedis2Store) removeOrphanedDirectoryListMember(ctx context.Context, dirListKey string, path util.FullPath, fileName string) {
+func (store *UniversalRedis2Store) removeOrphanedDirectoryListMember(ctx context.Context, dirPath util.FullPath, fileName string) {
+	dirListKey := store.getKey(genDirectoryListKey(string(dirPath)))
+	path := util.NewFullPath(string(dirPath), fileName)
+
 	if err := store.Client.ZRem(ctx, dirListKey, fileName).Err(); err != nil {
 		return
 	}

--- a/weed/filer/redis2/universal_redis_store_test.go
+++ b/weed/filer/redis2/universal_redis_store_test.go
@@ -120,6 +120,32 @@ func TestRemoveOrphanedDirectoryListMemberKeepsRecreatedEntry(t *testing.T) {
 	}
 }
 
+func TestRemoveOrphanedDirectoryListMemberKeepsDirectoryWithChildren(t *testing.T) {
+	store, dir := newTestStore(t, "")
+
+	sub := dir.Child("sub")
+	insertTestEntry(t, store, sub, 0)
+	insertTestEntry(t, store, sub.Child("kid"), 0)
+	defer store.DeleteFolderChildren(context.Background(), sub)
+
+	// evict the directory's own value while its child index is live
+	if err := store.Client.Del(context.Background(), store.getKey(string(sub))).Err(); err != nil {
+		t.Fatalf("drop value key: %v", err)
+	}
+
+	if names := listNames(t, store, dir); len(names) != 0 {
+		t.Fatalf("listed %v, want none", names)
+	}
+
+	if members := indexMembers(t, store, dir); len(members) != 1 || members[0] != "sub" {
+		t.Fatalf("directory index holds %v, want [sub]", members)
+	}
+
+	if exists, err := store.Client.Exists(context.Background(), store.getKey(string(sub.Child("kid")))).Result(); err != nil || exists != 1 {
+		t.Fatalf("child value key exists=%d err=%v, want it kept", exists, err)
+	}
+}
+
 func TestRemoveOrphanedDirectoryListMemberSkipsSuperLargeDirectory(t *testing.T) {
 	store, dir := newTestStore(t, "")
 	store.loadSuperLargeDirectories([]string{string(dir)})

--- a/weed/filer/redis2/universal_redis_store_test.go
+++ b/weed/filer/redis2/universal_redis_store_test.go
@@ -27,7 +27,11 @@ func newTestStore(t *testing.T, keyPrefix string) (*UniversalRedis2Store, util.F
 
 	ctx := context.Background()
 	client := redis.NewClient(&redis.Options{Addr: addr})
-	t.Cleanup(func() { client.Close() })
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("close redis client: %v", err)
+		}
+	})
 	if err := client.Ping(ctx).Err(); err != nil {
 		t.Fatalf("connect to redis at %s: %v", addr, err)
 	}
@@ -36,8 +40,12 @@ func newTestStore(t *testing.T, keyPrefix string) (*UniversalRedis2Store, util.F
 
 	dir := util.FullPath(fmt.Sprintf("/redis2_test_%d", time.Now().UnixNano()))
 	t.Cleanup(func() {
-		store.DeleteFolderChildren(ctx, dir)
-		store.DeleteEntry(ctx, dir)
+		if err := store.DeleteFolderChildren(ctx, dir); err != nil {
+			t.Errorf("cleanup %s children: %v", dir, err)
+		}
+		if err := store.DeleteEntry(ctx, dir); err != nil {
+			t.Errorf("cleanup %s: %v", dir, err)
+		}
 	})
 
 	return store, dir
@@ -60,7 +68,7 @@ func listNames(t *testing.T, store *UniversalRedis2Store, dir util.FullPath) []s
 
 	names := []string{}
 	if _, err := store.ListDirectoryEntries(context.Background(), dir, "", true, 100, func(entry *filer.Entry) (bool, error) {
-		_, name := entry.FullPath.DirAndName()
+		_, name := entry.DirAndName()
 		names = append(names, name)
 		return true, nil
 	}); err != nil {
@@ -131,7 +139,11 @@ func TestRemoveOrphanedDirectoryListMemberKeepsDirectoryWithChildren(t *testing.
 			sub := dir.Child("sub")
 			insertTestEntry(t, store, sub, 0)
 			insertTestEntry(t, store, sub.Child("kid"), 0)
-			defer store.DeleteFolderChildren(context.Background(), sub)
+			defer func() {
+				if err := store.DeleteFolderChildren(context.Background(), sub); err != nil {
+					t.Errorf("cleanup %s children: %v", sub, err)
+				}
+			}()
 
 			// evict the directory's own value while its child index is live
 			if err := store.Client.Del(context.Background(), store.getKey(string(sub))).Err(); err != nil {

--- a/weed/filer/redis2/universal_redis_store_test.go
+++ b/weed/filer/redis2/universal_redis_store_test.go
@@ -120,6 +120,22 @@ func TestRemoveOrphanedDirectoryListMemberKeepsRecreatedEntry(t *testing.T) {
 	}
 }
 
+func TestRemoveOrphanedDirectoryListMemberSkipsSuperLargeDirectory(t *testing.T) {
+	store, dir := newTestStore(t, "")
+	store.loadSuperLargeDirectories([]string{string(dir)})
+
+	// a member left from before the directory became super large
+	if err := store.Client.ZAdd(context.Background(), store.getKey(genDirectoryListKey(string(dir))), redis.Z{Score: 0, Member: "legacy"}).Err(); err != nil {
+		t.Fatalf("plant legacy member: %v", err)
+	}
+
+	store.removeOrphanedDirectoryListMember(context.Background(), dir, "legacy")
+
+	if members := indexMembers(t, store, dir); len(members) != 1 || members[0] != "legacy" {
+		t.Fatalf("directory index holds %v, want [legacy] untouched", members)
+	}
+}
+
 func TestListDirectoryEntriesRemovesIndexMembersExpiredByRedis(t *testing.T) {
 	store, dir := newTestStore(t, "")
 

--- a/weed/filer/redis2/universal_redis_store_test.go
+++ b/weed/filer/redis2/universal_redis_store_test.go
@@ -109,7 +109,7 @@ func TestRemoveOrphanedDirectoryListMemberKeepsRecreatedEntry(t *testing.T) {
 	path := dir.Child("recreated")
 	insertTestEntry(t, store, path, 0)
 
-	store.removeOrphanedDirectoryListMember(context.Background(), store.getKey(genDirectoryListKey(string(dir))), path, "recreated")
+	store.removeOrphanedDirectoryListMember(context.Background(), dir, "recreated")
 
 	if members := indexMembers(t, store, dir); len(members) != 1 || members[0] != "recreated" {
 		t.Fatalf("directory index holds %v, want [recreated]", members)

--- a/weed/filer/redis2/universal_redis_store_test.go
+++ b/weed/filer/redis2/universal_redis_store_test.go
@@ -27,18 +27,17 @@ func newTestStore(t *testing.T, keyPrefix string) (*UniversalRedis2Store, util.F
 
 	ctx := context.Background()
 	client := redis.NewClient(&redis.Options{Addr: addr})
+	t.Cleanup(func() { client.Close() })
 	if err := client.Ping(ctx).Err(); err != nil {
 		t.Fatalf("connect to redis at %s: %v", addr, err)
 	}
 
 	store := &UniversalRedis2Store{Client: client, keyPrefix: keyPrefix}
-	store.loadSuperLargeDirectories(nil)
 
 	dir := util.FullPath(fmt.Sprintf("/redis2_test_%d", time.Now().UnixNano()))
 	t.Cleanup(func() {
 		store.DeleteFolderChildren(ctx, dir)
 		store.DeleteEntry(ctx, dir)
-		client.Close()
 	})
 
 	return store, dir
@@ -104,45 +103,53 @@ func TestListDirectoryEntriesRemovesOrphanedIndexMembers(t *testing.T) {
 }
 
 func TestRemoveOrphanedDirectoryListMemberKeepsRecreatedEntry(t *testing.T) {
-	store, dir := newTestStore(t, "")
+	for _, keyPrefix := range []string{"", "sw:"} {
+		t.Run("keyPrefix="+keyPrefix, func(t *testing.T) {
+			store, dir := newTestStore(t, keyPrefix)
 
-	path := dir.Child("recreated")
-	insertTestEntry(t, store, path, 0)
+			path := dir.Child("recreated")
+			insertTestEntry(t, store, path, 0)
 
-	store.removeOrphanedDirectoryListMember(context.Background(), dir, "recreated")
+			store.removeOrphanedDirectoryListMember(context.Background(), dir, "recreated")
 
-	if members := indexMembers(t, store, dir); len(members) != 1 || members[0] != "recreated" {
-		t.Fatalf("directory index holds %v, want [recreated]", members)
-	}
+			if members := indexMembers(t, store, dir); len(members) != 1 || members[0] != "recreated" {
+				t.Fatalf("directory index holds %v, want [recreated]", members)
+			}
 
-	if names := listNames(t, store, dir); len(names) != 1 || names[0] != "recreated" {
-		t.Fatalf("listed %v, want [recreated]", names)
+			if names := listNames(t, store, dir); len(names) != 1 || names[0] != "recreated" {
+				t.Fatalf("listed %v, want [recreated]", names)
+			}
+		})
 	}
 }
 
 func TestRemoveOrphanedDirectoryListMemberKeepsDirectoryWithChildren(t *testing.T) {
-	store, dir := newTestStore(t, "")
+	for _, keyPrefix := range []string{"", "sw:"} {
+		t.Run("keyPrefix="+keyPrefix, func(t *testing.T) {
+			store, dir := newTestStore(t, keyPrefix)
 
-	sub := dir.Child("sub")
-	insertTestEntry(t, store, sub, 0)
-	insertTestEntry(t, store, sub.Child("kid"), 0)
-	defer store.DeleteFolderChildren(context.Background(), sub)
+			sub := dir.Child("sub")
+			insertTestEntry(t, store, sub, 0)
+			insertTestEntry(t, store, sub.Child("kid"), 0)
+			defer store.DeleteFolderChildren(context.Background(), sub)
 
-	// evict the directory's own value while its child index is live
-	if err := store.Client.Del(context.Background(), store.getKey(string(sub))).Err(); err != nil {
-		t.Fatalf("drop value key: %v", err)
-	}
+			// evict the directory's own value while its child index is live
+			if err := store.Client.Del(context.Background(), store.getKey(string(sub))).Err(); err != nil {
+				t.Fatalf("drop value key: %v", err)
+			}
 
-	if names := listNames(t, store, dir); len(names) != 0 {
-		t.Fatalf("listed %v, want none", names)
-	}
+			if names := listNames(t, store, dir); len(names) != 0 {
+				t.Fatalf("listed %v, want none", names)
+			}
 
-	if members := indexMembers(t, store, dir); len(members) != 1 || members[0] != "sub" {
-		t.Fatalf("directory index holds %v, want [sub]", members)
-	}
+			if members := indexMembers(t, store, dir); len(members) != 1 || members[0] != "sub" {
+				t.Fatalf("directory index holds %v, want [sub]", members)
+			}
 
-	if exists, err := store.Client.Exists(context.Background(), store.getKey(string(sub.Child("kid")))).Result(); err != nil || exists != 1 {
-		t.Fatalf("child value key exists=%d err=%v, want it kept", exists, err)
+			if exists, err := store.Client.Exists(context.Background(), store.getKey(string(sub.Child("kid")))).Result(); err != nil || exists != 1 {
+				t.Fatalf("child value key exists=%d err=%v, want it kept", exists, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
# What problem are we solving?

Follow-ups to #10735's `removeOrphanedDirectoryListMember`, from reviewing it in depth. Stacked on that PR — the first two commits here are its commits; review the last five.

Four gaps in the compensation, each its own commit:

1. **The helper's parameters were mutually derivable.** `dirListKey` arrived pre-prefixed while `path` arrived raw and was prefixed inside — a mix-up at a future call site (double prefix, missing prefix) would silently `ZREM` the wrong member. The helper now takes `(ctx, dirPath, fileName)` and derives both keys itself.

2. **Super large directories.** The PR argued the cleanup is unreachable for them because the index key never exists — not true for a directory converted to super large after accumulating members: the legacy ZSET lingers, listings still return its members, and the cleanup would strip them irrecoverably (recreates never re-add, since `InsertEntry` skips the `ZAdd`). The helper now carries the same `isSuperLargeDirectory` guard as `InsertEntry`, `DeleteEntry` and `DeleteFolderChildren`.

3. **The repair was not failure-atomic.** The `ZREM` and the restoring `ZAddNX` ran on the listing request's context, so a client disconnect mid-repair canceled the restore after the removal had landed — permanently de-indexing a live, concurrently recreated entry — and the failed restore was discarded without a log line. The repair now runs on `context.WithoutCancel` and a failed restore is logged.

4. **Directory orphans.** For a member whose value key was lost (eviction, out-of-band `DEL`) but whose own child index still exists, stripping the member detaches a live subtree: nothing can list it or recursively delete it afterwards, and its keys leak forever. Empty ZSETs self-delete, so a present index means children — such a member is now kept, matching the pre-#10735 behavior where the lingering member kept the subtree reachable to `DeleteFolderChildren`.

# How is the PR tested?

Two new gated tests (super large guard, directory with live children), and the recreated-entry test now runs under both key prefixes like the orphan test — with a single-prefix test, a dropped or doubled prefix on the `EXISTS` key passes the whole suite. Harness: the client is closed even when the `PING` fails, and the dead `loadSuperLargeDirectories(nil)` ritual is gone. Full suite passes with `-race` against a live Redis.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Directory listings now automatically remove stale entries left behind after files or directories are deleted.
  * Recreated files and directories are preserved correctly during cleanup.
  * Large directories are handled safely without triggering potentially expensive cleanup operations.
  * Expired Redis entries are excluded from directory listings.

* **Tests**
  * Added coverage for stale-entry cleanup, recreated items, child directories, large directories, key configurations, and expired entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->