### PR TITLE
Give the local Unix socket gRPC transport room to breathe

### DIFF
--- a/weed/pb/grpc_client_server.go
+++ b/weed/pb/grpc_client_server.go
@@ -150,7 +150,8 @@ func ServeGrpcOnLocalSocket(grpcServer *grpc.Server, grpcPort int) {
 	if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
 		glog.Warningf("Failed to remove old gRPC socket %s: %v", socketPath, err)
 	}
-	listener, err := net.Listen("unix", socketPath)
+	lc := net.ListenConfig{Control: setLocalSocketBuffers}
+	listener, err := lc.Listen(context.Background(), "unix", socketPath)
 	if err != nil {
 		glog.Errorf("Failed to listen on gRPC Unix socket %s: %v", socketPath, err)
 		return
@@ -209,7 +210,7 @@ func GrpcDial(ctx context.Context, address string, waitForReady bool, opts ...gr
 	// Route through Unix socket if one is registered for this address's port
 	if socketPath := resolveLocalGrpcSocket(address); socketPath != "" {
 		options = append(options, grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
-			var d net.Dialer
+			d := net.Dialer{Control: setLocalSocketBuffers}
 			return d.DialContext(ctx, "unix", socketPath)
 		}))
 	} else {

--- a/weed/pb/grpc_client_server.go
+++ b/weed/pb/grpc_client_server.go
@@ -156,6 +156,7 @@ func ServeGrpcOnLocalSocket(grpcServer *grpc.Server, grpcPort int) {
 		glog.Errorf("Failed to listen on gRPC Unix socket %s: %v", socketPath, err)
 		return
 	}
+	listener = &localSocketListener{Listener: listener}
 	glog.V(0).Infof("gRPC also listening on Unix socket %s", socketPath)
 	go func() {
 		if err := grpcServer.Serve(listener); err != nil && err != grpc.ErrServerStopped {
@@ -163,6 +164,20 @@ func ServeGrpcOnLocalSocket(grpcServer *grpc.Server, grpcPort int) {
 		}
 		os.Remove(socketPath)
 	}()
+}
+
+// localSocketListener re-applies the buffer sizes to every accepted connection.
+type localSocketListener struct {
+	net.Listener
+}
+
+func (l *localSocketListener) Accept() (net.Conn, error) {
+	c, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	applyLocalSocketBuffers(c)
+	return c, nil
 }
 
 func NewGrpcServer(opts ...grpc.ServerOption) *grpc.Server {

--- a/weed/pb/local_socket_buffers.go
+++ b/weed/pb/local_socket_buffers.go
@@ -2,18 +2,38 @@
 
 package pb
 
-import "syscall"
+import (
+	"net"
+	"syscall"
+)
 
 // Unix socket buffers default small and never autotune (208KB on Linux, 8KB on
-// macOS). Once one cannot absorb what gRPC's loopyWriter emits for the in-flight
-// streams the writer blocks, both peers latch grpc-go's control-buffer throttle,
-// and the connection deadlocks for good. Best effort: a value the OS clamps down
-// only lowers the concurrency this survives.
+// macOS). Once a buffer cannot absorb what gRPC's loopyWriter emits for the
+// in-flight streams the writer blocks, both peers latch grpc-go's control-buffer
+// throttle, and the connection deadlocks for good. Best effort: a value the OS
+// clamps down only lowers the concurrency this survives.
 const localSocketBufBytes = 8 << 20
 
+func setLocalSocketBufferFD(fd uintptr) {
+	syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_SNDBUF, localSocketBufBytes)
+	syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_RCVBUF, localSocketBufBytes)
+}
+
 func setLocalSocketBuffers(_, _ string, c syscall.RawConn) error {
-	return c.Control(func(fd uintptr) {
-		syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_SNDBUF, localSocketBufBytes)
-		syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_RCVBUF, localSocketBufBytes)
-	})
+	return c.Control(setLocalSocketBufferFD)
+}
+
+// applyLocalSocketBuffers tunes an already-established connection. Linux does
+// not carry the listener's buffer sizes onto accepted sockets, so the server
+// half needs setting explicitly or only the dialing side gets the headroom.
+func applyLocalSocketBuffers(c net.Conn) {
+	sc, ok := c.(syscall.Conn)
+	if !ok {
+		return
+	}
+	raw, err := sc.SyscallConn()
+	if err != nil {
+		return
+	}
+	raw.Control(setLocalSocketBufferFD)
 }

--- a/weed/pb/local_socket_buffers.go
+++ b/weed/pb/local_socket_buffers.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package pb
+
+import "syscall"
+
+// Unix socket buffers default small and never autotune (208KB on Linux, 8KB on
+// macOS). Once one cannot absorb what gRPC's loopyWriter emits for the in-flight
+// streams the writer blocks, both peers latch grpc-go's control-buffer throttle,
+// and the connection deadlocks for good. Best effort: a value the OS clamps down
+// only lowers the concurrency this survives.
+const localSocketBufBytes = 8 << 20
+
+func setLocalSocketBuffers(_, _ string, c syscall.RawConn) error {
+	return c.Control(func(fd uintptr) {
+		syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_SNDBUF, localSocketBufBytes)
+		syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_RCVBUF, localSocketBufBytes)
+	})
+}

--- a/weed/pb/local_socket_buffers_windows.go
+++ b/weed/pb/local_socket_buffers_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+
+package pb
+
+import "syscall"
+
+// Windows never registers local Unix sockets, so there is nothing to tune.
+func setLocalSocketBuffers(_, _ string, _ syscall.RawConn) error { return nil }

--- a/weed/pb/local_socket_buffers_windows.go
+++ b/weed/pb/local_socket_buffers_windows.go
@@ -2,7 +2,12 @@
 
 package pb
 
-import "syscall"
+import (
+	"net"
+	"syscall"
+)
 
 // Windows never registers local Unix sockets, so there is nothing to tune.
 func setLocalSocketBuffers(_, _ string, _ syscall.RawConn) error { return nil }
+
+func applyLocalSocketBuffers(_ net.Conn) {}


### PR DESCRIPTION
Fixes a permanent gRPC transport deadlock on the local Unix sockets, without touching the grpc version. Supersedes #10821, which pinned grpc back to v1.82.0 — `dependency-review` correctly rejected that, since v1.82.1 is the fixed version for GHSA-hrxh-6v49-42gf (high) and the change that causes the deadlock *is* that security fix: the HTTP/2 Rapid Reset mitigation now counts `registerStream`/`cleanupStream` toward the control-buffer throttle.

The deadlock needs a socket send buffer too small to absorb what `loopyWriter` emits for the in-flight streams. When the writer blocks on `Write`, the control buffer backs past the throttle limit, the reader stops reading, and the peer does the same — neither can drain the other and it never recovers. Every in-flight PUT sits in `waitOnHeader` on a filer RPC with zero filer handlers running, both transports parked in `controlBuffer.throttle`, both `loopyWriter`s in `net.(*conn).Write`.

It is buffer size, not transport: forcing TCP down to a 64KB buffer deadlocks it too, and a Unix socket at 2MB does not. Unix sockets are simply the small fixed case, and they are the only sockets we open ourselves, so 8MB on both ends is enough.

**Where this actually bites.** `weed mini` deadlocks deterministically on **macOS** from about 320 concurrent S3 PUTs — the AF_UNIX default there is 8KB and never autotunes:

| concurrent PUTs | before | after |
|---|---|---|
| 512 | 45 ops/s, 14% failures, 65s stalls | 11,649 ops/s, 0 failures, no stall |
| 2048 | wedged | 8,763 ops/s, 0 failures, no stall |

On **Linux** the AF_UNIX default is 208KB and I could **not** get `weed mini` to deadlock — clean at c=512, 1024 and 2048 (440k ops at 10,934 ops/s at c=512). So this is headroom on Linux, not a fix for an observed failure there. The mechanism does exist on Linux — a standalone grpc-only repro deadlocks over a Unix socket at c=512 — but weed's PUT path does not generate enough stream churn per connection to reach it at the concurrencies I could drive. I am not claiming this resolves the self-hosted Sentry reports; those run Linux and I have not reproduced the deadlock there.

Linux does not carry the listener's `SO_SNDBUF` onto accepted sockets, so the listener, the dialer, and each accepted connection all get it explicitly (measured: without the accept-side fix, Linux left the server half at the 212992 default while the client half had 8388608).

Caveats: this raises the concurrency the transport survives rather than making the deadlock unreachable, and a kernel that clamps `SO_SNDBUF` gets less headroom than requested. The real fix is upstream — grpc/grpc-go#9330. A remote filer over ordinary TCP is exposed too wherever send buffers are constrained, which this does not address.

Windows never registers these sockets and gets a no-op; `syscall.SetsockoptInt` takes a `Handle` there, hence the build-tagged split. Cross-compiles clean for windows/amd64, windows/arm64, freebsd/amd64, darwin/arm64.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Unix socket communication reliability by applying larger send and receive buffers to both servers and clients.
  * Reduced the likelihood of gRPC connections stalling during high-throughput communication.
  * Ensured buffer settings are reapplied to established Unix socket connections where supported.
  * Preserved existing TCP behavior and maintained compatibility on Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->