### PR TITLE
sftp: url-encode the upload path

### DIFF
--- a/weed/sftpd/sftp_filer.go
+++ b/weed/sftpd/sftp_filer.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
 	"strings"
@@ -322,7 +323,8 @@ func (fs *SftpServer) removeDir(absPath string) error {
 
 func (fs *SftpServer) putFile(filepath string, reader io.Reader, user *user.User) error {
 	dir, filename := util.FullPath(filepath).DirAndName()
-	uploadUrl := fmt.Sprintf("http://%s%s", fs.filerAddr, filepath)
+	// Escape the path so a "?" in the filename cannot inject filer query commands like cp.from/mv.from.
+	uploadUrl := (&url.URL{Scheme: "http", Host: fs.filerAddr.ToHttpAddress(), Path: filepath}).String()
 	// Let the global HTTP client normalize the scheme to https:// when TLS is configured
 	normalizedUrl, err := util_http.NormalizeUrl(uploadUrl)
 	if err != nil {

--- a/weed/sftpd/sftp_filer_test.go
+++ b/weed/sftpd/sftp_filer_test.go
@@ -1,0 +1,39 @@
+package sftpd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb"
+)
+
+// TestPutFileEscapesQueryInjection ensures a filename containing "?" cannot be
+// reinterpreted by the filer as a query string that injects cp.from/mv.from
+// commands, which would let an SFTP user escape their home directory.
+func TestPutFileEscapesQueryInjection(t *testing.T) {
+	var gotPath, gotRawQuery string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotRawQuery = r.URL.RawQuery
+		if _, err := w.Write([]byte(`{}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer ts.Close()
+
+	fs := &SftpServer{filerAddr: pb.ServerAddress(strings.TrimPrefix(ts.URL, "http://"))}
+
+	malicious := "/home/alice/steal?cp.from=/home/bob/secret.txt"
+	if err := fs.putFile(malicious, strings.NewReader("dummy"), nil); err != nil {
+		t.Fatalf("putFile: %v", err)
+	}
+
+	if gotRawQuery != "" {
+		t.Errorf("filename leaked into query string: RawQuery=%q", gotRawQuery)
+	}
+	if gotPath != malicious {
+		t.Errorf("path not delivered literally: got %q, want %q", gotPath, malicious)
+	}
+}


### PR DESCRIPTION
### Problem
The SFTP upload handler built the filer upload URL by concatenating the filename directly into the path:

```go
uploadUrl := fmt.Sprintf("http://%s%s", fs.filerAddr, filepath)
```

A filename containing `?` is then parsed by the HTTP client as a query string rather than a literal path segment, so query parameters the filer write handler acts on (`cp.from`, `mv.from`, ...) can be smuggled in through the file name.

### Fix
Build the URL with `url.URL{Path: filepath}` so the path is properly escaped (`?` -> `%3F`, `#` -> `%23`, ...) and always reaches the filer as a literal path.

Added a regression test that uploads a name containing `?` and asserts the filer receives an empty query string.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file uploads for filenames containing query characters such as `?`.
  * Ensured special characters remain part of the filename rather than being interpreted as upload commands or request parameters.
  * Preserved existing upload processing, authorization, and ownership behavior.

* **Tests**
  * Added coverage confirming that filenames are transmitted safely in upload requests without unintended query parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->