### PR TITLE
iceberg maintenance: fix the test build master merged broken

### DIFF
--- a/weed/worker/tasks/iceberg/table_config_test.go
+++ b/weed/worker/tasks/iceberg/table_config_test.go
@@ -388,7 +388,7 @@ func TestResolveCompactionRewritePlanAuto(t *testing.T) {
 	cfg := baseTestConfig()
 	cfg.RewriteStrategy = rewriteStrategyAuto
 
-	unsorted := buildTestMetadata(t, nil)
+	unsorted := buildTestMetadata(t, nil, nil, 0)
 	plan, err := resolveCompactionRewritePlan(cfg, unsorted)
 	if err != nil {
 		t.Fatalf("auto must not fail on an unsorted table: %v", err)


### PR DESCRIPTION
`go vet ./weed/...` and `go test ./weed/worker/tasks/iceberg/` fail on master as of 5f6dd4d:

```
vet: weed/worker/tasks/iceberg/table_config_test.go:391:38: not enough arguments in call to buildTestMetadata
	have (*testing.T, nil)
	want (*testing.T, []table.Snapshot, map[string]table.SnapshotRef, time.Duration)
```

#10774 gave `buildTestMetadata` its `refs` and `age` parameters; #10773 added a caller with the old arity. Both were green against a master that did not have the other, and merging them in sequence produced a combination neither run compiled. One call site, `nil, 0`.

This is blocking every open PR: #10775, #10776 and #10777 all report Go Vet / Test / Go Vet 32-bit / Test 32-bit failures that are only this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated an unsorted-table test fixture to match the current test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->