### PR TITLE
Pin grpc-go to v1.82.0 to avoid a Unix-socket transport deadlock

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -527,3 +527,19 @@ replace github.com/apache/thrift => github.com/apache/thrift v0.23.1-0.202604291
 // through rclone's internxt backend, which calls IsMnemonicValid and NewSeed.
 // cosmos/go-bip39 is a maintained, API-compatible fork.
 replace github.com/tyler-smith/go-bip39 => github.com/cosmos/go-bip39 v1.0.0
+
+// grpc-go v1.82.1 started counting registerStream/cleanupStream toward the
+// control-buffer throttle limit. Those are per-RPC bookkeeping items that emit
+// no wire traffic, so a connection carrying enough concurrent RPCs latches
+// throttling in both directions at once and deadlocks for good: both peers stop
+// reading, both loopyWriters block writing to a full socket.
+//
+// It triggers whenever the socket send buffer is too small to absorb the burst
+// loopyWriter emits for the in-flight streams, so it is about buffer size, not
+// transport: TCP forced to a 64KB buffer deadlocks, a Unix socket with a 2MB
+// buffer does not. Local gRPC rides Unix sockets, whose buffers are small and
+// fixed (208KB on Linux, 8KB on macOS), which is why weed mini wedges under
+// concurrent S3 writes; a remote filer over TCP is exposed too wherever
+// send buffers are constrained. Pin to the last unaffected release until
+// grpc/grpc-go#9330 is fixed.
+replace google.golang.org/grpc => google.golang.org/grpc v1.82.0

--- a/go.sum
+++ b/go.sum
@@ -2838,6 +2838,8 @@ google.golang.org/grpc v1.51.0/go.mod h1:wgNDFcnuBGmxLKI/qn4T+m5BtEBYXJPvibbUPsA
 google.golang.org/grpc v1.52.0/go.mod h1:pu6fVzoFb+NBYNAvQL08ic+lvB2IojljRYuun5vorUY=
 google.golang.org/grpc v1.53.0/go.mod h1:OnIrk0ipVdj4N5d9IUoFUx72/VlD7+jUsHwZgwSMQpw=
 google.golang.org/grpc v1.55.0/go.mod h1:iYEXKGkEBhg1PjZQvoYEVPTDkHo1/bjTnfwTeGONTY8=
+google.golang.org/grpc v1.82.0 h1:vguDnZUPjE26w09A63VoxZPnvPjB5Riyc0mkXPFmAIU=
+google.golang.org/grpc v1.82.0/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/grpc v1.84.0-dev.0.20260723093437-b6eac429d7b6 h1:HfjjkdGIa8u9sP9EW5WCygy0kQDuTI/Tax4j//t24Fo=
 google.golang.org/grpc v1.84.0-dev.0.20260723093437-b6eac429d7b6/go.mod h1:ljCht0DrxQrXBDRTZp52Qxh3Ffk8CdYm2sj4O2QN2C0=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=


### PR DESCRIPTION
Temporary pin while grpc/grpc-go#9330 is open.

grpc-go v1.82.1 broadened the control-buffer throttle to count `registerStream` and `cleanupStream`. Those are per-RPC bookkeeping items that emit no wire traffic, so a connection carrying enough concurrent RPCs latches throttling in both directions at once — both peers stop reading, both `loopyWriter`s block writing to a full socket, and it never recovers. It triggers whenever the socket send buffer is too small to absorb the burst `loopyWriter` emits for the in-flight streams — so it is about buffer size, not transport (TCP forced to a 64KB buffer deadlocks; a Unix socket with a 2MB buffer does not). Local gRPC rides Unix sockets, whose buffers are small and fixed (208KB on Linux, 8KB on macOS), which is why we see it first there; a remote filer over TCP is exposed too wherever send buffers are constrained. We picked this up in `0e78031fa` (the 1.82.0 -> 1.82.1 dependabot bump).

Symptom is `weed mini` wedging under concurrent S3 writes, which is how self-hosted Sentry hits it. Measured with a Sentry-nodestore-shaped load (flat keys, small objects) against Sentry's own mini flags:

| concurrent PUTs | before | after |
|---|---|---|
| 512 | 45 ops/s, 14% failures, 65s stalls | 6,375 ops/s, 0 failures, no stall |
| 2048 | wedged | 2,407 ops/s, 0 failures, no stall |

During a wedge every in-flight PUT sits in `waitOnHeader` on a filer RPC with zero filer handlers running; both transports are parked in `controlBuffer.throttle` and both `loopyWriter`s in `net.(*conn).Write`.

Pinned to v1.82.0, the newest unaffected release — bisected v1.82.0 clean / v1.82.1 deadlocking, on both linux and darwin, with a standalone repro that uses only default gRPC options (in the upstream issue). A `replace` is needed rather than a `require` because rclone v1.75.0 requires the unreleased grpc dev snapshot. `go.sum` picks up only the two v1.82.0 hashes; no `go mod tidy` churn.

Revert once upstream lands a fix. Worth noting connection pooling does not solve this — 8 connections still wedge at c=2048, since it divides stream churn rather than removing the condition. Nor does switching local gRPC to TCP loopback: that only works because Linux TCP defaults are large, not because TCP is immune.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for concurrent network operations by addressing a potential connection stall under constrained network conditions.
  * Reduced the risk of requests becoming unresponsive when system or network buffers are limited.

* **Maintenance**
  * No new user-facing features or interface changes are included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->