### PR TITLE
skiplist: fix TestFindGreaterOrEqual flake (compare against largest key, not value)

### DIFF
--- a/weed/util/skiplist/skiplist_test.go
+++ b/weed/util/skiplist/skiplist_test.go
@@ -295,10 +295,9 @@ func TestFindGreaterOrEqual(t *testing.T) {
 			}
 		} else {
 			lastNode, _ := list.GetLargestNode()
-			lastV := lastNode.GetValue()
-			// It is OK, to fail, as long as f is bigger than the last element.
-			if bytes.Compare(key, lastV) <= 0 {
-				t.Errorf("lastV: %s\n    key: %s\n\n", string(lastV), string(key))
+			// It is OK, to fail, as long as the key is bigger than the largest key.
+			if bytes.Compare(key, lastNode.Key) <= 0 {
+				t.Errorf("largest key: %s\n    key: %s\n\n", string(lastNode.Key), string(key))
 			}
 		}
 	}


### PR DESCRIPTION
`TestFindGreaterOrEqual` occasionally fails with output like:

```
--- FAIL: TestFindGreaterOrEqual (0.04s)
    skiplist_test.go:301: lastV: 9999
            key: 999899
```

When `FindGreaterOrEqual` legitimately finds nothing (the random probe key is lexicographically greater than every key in the list), the test compared the probe key against the largest node's **value** — `Element(i)`, the insertion counter, which has no relation to key order — instead of its **key**. The flake fires when the lexicographically largest node happens to carry value `"9999"` and no `9999xx`-range keys were drawn; with `math/rand/v2` the test is never deterministically seeded, so this occasionally surfaces in CI.

The skiplist itself is fine — `FindGreaterOrEqual` compares on keys. The check now compares the probe against `lastNode.Key`.

Verified with `go test ./weed/util/skiplist/ -count=100`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated skip-list coverage to verify the largest matching key directly.
  * Improved test clarity without changing user-visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->