### PR TITLE
redis2: orphan cleanup existence checks must not read replicas

### DIFF
--- a/weed/command/scaffold/filer.toml
+++ b/weed/command/scaffold/filer.toml
@@ -285,7 +285,7 @@ ca_cert_path = ""
 client_cert_path = ""
 client_key_path = ""
 # allows reads from slave servers or the master, but all writes still go to the master
-readOnly = false
+useReadOnly = false
 # automatically use the closest Redis server for reads
 routeByLatency = false
 # This changes the data layout. Only add new directories. Removing/Updating will cause data loss.

--- a/weed/filer/redis2/universal_redis_store.go
+++ b/weed/filer/redis2/universal_redis_store.go
@@ -250,11 +250,11 @@ func (store *UniversalRedis2Store) removeOrphanedDirectoryListMember(ctx context
 	// InsertEntry writes the value before adding the member, so a value present
 	// again here may belong to an insert that found the member still in place
 	// and whose ZAddNX was therefore a no-op.
-	exists, err := store.Client.Exists(ctx, store.getKey(string(path))).Result()
+	exists, err := store.existsOnMaster(ctx, store.getKey(string(path)))
 	if err == nil && exists == 0 {
 		// an evicted directory may still have a live child index; empty zsets self-delete,
 		// so a present index holds children a recursive delete still needs to reach
-		children, childrenErr := store.Client.Exists(ctx, store.getKey(genDirectoryListKey(string(path)))).Result()
+		children, childrenErr := store.existsOnMaster(ctx, store.getKey(genDirectoryListKey(string(path))))
 		if childrenErr == nil && children == 0 {
 			return
 		}
@@ -263,6 +263,15 @@ func (store *UniversalRedis2Store) removeOrphanedDirectoryListMember(ctx context
 	if err := store.Client.ZAddNX(ctx, dirListKey, redis.Z{Score: 0, Member: fileName}).Err(); err != nil {
 		glog.V(0).InfofCtx(ctx, "restore %s in %s: %v", fileName, dirPath, err)
 	}
+}
+
+var existsScript = redis.NewScript(`return redis.call('EXISTS', KEYS[1])`)
+
+// replica-routed clients (useReadOnly, routeByLatency) would run a plain EXISTS on a lagging
+// replica and misread a live value as absent, turning the repair destructive; a script always
+// runs on the key's master
+func (store *UniversalRedis2Store) existsOnMaster(ctx context.Context, key string) (int64, error) {
+	return existsScript.Run(ctx, store.Client, []string{key}).Int64()
 }
 
 func isLogicallyExpired(entry *filer.Entry) bool {


### PR DESCRIPTION
# What problem are we solving?

Under `redis_cluster2` with `useReadOnly` or `routeByLatency`, go-redis routes read-flagged commands (`GET`, `EXISTS`) to replicas while writes go to the master. That turns the #10735 cleanup destructive under replica lag: an insert lands on the master, a listing's `GET` hits a replica that has not applied it yet, the not-found branch fires, the `ZREM` removes the live member on the master — and the compensating `EXISTS` asks the same lagging replica, gets 0, and skips the restore. The entry vanishes from every listing until it is re-inserted. Before the cleanup existed, that same stale read cost a transient one-page miss, not a lost index member.

Stacked on #10744; review the last two commits.

# How are we solving the problem?

The repair's two existence checks now run as a single-key `EVAL` (`return redis.call('EXISTS', KEYS[1])`). Scripts may write, so every transport routes them to the key slot's master — the check can no longer be answered from a stale view, and the cleanup stays enabled for replica-read deployments instead of being config-gated off. Single key, so no `CROSSSLOT` concern, and on non-cluster transports it is the same node it always was. Where `EVAL` is unavailable the check errors and the repair keeps the member — the fail-safe direction it already had.

The triggering `GET` itself may still read a lagging replica, but that now converges: the `ZREM` lands on the master, the master-side check sees the value, and the member is restored.

Second commit: the scaffold documented this store's read-routing key as `readOnly`, but the code reads `useReadOnly` — anyone enabling it through the documented key got master-only routing silently.

# How is the PR tested?

The existing gated suite exercises the script path in every repair test and passes with `-race` against a live Redis. Replica lag itself is not reproducible on a single node; the argument above is the go-redis routing rule (scripts never take the replica path).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory listings by removing stale entries while preserving valid entries when directories are recreated or still contain children.
  * Improved expiration handling with race-safe cleanup that prevents newly recreated data from being deleted.
  * Increased reliability for large directories and Redis configurations using different key prefixes.
* **Configuration**
  * Renamed the Redis cluster filer setting from `readOnly` to `useReadOnly`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->