### PR TITLE
test(s3/versioning): read the whole version body instead of one Read

### DIFF
--- a/test/s3/versioning/s3_versioning_pagination_stress_test.go
+++ b/test/s3/versioning/s3_versioning_pagination_stress_test.go
@@ -3,6 +3,7 @@ package s3api
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -184,12 +185,11 @@ func TestVersioningPaginationOver1000Versions(t *testing.T) {
 			})
 			require.NoError(t, err, "Failed to get version at index %d", idx)
 
-			buf := make([]byte, len(expectedContent))
-			_, err = getResp.Body.Read(buf)
-			require.NoError(t, err)
+			body, err := io.ReadAll(getResp.Body)
 			getResp.Body.Close()
+			require.NoError(t, err, "Failed to read version at index %d", idx)
 
-			assert.Equal(t, expectedContent, string(buf), "Content mismatch for version %d", idx+1)
+			assert.Equal(t, expectedContent, string(body), "Content mismatch for version %d", idx+1)
 		}
 	})
 }


### PR DESCRIPTION
The `S3 Versioning Stress Test` job has been failing since #10813:

```
--- FAIL: TestVersioningPaginationOver1000Versions/RetrieveSpecificVersions
    Error: Received unexpected error: EOF
```

#10813 added `require.NoError` after a single `getResp.Body.Read(buf)`. That
check is wrong: `io.Reader` permits returning the final bytes together with
`io.EOF`, and that is exactly what happens here — the buffer is sized to the
expected content, so the one read consumes the entire body.

Reproduced against `weed mini`: `n=17`, body `"content-version-1"`, `err=EOF`,
`Content-Length: 17`, no chunked encoding. The server response is correct and
the failure is deterministic, not a flake.

Read the body with `io.ReadAll`, as every other test in this package does. That
keeps the error check #10813 wanted and also compares the full body rather than
a prefix.

`ENABLE_STRESS_TESTS=true go test -run TestVersioningPagination` passes locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved version retrieval test validation by reading complete object contents before comparison.
  * Ensured response bodies are properly handled after content verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->