### PR TITLE
go 1.26

### DIFF
--- a/.github/workflows/ec-integration-tests.yml
+++ b/.github/workflows/ec-integration-tests.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v7
       with:
-        go-version: ^1.25
+        go-version: ^1.26
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/kafka-quicktest.yml
+++ b/.github/workflows/kafka-quicktest.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v7
       with:
-        go-version: ^1.25
+        go-version: ^1.26
         cache: true
         cache-dependency-path: |
           **/go.sum

--- a/.github/workflows/kafka-tests.yml
+++ b/.github/workflows/kafka-tests.yml
@@ -43,7 +43,7 @@ jobs:
       matrix:
         container-id: [unit-tests-1]
     container:
-      image: golang:1.24-alpine
+      image: golang:1.26-alpine
       options: --cpus 1.0 --memory 1g --hostname kafka-unit-${{ matrix.container-id }}
     env:
       GOMAXPROCS: 1
@@ -53,7 +53,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v7
       with:
-        go-version: ^1.25
+        go-version: ^1.26
       id: go
 
     - name: Check out code
@@ -87,7 +87,7 @@ jobs:
       matrix:
         container-id: [integration-1]
     container:
-      image: golang:1.24-alpine
+      image: golang:1.26-alpine
       options: --cpus 2.0 --memory 2g --ulimit nofile=1024:1024 --hostname kafka-integration-${{ matrix.container-id }}
     env:
       GOMAXPROCS: 2
@@ -98,7 +98,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v7
       with:
-        go-version: ^1.25
+        go-version: ^1.26
       id: go
 
     - name: Check out code
@@ -134,7 +134,7 @@ jobs:
       matrix:
         container-id: [e2e-1]
     container:
-      image: golang:1.24-alpine
+      image: golang:1.26-alpine
       options: --cpus 2.0 --memory 2g --hostname kafka-e2e-${{ matrix.container-id }}
     env:
       GOMAXPROCS: 2
@@ -148,7 +148,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v7
       with:
-        go-version: ^1.25
+        go-version: ^1.26
         cache: true
         cache-dependency-path: |
           **/go.sum
@@ -313,7 +313,7 @@ jobs:
       matrix:
         container-id: [consumer-group-1]
     container:
-      image: golang:1.24-alpine
+      image: golang:1.26-alpine
       options: --cpus 1.0 --memory 2g --ulimit nofile=512:512 --hostname kafka-consumer-${{ matrix.container-id }}
     env:
       GOMAXPROCS: 1
@@ -327,7 +327,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v7
       with:
-        go-version: ^1.25
+        go-version: ^1.26
         cache: true
         cache-dependency-path: |
           **/go.sum
@@ -475,7 +475,7 @@ jobs:
       matrix:
         container-id: [client-compat-1]
     container:
-      image: golang:1.24-alpine
+      image: golang:1.26-alpine
       options: --cpus 1.0 --memory 1.5g --shm-size 256m --hostname kafka-client-${{ matrix.container-id }}
     env:
       GOMAXPROCS: 1
@@ -489,7 +489,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v7
       with:
-        go-version: ^1.25
+        go-version: ^1.26
         cache: true
         cache-dependency-path: |
           **/go.sum
@@ -633,7 +633,7 @@ jobs:
       matrix:
         container-id: [smq-integration-1]
     container:
-      image: golang:1.24-alpine
+      image: golang:1.26-alpine
       options: --cpus 1.0 --memory 2g --hostname kafka-smq-${{ matrix.container-id }}
     env:
       GOMAXPROCS: 1
@@ -647,7 +647,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v7
       with:
-        go-version: ^1.25
+        go-version: ^1.26
         cache: true
         cache-dependency-path: |
           **/go.sum
@@ -794,7 +794,7 @@ jobs:
       matrix:
         container-id: [protocol-1]
     container:
-      image: golang:1.24-alpine
+      image: golang:1.26-alpine
       options: --cpus 1.0 --memory 1g --tmpfs /tmp:exec --hostname kafka-protocol-${{ matrix.container-id }}
     env:
       GOMAXPROCS: 1
@@ -805,7 +805,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v7
       with:
-        go-version: ^1.25
+        go-version: ^1.26
       id: go
 
     - name: Check out code

--- a/.github/workflows/postgres-tests.yml
+++ b/.github/workflows/postgres-tests.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v7
       with:
-        go-version: ^1.25
+        go-version: ^1.26
       id: go
 
     - name: Check out code

--- a/.github/workflows/s3-parquet-tests.yml
+++ b/.github/workflows/s3-parquet-tests.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: ^1.25
+          go-version: ^1.26
           cache: true
       
       - name: Set up Python ${{ matrix.python-version }}
@@ -148,7 +148,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: ^1.25
+          go-version: ^1.26
           cache: true
       
       - name: Run Go unit tests

--- a/.github/workflows/test-s3-over-https-using-awscli.yml
+++ b/.github/workflows/test-s3-over-https-using-awscli.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: ^1.25
+          go-version: ^1.26
 
       - name: Build SeaweedFS
         run: |

--- a/.github/workflows/tls-rotation-tests.yml
+++ b/.github/workflows/tls-rotation-tests.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v7
       with:
-        go-version: ^1.25
+        go-version: ^1.26
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/vacuum-integration-tests.yml
+++ b/.github/workflows/vacuum-integration-tests.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v7
       with:
-        go-version: ^1.25
+        go-version: ^1.26
       id: go
 
     - name: Check out code into the Go module directory

--- a/docker/Dockerfile.foundationdb_large
+++ b/docker/Dockerfile.foundationdb_large
@@ -1,4 +1,4 @@
-FROM golang:1.25 AS builder
+FROM golang:1.26 AS builder
 
 RUN apt-get update && \
     apt-get install -y build-essential wget ca-certificates && \

--- a/docker/Dockerfile.go_build
+++ b/docker/Dockerfile.go_build
@@ -1,6 +1,6 @@
 # Pin the builder to the host arch and cross-compile the (CGO-free) Go binary,
 # so arm64/arm/386 targets skip QEMU emulation of the whole compile.
-FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
 RUN apk add git g++ fuse
 RUN mkdir -p /go/src/github.com/seaweedfs/
 ARG BRANCH=${BRANCH:-master}

--- a/docker/Dockerfile.rocksdb_dev_env
+++ b/docker/Dockerfile.rocksdb_dev_env
@@ -1,4 +1,4 @@
-FROM golang:1.25 AS builder
+FROM golang:1.26 AS builder
 
 RUN apt-get update
 RUN apt-get install -y build-essential libsnappy-dev zlib1g-dev libbz2-dev libgflags-dev liblz4-dev libzstd-dev

--- a/docker/Dockerfile.rocksdb_large
+++ b/docker/Dockerfile.rocksdb_large
@@ -1,4 +1,4 @@
-FROM golang:1.25 AS builder
+FROM golang:1.26 AS builder
 
 RUN apt-get update
 RUN apt-get install -y build-essential libsnappy-dev zlib1g-dev libbz2-dev libgflags-dev liblz4-dev libzstd-dev

--- a/seaweedfs-rdma-sidecar/Dockerfile.sidecar
+++ b/seaweedfs-rdma-sidecar/Dockerfile.sidecar
@@ -1,5 +1,5 @@
 # Multi-stage build for Go Sidecar
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git ca-certificates tzdata

--- a/seaweedfs-rdma-sidecar/Dockerfile.test-client
+++ b/seaweedfs-rdma-sidecar/Dockerfile.test-client
@@ -1,5 +1,5 @@
 # Multi-stage build for Test Client
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git ca-certificates tzdata

--- a/seaweedfs-rdma-sidecar/README.md
+++ b/seaweedfs-rdma-sidecar/README.md
@@ -61,7 +61,7 @@ This project implements a **high-performance RDMA (Remote Direct Memory Access) 
 
 ```bash
 # Required dependencies
-- Go 1.23+
+- Go 1.26+
 - Rust 1.70+
 - UCX libraries (for hardware RDMA)
 - Linux with RDMA-capable hardware (InfiniBand/RoCE)

--- a/telemetry/server/Dockerfile
+++ b/telemetry/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /app
 

--- a/test/foundationdb/Dockerfile.build
+++ b/test/foundationdb/Dockerfile.build
@@ -1,6 +1,6 @@
 # Simplified single-stage build for SeaweedFS with FoundationDB support
 # Force x86_64 platform to use AMD64 FoundationDB packages
-FROM --platform=linux/amd64 golang:1.25-bookworm
+FROM --platform=linux/amd64 golang:1.26-bookworm
 
 ARG FOUNDATIONDB_VERSION=7.4.5
 ENV FOUNDATIONDB_VERSION=${FOUNDATIONDB_VERSION}
@@ -43,7 +43,7 @@ WORKDIR /build
 # Copy source code
 COPY . .
 
-# Using Go 1.24 to match project requirements
+# Using Go 1.26 to match project requirements
 
 # Download dependencies (using versions from go.mod for deterministic builds)
 RUN go mod download

--- a/test/foundationdb/Dockerfile.build.arm64
+++ b/test/foundationdb/Dockerfile.build.arm64
@@ -1,5 +1,5 @@
 # Multi-stage Dockerfile to build SeaweedFS with FoundationDB support for ARM64
-FROM --platform=linux/arm64 golang:1.25-bookworm AS builder
+FROM --platform=linux/arm64 golang:1.26-bookworm AS builder
 
 ARG FOUNDATIONDB_VERSION=7.4.5
 ENV FOUNDATIONDB_VERSION=${FOUNDATIONDB_VERSION}

--- a/test/foundationdb/Dockerfile.test
+++ b/test/foundationdb/Dockerfile.test
@@ -1,5 +1,5 @@
 # Test environment with Go and FoundationDB support
-FROM golang:1.25-bookworm
+FROM golang:1.26-bookworm
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \

--- a/test/fuse_integration/Makefile
+++ b/test/fuse_integration/Makefile
@@ -2,7 +2,7 @@
 
 # Configuration
 WEED_BINARY := weed
-GO_VERSION := 1.24
+GO_VERSION := 1.26
 TEST_TIMEOUT := 30m
 COVERAGE_FILE := coverage.out
 

--- a/test/fuse_integration/README.md
+++ b/test/fuse_integration/README.md
@@ -216,7 +216,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.24'
+        go-version: '1.26'
     
     - name: Install FUSE
       run: sudo apt-get install -y fuse
@@ -232,7 +232,7 @@ jobs:
 
 ### Docker Testing
 ```dockerfile
-FROM golang:1.24
+FROM golang:1.26
 RUN apt-get update && apt-get install -y fuse
 COPY . /seaweedfs
 WORKDIR /seaweedfs

--- a/test/kafka/Dockerfile.kafka-gateway
+++ b/test/kafka/Dockerfile.kafka-gateway
@@ -1,5 +1,5 @@
 # Dockerfile for Kafka Gateway Integration Testing
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git make gcc musl-dev sqlite-dev

--- a/test/kafka/Dockerfile.seaweedfs
+++ b/test/kafka/Dockerfile.seaweedfs
@@ -1,5 +1,5 @@
 # Dockerfile for building SeaweedFS components from the current workspace
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 RUN apk add --no-cache git make gcc musl-dev sqlite-dev
 

--- a/test/kafka/Dockerfile.test-setup
+++ b/test/kafka/Dockerfile.test-setup
@@ -1,5 +1,5 @@
 # Dockerfile for Kafka Integration Test Setup
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git make gcc musl-dev

--- a/test/kafka/kafka-client-loadtest/Dockerfile.loadtest
+++ b/test/kafka/kafka-client-loadtest/Dockerfile.loadtest
@@ -2,7 +2,7 @@
 # Multi-stage build for cross-platform support
 
 # Stage 1: Builder
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /app
 

--- a/test/kafka/kafka-client-loadtest/README.md
+++ b/test/kafka/kafka-client-loadtest/README.md
@@ -314,7 +314,7 @@ make dev-env
 # Build load test binary
 make build
 
-# Run tests locally (requires Go 1.21+)
+# Run tests locally (requires Go 1.26+)
 cd cmd/loadtest && go run main.go -config ../../config/loadtest.yaml
 ```
 

--- a/test/postgres/Dockerfile.client
+++ b/test/postgres/Dockerfile.client
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 # Set working directory
 WORKDIR /app

--- a/test/postgres/Dockerfile.producer
+++ b/test/postgres/Dockerfile.producer
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 # Set working directory
 WORKDIR /app

--- a/test/postgres/Dockerfile.seaweedfs
+++ b/test/postgres/Dockerfile.seaweedfs
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 # Install git and other build dependencies
 RUN apk add --no-cache git make

--- a/test/s3/iam/Dockerfile.s3
+++ b/test/s3/iam/Dockerfile.s3
@@ -1,5 +1,5 @@
 # Multi-stage build for SeaweedFS S3 with IAM
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git make curl wget

--- a/test/s3/iam/README.md
+++ b/test/s3/iam/README.md
@@ -83,7 +83,7 @@ The S3 IAM integration tests validate the complete end-to-end functionality of:
 
 ### Prerequisites
 
-1. **Go 1.19+** with modules enabled
+1. **Go 1.26+** with modules enabled
 2. **SeaweedFS Binary** (`weed`) built with IAM support
 3. **Test Dependencies**:
    ```bash
@@ -425,7 +425,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version-file: 'go.mod'
       
       - name: Build SeaweedFS
         run: go build -o weed ./main.go


### PR DESCRIPTION
The etcd client v3 3.7.1 bump in #10789 moves the go.mod directive from 1.25.8
to 1.26. Every builder image we pin is still `golang:1.25`/`1.24`, and the
official Go images set `GOTOOLCHAIN=local`, so they cannot pick up a newer
toolchain on their own:

    go: go.mod requires go >= 1.26 (running go 1.25.13; GOTOOLCHAIN=local)

That is what fails the PostgreSQL Gateway Tests on #10789
(https://github.com/seaweedfs/seaweedfs/actions/runs/32072598094/job/95518885757),
and it would fail every other containerized job the same way once the directive
lands.

Same sweep as the earlier `go 1.25` bump (3d9f7f6f8), plus the spots it missed:
the `container: image: golang:1.24-alpine` jobs in kafka-tests.yml, the
test/postgres and telemetry/server Dockerfiles, tls-rotation and
vacuum-integration, and test/fuse_integration's GO_VERSION.

Language-level fallout from the same directive flip was handled separately in #10794.

Verified against #10789's go.mod: `go mod download` fails on `golang:1.25-alpine`
and succeeds on `golang:1.26-alpine` (go1.26.6).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded build, test, and development environments to Go 1.26.
  * Updated automated integration, compatibility, and end-to-end test workflows to run with Go 1.26.
  * Updated containerized testing and service build environments to use Go 1.26 base images.
  * Refreshed testing documentation and configuration to reference Go 1.26.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->