### PR TITLE
master: align default volume size with EC rows

### DIFF
--- a/weed/command/master.go
+++ b/weed/command/master.go
@@ -88,7 +88,7 @@ func init() {
 	m.ipBind = cmdMaster.Flag.String("ip.bind", "", "ip address to bind to. If empty, default to same as -ip option.")
 	m.metaFolder = cmdMaster.Flag.String("mdir", os.TempDir(), "data directory to store meta data")
 	m.peers = cmdMaster.Flag.String("peers", "", "all master nodes in comma separated ip:port list, example: 127.0.0.1:9093,127.0.0.1:9094,127.0.0.1:9095; use 'none' for single-master mode")
-	m.volumeSizeLimitMB = cmdMaster.Flag.Uint("volumeSizeLimitMB", 30*1000, "Master stops directing writes to oversized volumes.")
+	m.volumeSizeLimitMB = cmdMaster.Flag.Uint("volumeSizeLimitMB", util.DefaultVolumeSizeLimitMB, "Master stops directing writes to oversized volumes.")
 	m.volumePreallocate = cmdMaster.Flag.Bool("volumePreallocate", false, "Preallocate disk space for volumes.")
 	m.maxParallelVacuumPerServer = cmdMaster.Flag.Int("maxParallelVacuumPerServer", 1, "maximum number of volumes to vacuum in parallel per volume server")
 	// m.pulseSeconds = cmdMaster.Flag.Int("pulseSeconds", 5, "number of seconds between heartbeats")
@@ -160,8 +160,8 @@ func runMaster(cmd *Command, args []string) bool {
 	}
 
 	masterWhiteList := util.StringSplit(*m.whiteList, ",")
-	if *m.volumeSizeLimitMB > util.VolumeSizeLimitGB*1000 {
-		glog.Fatalf("volumeSizeLimitMB should be smaller than 30000")
+	if *m.volumeSizeLimitMB > util.MaxVolumeSizeLimitMB {
+		glog.Fatalf("volumeSizeLimitMB should not exceed %d", util.MaxVolumeSizeLimitMB)
 	}
 
 	switch {

--- a/weed/command/master_test.go
+++ b/weed/command/master_test.go
@@ -4,7 +4,24 @@ import (
 	"testing"
 
 	"github.com/seaweedfs/seaweedfs/weed/pb"
+	"github.com/seaweedfs/seaweedfs/weed/storage/erasure_coding"
+	"github.com/seaweedfs/seaweedfs/weed/util"
 )
+
+func TestDefaultVolumeSizeLimitAlignsWithErasureCodingRows(t *testing.T) {
+	if got := *m.volumeSizeLimitMB; got != util.DefaultVolumeSizeLimitMB {
+		t.Fatalf("master volume size default = %d MiB, want %d MiB", got, util.DefaultVolumeSizeLimitMB)
+	}
+	if got := *masterOptions.volumeSizeLimitMB; got != util.DefaultVolumeSizeLimitMB {
+		t.Fatalf("server master volume size default = %d MiB, want %d MiB", got, util.DefaultVolumeSizeLimitMB)
+	}
+
+	defaultSize := int64(util.DefaultVolumeSizeLimitMB) * util.MiByte
+	largeRowSize := int64(erasure_coding.DataShardsCount) * erasure_coding.ErasureCodingLargeBlockSize
+	if remainder := defaultSize % largeRowSize; remainder != 0 {
+		t.Fatalf("default volume size leaves %d bytes outside complete EC large-block rows", remainder)
+	}
+}
 
 func TestPeerIndexIgnoresGrpcPort(t *testing.T) {
 	self := pb.ServerAddress("127.0.0.1:9000.19000")

--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -1265,8 +1265,8 @@ func runMini(cmd *Command, args []string) bool {
 
 	go stats_collect.StartMetricsServer(*miniMetricsHttpIp, *miniMetricsHttpPort)
 
-	if *miniMasterOptions.volumeSizeLimitMB > util.VolumeSizeLimitGB*1000 {
-		glog.Fatalf("masterVolumeSizeLimitMB should be less than 30000")
+	if *miniMasterOptions.volumeSizeLimitMB > util.MaxVolumeSizeLimitMB {
+		glog.Fatalf("master.volumeSizeLimitMB should not exceed %d", util.MaxVolumeSizeLimitMB)
 	}
 
 	if *miniMasterOptions.metaFolder == "" {

--- a/weed/command/server.go
+++ b/weed/command/server.go
@@ -95,7 +95,7 @@ func init() {
 	masterOptions.portGrpc = cmdServer.Flag.Int("master.port.grpc", 0, "master server grpc listen port")
 	masterOptions.metaFolder = cmdServer.Flag.String("master.dir", "", "data directory to store meta data, default to same as -dir specified")
 	masterOptions.peers = cmdServer.Flag.String("master.peers", "", "all master nodes in comma separated ip:masterPort list")
-	masterOptions.volumeSizeLimitMB = cmdServer.Flag.Uint("master.volumeSizeLimitMB", 30*1000, "Master stops directing writes to oversized volumes.")
+	masterOptions.volumeSizeLimitMB = cmdServer.Flag.Uint("master.volumeSizeLimitMB", util.DefaultVolumeSizeLimitMB, "Master stops directing writes to oversized volumes.")
 	masterOptions.volumePreallocate = cmdServer.Flag.Bool("master.volumePreallocate", false, "Preallocate disk space for volumes.")
 	masterOptions.maxParallelVacuumPerServer = cmdServer.Flag.Int("master.maxParallelVacuumPerServer", 1, "maximum number of volumes to vacuum in parallel on one volume server")
 	masterOptions.defaultReplication = cmdServer.Flag.String("master.defaultReplication", "", "Default replication type if not specified.")
@@ -340,8 +340,8 @@ func runServer(cmd *Command, args []string) bool {
 	*volumeDataFolders = util.ResolveCommaSeparatedPaths(*volumeDataFolders)
 	folders := strings.Split(*volumeDataFolders, ",")
 
-	if *masterOptions.volumeSizeLimitMB > util.VolumeSizeLimitGB*1000 {
-		glog.Fatalf("masterVolumeSizeLimitMB should be less than 30000")
+	if *masterOptions.volumeSizeLimitMB > util.MaxVolumeSizeLimitMB {
+		glog.Fatalf("master.volumeSizeLimitMB should not exceed %d", util.MaxVolumeSizeLimitMB)
 	}
 
 	if *masterOptions.metaFolder == "" {

--- a/weed/util/volume_size.go
+++ b/weed/util/volume_size.go
@@ -1,0 +1,11 @@
+package util
+
+const (
+	// DefaultVolumeSizeLimitMB is 30 GiB expressed in the MiB units used by
+	// volumeSizeLimitMB. This also aligns the default volume size with three
+	// complete 10 GiB erasure-coding data rows.
+	DefaultVolumeSizeLimitMB = 30 * KiByte
+	// MaxVolumeSizeLimitMB expresses VolumeSizeLimitGB in MiB: 30 GiB for
+	// 4-byte offsets and 8,000 GiB for 5-byte offsets.
+	MaxVolumeSizeLimitMB = VolumeSizeLimitGB * KiByte
+)


### PR DESCRIPTION
# What problem are we solving?

  Fixes #10673.

  The default `volumeSizeLimitMB` is 30,000 MiB (29.3 GiB), while erasure coding stores complete rows in 10 GiB units: 10 data shards × 1 GiB blocks.

  This produces two complete large-block rows followed by a 9,520 MiB small-block region. Consequently, about 31.7% of a default-sized volume uses 1 MiB EC blocks, causing objects larger than 1 MiB in that region
  to require reads from multiple shards.

# How are we solving the problem?

  Change the default volume limit to 30,720 MiB, which is exactly 30 GiB and three complete EC data rows.

  The change:

  - Introduces shared default and maximum volume-size constants expressed in MiB.
  - Uses the aligned default for both `weed master` and `weed server`.
  - Updates master, server, and mini validation to use the binary-unit maximum.
  - Adds a regression test verifying that both defaults align with complete EC large-block rows.

  The EC fullness threshold is unchanged because it controls eligibility for encoding rather than the size at which actively written volumes seal.

  # How is the PR tested?

  ```console
  go test ./weed/util ./weed/storage/erasure_coding ./weed/command
  go test -tags 5BytesOffset ./weed/command \
    -run TestDefaultVolumeSizeLimitAlignsWithErasureCodingRows \
    -count=1

  Both test runs pass.

# Checks

  - [x] I have added unit tests if possible.
  - [ ] I will add related wiki document changes and link to this PR after merging. (No documentation changes appear necessary.)
  - [ ] All AI code review comments have been addressed. No AI review comments have been received yet.

# Checks for AI generated PRs

  - [ ] I have reviewed every line of code. <!-- Check after your review. -->
  - [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized default volume size limits across server components.
  * Enforced a consistent maximum volume size limit with clearer validation messages.
  * Ensured the default volume size aligns with erasure-coding requirements.
  * Added shared size-limit configuration for consistent behavior across deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->