### PR TITLE
redis2: expire entries without destroying a concurrent recreate

### DIFF
--- a/weed/filer/redis2/universal_redis_store.go
+++ b/weed/filer/redis2/universal_redis_store.go
@@ -211,12 +211,9 @@ func (store *UniversalRedis2Store) ListDirectoryEntries(ctx context.Context, dir
 			}
 			break
 		} else {
-			if entry.TtlSec > 0 {
-				if entry.Attr.Crtime.Add(time.Duration(entry.TtlSec) * time.Second).Before(time.Now()) {
-					store.Client.Del(ctx, store.getKey(string(path))).Result()
-					store.Client.ZRem(ctx, dirListKey, fileName).Result()
-					continue
-				}
+			if isLogicallyExpired(entry) {
+				store.deleteExpiredEntry(ctx, dirPath, path, fileName)
+				continue
 			}
 
 			resEachEntryFunc, resEachEntryFuncErr := eachEntryFunc(entry)
@@ -266,6 +263,49 @@ func (store *UniversalRedis2Store) removeOrphanedDirectoryListMember(ctx context
 	if err := store.Client.ZAddNX(ctx, dirListKey, redis.Z{Score: 0, Member: fileName}).Err(); err != nil {
 		glog.V(0).InfofCtx(ctx, "restore %s in %s: %v", fileName, dirPath, err)
 	}
+}
+
+func isLogicallyExpired(entry *filer.Entry) bool {
+	return entry.TtlSec > 0 && entry.Attr.Crtime.Add(time.Duration(entry.TtlSec)*time.Second).Before(time.Now())
+}
+
+// deletes the value only when it still holds exactly the bytes the expiry decision was made on;
+// single-key, so it runs on all transports where a multi-key script would be CROSSSLOT
+var deleteIfUnchangedScript = redis.NewScript(`
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+	return redis.call('DEL', KEYS[1])
+end
+return 0`)
+
+func (store *UniversalRedis2Store) deleteExpiredEntry(ctx context.Context, dirPath util.FullPath, path util.FullPath, fileName string) {
+	// survive the listing request being canceled mid-delete
+	ctx = context.WithoutCancel(ctx)
+	valueKey := store.getKey(string(path))
+
+	// re-read so the delete can be conditioned on exactly the bytes checked
+	data, err := store.Client.Get(ctx, valueKey).Bytes()
+	if err == redis.Nil {
+		store.removeOrphanedDirectoryListMember(ctx, dirPath, fileName)
+		return
+	}
+	if err != nil {
+		return
+	}
+
+	entry := &filer.Entry{FullPath: path}
+	if err := entry.DecodeAttributesAndChunks(util.MaybeDecompressData(data)); err != nil {
+		return
+	}
+	if !isLogicallyExpired(entry) {
+		// a concurrent insert recreated it
+		return
+	}
+
+	deleted, err := deleteIfUnchangedScript.Run(ctx, store.Client, []string{valueKey}, data).Int()
+	if err != nil || deleted == 0 {
+		return
+	}
+	store.removeOrphanedDirectoryListMember(ctx, dirPath, fileName)
 }
 
 func genDirectoryListKey(dir string) (dirList string) {

--- a/weed/filer/redis2/universal_redis_store.go
+++ b/weed/filer/redis2/universal_redis_store.go
@@ -270,9 +270,14 @@ func isLogicallyExpired(entry *filer.Entry) bool {
 }
 
 // deletes the value only when it still holds exactly the bytes the expiry decision was made on;
-// single-key, so it runs on all transports where a multi-key script would be CROSSSLOT
+// single-key, so it runs on all transports where a multi-key script would be CROSSSLOT.
+// -1: already gone, 0: changed under us, 1: deleted
 var deleteIfUnchangedScript = redis.NewScript(`
-if redis.call('GET', KEYS[1]) == ARGV[1] then
+local v = redis.call('GET', KEYS[1])
+if v == false then
+	return -1
+end
+if v == ARGV[1] then
 	return redis.call('DEL', KEYS[1])
 end
 return 0`)
@@ -301,6 +306,8 @@ func (store *UniversalRedis2Store) deleteExpiredEntry(ctx context.Context, dirPa
 		return
 	}
 
+	// 0 means a concurrent recreate changed the value: keep it. -1 means the redis
+	// TTL won after the re-read: the member still needs the not-found repair.
 	deleted, err := deleteIfUnchangedScript.Run(ctx, store.Client, []string{valueKey}, data).Int()
 	if err != nil || deleted == 0 {
 		return

--- a/weed/filer/redis2/universal_redis_store_test.go
+++ b/weed/filer/redis2/universal_redis_store_test.go
@@ -277,4 +277,8 @@ func TestDeleteIfUnchangedScriptOnlyDeletesSameBytes(t *testing.T) {
 	if exists, err := store.Client.Exists(context.Background(), key).Result(); err != nil || exists != 0 {
 		t.Fatalf("exists=%d err=%v, want key gone", exists, err)
 	}
+
+	if deleted, err := deleteIfUnchangedScript.Run(context.Background(), store.Client, []string{key}, []byte("v1")).Int(); err != nil || deleted != -1 {
+		t.Fatalf("deleted=%d err=%v, want -1 on a missing key", deleted, err)
+	}
 }

--- a/weed/filer/redis2/universal_redis_store_test.go
+++ b/weed/filer/redis2/universal_redis_store_test.go
@@ -202,3 +202,79 @@ func TestListDirectoryEntriesRemovesIndexMembersExpiredByRedis(t *testing.T) {
 		t.Fatalf("directory index holds %v, want none", members)
 	}
 }
+
+// logically expired (Crtime + TtlSec long past) while the physical key survives,
+// because the redis TTL re-arms from the SET time
+func insertLogicallyExpiredTestEntry(t *testing.T, store *UniversalRedis2Store, path util.FullPath) {
+	t.Helper()
+
+	created := time.Now().Add(-time.Hour)
+	if err := store.InsertEntry(context.Background(), &filer.Entry{
+		FullPath: path,
+		Attr:     filer.Attr{Crtime: created, Mtime: created, Mode: 0644, TtlSec: 60},
+	}); err != nil {
+		t.Fatalf("InsertEntry %s: %v", path, err)
+	}
+}
+
+func TestListDirectoryEntriesDeletesLogicallyExpiredEntries(t *testing.T) {
+	for _, keyPrefix := range []string{"", "sw:"} {
+		t.Run("keyPrefix="+keyPrefix, func(t *testing.T) {
+			store, dir := newTestStore(t, keyPrefix)
+
+			insertLogicallyExpiredTestEntry(t, store, dir.Child("stale"))
+
+			if names := listNames(t, store, dir); len(names) != 0 {
+				t.Fatalf("listed %v, want none", names)
+			}
+
+			if exists, err := store.Client.Exists(context.Background(), store.getKey(string(dir.Child("stale")))).Result(); err != nil || exists != 0 {
+				t.Fatalf("value key exists=%d err=%v, want it deleted", exists, err)
+			}
+
+			if members := indexMembers(t, store, dir); len(members) != 0 {
+				t.Fatalf("directory index holds %v, want none", members)
+			}
+		})
+	}
+}
+
+func TestDeleteExpiredEntryKeepsRecreatedValue(t *testing.T) {
+	store, dir := newTestStore(t, "")
+
+	path := dir.Child("phoenix")
+	insertLogicallyExpiredTestEntry(t, store, path)
+	// a recreate lands after the lister decided to expire the old value
+	insertTestEntry(t, store, path, 0)
+
+	store.deleteExpiredEntry(context.Background(), dir, path, "phoenix")
+
+	if names := listNames(t, store, dir); len(names) != 1 || names[0] != "phoenix" {
+		t.Fatalf("listed %v, want [phoenix]", names)
+	}
+
+	if members := indexMembers(t, store, dir); len(members) != 1 || members[0] != "phoenix" {
+		t.Fatalf("directory index holds %v, want [phoenix]", members)
+	}
+}
+
+func TestDeleteIfUnchangedScriptOnlyDeletesSameBytes(t *testing.T) {
+	store, dir := newTestStore(t, "")
+
+	key := store.getKey(string(dir.Child("guarded")))
+	if err := store.Client.Set(context.Background(), key, "v1", 0).Err(); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	if deleted, err := deleteIfUnchangedScript.Run(context.Background(), store.Client, []string{key}, []byte("v2")).Int(); err != nil || deleted != 0 {
+		t.Fatalf("deleted=%d err=%v, want no delete on changed bytes", deleted, err)
+	}
+
+	if deleted, err := deleteIfUnchangedScript.Run(context.Background(), store.Client, []string{key}, []byte("v1")).Int(); err != nil || deleted != 1 {
+		t.Fatalf("deleted=%d err=%v, want delete on matching bytes", deleted, err)
+	}
+
+	if exists, err := store.Client.Exists(context.Background(), key).Result(); err != nil || exists != 0 {
+		t.Fatalf("exists=%d err=%v, want key gone", exists, err)
+	}
+}


### PR DESCRIPTION
# What problem are we solving?

The pre-existing race #10735 deliberately left open, with a worse outcome than the one it fixed: the logical-expiry branch in `ListDirectoryEntries` does an unconditional `DEL` of the value plus a bare `ZREM` of the member. A concurrent `InsertEntry` landing between the lister's `GET` and that `DEL` loses the freshly written value — not just an index member, the data. Its `ZAddNX` no-ops against the still-present member, so the recreate leaves neither value nor listing.

Stacked on #10743; review the last commit.

# How are we solving the problem?

The multi-key `MULTI`/Lua form is still off the table (`CROSSSLOT` under `redis_cluster2`, the value and index keys carry no hash tag), but the value delete only needs to be atomic against the value key itself, and single-key scripts are cluster-safe. The expiry branch now:

- re-reads the value and re-checks logical expiry on those exact bytes — a recreate that already landed is simply kept;
- deletes through a single-key compare-and-delete script, so the `DEL` fires only if the value still holds the bytes the decision was made on — a recreate that lands mid-flight survives untouched;
- removes the member through `removeOrphanedDirectoryListMember` instead of a bare `ZREM`, which restores the member if an insert races the removal, and reuses the not-found repair when the redis TTL won the race after all.

The expiry predicate moves into `isLogicallyExpired` so the loop and the recheck cannot drift apart. Costs one extra `GET` per expired entry, on the expiry path only.

# How is the PR tested?

Three new gated tests: end-to-end listing of a logically expired entry (value and member both gone, under both key prefixes — deterministic, no sleeps: `Crtime` an hour back with a 60s TTL keeps the physical key alive while logically expired), a recreate racing the expiry decision (value and member both survive), and the compare-and-delete script refusing mismatched bytes. Full suite passes with `-race` against a live Redis.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory listings by removing stale entries when files expire or are deleted.
  * Prevented cleanup from removing files or directories that were recreated or updated concurrently.
  * Preserved directory indexes when child directories or large directory structures require them.
  * Improved handling of entries expired by the storage system or application-level expiration.

* **Tests**
  * Added coverage for expiration, stale entries, concurrent updates, recreated items, and large directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->