### PR TITLE
ci: run the gated redis store tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -111,6 +111,16 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:8
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v7
@@ -119,6 +129,8 @@ jobs:
       with:
         go-version-file: 'go.mod'
     - name: Test
+      env:
+        RUN_REDIS_TESTS: "1"
       run: cd weed; go test -tags "elastic gocdk sqlite ydb tarantool tikv rclone" -v ./...
 
   test-32bit:

--- a/weed/command/scaffold/filer.toml
+++ b/weed/command/scaffold/filer.toml
@@ -285,7 +285,7 @@ ca_cert_path = ""
 client_cert_path = ""
 client_key_path = ""
 # allows reads from slave servers or the master, but all writes still go to the master
-readOnly = false
+useReadOnly = false
 # automatically use the closest Redis server for reads
 routeByLatency = false
 # This changes the data layout. Only add new directories. Removing/Updating will cause data loss.

--- a/weed/filer/redis2/universal_redis_store.go
+++ b/weed/filer/redis2/universal_redis_store.go
@@ -250,11 +250,11 @@ func (store *UniversalRedis2Store) removeOrphanedDirectoryListMember(ctx context
 	// InsertEntry writes the value before adding the member, so a value present
 	// again here may belong to an insert that found the member still in place
 	// and whose ZAddNX was therefore a no-op.
-	exists, err := store.Client.Exists(ctx, store.getKey(string(path))).Result()
+	exists, err := store.existsOnMaster(ctx, store.getKey(string(path)))
 	if err == nil && exists == 0 {
 		// an evicted directory may still have a live child index; empty zsets self-delete,
 		// so a present index holds children a recursive delete still needs to reach
-		children, childrenErr := store.Client.Exists(ctx, store.getKey(genDirectoryListKey(string(path)))).Result()
+		children, childrenErr := store.existsOnMaster(ctx, store.getKey(genDirectoryListKey(string(path))))
 		if childrenErr == nil && children == 0 {
 			return
 		}
@@ -263,6 +263,15 @@ func (store *UniversalRedis2Store) removeOrphanedDirectoryListMember(ctx context
 	if err := store.Client.ZAddNX(ctx, dirListKey, redis.Z{Score: 0, Member: fileName}).Err(); err != nil {
 		glog.V(0).InfofCtx(ctx, "restore %s in %s: %v", fileName, dirPath, err)
 	}
+}
+
+var existsScript = redis.NewScript(`return redis.call('EXISTS', KEYS[1])`)
+
+// replica-routed clients (useReadOnly, routeByLatency) would run a plain EXISTS on a lagging
+// replica and misread a live value as absent, turning the repair destructive; a script always
+// runs on the key's master
+func (store *UniversalRedis2Store) existsOnMaster(ctx context.Context, key string) (int64, error) {
+	return existsScript.Run(ctx, store.Client, []string{key}).Int64()
 }
 
 func isLogicallyExpired(entry *filer.Entry) bool {

--- a/weed/filer/redis2/universal_redis_store_test.go
+++ b/weed/filer/redis2/universal_redis_store_test.go
@@ -181,10 +181,19 @@ func TestRemoveOrphanedDirectoryListMemberSkipsSuperLargeDirectory(t *testing.T)
 	}
 }
 
+func requireValueKey(t *testing.T, store *UniversalRedis2Store, path util.FullPath) {
+	t.Helper()
+
+	if exists, err := store.Client.Exists(context.Background(), store.getKey(string(path))).Result(); err != nil || exists != 1 {
+		t.Fatalf("value key %s exists=%d err=%v, want it present", path, exists, err)
+	}
+}
+
 func TestListDirectoryEntriesRemovesIndexMembersExpiredByRedis(t *testing.T) {
 	store, dir := newTestStore(t, "")
 
 	insertTestEntry(t, store, dir.Child("ttl"), 1)
+	requireValueKey(t, store, dir.Child("ttl"))
 
 	deadline := time.Now().Add(5 * time.Second)
 	for {
@@ -230,6 +239,7 @@ func TestListDirectoryEntriesDeletesLogicallyExpiredEntries(t *testing.T) {
 			store, dir := newTestStore(t, keyPrefix)
 
 			insertLogicallyExpiredTestEntry(t, store, dir.Child("stale"))
+			requireValueKey(t, store, dir.Child("stale"))
 
 			if names := listNames(t, store, dir); len(names) != 0 {
 				t.Fatalf("listed %v, want none", names)

--- a/weed/filer/redis2/universal_redis_store_test.go
+++ b/weed/filer/redis2/universal_redis_store_test.go
@@ -186,12 +186,19 @@ func TestListDirectoryEntriesRemovesIndexMembersExpiredByRedis(t *testing.T) {
 
 	insertTestEntry(t, store, dir.Child("ttl"), 1)
 
-	time.Sleep(1500 * time.Millisecond)
-
-	if exists, err := store.Client.Exists(context.Background(), store.getKey(string(dir.Child("ttl")))).Result(); err != nil {
-		t.Fatalf("check value key: %v", err)
-	} else if exists != 0 {
-		t.Fatal("redis did not expire the value key, the logical expiry path is not being bypassed")
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		exists, err := store.Client.Exists(context.Background(), store.getKey(string(dir.Child("ttl")))).Result()
+		if err != nil {
+			t.Fatalf("check value key: %v", err)
+		}
+		if exists == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("redis did not expire the value key, the logical expiry path is not being bypassed")
+		}
+		time.Sleep(50 * time.Millisecond)
 	}
 
 	if names := listNames(t, store, dir); len(names) != 0 {


### PR DESCRIPTION
# What problem are we solving?

The regression tests #10735 added — and the ones its follow-ups add — skip in every CI run: nothing sets `RUN_REDIS_TESTS` and no workflow provisions a redis-server, so the coverage for the orphan-cleanup fixes is only real on a developer machine that bothers. The subtle pieces (the compensating restore, the compare-and-delete expiry) can regress silently.

Stacked on #10745; review the last commit.

# How are we solving the problem?

A `redis:8` service container on the main test job with a `redis-cli ping` health gate, and `RUN_REDIS_TESTS=1` on the test step. The gate means the job does not start until Redis accepts connections, so the suites' own `PING` check never races the container. Both the `redis` and `redis2` suites un-skip; everything else is untouched, and developer machines without the env var keep skipping as before.

This PR's own CI run is the proof: the `TestListDirectoryEntries*` / `TestRemoveOrphanedDirectoryListMember*` / `TestDeleteExpiredEntry*` tests appear in the test log instead of the skip lines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory listings by removing stale entries and orphaned index records.
  * Prevented cleanup from deleting recreated entries or directories that still contain children.
  * Improved handling of expired entries, including Redis-managed and logically expired data.
  * Preserved directory indexes during entry-existence checks.

* **Tests**
  * Added Redis integration coverage for expiration cleanup and concurrent updates.
  * Enabled Redis-dependent tests in the automated test workflow.
  * Improved expiration test reliability by waiting for actual expiration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->