### PR TITLE
mount: drop consumed entries when reading a directory through

### DIFF
--- a/weed/mount/weedfs_dir_read.go
+++ b/weed/mount/weedfs_dir_read.go
@@ -53,6 +53,26 @@ func (dh *DirectoryHandle) reset() {
 	dh.entryStreamOffset = directoryStreamBaseOffset
 }
 
+// dropConsumed releases the entries the client has already walked past.
+// Offsets are indexes into the stream from entryStreamOffset, so advancing the
+// two together keeps them lined up; one entry is kept back because the next
+// batch resumes from the name immediately before the offset.
+func (dh *DirectoryHandle) dropConsumed(offset uint64) {
+	if offset < dh.entryStreamOffset {
+		return
+	}
+	trim := int(offset-dh.entryStreamOffset) - 1
+	if trim <= 0 || trim > len(dh.entryStream) {
+		return
+	}
+	copy(dh.entryStream, dh.entryStream[trim:])
+	for i := len(dh.entryStream) - trim; i < len(dh.entryStream); i++ {
+		dh.entryStream[i] = nil
+	}
+	dh.entryStream = dh.entryStream[:len(dh.entryStream)-trim]
+	dh.entryStreamOffset += uint64(trim)
+}
+
 type DirectoryHandleToInode struct {
 	sync.Mutex
 	dir2inode map[DirectoryHandleId]*DirectoryHandle
@@ -251,25 +271,17 @@ func (wfs *WFS) doReadDirectory(input *fuse.ReadIn, out DirEntrySink, isPlusMode
 
 	var lastEntryName string
 
+	// Both the cached and the direct walk page through the same stream, and a
+	// directory read through is precisely one too big to hold, so drop the
+	// consumed head before either of them appends to it.
+	dh.dropConsumed(input.Offset)
+
 	if wfs.inodeToPath.ShouldReadDirectoryDirect(dirPath) {
 		return wfs.readDirectoryDirect(input, out, dh, dirPath, processEachEntryFn)
 	}
 
 	// Read from cache first, then load next batch if needed
 	if input.Offset >= dh.entryStreamOffset {
-		// Drop what the client has walked past. Offsets are indexes into the
-		// stream from entryStreamOffset, so advancing the two together keeps
-		// them lined up; one entry is kept back because the next batch resumes
-		// from the name immediately before the offset.
-		if trim := int(input.Offset-dh.entryStreamOffset) - 1; trim > 0 && trim <= len(dh.entryStream) {
-			copy(dh.entryStream, dh.entryStream[trim:])
-			for i := len(dh.entryStream) - trim; i < len(dh.entryStream); i++ {
-				dh.entryStream[i] = nil
-			}
-			dh.entryStream = dh.entryStream[:len(dh.entryStream)-trim]
-			dh.entryStreamOffset += uint64(trim)
-		}
-
 		// Handle case: new handle with non-zero offset but empty cache
 		// This happens when NFS-Ganesha opens multiple directory handles
 		if len(dh.entryStream) == 0 && input.Offset > dh.entryStreamOffset {

--- a/weed/mount/weedfs_dir_read_pagination_test.go
+++ b/weed/mount/weedfs_dir_read_pagination_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/mount/meta_cache"
 	"github.com/seaweedfs/seaweedfs/weed/pb"
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/util"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -240,6 +241,97 @@ func TestReadDirTrimsConsumedEntries(t *testing.T) {
 		}
 	}
 	// Without trimming the handle ends up holding every entry.
+	if peak >= total {
+		t.Errorf("handle held %d entries at peak, want well under the %d in the directory", peak, total)
+	}
+}
+
+// listingFilerServer serves a fixed, sorted child list the way the filer
+// paginates one.
+type listingFilerServer struct {
+	filer_pb.UnimplementedSeaweedFilerServer
+	names []string
+}
+
+func (s *listingFilerServer) ListEntries(req *filer_pb.ListEntriesRequest, stream filer_pb.SeaweedFiler_ListEntriesServer) error {
+	var sent uint32
+	for _, name := range s.names {
+		if name < req.StartFromFileName || (name == req.StartFromFileName && !req.InclusiveStartFrom) {
+			continue
+		}
+		if req.Limit > 0 && sent >= req.Limit {
+			break
+		}
+		if err := stream.Send(&filer_pb.ListEntriesResponse{Entry: &filer_pb.Entry{
+			Name:       name,
+			Attributes: &filer_pb.FuseAttributes{FileMode: 0o644, FileSize: 1},
+		}}); err != nil {
+			return err
+		}
+		sent++
+	}
+	return nil
+}
+
+// TestReadDirDirectTrimsConsumedEntries is the same check for a directory read
+// through to the filer. That path is taken precisely for directories too big to
+// cache, so holding the whole walk in the handle is where a listing turns into
+// gigabytes of resident memory.
+func TestReadDirDirectTrimsConsumedEntries(t *testing.T) {
+	dir := util.FullPath("/d")
+	const total = 5000
+	var names []string
+	for i := 0; i < total; i++ {
+		names = append(names, fmt.Sprintf("f%05d", i))
+	}
+	wfs := newPagingWFS(t, dir, nil, 0)
+	startFakeFiler(t, wfs, &listingFilerServer{names: names})
+	dirInode, _ := wfs.inodeToPath.GetInode(dir)
+	if !wfs.inodeToPath.MarkDirectoryReadThrough(dir, time.Now()) {
+		t.Fatal("directory did not enter read-through mode")
+	}
+
+	dhid, dh := wfs.AcquireDirectoryHandle()
+	defer wfs.ReleaseDirectoryHandle(dhid)
+
+	sink := &pagingSink{limit: 64}
+	var offset uint64
+	var seen []string
+	peak := 0
+	for round := 0; round < 500; round++ {
+		sink.round = 0
+		before := len(sink.names)
+		status := wfs.doReadDirectory(&fuse.ReadIn{
+			InHeader: fuse.InHeader{NodeId: dirInode},
+			Fh:       uint64(dhid),
+			Offset:   offset,
+			Size:     1 << 20,
+		}, sink, false)
+		if status != fuse.OK {
+			t.Fatalf("readdir: %v", status)
+		}
+		if n := len(dh.entryStream); n > peak {
+			peak = n
+		}
+		if len(sink.names) == before || sink.lastOff <= offset {
+			break
+		}
+		offset = sink.lastOff
+	}
+	for _, n := range sink.names {
+		if n != "." && n != ".." {
+			seen = append(seen, n)
+		}
+	}
+
+	if len(seen) != total {
+		t.Fatalf("listed %d entries, want %d", len(seen), total)
+	}
+	for i, name := range seen {
+		if want := fmt.Sprintf("f%05d", i); name != want {
+			t.Fatalf("entry %d is %q, want %q -- trimming misaligned the offsets", i, name, want)
+		}
+	}
 	if peak >= total {
 		t.Errorf("handle held %d entries at peak, want well under the %d in the directory", peak, total)
 	}

--- a/weed/mount/weedfs_invalidate_open_handle_test.go
+++ b/weed/mount/weedfs_invalidate_open_handle_test.go
@@ -156,7 +156,7 @@ func (s *fakeFilerServer) UpdateEntry(ctx context.Context, req *filer_pb.UpdateE
 }
 
 // startFakeFiler serves fake on a local port and points wfs at it.
-func startFakeFiler(t *testing.T, wfs *WFS, fake *fakeFilerServer) {
+func startFakeFiler(t *testing.T, wfs *WFS, fake filer_pb.SeaweedFilerServer) {
 	t.Helper()
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {


### PR DESCRIPTION
A mount serving a very large directory grows to many GB of resident memory. From the profile in #10020 (comment), ~7.2GB of the 8.3GB heap is live under `loadDirectoryEntriesDirect`:

```
2484.91MB 29.92%  filer.FromPbEntry
2315.28MB 27.88%  reflect.mapassign_faststr0
1208.11MB 14.55%  util.FullPath.Child
 ...
   0.50MB          mount.loadDirectoryEntriesDirect   (cum 7192.31MB)
  52.95MB          mount.(*WFS).readDirectoryDirect   (cum 8148.24MB)
```

Those entries are still reachable because `readDirectoryDirect` appends every batch to `dh.entryStream` and never releases the part the client has already walked past. The cached path does trim it, and has a regression test for it; the read-through path added in #10631 did not, so a directory with more than `cacheDirMaxEntries` children -- the only kind that takes that path -- is held whole in the directory handle until the client closes it. Each retained `filer.Entry` also pins the decoded protobuf entry behind it, which is where the `mapassign`/`FromPbEntry` bytes come from.

The trim is hoisted out of the cached branch into `dh.dropConsumed`, called once before either path runs, so both page through the stream with a bounded handle. Offsets index into the stream from `entryStreamOffset`, so the two advance together and one entry is kept back for the resume-by-name.

The new test walks a 5000-child read-through directory 64 entries at a time and checks both that the names come back once and in order, and that the handle never holds the whole directory. It fails on master at "handle held 5000 entries at peak".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory pagination by removing entries already delivered while retaining the necessary prior entry for reliable continuation.
  * Ensured directory listings remain complete and correctly ordered across paginated reads.
  * Reduced peak memory usage during directory traversal.

* **Tests**
  * Added end-to-end coverage for streaming directory reads and pagination behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Measured

87k-child directory, `-cacheDirMaxEntries=100` to force the read-through path, one cold `find` per mount, live heap sampled with a forced GC throughout the walk (so nothing is garbage, only what the handle still holds):

| | live heap, idle | live heap, peak during walk | `readDirectoryDirect` cum |
|---|---|---|---|
| master (3cf7d306a) | 37MB | 108MB | 69.05MB (61% of heap) |
| this PR | 37MB | 67MB | 15.12MB (25%) |

On master the profile reproduces the reporter's top frames exactly -- `loadDirectoryEntriesDirect` cum 51.52MB, `filer.FromPbEntry` 41.02MB flat. With the fix `loadDirectoryEntriesDirect` drops out of the profile entirely; what is left under readdir is `FullPath.Child` and `InodeToPath.Lookup`, the inode table taking a lookup ref per child, which is inherent to ReadDirPlus and released on FORGET.
