### PR TITLE
Fix what the Go 1.26 language bump breaks

### DIFF
--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -1473,7 +1473,7 @@ func startMiniService(name string, fn func(), port int) {
 // waitForServiceReady pings the service HTTP endpoint to check if it's ready
 // to accept connections, and reports the transition to the progress board.
 func waitForServiceReady(name string, port int, bindIp string) {
-	address := fmt.Sprintf("http://%s:%d", bindIp, port)
+	address := "http://" + util.JoinHostPort(bindIp, port)
 	healthAddr := getHealthCheckAddr(address)
 	maxAttempts := 30 // 30 * 200ms = 6 seconds max wait
 	attempt := 0
@@ -1595,7 +1595,7 @@ func startMiniAdminWithWorker(allServicesReady chan struct{}) {
 	}()
 
 	// Wait for admin server's HTTP port to be ready before launching worker
-	adminAddr := fmt.Sprintf("http://%s:%d", bindIp, *miniAdminOptions.port)
+	adminAddr := "http://" + util.JoinHostPort(bindIp, *miniAdminOptions.port)
 	if err := waitForAdminServerReady(ctx, adminAddr); err != nil {
 		// If the parent context was cancelled (e.g. a previous in-process
 		// mini run is being torn down), bail out gracefully instead of
@@ -1900,7 +1900,7 @@ func printWelcomeMessage() {
 // Best-effort: any error returns ok=false so the welcome banner simply omits
 // the lines.
 func miniVolumeCounts() (max, free int64, ok bool) {
-	url := getHealthCheckAddr(fmt.Sprintf("http://%s:%d/dir/status", *miniIp, *miniMasterOptions.port))
+	url := getHealthCheckAddr("http://" + util.JoinHostPort(*miniIp, *miniMasterOptions.port) + "/dir/status")
 	client := &http.Client{Timeout: 2 * time.Second}
 	resp, err := client.Get(url)
 	if err != nil {

--- a/weed/s3api/auto_signature_v4_test.go
+++ b/weed/s3api/auto_signature_v4_test.go
@@ -423,6 +423,7 @@ func TestSignatureV4WithoutProxy(t *testing.T) {
 	tests := []struct {
 		name         string
 		host         string
+		urlHost      string // request-URL form of host, when host is not valid in a URL
 		proto        string
 		expectedHost string
 	}{
@@ -489,12 +490,14 @@ func TestSignatureV4WithoutProxy(t *testing.T) {
 		{
 			name:         "IPv6 HTTP without port",
 			host:         "::1",
+			urlHost:      "[::1]",
 			proto:        "http",
 			expectedHost: "::1",
 		},
 		{
 			name:         "IPv6 HTTPS without port",
 			host:         "::1",
+			urlHost:      "[::1]",
 			proto:        "https",
 			expectedHost: "::1",
 		},
@@ -504,11 +507,19 @@ func TestSignatureV4WithoutProxy(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			iam := newTestIAM()
 
+			// A bare IPv6 literal is legal in a Host header but not in a URL, so the
+			// two forms are carried separately.
+			urlHost := tt.urlHost
+			if urlHost == "" {
+				urlHost = tt.host
+			}
+
 			// Create a request
-			r, err := newTestRequest("GET", tt.proto+"://"+tt.host+"/test-bucket/test-object", 0, nil)
+			r, err := newTestRequest("GET", tt.proto+"://"+urlHost+"/test-bucket/test-object", 0, nil)
 			if err != nil {
 				t.Fatalf("Failed to create test request: %v", err)
 			}
+			r.Host = tt.host
 
 			// Set the mux variables manually since we're not going through the actual router
 			r = mux.SetURLVars(r, map[string]string{

--- a/weed/worker/tasks/balance/balance_task.go
+++ b/weed/worker/tasks/balance/balance_task.go
@@ -81,7 +81,7 @@ func (t *BalanceTask) Execute(ctx context.Context, params *worker_pb.TaskParams)
 		IoBytePerSecond: balanceParams.IoBytePerSecond,
 		Progress: func(percent float64, stage string) {
 			t.ReportProgress(percent)
-			t.GetLogger().Info(stage)
+			t.GetLogger().Info("move stage: %s", stage)
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
Dependabot's etcd 3.7.1 bump (#10789) also drags the go.mod `go` directive from 1.25.8 to 1.26, and that flips CI onto the Go 1.26 language version. Three latent problems fall out of it. All three are fine on master today and only bite once the directive moves, so they land ahead of the bump rather than inside it.

**vet: non-constant format string.** Go 1.26's printf analyzer follows printf wrappers reached through an interface, so `Logger.Info(stage)` in the balance task is now a diagnostic. This is what breaks the build of `weed/worker/tasks/balance` in CI.

**net/url: bare IPv6 literals.** Go 1.26 defaults `urlstrictcolons` on, so `http://::1/…` no longer parses. `TestSignatureV4WithoutProxy` built its request URL out of the Host-header value, which for the two "IPv6 without port" cases is a bare `::1`. The Host header is the only place that form is legal, so the test now carries the two spellings separately and sets `r.Host` to what the client would have signed — which also makes the case test what it always claimed to, since the code under test reads `r.Host`, not the header the test was setting.

**mini refuses to start on an IPv6-only host.** Same `urlstrictcolons` change, but in production code. `-ip` defaults to `util.DetectedHostAddress()`, which returns a bare IPv6 literal, and three readiness probes pasted it into a URL with `%s:%d`. The admin-server wait is the bad one: every attempt fails to parse, and after 240 of them mini hits `glog.Fatalf`. `util.JoinHostPort` is the helper that already gets this right everywhere else.

Verified with the directive set to 1.26 locally: `go vet ./...` clean on amd64 and 386, and `weed/s3api`, `weed/worker/...`, `weed/command/...` all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP health-check and master status URL handling for IPv4, IPv6, and other host/port formats.
  * Corrected IPv6 URL handling during S3 signature verification.
* **Logging**
  * Made balance operation progress logs clearer by labeling the current move stage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->