### PR TITLE
mount: reuse the listed entry's path instead of rebuilding it

### DIFF
--- a/weed/mount/weedfs_dir_read.go
+++ b/weed/mount/weedfs_dir_read.go
@@ -3,6 +3,7 @@ package mount
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"time"
 
@@ -219,7 +220,11 @@ func (wfs *WFS) doReadDirectory(input *fuse.ReadIn, out DirEntrySink, isPlusMode
 	processEachEntryFn := func(entry *filer.Entry, index int64) bool {
 		dirEntry.Name = entry.Name()
 		dirEntry.Mode = toSyscallMode(entry.Mode)
-		childPath := dirPath.Child(dirEntry.Name)
+		// Rebuild only for a sanitized name: that is the one a LOOKUP carries.
+		childPath := entry.FullPath
+		if !strings.HasSuffix(string(childPath), dirEntry.Name) {
+			childPath = dirPath.Child(dirEntry.Name)
+		}
 		var inode uint64
 		if takesLookupRef {
 			inode = wfs.inodeToPath.Lookup(childPath, entry.Crtime.Unix(), entry.IsDirectory(), len(entry.HardLinkId) > 0, entry.Inode, false)

--- a/weed/mount/weedfs_dir_read_pagination_test.go
+++ b/weed/mount/weedfs_dir_read_pagination_test.go
@@ -336,3 +336,24 @@ func TestReadDirDirectTrimsConsumedEntries(t *testing.T) {
 		t.Errorf("handle held %d entries at peak, want well under the %d in the directory", peak, total)
 	}
 }
+
+// The table has to key on the sanitized name, not the stored bytes.
+func TestReadDirPlusSanitizedName(t *testing.T) {
+	dir := util.FullPath("/images")
+	const rawName = "bad\xffname.jpg"
+	wfs := newPagingWFS(t, dir, []string{"good.jpg", rawName}, 0)
+	dirInode, _ := wfs.inodeToPath.GetInode(dir)
+
+	sink := &benchSink{plus: true, takesRef: true, sinkLimit: 16}
+	if got := walkOnce(t, wfs, dirInode, sink, false); got != 4 {
+		t.Fatalf("listed %d entries, want 4 (. .. and two children)", got)
+	}
+
+	sanitized := dir.Child(util.SanitizeUTF8Name(rawName))
+	if !wfs.inodeToPath.HasPath(sanitized) {
+		t.Errorf("%s not in the inode table", sanitized)
+	}
+	if wfs.inodeToPath.HasPath(dir.Child(rawName)) {
+		t.Errorf("%s keyed on the unsanitized name", dir.Child(rawName))
+	}
+}


### PR DESCRIPTION
From the heap profile in #10020: on a mount over 32.7M files, `FullPath.Child` is 55% of a 2.1GB heap, all of it from readdir.

`processEachEntryFn` built `dirPath.Child(name)` for every child while `entry.FullPath` was already that exact string — `NewFullPath(dirPath, fileName)` on the meta cache path, `FromPbEntry(string(dirPath), entry)` on the read-through path. One allocation per entry, and at that mount's ~200-character paths it is most of what a listing allocates.

Reuse it, falling back to `Child` only when the name had to be UTF-8-sanitized: the inode table has to key on the name a later LOOKUP will carry.

`BenchmarkReadDirectory/kernel_readdirplus`, 200k entries:

```
allocs/op   2,039,656 -> 1,839,318
B/op          174.5MB ->   167.8MB
ns/op          152.6ms ->   135.1ms
```

This does not move `inuse_space` — the retained string is the entry's instead of a fresh one — but at those path lengths it is roughly 1.2GB less garbage per full pass over the tree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory listing behavior for entries with invalid UTF-8 names.
  * Ensured sanitized entry names are used consistently when resolving directory information and inode details.

* **Tests**
  * Added coverage for paginated directory listings containing invalid UTF-8 filenames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->