### PR TITLE
filer: let a remote mount skip delete propagation

### DIFF
--- a/weed/filer/filer_lazy_remote.go
+++ b/weed/filer/filer_lazy_remote.go
@@ -126,6 +126,11 @@ func (f *Filer) maybeDeleteFromRemote(ctx context.Context, entry *Entry) (bool, 
 		return false, nil
 	}
 
+	if remoteLoc.SkipRemoteDelete {
+		glog.V(3).InfofCtx(ctx, "maybeDeleteFromRemote: mount %s skips remote delete, removing %s locally only", mountDir, entry.FullPath)
+		return false, nil
+	}
+
 	client, _, found := f.RemoteStorage.GetRemoteStorageClient(remoteLoc.Name)
 	if !found {
 		return false, fmt.Errorf("resolve remote storage client for %s: not found", entry.FullPath)

--- a/weed/filer/filer_lazy_remote_test.go
+++ b/weed/filer/filer_lazy_remote_test.go
@@ -793,6 +793,78 @@ func TestDeleteEntryMetaAndData_DirectoryUnderMountDeletesRemoteDirectory(t *tes
 	require.ErrorIs(t, findErr, filer_pb.ErrNotFound)
 }
 
+func TestDeleteEntryMetaAndData_SkipRemoteDeleteRemovesMetadataOnly(t *testing.T) {
+	const storageType = "stub_lazy_skip_remote_delete"
+	stub := &stubRemoteClient{deleteErr: errors.New("remote delete must not be attempted")}
+	defer registerStubMaker(t, storageType, stub)()
+
+	conf := &remote_pb.RemoteConf{Name: "skipdelete", Type: storageType}
+	rs := NewFilerRemoteStorage()
+	rs.storageNameToConf[conf.Name] = conf
+	rs.mapDirectoryToRemoteStorage("/buckets/mybucket", &remote_pb.RemoteStorageLocation{
+		Name:             "skipdelete",
+		Bucket:           "mybucket",
+		Path:             "/",
+		SkipRemoteDelete: true,
+	})
+
+	store := newStubFilerStore()
+	filePath := util.FullPath("/buckets/mybucket/skipped.txt")
+	store.entries[string(filePath)] = &Entry{
+		FullPath: filePath,
+		Attr: Attr{
+			Mtime:    time.Unix(1700000000, 0),
+			Crtime:   time.Unix(1700000000, 0),
+			Mode:     0644,
+			FileSize: 42,
+		},
+		Remote: &filer_pb.RemoteEntry{RemoteMtime: 1700000000, RemoteSize: 42},
+	}
+	f := newTestFiler(t, store, rs)
+
+	err := f.DeleteEntryMetaAndData(context.Background(), filePath, false, false, false, false, nil, 0)
+	require.NoError(t, err)
+
+	require.Empty(t, stub.deleteCalls)
+	_, findErr := store.FindEntry(context.Background(), filePath)
+	require.ErrorIs(t, findErr, filer_pb.ErrNotFound)
+}
+
+func TestDeleteEntryMetaAndData_SkipRemoteDeleteLeavesRemoteDirectory(t *testing.T) {
+	const storageType = "stub_lazy_skip_remote_delete_dir"
+	stub := &stubRemoteClient{removeErr: errors.New("remote directory removal must not be attempted")}
+	defer registerStubMaker(t, storageType, stub)()
+
+	conf := &remote_pb.RemoteConf{Name: "skipdeletedir", Type: storageType}
+	rs := NewFilerRemoteStorage()
+	rs.storageNameToConf[conf.Name] = conf
+	rs.mapDirectoryToRemoteStorage("/buckets/mybucket", &remote_pb.RemoteStorageLocation{
+		Name:             "skipdeletedir",
+		Bucket:           "mybucket",
+		Path:             "/",
+		SkipRemoteDelete: true,
+	})
+
+	store := newStubFilerStore()
+	dirPath := util.FullPath("/buckets/mybucket/dir")
+	store.entries[string(dirPath)] = &Entry{
+		FullPath: dirPath,
+		Attr: Attr{
+			Mtime:  time.Unix(1700000000, 0),
+			Crtime: time.Unix(1700000000, 0),
+			Mode:   os.ModeDir | 0755,
+		},
+	}
+	f := newTestFiler(t, store, rs)
+
+	err := f.doDeleteEntryMetaAndData(context.Background(), store.entries[string(dirPath)], false, false, nil)
+	require.NoError(t, err)
+
+	require.Empty(t, stub.removeCalls)
+	_, findErr := store.FindEntry(context.Background(), dirPath)
+	require.ErrorIs(t, findErr, filer_pb.ErrNotFound)
+}
+
 func TestDeleteEntryMetaAndData_RecursiveFolderDeleteRemotesChildren(t *testing.T) {
 	const storageType = "stub_lazy_delete_folder_children"
 	stub := &stubRemoteClient{}

--- a/weed/filer/remote_storage_test.go
+++ b/weed/filer/remote_storage_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/pb/remote_pb"
 	"github.com/seaweedfs/seaweedfs/weed/util"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestFilerRemoteStorage_FindRemoteStorageClient(t *testing.T) {
@@ -67,4 +69,41 @@ func TestFilerRemoteStorage_FindMountDirectory_LongestPrefixWins(t *testing.T) {
 			assert.Equal(t, tt.wantBucket, loc.Bucket, "bucket for %s", tt.path)
 		}
 	}
+}
+
+func TestRemoteStorageMapping_SkipRemoteDeleteSurvivesMountMappingRoundTrip(t *testing.T) {
+	stored, err := proto.Marshal(&remote_pb.RemoteStorageMapping{
+		Mappings: map[string]*remote_pb.RemoteStorageLocation{
+			"/buckets/mybucket": {
+				Name:             "store",
+				Bucket:           "mybucket",
+				Path:             "/",
+				SkipRemoteDelete: true,
+			},
+			"/buckets/other": {
+				Name:   "store",
+				Bucket: "other",
+				Path:   "/",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	mappings, err := UnmarshalRemoteStorageMappings(stored)
+	require.NoError(t, err)
+
+	conf := &remote_pb.RemoteConf{Name: "store", Type: "s3"}
+	rs := NewFilerRemoteStorage()
+	rs.storageNameToConf[conf.Name] = conf
+	for dir, loc := range mappings.Mappings {
+		rs.mapDirectoryToRemoteStorage(util.FullPath(dir), loc)
+	}
+
+	_, skipLoc := rs.FindMountDirectory("/buckets/mybucket/file.txt")
+	require.NotNil(t, skipLoc)
+	assert.True(t, skipLoc.SkipRemoteDelete, "skipRemoteDelete should survive mount mapping serialisation")
+
+	_, plainLoc := rs.FindMountDirectory("/buckets/other/file.txt")
+	require.NotNil(t, plainLoc)
+	assert.False(t, plainLoc.SkipRemoteDelete, "mounts without the flag should keep propagating deletes")
 }

--- a/weed/pb/remote.proto
+++ b/weed/pb/remote.proto
@@ -76,4 +76,5 @@ message RemoteStorageLocation {
   string bucket = 2;
   string path = 3;
   int32 listing_cache_ttl_seconds = 4; // 0 = disabled; >0 enables on-demand directory listing with this TTL in seconds
+  bool skip_remote_delete = 5; // true = delete filer metadata only, never propagate deletions to remote storage
 }

--- a/weed/pb/remote_pb/remote.pb.go
+++ b/weed/pb/remote_pb/remote.pb.go
@@ -478,6 +478,7 @@ type RemoteStorageLocation struct {
 	Bucket                 string                 `protobuf:"bytes,2,opt,name=bucket,proto3" json:"bucket,omitempty"`
 	Path                   string                 `protobuf:"bytes,3,opt,name=path,proto3" json:"path,omitempty"`
 	ListingCacheTtlSeconds int32                  `protobuf:"varint,4,opt,name=listing_cache_ttl_seconds,json=listingCacheTtlSeconds,proto3" json:"listing_cache_ttl_seconds,omitempty"` // 0 = disabled; >0 enables on-demand directory listing with this TTL in seconds
+	SkipRemoteDelete       bool                   `protobuf:"varint,5,opt,name=skip_remote_delete,json=skipRemoteDelete,proto3" json:"skip_remote_delete,omitempty"`                     // true = delete filer metadata only, never propagate deletions to remote storage
 	unknownFields          protoimpl.UnknownFields
 	sizeCache              protoimpl.SizeCache
 }
@@ -540,6 +541,13 @@ func (x *RemoteStorageLocation) GetListingCacheTtlSeconds() int32 {
 	return 0
 }
 
+func (x *RemoteStorageLocation) GetSkipRemoteDelete() bool {
+	if x != nil {
+		return x.SkipRemoteDelete
+	}
+	return false
+}
+
 var File_remote_proto protoreflect.FileDescriptor
 
 const file_remote_proto_rawDesc = "" +
@@ -599,12 +607,13 @@ const file_remote_proto_rawDesc = "" +
 	"\x1bprimary_bucket_storage_name\x18\x02 \x01(\tR\x18primaryBucketStorageName\x1a]\n" +
 	"\rMappingsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x126\n" +
-	"\x05value\x18\x02 \x01(\v2 .remote_pb.RemoteStorageLocationR\x05value:\x028\x01\"\x92\x01\n" +
+	"\x05value\x18\x02 \x01(\v2 .remote_pb.RemoteStorageLocationR\x05value:\x028\x01\"\xc0\x01\n" +
 	"\x15RemoteStorageLocation\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x16\n" +
 	"\x06bucket\x18\x02 \x01(\tR\x06bucket\x12\x12\n" +
 	"\x04path\x18\x03 \x01(\tR\x04path\x129\n" +
-	"\x19listing_cache_ttl_seconds\x18\x04 \x01(\x05R\x16listingCacheTtlSecondsBP\n" +
+	"\x19listing_cache_ttl_seconds\x18\x04 \x01(\x05R\x16listingCacheTtlSeconds\x12,\n" +
+	"\x12skip_remote_delete\x18\x05 \x01(\bR\x10skipRemoteDeleteBP\n" +
 	"\x10seaweedfs.clientB\n" +
 	"FilerProtoZ0github.com/seaweedfs/seaweedfs/weed/pb/remote_pbb\x06proto3"
 

--- a/weed/shell/command_remote_mount.go
+++ b/weed/shell/command_remote_mount.go
@@ -50,6 +50,8 @@ func (c *commandRemoteMount) Help() string {
 	remote.mount -dir=/xxx -remote=cloud1/bucket/dir1
 	# mount with on-demand directory listing cached for 5 minutes
 	remote.mount -dir=/xxx -remote=cloud1/bucket -listingCacheTTL=300
+	# mount where deletions only remove filer metadata, never the remote object
+	remote.mount -dir=/xxx -remote=cloud1/bucket -skipRemoteDelete
 
 	# after mount, start a separate process to write updates to remote storage
 	weed filer.remote.sync -filer=<filerHost>:<filerPort> -dir=/xxx
@@ -70,6 +72,7 @@ func (c *commandRemoteMount) Do(args []string, commandEnv *CommandEnv, writer io
 	metadataStrategy := remoteMountCommand.String("metadataStrategy", string(MetadataCacheEager), "lazy: skip upfront metadata pull; eager: full metadata pull (default)")
 	remote := remoteMountCommand.String("remote", "", "a directory in remote storage, ex. <storageName>/<bucket>/path/to/dir")
 	listingCacheTTL := remoteMountCommand.Int("listingCacheTTL", 0, "seconds to cache remote directory listings (0 = disabled)")
+	skipRemoteDelete := remoteMountCommand.Bool("skipRemoteDelete", false, "delete filer metadata only; never propagate deletions to remote storage")
 
 	if err = remoteMountCommand.Parse(args); err != nil {
 		return nil
@@ -91,6 +94,7 @@ func (c *commandRemoteMount) Do(args []string, commandEnv *CommandEnv, writer io
 		return err
 	}
 	remoteStorageLocation.ListingCacheTtlSeconds = int32(*listingCacheTTL)
+	remoteStorageLocation.SkipRemoteDelete = *skipRemoteDelete
 
 	strategy := MetadataCacheStrategy(strings.ToLower(*metadataStrategy))
 	if strategy != MetadataCacheLazy && strategy != MetadataCacheEager {


### PR DESCRIPTION
# What problem are we solving?

`maybeDeleteFromRemote` propagates every delete under a remote mount, and any failure aborts `doDeleteEntryMetaAndData` before the filer entry is removed. For a read-through mount — where the remote is the system of record and the filer is only a cache — that coupling causes two problems.

**A filer-side directory removal can delete a live remote prefix.** `RemoveDirectory` fires for any directory under a mount whether or not it was ever cached, because the `entry.Remote == nil` guard only covers the file path. The filer can therefore delete remote data it never owned.

**Deletes cannot be made idempotent when the mount credentials are scoped to reads.** GCS answers `403` rather than `404` for a missing object when the caller lacks `storage.objects.delete`, since it will not confirm non-existence to a caller that cannot delete. An object already removed out of band is then indistinguishable from one that is genuinely undeletable, and `DeleteFile`'s `ErrRemoteObjectNotFound` mapping only covers the `404`. Such deletes fail permanently: the S3 gateway returns `500` and the stale filer entry survives until it ages out.

Both are structural for a mount used as a read-through cache, where the application owns the bucket and writes and deletes it directly. There is currently no way to say "this mount is a cache; never write to the remote on delete" — the only alternatives are granting the filer a delete permission it should not have, or accepting permanent `DeleteObject` failures.

# How are we solving the problem?

Add a per-mount `skip_remote_delete` field on `RemoteStorageLocation` (field 5), following the existing `listing_cache_ttl_seconds` precedent, set by `remote.mount -skipRemoteDelete` and honoured by `maybeDeleteFromRemote`.

The check is a single early return covering both the file and directory paths, placed before remote-client resolution so a skip-delete mount cannot fail on client lookup either. The mount then removes filer metadata only and leaves the remote object untouched.

The default is `false`, so existing mounts keep propagating deletes and behaviour is unchanged unless the flag is passed.

Scope: the field governs the filer's inline propagation only. `filer.remote.sync` is a separate write-back path and is untouched.

# How is the PR tested?

Three unit tests in `weed/filer`:

- `TestDeleteEntryMetaAndData_SkipRemoteDeleteRemovesMetadataOnly` — asserts `DeleteFile` is never invoked and the filer entry is still removed
- `TestDeleteEntryMetaAndData_SkipRemoteDeleteLeavesRemoteDirectory` — the same for `RemoveDirectory`
- `TestRemoteStorageMapping_SkipRemoteDeleteSurvivesMountMappingRoundTrip` — the field survives a `RemoteStorageMapping` proto round-trip and is still set when read back through `FindMountDirectory`

The first two stub a remote client whose delete and remove calls return an error, so they fail if the gate is ever bypassed rather than passing vacuously.

`go build ./weed/...`, `go test ./weed/filer ./weed/shell ./weed/remote_storage/...` and `gofmt` are clean on this branch.

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `-skipRemoteDelete` option for remote mounts.
  * Local metadata can now be deleted without deleting the corresponding remote file or directory.
  * The setting is preserved when remote storage configurations are saved and restored.

* **Bug Fixes**
  * Deletions no longer fail when remote access is unavailable and remote deletion is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->