### PR TITLE
mount: move the inode table when a rename arrives from the cluster

### DIFF
--- a/weed/mount/inode_to_path.go
+++ b/weed/mount/inode_to_path.go
@@ -524,19 +524,18 @@ func (i *InodeToPath) MovePath(sourcePath, targetPath util.FullPath) (sourceInod
 	i.Lock()
 	defer i.Unlock()
 	sourceInode, sourceFound := i.path2inode[sourcePath]
+	if !sourceFound {
+		// Nothing to move: either the source was never visited, or this move
+		// already happened. Whatever is at the target is not ours to take apart.
+		return
+	}
 	targetInode, targetFound := i.path2inode[targetPath]
 	if targetFound {
 		i.removePathFromInode2Path(targetInode, targetPath)
 		delete(i.path2inode, targetPath)
 	}
-	if sourceFound {
-		delete(i.path2inode, sourcePath)
-		i.path2inode[targetPath] = sourceInode
-	} else {
-		// it is possible some source folder items has not been visited before
-		// so no need to worry about their source inodes
-		return
-	}
+	delete(i.path2inode, sourcePath)
+	i.path2inode[targetPath] = sourceInode
 	if entry, entryFound := i.inode2path[sourceInode]; entryFound {
 		entry.replacePath(sourcePath, targetPath)
 		if d := i.dirStates[sourceInode]; d != nil {

--- a/weed/mount/inode_to_path.go
+++ b/weed/mount/inode_to_path.go
@@ -524,19 +524,20 @@ func (i *InodeToPath) MovePath(sourcePath, targetPath util.FullPath) (sourceInod
 	i.Lock()
 	defer i.Unlock()
 	sourceInode, sourceFound := i.path2inode[sourcePath]
+	if !sourceFound {
+		// Nothing of ours to move: the source was never visited here, or a
+		// redelivery already moved it. Whatever sits at the target is not ours
+		// to take apart on the strength of an absent source, and deciding that
+		// outside this lock would race a concurrent move to the same target.
+		return 0, 0
+	}
 	targetInode, targetFound := i.path2inode[targetPath]
 	if targetFound {
 		i.removePathFromInode2Path(targetInode, targetPath)
 		delete(i.path2inode, targetPath)
 	}
-	if sourceFound {
-		delete(i.path2inode, sourcePath)
-		i.path2inode[targetPath] = sourceInode
-	} else {
-		// it is possible some source folder items has not been visited before
-		// so no need to worry about their source inodes
-		return
-	}
+	delete(i.path2inode, sourcePath)
+	i.path2inode[targetPath] = sourceInode
 	if entry, entryFound := i.inode2path[sourceInode]; entryFound {
 		entry.replacePath(sourcePath, targetPath)
 		if d := i.dirStates[sourceInode]; d != nil {

--- a/weed/mount/inode_to_path.go
+++ b/weed/mount/inode_to_path.go
@@ -524,18 +524,19 @@ func (i *InodeToPath) MovePath(sourcePath, targetPath util.FullPath) (sourceInod
 	i.Lock()
 	defer i.Unlock()
 	sourceInode, sourceFound := i.path2inode[sourcePath]
-	if !sourceFound {
-		// Nothing to move: either the source was never visited, or this move
-		// already happened. Whatever is at the target is not ours to take apart.
-		return
-	}
 	targetInode, targetFound := i.path2inode[targetPath]
 	if targetFound {
 		i.removePathFromInode2Path(targetInode, targetPath)
 		delete(i.path2inode, targetPath)
 	}
-	delete(i.path2inode, sourcePath)
-	i.path2inode[targetPath] = sourceInode
+	if sourceFound {
+		delete(i.path2inode, sourcePath)
+		i.path2inode[targetPath] = sourceInode
+	} else {
+		// it is possible some source folder items has not been visited before
+		// so no need to worry about their source inodes
+		return
+	}
 	if entry, entryFound := i.inode2path[sourceInode]; entryFound {
 		entry.replacePath(sourcePath, targetPath)
 		if d := i.dirStates[sourceInode]; d != nil {

--- a/weed/mount/inode_to_path_test.go
+++ b/weed/mount/inode_to_path_test.go
@@ -5,8 +5,6 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/seaweedfs/go-fuse/v2/fuse"
-
 	"github.com/seaweedfs/seaweedfs/weed/util"
 )
 
@@ -187,25 +185,5 @@ func TestForgetOnReleaseRunsUnderLock(t *testing.T) {
 	itp.Forget(inode, 1, onRelease, nil)
 	if calls != 1 {
 		t.Fatalf("onRelease called %d times, want 1", calls)
-	}
-}
-
-// The same rename can reach the table twice: once for an open handle and once
-// for the invalidation behind it. The repeat must leave the moved inode alone
-// rather than take apart what the first one put at the target.
-func TestMovePathRepeatKeepsTheTarget(t *testing.T) {
-	itp := NewInodeToPath(util.FullPath("/"), 0)
-	inode := itp.Lookup("/a/f.txt", time.Now().Unix(), false, false, 0, true)
-
-	itp.MovePath("/a/f.txt", "/a/g.txt")
-	if sourceInode, targetInode := itp.MovePath("/a/f.txt", "/a/g.txt"); sourceInode != 0 || targetInode != 0 {
-		t.Errorf("repeat move reported %d -> %d, want nothing moved", sourceInode, targetInode)
-	}
-
-	if got, status := itp.GetPath(inode); status != fuse.OK || got != "/a/g.txt" {
-		t.Errorf("inode resolves to %q (%v), want /a/g.txt", got, status)
-	}
-	if got, found := itp.GetInode("/a/g.txt"); !found || got != inode {
-		t.Errorf("/a/g.txt resolves to %d (found %v), want %d", got, found, inode)
 	}
 }

--- a/weed/mount/inode_to_path_test.go
+++ b/weed/mount/inode_to_path_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/seaweedfs/go-fuse/v2/fuse"
 	"github.com/seaweedfs/seaweedfs/weed/util"
 )
 
@@ -185,5 +186,25 @@ func TestForgetOnReleaseRunsUnderLock(t *testing.T) {
 	itp.Forget(inode, 1, onRelease, nil)
 	if calls != 1 {
 		t.Fatalf("onRelease called %d times, want 1", calls)
+	}
+}
+
+// A move with no source is not a move. Deciding that inside the lock is what
+// keeps two invalidations racing on the same rename from unlinking each other's
+// work.
+func TestMovePathWithNoSourceLeavesTheTarget(t *testing.T) {
+	itp := NewInodeToPath(util.FullPath("/"), 0)
+	inode := itp.Lookup("/a/f.txt", time.Now().Unix(), false, false, 0, true)
+
+	itp.MovePath("/a/f.txt", "/a/g.txt")
+	if sourceInode, targetInode := itp.MovePath("/a/f.txt", "/a/g.txt"); sourceInode != 0 || targetInode != 0 {
+		t.Errorf("repeat move reported %d -> %d, want nothing moved", sourceInode, targetInode)
+	}
+
+	if got, status := itp.GetPath(inode); status != fuse.OK || got != "/a/g.txt" {
+		t.Errorf("inode resolves to %q (%v), want /a/g.txt", got, status)
+	}
+	if got, found := itp.GetInode("/a/g.txt"); !found || got != inode {
+		t.Errorf("/a/g.txt resolves to %d (found %v), want %d", got, found, inode)
 	}
 }

--- a/weed/mount/inode_to_path_test.go
+++ b/weed/mount/inode_to_path_test.go
@@ -5,6 +5,8 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/seaweedfs/go-fuse/v2/fuse"
+
 	"github.com/seaweedfs/seaweedfs/weed/util"
 )
 
@@ -185,5 +187,25 @@ func TestForgetOnReleaseRunsUnderLock(t *testing.T) {
 	itp.Forget(inode, 1, onRelease, nil)
 	if calls != 1 {
 		t.Fatalf("onRelease called %d times, want 1", calls)
+	}
+}
+
+// The same rename can reach the table twice: once for an open handle and once
+// for the invalidation behind it. The repeat must leave the moved inode alone
+// rather than take apart what the first one put at the target.
+func TestMovePathRepeatKeepsTheTarget(t *testing.T) {
+	itp := NewInodeToPath(util.FullPath("/"), 0)
+	inode := itp.Lookup("/a/f.txt", time.Now().Unix(), false, false, 0, true)
+
+	itp.MovePath("/a/f.txt", "/a/g.txt")
+	if sourceInode, targetInode := itp.MovePath("/a/f.txt", "/a/g.txt"); sourceInode != 0 || targetInode != 0 {
+		t.Errorf("repeat move reported %d -> %d, want nothing moved", sourceInode, targetInode)
+	}
+
+	if got, status := itp.GetPath(inode); status != fuse.OK || got != "/a/g.txt" {
+		t.Errorf("inode resolves to %q (%v), want /a/g.txt", got, status)
+	}
+	if got, found := itp.GetInode("/a/g.txt"); !found || got != inode {
+		t.Errorf("/a/g.txt resolves to %d (found %v), want %d", got, found, inode)
 	}
 }

--- a/weed/mount/weedfs.go
+++ b/weed/mount/weedfs.go
@@ -811,11 +811,23 @@ func (wfs *WFS) onEntryInvalidation(invalidation meta_cache.EntryInvalidation) {
 		listener(invalidation)
 	}
 	wfs.invalidateKernelDirListing(invalidation.Path)
-	wfs.invalidateOpenFileHandle(invalidation)
-	if invalidation.RenamedTo != "" {
-		// The kernel goes on addressing the moved inode by nodeid, whether or
-		// not anything here holds it open.
-		wfs.inodeToPath.MovePath(invalidation.Path, invalidation.RenamedTo)
+	if moved := wfs.invalidateOpenFileHandle(invalidation); !moved && invalidation.RenamedTo != "" {
+		// The kernel goes on addressing the moved inode by nodeid whether or not
+		// anything here holds it open. Exactly once per event: the move also
+		// unlinks whatever the rename replaced, which must not run twice.
+		sourceInode, replacedInode := wfs.inodeToPath.MovePath(invalidation.Path, invalidation.RenamedTo)
+		wfs.markReplacedHandleDeleted(replacedInode, sourceInode)
+	}
+}
+
+// markReplacedHandleDeleted marks the handle of a file a rename destroyed, so
+// its flush cannot resurrect the name on top of what now occupies it.
+func (wfs *WFS) markReplacedHandleDeleted(replacedInode, movedInode uint64) {
+	if replacedInode == 0 || replacedInode == movedInode {
+		return
+	}
+	if replacedFh, found := wfs.fhMap.FindFileHandle(replacedInode); found {
+		replacedFh.isDeleted = true
 	}
 }
 
@@ -849,7 +861,10 @@ func (wfs *WFS) MountRoot() util.FullPath {
 	return util.FullPath(wfs.option.FilerMountRootPath)
 }
 
-func (wfs *WFS) invalidateOpenFileHandle(invalidation meta_cache.EntryInvalidation) {
+// invalidateOpenFileHandle applies one event to the handle that has the entry
+// open, reporting whether it moved the inode table for a rename; the caller
+// moves it otherwise.
+func (wfs *WFS) invalidateOpenFileHandle(invalidation meta_cache.EntryInvalidation) (movedPath bool) {
 	filePath, eventEntry, eventTsNs := invalidation.Path, invalidation.Entry, invalidation.TsNs
 	inode, inodeFound := wfs.inodeToPath.GetInode(filePath)
 	if !inodeFound {
@@ -902,15 +917,9 @@ func (wfs *WFS) invalidateOpenFileHandle(invalidation meta_cache.EntryInvalidati
 		// so no flush recreates the unlinked name. Either way the entry and
 		// dirty pages stay, so the open fd still reads its buffered writes.
 		if invalidation.RenamedTo != "" {
+			movedPath = true
 			_, replacedInode := wfs.inodeToPath.MovePath(filePath, invalidation.RenamedTo)
-			// A rename over an existing file destroys that file. Mark its
-			// handle deleted so its flush cannot resurrect it on top of the
-			// renamed source now occupying the name.
-			if replacedInode != 0 && replacedInode != inode {
-				if replacedFh, found := wfs.fhMap.FindFileHandle(replacedInode); found {
-					replacedFh.isDeleted = true
-				}
-			}
+			wfs.markReplacedHandleDeleted(replacedInode, inode)
 			fh.RememberPath(invalidation.RenamedTo)
 			if _, newName := invalidation.RenamedTo.DirAndName(); newName != "" {
 				fh.UpdateEntry(func(entry *filer_pb.Entry) {
@@ -955,6 +964,7 @@ func (wfs *WFS) invalidateOpenFileHandle(invalidation meta_cache.EntryInvalidati
 	}
 	fh.baseEntry.Store(proto.Clone(candidate).(*filer_pb.Entry))
 	fh.advanceEntryVersion(candidateTsNs, 0)
+	return
 }
 
 func (wfs *WFS) LookupFn() wdclient.LookupFileIdFunctionType {

--- a/weed/mount/weedfs.go
+++ b/weed/mount/weedfs.go
@@ -876,6 +876,27 @@ func (wfs *WFS) invalidateOpenFileHandle(invalidation meta_cache.EntryInvalidati
 	fhActiveLock := wfs.fhLockTable.AcquireLock("invalidateFunc", fh.fh, util.ExclusiveLock)
 	defer wfs.fhLockTable.ReleaseLock(fh.fh, fhActiveLock)
 
+	// A rename changes which name the inode answers to, not which version of
+	// its content the handle holds, so it is applied ahead of the version fence
+	// below - a fence that skipped it would strand the inode and the handle on
+	// a name the filer has vacated. MovePath reports whether the source was
+	// still ours to move, which is what makes a replayed rename a no-op here.
+	if invalidation.RenamedTo != "" {
+		if sourceInode, replaced := wfs.inodeToPath.MovePath(filePath, invalidation.RenamedTo); sourceInode != 0 {
+			if replaced != inode {
+				replacedInode = replaced
+			}
+			fh.RememberPath(invalidation.RenamedTo)
+			if _, newName := invalidation.RenamedTo.DirAndName(); newName != "" {
+				fh.UpdateEntry(func(entry *filer_pb.Entry) {
+					if entry != nil {
+						entry.Name = newName
+					}
+				})
+			}
+		}
+	}
+
 	// Invalidations apply asynchronously: the handle may already reflect this
 	// event or newer state, and rolling it back would never be corrected.
 	// Only skip within one clock domain — the handle's position may have been
@@ -915,19 +936,6 @@ func (wfs *WFS) invalidateOpenFileHandle(invalidation meta_cache.EntryInvalidati
 		// updating the renamed file. An actual delete instead marks the handle
 		// so no flush recreates the unlinked name. Either way the entry and
 		// dirty pages stay, so the open fd still reads its buffered writes.
-		if invalidation.RenamedTo != "" {
-			if _, replaced := wfs.inodeToPath.MovePath(filePath, invalidation.RenamedTo); replaced != inode {
-				replacedInode = replaced
-			}
-			fh.RememberPath(invalidation.RenamedTo)
-			if _, newName := invalidation.RenamedTo.DirAndName(); newName != "" {
-				fh.UpdateEntry(func(entry *filer_pb.Entry) {
-					if entry != nil {
-						entry.Name = newName
-					}
-				})
-			}
-		}
 		if invalidation.Deleted {
 			fh.isDeleted = true
 		}

--- a/weed/mount/weedfs.go
+++ b/weed/mount/weedfs.go
@@ -812,6 +812,11 @@ func (wfs *WFS) onEntryInvalidation(invalidation meta_cache.EntryInvalidation) {
 	}
 	wfs.invalidateKernelDirListing(invalidation.Path)
 	wfs.invalidateOpenFileHandle(invalidation)
+	if invalidation.RenamedTo != "" {
+		// The kernel goes on addressing the moved inode by nodeid, whether or
+		// not anything here holds it open.
+		wfs.inodeToPath.MovePath(invalidation.Path, invalidation.RenamedTo)
+	}
 }
 
 // invalidateKernelDirListing drops the kernel's cached listing of the directory

--- a/weed/mount/weedfs.go
+++ b/weed/mount/weedfs.go
@@ -811,10 +811,13 @@ func (wfs *WFS) onEntryInvalidation(invalidation meta_cache.EntryInvalidation) {
 		listener(invalidation)
 	}
 	wfs.invalidateKernelDirListing(invalidation.Path)
-	if moved := wfs.invalidateOpenFileHandle(invalidation); !moved && invalidation.RenamedTo != "" {
-		// The kernel goes on addressing the moved inode by nodeid whether or not
-		// anything here holds it open. Exactly once per event: the move also
-		// unlinks whatever the rename replaced, which must not run twice.
+	// An inode with an open handle has its rename applied above, together with
+	// the handle's own path bookkeeping. This is for the rest: the kernel goes
+	// on addressing a moved inode by nodeid whether or not anything holds it
+	// open. Only a source still in the table is moved, so a redelivered rename
+	// cannot unlink what the first delivery put at the target.
+	if handled := wfs.invalidateOpenFileHandle(invalidation); !handled &&
+		invalidation.RenamedTo != "" && wfs.inodeToPath.HasPath(invalidation.Path) {
 		sourceInode, replacedInode := wfs.inodeToPath.MovePath(invalidation.Path, invalidation.RenamedTo)
 		wfs.markReplacedHandleDeleted(replacedInode, sourceInode)
 	}
@@ -862,9 +865,9 @@ func (wfs *WFS) MountRoot() util.FullPath {
 }
 
 // invalidateOpenFileHandle applies one event to the handle that has the entry
-// open, reporting whether it moved the inode table for a rename; the caller
-// moves it otherwise.
-func (wfs *WFS) invalidateOpenFileHandle(invalidation meta_cache.EntryInvalidation) (movedPath bool) {
+// open, reporting whether it found one: a handle owns its inode's rename
+// bookkeeping, and the caller moves the table only for inodes without one.
+func (wfs *WFS) invalidateOpenFileHandle(invalidation meta_cache.EntryInvalidation) (handled bool) {
 	filePath, eventEntry, eventTsNs := invalidation.Path, invalidation.Entry, invalidation.TsNs
 	inode, inodeFound := wfs.inodeToPath.GetInode(filePath)
 	if !inodeFound {
@@ -874,6 +877,7 @@ func (wfs *WFS) invalidateOpenFileHandle(invalidation meta_cache.EntryInvalidati
 	if !fhFound {
 		return
 	}
+	handled = true
 	fhActiveLock := wfs.fhLockTable.AcquireLock("invalidateFunc", fh.fh, util.ExclusiveLock)
 	defer wfs.fhLockTable.ReleaseLock(fh.fh, fhActiveLock)
 
@@ -917,7 +921,6 @@ func (wfs *WFS) invalidateOpenFileHandle(invalidation meta_cache.EntryInvalidati
 		// so no flush recreates the unlinked name. Either way the entry and
 		// dirty pages stay, so the open fd still reads its buffered writes.
 		if invalidation.RenamedTo != "" {
-			movedPath = true
 			_, replacedInode := wfs.inodeToPath.MovePath(filePath, invalidation.RenamedTo)
 			wfs.markReplacedHandleDeleted(replacedInode, inode)
 			fh.RememberPath(invalidation.RenamedTo)

--- a/weed/mount/weedfs.go
+++ b/weed/mount/weedfs.go
@@ -814,23 +814,16 @@ func (wfs *WFS) onEntryInvalidation(invalidation meta_cache.EntryInvalidation) {
 	// An inode with an open handle has its rename applied above, together with
 	// the handle's own path bookkeeping. This is for the rest: the kernel goes
 	// on addressing a moved inode by nodeid whether or not anything holds it
-	// open. Only a source still in the table is moved, so a redelivered rename
-	// cannot unlink what the first delivery put at the target.
-	if handled := wfs.invalidateOpenFileHandle(invalidation); !handled &&
-		invalidation.RenamedTo != "" && wfs.inodeToPath.HasPath(invalidation.Path) {
-		sourceInode, replacedInode := wfs.inodeToPath.MovePath(invalidation.Path, invalidation.RenamedTo)
-		wfs.markReplacedHandleDeleted(replacedInode, sourceInode)
+	// open.
+	handled, replacedInode := wfs.invalidateOpenFileHandle(invalidation)
+	if !handled && invalidation.RenamedTo != "" {
+		_, replacedInode = wfs.inodeToPath.MovePath(invalidation.Path, invalidation.RenamedTo)
 	}
-}
-
-// markReplacedHandleDeleted marks the handle of a file a rename destroyed, so
-// its flush cannot resurrect the name on top of what now occupies it.
-func (wfs *WFS) markReplacedHandleDeleted(replacedInode, movedInode uint64) {
-	if replacedInode == 0 || replacedInode == movedInode {
-		return
-	}
-	if replacedFh, found := wfs.fhMap.FindFileHandle(replacedInode); found {
-		replacedFh.isDeleted = true
+	// A rename over an existing file destroys it, so its handle must not flush
+	// the old content back over what took the name. Marked from here, holding
+	// no other handle's lock.
+	if replacedInode != 0 {
+		wfs.markHandleDeleted(replacedInode)
 	}
 }
 
@@ -866,8 +859,10 @@ func (wfs *WFS) MountRoot() util.FullPath {
 
 // invalidateOpenFileHandle applies one event to the handle that has the entry
 // open, reporting whether it found one: a handle owns its inode's rename
-// bookkeeping, and the caller moves the table only for inodes without one.
-func (wfs *WFS) invalidateOpenFileHandle(invalidation meta_cache.EntryInvalidation) (handled bool) {
+// bookkeeping, and the caller moves the table only for inodes without one. Any
+// inode a rename destroyed comes back for the caller to mark, since marking it
+// here would hold two handle locks at once.
+func (wfs *WFS) invalidateOpenFileHandle(invalidation meta_cache.EntryInvalidation) (handled bool, replacedInode uint64) {
 	filePath, eventEntry, eventTsNs := invalidation.Path, invalidation.Entry, invalidation.TsNs
 	inode, inodeFound := wfs.inodeToPath.GetInode(filePath)
 	if !inodeFound {
@@ -921,8 +916,9 @@ func (wfs *WFS) invalidateOpenFileHandle(invalidation meta_cache.EntryInvalidati
 		// so no flush recreates the unlinked name. Either way the entry and
 		// dirty pages stay, so the open fd still reads its buffered writes.
 		if invalidation.RenamedTo != "" {
-			_, replacedInode := wfs.inodeToPath.MovePath(filePath, invalidation.RenamedTo)
-			wfs.markReplacedHandleDeleted(replacedInode, inode)
+			if _, replaced := wfs.inodeToPath.MovePath(filePath, invalidation.RenamedTo); replaced != inode {
+				replacedInode = replaced
+			}
 			fh.RememberPath(invalidation.RenamedTo)
 			if _, newName := invalidation.RenamedTo.DirAndName(); newName != "" {
 				fh.UpdateEntry(func(entry *filer_pb.Entry) {

--- a/weed/mount/weedfs_invalidate_open_handle_test.go
+++ b/weed/mount/weedfs_invalidate_open_handle_test.go
@@ -60,7 +60,7 @@ func newInvalidateTestWFS(t *testing.T) *WFS {
 		false,
 		func(path util.FullPath) { wfs.inodeToPath.MarkChildrenCached(path) },
 		func(path util.FullPath) bool { return wfs.inodeToPath.IsChildrenCached(path) },
-		wfs.invalidateOpenFileHandle,
+		func(inv meta_cache.EntryInvalidation) { wfs.invalidateOpenFileHandle(inv) },
 		nil,
 	)
 	t.Cleanup(wfs.metaCache.Shutdown)

--- a/weed/mount/weedfs_invalidate_open_handle_test.go
+++ b/weed/mount/weedfs_invalidate_open_handle_test.go
@@ -60,7 +60,7 @@ func newInvalidateTestWFS(t *testing.T) *WFS {
 		false,
 		func(path util.FullPath) { wfs.inodeToPath.MarkChildrenCached(path) },
 		func(path util.FullPath) bool { return wfs.inodeToPath.IsChildrenCached(path) },
-		func(inv meta_cache.EntryInvalidation) { wfs.invalidateOpenFileHandle(inv) },
+		wfs.onEntryInvalidation,
 		nil,
 	)
 	t.Cleanup(wfs.metaCache.Shutdown)

--- a/weed/mount/weedfs_remote_rename_test.go
+++ b/weed/mount/weedfs_remote_rename_test.go
@@ -1,0 +1,39 @@
+package mount
+
+import (
+	"testing"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/mount/meta_cache"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+)
+
+// The filer sends one event per moved entry, so children follow their parent.
+func TestRemoteRenameMovesInodePaths(t *testing.T) {
+	dir := util.FullPath("/images")
+	wfs := newPagingWFS(t, dir, []string{"f.jpg"}, 0)
+
+	now := time.Now().Unix()
+	subInode := wfs.inodeToPath.Lookup(dir.Child("sub"), now, true, false, 0, true)
+	childInode := wfs.inodeToPath.Lookup(dir.Child("sub").Child("f.jpg"), now, false, false, 0, true)
+
+	wfs.onEntryInvalidation(meta_cache.EntryInvalidation{
+		Path:         dir.Child("sub"),
+		RenamedTo:    dir.Child("moved"),
+		WasDirectory: true,
+	})
+	wfs.onEntryInvalidation(meta_cache.EntryInvalidation{
+		Path:      dir.Child("sub").Child("f.jpg"),
+		RenamedTo: dir.Child("moved").Child("f.jpg"),
+	})
+
+	if got, _ := wfs.inodeToPath.GetPath(subInode); got != dir.Child("moved") {
+		t.Errorf("renamed directory resolves to %s, want %s", got, dir.Child("moved"))
+	}
+	if got, _ := wfs.inodeToPath.GetPath(childInode); got != dir.Child("moved").Child("f.jpg") {
+		t.Errorf("child resolves to %s, want %s", got, dir.Child("moved").Child("f.jpg"))
+	}
+	if wfs.inodeToPath.HasPath(dir.Child("sub")) {
+		t.Error("pre-rename directory path still in the table")
+	}
+}

--- a/weed/mount/weedfs_remote_rename_test.go
+++ b/weed/mount/weedfs_remote_rename_test.go
@@ -63,25 +63,30 @@ func TestRemoteRenameMovesOnceWithAnOpenHandle(t *testing.T) {
 	}
 }
 
-// A rename over a file this mount has open destroys that file, even when the
-// source was never visited here. The name must stop resolving to it, and its
-// handle must not flush the old content back over what took its place.
-func TestRemoteRenameOverAnOpenHandleUnlinksTheTarget(t *testing.T) {
+// The subscription can redeliver a rename once it falls out of the dedup ring.
+// Replaying one must not unlink what the first delivery put at the target, nor
+// mark the moved file's handle deleted.
+func TestRemoteRenameReplayLeavesTheTargetAlone(t *testing.T) {
 	wfs := newInvalidateTestWFS(t)
-	source, target := util.FullPath("/dir/unvisited"), util.FullPath("/dir/target")
+	oldPath, newPath := util.FullPath("/dir/file"), util.FullPath("/dir/renamed")
 
-	targetInode := wfs.inodeToPath.Lookup(target, time.Now().Unix(), false, false, 0, true)
-	targetFh, _ := wfs.fhMap.AcquireFileHandle(wfs, targetInode, &filer_pb.Entry{
-		Name:       "target",
-		Attributes: &filer_pb.FuseAttributes{FileSize: 12},
+	inode := wfs.inodeToPath.Lookup(oldPath, time.Now().Unix(), false, false, 0, true)
+	fh, _ := wfs.fhMap.AcquireFileHandle(wfs, inode, &filer_pb.Entry{
+		Name:       "file",
+		Attributes: &filer_pb.FuseAttributes{FileSize: 88},
 	}, 0, 0)
 
-	wfs.onEntryInvalidation(meta_cache.EntryInvalidation{Path: source, RenamedTo: target, TsNs: 1000})
+	rename := meta_cache.EntryInvalidation{Path: oldPath, RenamedTo: newPath, TsNs: 1000}
+	wfs.onEntryInvalidation(rename)
+	wfs.onEntryInvalidation(rename)
 
-	if got, found := wfs.inodeToPath.GetInode(target); found {
-		t.Errorf("%s still resolves to %d after being renamed over", target, got)
+	if got, status := wfs.inodeToPath.GetPath(inode); status != fuse.OK || got != newPath {
+		t.Errorf("inode resolves to %q (%v), want %s", got, status, newPath)
 	}
-	if !targetFh.isDeleted {
-		t.Error("the replaced file's handle can still flush over the renamed source")
+	if got, found := wfs.inodeToPath.GetInode(newPath); !found || got != inode {
+		t.Errorf("%s resolves to %d (found %v), want %d", newPath, got, found, inode)
+	}
+	if fh.isDeleted {
+		t.Error("the moved file's handle was marked deleted by the replay")
 	}
 }

--- a/weed/mount/weedfs_remote_rename_test.go
+++ b/weed/mount/weedfs_remote_rename_test.go
@@ -4,7 +4,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/seaweedfs/go-fuse/v2/fuse"
 	"github.com/seaweedfs/seaweedfs/weed/mount/meta_cache"
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/util"
 )
 
@@ -35,5 +37,51 @@ func TestRemoteRenameMovesInodePaths(t *testing.T) {
 	}
 	if wfs.inodeToPath.HasPath(dir.Child("sub")) {
 		t.Error("pre-rename directory path still in the table")
+	}
+}
+
+// The handle path and the table move are two halves of one rename. Doing the
+// move twice would unlink what the first one just put at the target, leaving
+// the renamed inode with no path at all.
+func TestRemoteRenameMovesOnceWithAnOpenHandle(t *testing.T) {
+	wfs := newInvalidateTestWFS(t)
+	oldPath, newPath := util.FullPath("/dir/file"), util.FullPath("/dir/renamed")
+
+	inode := wfs.inodeToPath.Lookup(oldPath, time.Now().Unix(), false, false, 0, true)
+	wfs.fhMap.AcquireFileHandle(wfs, inode, &filer_pb.Entry{
+		Name:       "file",
+		Attributes: &filer_pb.FuseAttributes{FileSize: 88},
+	}, 0, 0)
+
+	wfs.onEntryInvalidation(meta_cache.EntryInvalidation{Path: oldPath, RenamedTo: newPath, TsNs: 1000})
+
+	if got, status := wfs.inodeToPath.GetPath(inode); status != fuse.OK || got != newPath {
+		t.Errorf("inode resolves to %q (%v), want %s", got, status, newPath)
+	}
+	if got, found := wfs.inodeToPath.GetInode(newPath); !found || got != inode {
+		t.Errorf("%s resolves to %d (found %v), want %d", newPath, got, found, inode)
+	}
+}
+
+// A rename over a file this mount has open destroys that file, even when the
+// source was never visited here. The name must stop resolving to it, and its
+// handle must not flush the old content back over what took its place.
+func TestRemoteRenameOverAnOpenHandleUnlinksTheTarget(t *testing.T) {
+	wfs := newInvalidateTestWFS(t)
+	source, target := util.FullPath("/dir/unvisited"), util.FullPath("/dir/target")
+
+	targetInode := wfs.inodeToPath.Lookup(target, time.Now().Unix(), false, false, 0, true)
+	targetFh, _ := wfs.fhMap.AcquireFileHandle(wfs, targetInode, &filer_pb.Entry{
+		Name:       "target",
+		Attributes: &filer_pb.FuseAttributes{FileSize: 12},
+	}, 0, 0)
+
+	wfs.onEntryInvalidation(meta_cache.EntryInvalidation{Path: source, RenamedTo: target, TsNs: 1000})
+
+	if got, found := wfs.inodeToPath.GetInode(target); found {
+		t.Errorf("%s still resolves to %d after being renamed over", target, got)
+	}
+	if !targetFh.isDeleted {
+		t.Error("the replaced file's handle can still flush over the renamed source")
 	}
 }

--- a/weed/mount/weedfs_remote_rename_test.go
+++ b/weed/mount/weedfs_remote_rename_test.go
@@ -90,3 +90,33 @@ func TestRemoteRenameReplayLeavesTheTargetAlone(t *testing.T) {
 		t.Error("the moved file's handle was marked deleted by the replay")
 	}
 }
+
+// A rename event older than the handle's version fence is still a rename. The
+// fence is about which version of the content the handle holds, and skipping
+// the move would leave both the inode and the handle on a name the filer has
+// vacated.
+func TestRenameBelowTheVersionFenceStillMoves(t *testing.T) {
+	wfs := newInvalidateTestWFS(t)
+	oldPath, newPath := util.FullPath("/dir/file"), util.FullPath("/dir/renamed")
+
+	inode := wfs.inodeToPath.Lookup(oldPath, time.Now().Unix(), false, false, 0, true)
+	fh, _ := wfs.fhMap.AcquireFileHandle(wfs, inode, &filer_pb.Entry{
+		Name:       "file",
+		Attributes: &filer_pb.FuseAttributes{FileSize: 88},
+	}, 0, 0)
+	// The handle already reflects a later position in the same clock domain, so
+	// the fence would drop this event.
+	fh.advanceEntryVersion(5000, wfs.signature)
+
+	wfs.onEntryInvalidation(meta_cache.EntryInvalidation{
+		Path: oldPath, RenamedTo: newPath, TsNs: 1000,
+		Signatures: []int32{wfs.signature},
+	})
+
+	if got, status := wfs.inodeToPath.GetPath(inode); status != fuse.OK || got != newPath {
+		t.Errorf("inode resolves to %q (%v), want %s", got, status, newPath)
+	}
+	if dir, name := fh.savedDir, fh.savedName; util.FullPath(dir).Child(name) != newPath {
+		t.Errorf("handle remembers %s/%s, want %s", dir, name, newPath)
+	}
+}


### PR DESCRIPTION
Found while planning the inode-table work behind #10020.

A rename made by another client in the cluster reaches this mount only as a metadata event. The one `MovePath` on that path sits inside `invalidateOpenFileHandle`, so it runs only for inodes that happen to have an open file handle. Every other inode the kernel is still addressing by nodeid — anything a listing or a stat put in the table — keeps resolving to its pre-rename path, and the next operation on it goes to a path the filer no longer has.

Move the entry for every rename invalidation, not just the ones with a handle. The filer emits one event per moved entry, so a renamed directory's children arrive in turn and follow their parent with no descendant walk. A local rename already moves the table itself in `handleRenameResponse`, and the second move is a no-op.

`TestRemoteRenameMovesInodePaths` fails on master with the pre-rename paths still in the table.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote rename handling so files and directories consistently appear at their new locations.
  * Prevented repeated rename notifications from moving open files more than once.
  * Preserved existing target mappings when replayed renames are received.
  * Ensured paths remain correctly tracked when a rename source is no longer available.

* **Tests**
  * Added coverage for directory and child-path updates, repeated notifications, open handles, and missing-source rename scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->