### PR TITLE
fix(test/s3/versioning): dropped test error

### DIFF
--- a/test/s3/versioning/s3_versioning_pagination_stress_test.go
+++ b/test/s3/versioning/s3_versioning_pagination_stress_test.go
@@ -186,6 +186,7 @@ func TestVersioningPaginationOver1000Versions(t *testing.T) {
 
 			buf := make([]byte, len(expectedContent))
 			_, err = getResp.Body.Read(buf)
+			require.NoError(t, err)
 			getResp.Body.Close()
 
 			assert.Equal(t, expectedContent, string(buf), "Content mismatch for version %d", idx+1)


### PR DESCRIPTION
This fixes a dropped `err` test variable in `test/s3/versioning`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved versioning pagination test coverage by explicitly detecting response body read failures before comparing object contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->