### PR TITLE
filer: keep generated inodes in signed 64-bit range

### DIFF
--- a/weed/filer/filer_inode.go
+++ b/weed/filer/filer_inode.go
@@ -1,6 +1,7 @@
 package filer
 
 import (
+	"math"
 	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/util"
@@ -19,7 +20,10 @@ func (f *Filer) ensureEntryInode(entry *Entry) {
 		entry.Attr.Crtime = time.Now()
 	}
 	if len(entry.HardLinkId) > 0 {
-		entry.Attr.Inode = uint64(util.HashStringToLong(string(entry.HardLinkId)))
+		entry.Attr.Inode = uint64(util.HashStringToLong(string(entry.HardLinkId))) & uint64(math.MaxInt64)
+		if entry.Attr.Inode == 0 {
+			entry.Attr.Inode = 1
+		}
 		return
 	}
 	entry.Attr.Inode = entry.FullPath.AsInode(entry.Attr.Crtime.Unix())

--- a/weed/filer/filer_inode_test.go
+++ b/weed/filer/filer_inode_test.go
@@ -2,6 +2,7 @@ package filer
 
 import (
 	"context"
+	"math"
 	"os"
 	"testing"
 	"time"
@@ -49,8 +50,22 @@ func TestEnsureEntryInodeSharesAcrossHardLinks(t *testing.T) {
 
 	// Every link to the same target resolves to one inode, independent of path
 	// or creation time.
-	assert.Equal(t, uint64(util.HashStringToLong(string(hardLinkId))), a.Attr.Inode)
+	assert.Equal(t, uint64(util.HashStringToLong(string(hardLinkId)))&uint64(math.MaxInt64), a.Attr.Inode)
 	assert.Equal(t, a.Attr.Inode, b.Attr.Inode)
+}
+
+func TestEnsureEntryInodeFitsSignedLong(t *testing.T) {
+	f := &Filer{}
+	entries := []*Entry{
+		{FullPath: util.FullPath("/topics/.system/log/2026-08-18/07-24.741c9e0e"), Attr: Attr{Crtime: time.Unix(1787038150, 0)}},
+		{FullPath: util.FullPath("/hard-link"), Attr: Attr{Crtime: time.Unix(1787038150, 0)}, HardLinkId: HardLinkId{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}},
+	}
+
+	for _, entry := range entries {
+		f.ensureEntryInode(entry)
+		require.NotZero(t, entry.Attr.Inode)
+		require.LessOrEqual(t, entry.Attr.Inode, uint64(math.MaxInt64))
+	}
 }
 
 func newTestFilerWithStubStore() (*Filer, *stubFilerStore) {

--- a/weed/filer/filer_inode_test.go
+++ b/weed/filer/filer_inode_test.go
@@ -50,7 +50,11 @@ func TestEnsureEntryInodeSharesAcrossHardLinks(t *testing.T) {
 
 	// Every link to the same target resolves to one inode, independent of path
 	// or creation time.
-	assert.Equal(t, uint64(util.HashStringToLong(string(hardLinkId)))&uint64(math.MaxInt64), a.Attr.Inode)
+	expectedInode := uint64(util.HashStringToLong(string(hardLinkId))) & uint64(math.MaxInt64)
+	if expectedInode == 0 {
+		expectedInode = 1
+	}
+	assert.Equal(t, expectedInode, a.Attr.Inode)
 	assert.Equal(t, a.Attr.Inode, b.Attr.Inode)
 }
 

--- a/weed/util/fullpath.go
+++ b/weed/util/fullpath.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"math"
 	"path"
 	"path/filepath"
 	"strings"
@@ -92,6 +93,12 @@ func (fp FullPath) Child(name string) FullPath {
 func (fp FullPath) AsInode(unixTime int64) uint64 {
 	inode := uint64(HashStringToLong(string(fp)))
 	inode = inode + uint64(unixTime)*37
+	// Inodes are persisted by metadata stores such as Elasticsearch, whose
+	// integer type is a signed 64-bit long. Keep generated values in that range.
+	inode &= uint64(math.MaxInt64)
+	if inode == 0 {
+		return 1
+	}
 	return inode
 }
 


### PR DESCRIPTION
## What changed

- Keep path-based and hard-link inode values within the positive signed 64-bit range.
- Reserve zero by converting the rare zero result to one.
- Add regression coverage for both inode generation paths.

## Why

SeaweedFS exposes inodes as `uint64`, but generated values are persisted by metadata stores whose integer fields commonly use signed 64-bit values. A generated inode with the high bit set cannot be encoded into an Elasticsearch `long`, causing metadata writes to fail for affected paths or hard links.

Masking generated values to `math.MaxInt64` keeps them compatible with signed 64-bit stores while preserving deterministic inode generation and hard-link identity.

## Validation

```text
go test ./weed/filer -run 'TestEnsureEntryInode(SharesAcrossHardLinks|FitsSignedLong)$' -count=1
```

Fixes #10806


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inode generation for files and hard links to keep values within signed 64-bit limits.
  * Prevented invalid zero inode values by assigning a safe fallback.
  * Added coverage for edge-case identifiers, paths, and hard-linked entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->