### PR TITLE
filer: do not sweep children when deleting a folder non-recursively

### DIFF
--- a/weed/filer/filer_delete_entry.go
+++ b/weed/filer/filer_delete_entry.go
@@ -78,7 +78,8 @@ func (f *Filer) doBatchDeleteFolderMetaAndData(ctx context.Context, entry *Entry
 	var chunksToDelete []*filer_pb.FileChunk
 	lastFileName := ""
 	includeLastFile := false
-	if !isDeletingBucket || !f.Store.CanDropWholeBucket() {
+	listedChildren := !isDeletingBucket || !f.Store.CanDropWholeBucket()
+	if listedChildren {
 		for {
 			entries, _, err := f.ListDirectoryEntries(ctx, entry.FullPath, lastFileName, includeLastFile, PaginationSize, "", "", "")
 			if err != nil {
@@ -131,8 +132,12 @@ func (f *Filer) doBatchDeleteFolderMetaAndData(ctx context.Context, entry *Entry
 
 	glog.V(3).InfofCtx(ctx, "deleting directory %v delete chunks: %v", entry.FullPath, shouldDeleteChunks)
 
-	if storeDeletionErr := f.Store.DeleteFolderChildren(ctx, entry.FullPath); storeDeletionErr != nil {
-		return fmt.Errorf("filer store delete: %w", storeDeletionErr)
+	// a non-recursive delete already proved the folder empty above, so sweeping the
+	// children now can only remove entries that raced in after that listing
+	if isRecursive || !listedChildren {
+		if storeDeletionErr := f.Store.DeleteFolderChildren(ctx, entry.FullPath); storeDeletionErr != nil {
+			return fmt.Errorf("filer store delete: %w", storeDeletionErr)
+		}
 	}
 
 	f.NotifyUpdateEvent(ctx, entry, nil, shouldDeleteChunks, isFromOtherCluster, signatures)

--- a/weed/filer/leveldb2/empty_folder_race_test.go
+++ b/weed/filer/leveldb2/empty_folder_race_test.go
@@ -2,11 +2,13 @@ package leveldb
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 
 	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/pb"
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/util"
 )
 
@@ -64,5 +66,13 @@ func TestNonRecursiveFolderDeleteKeepsRacingChild(t *testing.T) {
 
 	if _, err := testFiler.FindEntry(ctx, child); err != nil {
 		t.Errorf("entry created during the folder delete was removed: %v", err)
+	}
+
+	// The folder entry itself still goes, so the surviving entry is reachable by
+	// path but absent from listings until the folder comes back. Pinning that here
+	// keeps the remaining exposure visible; tighten it if the two steps ever become
+	// atomic.
+	if _, err := testFiler.FindEntry(ctx, dir); !errors.Is(err, filer_pb.ErrNotFound) {
+		t.Errorf("folder entry should still be removed, got %v", err)
 	}
 }

--- a/weed/filer/leveldb2/empty_folder_race_test.go
+++ b/weed/filer/leveldb2/empty_folder_race_test.go
@@ -1,0 +1,68 @@
+package leveldb
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/filer"
+	"github.com/seaweedfs/seaweedfs/weed/pb"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+)
+
+// listHookStore runs a hook once, right after a directory listing returns, so a
+// test can act inside the window between a delete's emptiness check and the
+// removal of the folder.
+type listHookStore struct {
+	filer.FilerStore
+	hook  func()
+	fired bool
+}
+
+func (s *listHookStore) ListDirectoryPrefixedEntries(ctx context.Context, dirPath util.FullPath, startFileName string, includeStartFile bool, limit int64, prefix string, eachEntryFunc filer.ListEachEntryFunc) (string, error) {
+	lastFileName, err := s.FilerStore.ListDirectoryPrefixedEntries(ctx, dirPath, startFileName, includeStartFile, limit, prefix, eachEntryFunc)
+	if s.hook != nil && !s.fired {
+		s.fired = true
+		s.hook()
+	}
+	return lastFileName, err
+}
+
+// TestNonRecursiveFolderDeleteKeepsRacingChild covers the S3 empty-folder
+// cleanup path: the delete lists a folder, finds it empty, and must not then
+// bulk-delete its children, because an object written in between would be
+// destroyed after the write was already acknowledged.
+func TestNonRecursiveFolderDeleteKeepsRacingChild(t *testing.T) {
+	testFiler := filer.NewFiler(pb.ServerDiscovery{}, nil, "", "", "", "", "", 255, nil)
+	store := &LevelDB2Store{}
+	if err := store.initialize(t.TempDir(), 2); err != nil {
+		t.Fatal(err)
+	}
+	hooked := &listHookStore{FilerStore: store}
+	testFiler.SetStore(hooked)
+
+	// the test has no metadata log consumer
+	ctx := filer.WithSuppressedMetadataEvents(context.Background())
+	dir := util.FullPath("/buckets/testbucket/data/abc")
+	child := dir.Child("obj")
+
+	dirEntry := &filer.Entry{FullPath: dir, Attr: filer.Attr{Mode: os.ModeDir | 0755}}
+	if err := testFiler.CreateEntry(ctx, dirEntry, nil, false, false, nil, false, testFiler.MaxFilenameLength); err != nil {
+		t.Fatalf("create folder: %v", err)
+	}
+
+	hooked.hook = func() {
+		entry := &filer.Entry{FullPath: child, Attr: filer.Attr{Mode: 0640}}
+		if err := testFiler.CreateEntry(ctx, entry, nil, false, false, nil, false, testFiler.MaxFilenameLength); err != nil {
+			t.Errorf("create entry racing the folder delete: %v", err)
+		}
+	}
+
+	if err := testFiler.DeleteEntryMetaAndData(ctx, dir, false, false, false, false, nil, 0); err != nil {
+		t.Fatalf("delete empty folder: %v", err)
+	}
+
+	if _, err := testFiler.FindEntry(ctx, child); err != nil {
+		t.Errorf("entry created during the folder delete was removed: %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #10779

`doBatchDeleteFolderMetaAndData` lists a folder's children and returns `fail to delete non-empty folder` if it finds any, then calls `Store.DeleteFolderChildren` unconditionally. On the non-recursive path that bulk sweep has nothing legitimate to remove — it is only reached once the listing came back empty, so the only rows it can possibly delete are ones inserted after the check.

The S3 empty-folder cleaner deletes through exactly this path. An object written between the listing and the sweep loses its entry after the write was already acknowledged, and the failure is silent on both sides: the client has its 200, and the cleaner logs an ordinary `deleting empty folder`. The chunks leak too, because the cleaner passes `shouldDeleteChunks=false` and the empty listing collected nothing, so the needles stay on the volume unreferenced until someone runs `volume.fsck`.

The window is reachable on any workload that shards object keys over a small fixed set of shallow prefixes. A layout like `<prefix>/<3 chars>/<random>` spreads objects uniformly across a few thousand folders, so once the live object count drops below the folder count, nearly every delete empties a folder and nearly every write revives one that has been idle long enough to be queued for cleanup. The set of folders pending deletion and the set about to be written are then the same set, and a single run can log tens of thousands of folder deletions, each carrying the window.

ClickHouse hit exactly this in their stateless CI. Their S3 disk generates keys as `<prefix>/[a-z]{3}/[a-z]{29}`, and one job logged 34,819 folder deletions at a peak of 3,238/min. The symptom is `Object <key> in bucket <bucket> suddenly disappeared`, raised by `s3_check_objects_after_upload` doing a HEAD immediately after upload. They worked around it in ClickHouse/ClickHouse#114660 by pushing `empty_folder_cleanup_delay` out to 24h.

That workaround does not fix the bug. The delay changes how often the deletion runs, not what it does when it runs, so a long delay defers the problem rather than removing it.

The `.uploads` guard added in #10273 covered one subtree where this first surfaced. The window is not specific to multipart staging — every object folder has it.

## Fix

Sweep only when the delete is recursive, or when the whole-bucket shortcut skipped the listing and relies on the sweep to drop the table.

## Reproduction

A stress harness driving the cleaner's exact call against a concurrent writer, on a real `Filer` over leveldb2, destroyed 33 entries out of 105,521 creates across 7,554 folder deletions. End to end over S3 against a stock `weed server` in that CI's configuration, 9 objects were destroyed out of 456,762 PUTs, each loss matching a `deleting empty folder` line for that same folder in the same second. With this change the same harness reports 0 losses over 291,628 creates and 13,243 folder deletions.

The test added here is the deterministic form of that: it hooks the store listing to create an entry inside the window, then asserts the entry survives the folder delete. It fails on master and passes with the fix. It also pins what this change does *not* fix — the folder entry is still removed, so the surviving entry is reachable by path but absent from listings.

## Follow-up

That remaining exposure is handled in #10783, stacked on this branch: the cleaner records the folders it deleted each pass and restores any that turn out to hold entries. Closing it inside this function instead would need the emptiness check and the entry delete to be atomic, which is per-store — one statement on SQL, a Lua script on redis, but not expressible on leveldb2, where children hash by `md5(dir)` and the directory entry by `md5(parent)` into different partitions.

https://claude.ai/code/session_01HdLXMUopwgofPb1ZEmiE6r