### PR TITLE
ec.decode: finish the cleanup an interrupted decode left behind

### DIFF
--- a/weed/ec/ec_decode.go
+++ b/weed/ec/ec_decode.go
@@ -35,6 +35,29 @@ func DoEcDecode(env *Env, topoInfo *master_pb.TopologyInfo, collection string, v
 		return fmt.Errorf("no EC shards found for volume %d", vid)
 	}
 
+	// A decode interrupted while deleting the shards leaves the regenerated
+	// volume in place with the set half gone, so a re-run finds both and fails
+	// re-collecting the first shard the interrupted run removed.
+	//
+	// Finding a volume beside the shards is not enough to act on: an encode
+	// interrupted before it deleted the original leaves the same shape, as does
+	// a decode killed while generating, whose volume may be half written. Both
+	// of those leave the shard set COMPLETE. Only the deletion phase can remove
+	// a data shard, so require one to be gone -- that is also exactly the state
+	// no decode can recover from, which makes finishing the cleanup the only
+	// move left rather than a choice between two.
+	if _, found := missingDataShard(nodeToEcShardsInfo, dataShards); found {
+		holder, hasVolume := regularVolumeHolder(topoInfo, vid)
+		if !hasVolume {
+			return fmt.Errorf("volume %d cannot be decoded: data shards are missing and no decoded volume exists to finish", vid)
+		}
+		if err := verifyDecodedVolumeBeforeDelete(env.GrpcDialOption, holder, vid); err != nil {
+			return fmt.Errorf("volume %d is already decoded on %s but did not verify, keeping its ec shards: %v", vid, holder, err)
+		}
+		fmt.Printf("volume %d is already decoded on %s; deleting the ec shards the interrupted run left behind\n", vid, holder)
+		return unmountAndDeleteEcShardsWithPrefix("deleteDecodedEcShards", env.GrpcDialOption, collection, nodeToEcShardsInfo, vid)
+	}
+
 	var originalShardCounts map[pb.ServerAddress]int
 	if diskUsageState != nil {
 		originalShardCounts = make(map[pb.ServerAddress]int, len(nodeToEcShardsInfo))
@@ -143,6 +166,48 @@ func unmountAndDeleteEcShardsWithPrefix(prefix string, grpcDialOption grpc.DialO
 		})
 	}
 	return ewg.Wait()
+}
+
+// missingDataShard reports the first data shard absent from every holder.
+// Parity shards are not enough to answer this: the decode rebuilds the volume
+// from the data shards, so one of those going missing is what makes a re-run
+// impossible.
+func missingDataShard(nodeToShardsInfo map[pb.ServerAddress]*erasure_coding.ShardsInfo, dataShards int) (erasure_coding.ShardId, bool) {
+	var present erasure_coding.ShardBits
+	for _, si := range nodeToShardsInfo {
+		for _, id := range si.Ids() {
+			present = present.Set(id)
+		}
+	}
+	for id := 0; id < dataShards; id++ {
+		if !present.Has(erasure_coding.ShardId(id)) {
+			return erasure_coding.ShardId(id), true
+		}
+	}
+	return 0, false
+}
+
+// regularVolumeHolder returns a server already serving vid as a regular
+// volume. A decode only finds one when an earlier run was interrupted between
+// regenerating the volume and deleting the shards it came from.
+func regularVolumeHolder(topoInfo *master_pb.TopologyInfo, vid needle.VolumeId) (pb.ServerAddress, bool) {
+	var holder pb.ServerAddress
+	found := false
+	EachDataNode(topoInfo, func(dc DataCenterId, rack RackId, dn *master_pb.DataNodeInfo) {
+		if found {
+			return
+		}
+		for _, diskInfo := range dn.DiskInfos {
+			for _, vi := range diskInfo.VolumeInfos {
+				if needle.VolumeId(vi.Id) == vid {
+					holder = pb.NewServerAddressFromDataNode(dn)
+					found = true
+					return
+				}
+			}
+		}
+	})
+	return holder, found
 }
 
 func verifyDecodedVolumeBeforeDelete(grpcDialOption grpc.DialOption, target pb.ServerAddress, vid needle.VolumeId) error {

--- a/weed/ec/ec_decode_test.go
+++ b/weed/ec/ec_decode_test.go
@@ -1,0 +1,91 @@
+package ec
+
+import (
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb"
+	"github.com/seaweedfs/seaweedfs/weed/storage/erasure_coding"
+)
+
+// shardsOn builds one holder's inventory.
+func shardsOn(ids ...int) *erasure_coding.ShardsInfo {
+	si := erasure_coding.NewShardsInfo()
+	for _, id := range ids {
+		si.Set(erasure_coding.NewShardInfo(erasure_coding.ShardId(id), 1024))
+	}
+	return si
+}
+
+// missingDataShard decides whether a decode may delete the shards of a volume
+// that already exists elsewhere. Only the deletion phase of a decode removes a
+// data shard, so the answer separates "an earlier decode was interrupted while
+// cleaning up" from the two states that look the same from the outside: an
+// encode interrupted before it deleted the original, and a decode killed while
+// generating. Both of those leave every shard in place, and the volume beside
+// them may be the untouched original or a half-written one -- neither is safe
+// to trade for the shards.
+func TestMissingDataShard(t *testing.T) {
+	const dataShards = 10
+
+	tests := []struct {
+		name       string
+		holders    map[pb.ServerAddress]*erasure_coding.ShardsInfo
+		wantID     erasure_coding.ShardId
+		wantMissed bool
+	}{
+		{
+			name: "complete set on one holder decodes, so nothing is finished",
+			holders: map[pb.ServerAddress]*erasure_coding.ShardsInfo{
+				"server1:8080": shardsOn(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13),
+			},
+		},
+		{
+			name: "complete set spread across holders is still complete",
+			holders: map[pb.ServerAddress]*erasure_coding.ShardsInfo{
+				"server1:8080": shardsOn(0, 1, 2, 3, 4),
+				"server2:8080": shardsOn(5, 6, 7, 8, 9),
+				"server3:8080": shardsOn(10, 11, 12, 13),
+			},
+		},
+		{
+			name: "parity gone is not the deletion phase: the volume still decodes",
+			holders: map[pb.ServerAddress]*erasure_coding.ShardsInfo{
+				"server1:8080": shardsOn(0, 1, 2, 3, 4, 5, 6, 7, 8, 9),
+			},
+		},
+		{
+			name: "a data shard gone is a decode that was interrupted mid-cleanup",
+			holders: map[pb.ServerAddress]*erasure_coding.ShardsInfo{
+				"server1:8080": shardsOn(0, 1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13),
+			},
+			wantID:     6,
+			wantMissed: true,
+		},
+		{
+			name: "the first gap is reported, not the last",
+			holders: map[pb.ServerAddress]*erasure_coding.ShardsInfo{
+				"server1:8080": shardsOn(0, 3, 4, 5, 6, 7, 8, 9),
+			},
+			wantID:     1,
+			wantMissed: true,
+		},
+		{
+			name:       "no holders at all leaves every data shard missing",
+			holders:    map[pb.ServerAddress]*erasure_coding.ShardsInfo{},
+			wantID:     0,
+			wantMissed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, missed := missingDataShard(tt.holders, dataShards)
+			if missed != tt.wantMissed {
+				t.Fatalf("missingDataShard = %v, want %v", missed, tt.wantMissed)
+			}
+			if missed && id != tt.wantID {
+				t.Errorf("missing shard id = %d, want %d", id, tt.wantID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## The failure

`TestECInterruptionMatrix/decode@unmountecvolume` fails intermittently on master:

```
    Error Trace: test/erasure_coding/chaos_lifecycle_test.go:603
    Error:       Received unexpected error:
                 generate normal volume 3 on 127.0.0.1:8112: rpc error: code = Unknown desc = ec volume 3 missing shard 6
    Messages:    recovery ec.decode volume 3 after interruption
--- FAIL: TestECInterruptionMatrix/decode@unmountecvolume
```

Seen on an unrelated PR's run: https://github.com/seaweedfs/seaweedfs/actions/runs/31898145161/job/95044539363

## Why

`DoEcDecode` deletes the shards last, only once the regenerated volume is mounted and verified:

    collect shards -> generate volume -> mount -> verify -> delete shards

That ordering is right — it never destroys the shards before a working volume exists — but a run interrupted in the final phase leaves the volume **in place** with its shards partway through deletion. The subtest kills the decode exactly there.

The re-run then finds both and takes the only path it has: collect the shards again to rebuild a volume that already exists. It fails on the first shard the interrupted run had removed, and no retry can do better — the shard set is deliberately being destroyed, while the decoded volume sits there already complete. That is why the harness's restart-not-resume recovery cannot converge.

## The change

Recognise that state and finish the interrupted cleanup instead of redoing the decode.

The condition matters more than it first looks. A volume sitting beside its shards is **not** enough to act on, because two other interruptions leave the same shape:

| state | volume | shards |
|---|---|---|
| decode killed while deleting shards | complete | **partially deleted** |
| encode killed before deleting the original | complete (the original) | complete |
| decode killed while generating | **possibly half written** | complete |

Deleting the shards is only correct in the first. In the third it would trade a complete shard set for a volume that may be truncated — `verifyDecodedVolumeBeforeDelete` proves the files are non-empty, not that they are whole, which is fine as the last gate in a run that just wrote the volume itself but far too weak as an entry condition for a run that did not.

So the gate is a **missing data shard**, not merely an existing volume. Only the deletion phase removes one; both ambiguous states leave the set complete and now fall through to the normal decode path untouched. It is also self-limiting: a missing data shard is precisely the state no decode can recover from, so finishing the cleanup is the only move left rather than a choice between two valid ones. The deletion still runs behind `verifyDecodedVolumeBeforeDelete`, and when data shards are gone with no decoded volume to finish, the error now says that plainly instead of failing later inside `generate`.

This also makes `ec.decode` idempotent for the operator: re-running it after an interruption converges instead of erroring on a volume that is already decoded.

## Test

`TestMissingDataShard` pins the discriminator, including the case that makes it safe — only parity missing must **not** trigger the cleanup — and that a complete set spread across several holders is still complete.

`TestECInterruptionMatrix` passes 9/9. With the earlier, looser gate the new path fired on exactly the failing scenario:

```
volume 3 is already decoded on 127.0.0.1:8112; deleting the ec shards the interrupted run left behind
--- PASS: TestECInterruptionMatrix/decode@unmountecvolume
```

The failure is intermittent by nature — it needs the kill to land after at least one shard deletion — so a pristine run can pass, and one of mine did. The evidence is the CI failure above plus that path firing on precisely the state it describes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery after an interrupted erasure-coded volume decode.
  * Detects when a valid regular volume has been created and removes leftover shards automatically.
  * Verifies that the recovered volume contains required data and index files before cleanup.
  * Preserves shards and reports an error when verification fails or required data is missing, preventing unsafe data removal.
  * Correctly distinguishes recoverable parity loss from unrecoverable missing data shards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->