### PR TITLE
filer: reduce forwarded lock log noise

### DIFF
--- a/weed/server/filer_grpc_server_dlm.go
+++ b/weed/server/filer_grpc_server_dlm.go
@@ -30,7 +30,7 @@ func (fs *FilerServer) DistributedLock(ctx context.Context, req *filer_pb.LockRe
 		req.Name, resp.LockOwner, resp.RenewToken, movedTo, err)
 	glog.V(4).Infof("lock %s %v %v %v, isMoved=%v %v", req.Name, req.SecondsToLock, req.RenewToken, req.Owner, req.IsMoved, movedTo)
 	if movedTo != "" && movedTo != fs.option.Host && !req.IsMoved {
-		glog.V(0).Infof("FILER LOCK: Forwarding to correct filer - from=%s to=%s", fs.option.Host, movedTo)
+		glog.V(3).Infof("FILER LOCK: Forwarding to correct filer - from=%s to=%s", fs.option.Host, movedTo)
 		err = pb.WithFilerClient(false, 0, movedTo, fs.grpcDialOption, func(client filer_pb.SeaweedFilerClient) error {
 			secondResp, err := client.DistributedLock(ctx, &filer_pb.LockRequest{
 				Name:          req.Name,
@@ -44,7 +44,9 @@ func (fs *FilerServer) DistributedLock(ctx context.Context, req *filer_pb.LockRe
 				resp.LockOwner = secondResp.LockOwner
 				resp.Error = secondResp.Error
 				resp.Generation = secondResp.Generation
-				glog.V(0).Infof("FILER LOCK: Forwarded lock acquired - name=%s renewToken=%s", req.Name, resp.RenewToken)
+				if forwardedLockAcquired(secondResp) {
+					glog.V(3).Infof("FILER LOCK: Forwarded lock acquired - name=%s renewToken=%s", req.Name, resp.RenewToken)
+				}
 			} else {
 				glog.V(0).Infof("FILER LOCK: Forward failed - name=%s err=%v", req.Name, err)
 			}
@@ -66,6 +68,10 @@ func (fs *FilerServer) DistributedLock(ctx context.Context, req *filer_pb.LockRe
 		req.Name, resp.RenewToken, resp.LockOwner, resp.Error, resp.LockHostMovedTo)
 
 	return resp, nil
+}
+
+func forwardedLockAcquired(resp *filer_pb.LockResponse) bool {
+	return resp != nil && resp.Error == "" && resp.RenewToken != ""
 }
 
 // Unlock is a grpc handler to handle FilerServer's UnlockRequest

--- a/weed/server/filer_grpc_server_dlm_test.go
+++ b/weed/server/filer_grpc_server_dlm_test.go
@@ -34,3 +34,22 @@ func TestFindLockOwnerExpiredLockReturnsNotFound(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, codes.NotFound, st.Code())
 }
+
+func TestForwardedLockAcquired(t *testing.T) {
+	tests := []struct {
+		name string
+		resp *filer_pb.LockResponse
+		want bool
+	}{
+		{name: "nil response"},
+		{name: "empty token", resp: &filer_pb.LockResponse{}},
+		{name: "application error", resp: &filer_pb.LockResponse{RenewToken: "token", Error: "lock already owned"}},
+		{name: "acquired", resp: &filer_pb.LockResponse{RenewToken: "token"}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, forwardedLockAcquired(tt.resp))
+		})
+	}
+}


### PR DESCRIPTION
## What changed

- Move routine distributed-lock forwarding and acquisition messages from `V(0)` to `V(3)`.
- Log a forwarded lock as acquired only when the response has no application error and includes a renewal token.
- Add regression coverage for successful, rejected, empty, and nil forwarded responses.

## Why

Normal lock forwarding can happen frequently in a multi-filer deployment. Logging every forwarding attempt and successful acquisition at the default level creates sustained log noise. In addition, a successful gRPC call can still carry an application-level lock error, so treating every non-transport-error response as an acquired lock is misleading.

Transport failures remain visible at the default log level.

## Validation

```text
go test ./weed/server -run 'Test(ForwardedLockAcquired|FindLockOwnerExpiredLockReturnsNotFound)$' -count=1
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced routine distributed-lock logging to minimize unnecessary log noise.
  * Successful lock-forwarding messages now appear only when a valid lock renewal token is returned.

* **Tests**
  * Added coverage for successful and unsuccessful lock-forwarding responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->