### PR TITLE
rust: stop writing when a durable write's index flush fails

### DIFF
--- a/seaweed-volume/src/server/heartbeat.rs
+++ b/seaweed-volume/src/server/heartbeat.rs
@@ -771,6 +771,10 @@ fn collect_volume_snapshot(
     build_heartbeat_with_ec_status(config, &mut store, Vec::new(), true, false).1
 }
 
+/// The heartbeat alone, without the volume snapshot the send loop pairs it
+/// with. Only the tests want it that way; the loop calls
+/// collect_heartbeat_with_snapshot directly.
+#[cfg(test)]
 fn collect_heartbeat(
     config: &HeartbeatConfig,
     state: &Arc<VolumeServerState>,

--- a/seaweed-volume/src/storage/volume.rs
+++ b/seaweed-volume/src/storage/volume.rs
@@ -1537,11 +1537,13 @@ impl Volume {
     // ---- Write ----
 
     /// Write a needle to the volume (synchronous path).
-    /// Write a needle to the volume. With `fsync` the write is only reported
-    /// successful once both the .dat record and the .idx row that indexes it
-    /// are on disk, so an ack survives a crash rather than sitting in the page
-    /// cache. Both flushes happen under the same lock as the append, so a
-    /// failed one can take its own append back off the end and nobody else's.
+    ///
+    /// With `fsync` the write is only reported successful once both the .dat
+    /// record and the .idx row that indexes it are on disk, so an ack survives a
+    /// crash rather than sitting in the page cache. The two flushes fail
+    /// differently: a failed .dat flush happens before anything is published, so
+    /// it takes its own append back off the end and nobody else's, while a
+    /// failed .idx flush cannot be undone and stops the volume taking writes.
     pub fn write_needle(
         &mut self,
         n: &mut Needle,
@@ -1573,20 +1575,40 @@ impl Volume {
         }
     }
 
-    /// Flush the .idx. Paired with flush_dat on the durable path: load() rebuilds
-    /// the map from .idx, so both files have to be down before a write is acked.
-    fn flush_idx(&self) -> io::Result<()> {
+    /// Flush the .idx, the second half of a durable write. load() rebuilds the
+    /// map from .idx, not from .dat, so the row has to be down before the write
+    /// is acked: lose it and the volume comes back with a .dat tail the
+    /// integrity check cannot account for, and loads read only.
+    ///
+    /// By the time this runs the row is published and cannot be taken back -
+    /// undoing it would mean writing to a disk that is already failing, and
+    /// would leave an .idx row pointing past a truncated .dat. So a failure
+    /// stops the volume taking writes instead: nothing more gets appended past a
+    /// record whose index may not survive, and the master routes writes
+    /// elsewhere once the volume heartbeats read only.
+    fn flush_idx(&mut self) -> Result<(), VolumeError> {
         #[cfg(test)]
         if self.fail_idx_sync_for_test {
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
-                "injected idx sync failure",
-            ));
+            let e = io::Error::new(io::ErrorKind::Other, "injected idx sync failure");
+            self.no_write_or_delete = true;
+            return Err(VolumeError::Io(e));
         }
-        match self.nm.as_ref() {
+        let synced = match self.nm.as_ref() {
             Some(nm) => nm.sync(),
             None => Ok(()),
+        };
+        if let Err(e) = synced {
+            self.check_read_write_error(Some(&e));
+            self.no_write_or_delete = true;
+            tracing::error!(
+                "volume {}: failed to flush the index after a durable write, \
+                 marking read only: {}",
+                self.id.0,
+                e
+            );
+            return Err(VolumeError::Io(e));
         }
+        Ok(())
     }
 
     fn do_write_request(
@@ -1613,13 +1635,16 @@ impl Volume {
         // Dedup check (matches Go: n.DataSize = oldNeedle.DataSize on dedup)
         if let Some(old_data_size) = self.is_file_unchanged(n) {
             n.data_size = old_data_size;
-            // Nothing to append, but an earlier write may have left this content
-            // in the page cache, and the caller is asking for it to be on disk.
+            // Nothing to append, but the write this matched may have been
+            // non-durable, and the caller is asking for the content to be on
+            // disk. Its .idx row can be sitting in the page cache too, so both
+            // files get flushed exactly as they would for a fresh append.
             if fsync {
                 self.flush_dat().map_err(|e| {
                     self.check_read_write_error(Some(&e));
                     VolumeError::Io(e)
                 })?;
+                self.flush_idx()?;
             }
             return Ok((0, Size(n.data_size as i32), true));
         }
@@ -1708,29 +1733,8 @@ impl Volume {
             }
         }
 
-        // load() rebuilds the map from .idx, not from .dat, so the row has to be
-        // down before the write is acked. Lose it and the volume comes back with
-        // a .dat tail the integrity check cannot account for, and loads read only
-        // - a worse outcome than losing the write.
         if fsync {
-            if let Err(e) = self.flush_idx() {
-                self.check_read_write_error(Some(&e));
-                // The row is published and the .dat record is down, but we cannot
-                // promise the row comes back. Taking it out again would mean
-                // undoing published state on a disk that is already failing, and
-                // would leave an .idx row pointing past a truncated .dat. Stop
-                // writing instead: nothing more gets appended past a record whose
-                // index may not survive, and the master routes writes elsewhere
-                // once the volume heartbeats read only.
-                self.no_write_or_delete = true;
-                tracing::error!(
-                    "volume {}: failed to flush the index after a durable write, \
-                     marking read only: {}",
-                    self.id.0,
-                    e
-                );
-                return Err(VolumeError::Io(e));
-            }
+            self.flush_idx()?;
         }
 
         if self.last_modified_ts_seconds < n.last_modified {
@@ -4315,6 +4319,46 @@ mod tests {
         assert_eq!(read_n.data, b"first-copy");
     }
 
+
+    /// A durable write that dedups against an earlier non-durable one still has
+    /// to flush the index. The row that earlier write left behind can be sitting
+    /// in the page cache, so acking without flushing is the same false promise
+    /// as skipping the flush on a fresh append.
+    #[test]
+    fn test_dedup_durable_write_flushes_the_index() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().to_str().unwrap();
+        let mut v = make_test_volume(dir);
+
+        let mut first = Needle {
+            id: NeedleId(1),
+            cookie: Cookie(0xaa),
+            data: b"same-content".to_vec(),
+            data_size: 12,
+            ..Needle::default()
+        };
+        v.write_needle(&mut first, true, false).unwrap();
+
+        v.fail_next_idx_sync_for_test(true);
+        let mut same = Needle {
+            id: NeedleId(1),
+            cookie: Cookie(0xaa),
+            data: b"same-content".to_vec(),
+            data_size: 12,
+            ..Needle::default()
+        };
+        let result = v.write_needle(&mut same, true, true);
+        v.fail_next_idx_sync_for_test(false);
+
+        assert!(
+            result.is_err(),
+            "a dedup hit must not be acked without flushing the index"
+        );
+        assert!(
+            v.is_read_only(),
+            "and the failed index flush quarantines the volume, dedup or not"
+        );
+    }
 
     /// A durable write whose index flush fails leaves the .dat record down and
     /// its row published but not guaranteed to come back. The volume stops

--- a/seaweed-volume/src/storage/volume.rs
+++ b/seaweed-volume/src/storage/volume.rs
@@ -22,9 +22,7 @@ use tracing::{error, info, warn};
 #[cfg(test)]
 use crate::storage::idx;
 use crate::storage::needle::needle::{self, get_actual_size, Needle, NeedleError};
-use crate::storage::needle_map::{
-    CompactNeedleMap, NeedleMap, NeedleMapKind, NeedleValue, RedbNeedleMap,
-};
+use crate::storage::needle_map::{CompactNeedleMap, NeedleMap, NeedleMapKind, RedbNeedleMap};
 use crate::storage::super_block::{ReplicaPlacement, SuperBlock, SUPER_BLOCK_SIZE};
 use crate::storage::types::*;
 

--- a/seaweed-volume/src/storage/volume.rs
+++ b/seaweed-volume/src/storage/volume.rs
@@ -509,10 +509,12 @@ pub struct Volume {
     dat_file: Option<File>,
     remote_dat_file: Option<RemoteDatFile>,
     nm: Option<NeedleMap>,
-    /// Makes the next .dat flush fail, so tests can exercise the durable
-    /// write's failure path without a real disk fault.
+    /// Make the next .dat or .idx flush fail, so tests can exercise the durable
+    /// write's failure paths without a real disk fault.
     #[cfg(test)]
     fail_fsync_for_test: bool,
+    #[cfg(test)]
+    fail_idx_sync_for_test: bool,
     needle_map_kind: NeedleMapKind,
     data_file_access_control: Arc<DataFileAccessControl>,
 
@@ -589,6 +591,8 @@ impl Volume {
             remote_dat_file: None,
             #[cfg(test)]
             fail_fsync_for_test: false,
+            #[cfg(test)]
+            fail_idx_sync_for_test: false,
             nm: None,
             needle_map_kind,
             data_file_access_control: Arc::new(DataFileAccessControl::default()),
@@ -629,6 +633,8 @@ impl Volume {
             remote_dat_file: None,
             #[cfg(test)]
             fail_fsync_for_test: false,
+            #[cfg(test)]
+            fail_idx_sync_for_test: false,
             nm: None,
             needle_map_kind: NeedleMapKind::InMemory,
             data_file_access_control: Arc::new(DataFileAccessControl::default()),
@@ -1533,10 +1539,11 @@ impl Volume {
     // ---- Write ----
 
     /// Write a needle to the volume (synchronous path).
-    /// Write a needle to the volume. With `fsync` the .dat is flushed before
-    /// returning, so an ack means the data is on disk and not just in the page
-    /// cache. The flush happens under the same lock as the append, so a failed
-    /// one can take its own append back off the end and nobody else's.
+    /// Write a needle to the volume. With `fsync` the write is only reported
+    /// successful once both the .dat record and the .idx row that indexes it
+    /// are on disk, so an ack survives a crash rather than sitting in the page
+    /// cache. Both flushes happen under the same lock as the append, so a
+    /// failed one can take its own append back off the end and nobody else's.
     pub fn write_needle(
         &mut self,
         n: &mut Needle,
@@ -1551,8 +1558,9 @@ impl Volume {
         self.do_write_request(n, check_cookie, fsync)
     }
 
-    /// Flush the .dat. The index is left out on purpose: it is rebuilt from the
-    /// .dat, so a durable write only has to get the data down.
+    /// Flush the .dat, the first half of a durable write. The .idx is flushed
+    /// separately by flush_idx once the row is published; the two are split so
+    /// nothing is indexed before the bytes it points at are down.
     fn flush_dat(&self) -> io::Result<()> {
         #[cfg(test)]
         if self.fail_fsync_for_test {
@@ -1564,6 +1572,22 @@ impl Volume {
         match self.dat_file.as_ref() {
             Some(dat_file) => dat_file.sync_all(),
             None => Err(io::Error::new(io::ErrorKind::Other, "dat file not open")),
+        }
+    }
+
+    /// Flush the .idx. Paired with flush_dat on the durable path: load() rebuilds
+    /// the map from .idx, so both files have to be down before a write is acked.
+    fn flush_idx(&self) -> io::Result<()> {
+        #[cfg(test)]
+        if self.fail_idx_sync_for_test {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "injected idx sync failure",
+            ));
+        }
+        match self.nm.as_ref() {
+            Some(nm) => nm.sync(),
+            None => Ok(()),
         }
     }
 
@@ -1664,8 +1688,25 @@ impl Volume {
         };
 
         if should_update {
-            if let Some(nm) = &mut self.nm {
-                nm.put(n.id, Offset::from_actual_offset(offset as i64), n.size)?;
+            let indexed = match self.nm.as_mut() {
+                Some(nm) => nm.put(n.id, Offset::from_actual_offset(offset as i64), n.size),
+                None => Ok(()),
+            };
+            if let Err(e) = indexed {
+                if fsync {
+                    // The record is already down but nothing indexes it, the
+                    // same state a failed .idx flush leaves behind, so it gets
+                    // the same treatment rather than another write on top.
+                    self.no_write_or_delete = true;
+                    tracing::error!(
+                        "volume {}: failed to index a durable write at {}, \
+                         marking read only: {}",
+                        self.id.0,
+                        offset,
+                        e
+                    );
+                }
+                return Err(VolumeError::Io(e));
             }
         }
 
@@ -1674,11 +1715,23 @@ impl Volume {
         // a .dat tail the integrity check cannot account for, and loads read only
         // - a worse outcome than losing the write.
         if fsync {
-            if let Some(nm) = self.nm.as_ref() {
-                if let Err(e) = nm.sync() {
-                    self.check_read_write_error(Some(&e));
-                    return Err(VolumeError::Io(e));
-                }
+            if let Err(e) = self.flush_idx() {
+                self.check_read_write_error(Some(&e));
+                // The row is published and the .dat record is down, but we cannot
+                // promise the row comes back. Taking it out again would mean
+                // undoing published state on a disk that is already failing, and
+                // would leave an .idx row pointing past a truncated .dat. Stop
+                // writing instead: nothing more gets appended past a record whose
+                // index may not survive, and the master routes writes elsewhere
+                // once the volume heartbeats read only.
+                self.no_write_or_delete = true;
+                tracing::error!(
+                    "volume {}: failed to flush the index after a durable write, \
+                     marking read only: {}",
+                    self.id.0,
+                    e
+                );
+                return Err(VolumeError::Io(e));
             }
         }
 
@@ -3760,6 +3813,11 @@ impl Volume {
     }
 
     #[cfg(test)]
+    pub(crate) fn fail_next_idx_sync_for_test(&mut self, fail: bool) {
+        self.fail_idx_sync_for_test = fail;
+    }
+
+    #[cfg(test)]
     pub(crate) fn set_last_modified_ts_for_test(&mut self, ts_seconds: u64) {
         self.last_modified_ts_seconds = ts_seconds;
     }
@@ -4257,6 +4315,48 @@ mod tests {
         };
         assert_eq!(v.read_needle(&mut read_n).unwrap(), 10);
         assert_eq!(read_n.data, b"first-copy");
+    }
+
+
+    /// A durable write whose index flush fails leaves the .dat record down and
+    /// its row published but not guaranteed to come back. The volume stops
+    /// taking writes rather than appending more past a record whose index may
+    /// not survive a restart.
+    #[test]
+    fn test_write_needle_failed_idx_sync_quarantines_volume() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().to_str().unwrap();
+        let mut v = make_test_volume(dir);
+
+        v.fail_next_idx_sync_for_test(true);
+        let mut n = Needle {
+            id: NeedleId(1),
+            cookie: Cookie(0xaa),
+            data: b"index-never-flushed".to_vec(),
+            data_size: 19,
+            ..Needle::default()
+        };
+        v.write_needle(&mut n, true, true).unwrap_err();
+        v.fail_next_idx_sync_for_test(false);
+
+        assert!(
+            v.is_read_only(),
+            "a volume whose index flush failed must stop taking writes"
+        );
+        let mut later = Needle {
+            id: NeedleId(2),
+            cookie: Cookie(0xbb),
+            data: b"should-be-refused".to_vec(),
+            data_size: 17,
+            ..Needle::default()
+        };
+        assert!(
+            matches!(
+                v.write_needle(&mut later, true, false),
+                Err(VolumeError::ReadOnly)
+            ),
+            "later writes must not append past the record whose index is in doubt"
+        );
     }
 
     /// Same for a needle the failed write introduced: it never becomes visible,


### PR DESCRIPTION
Follow-up to #10816, which merged before this review point was addressed - Greptile raised it two minutes after my reply and I did not catch it in time. Original comment: https://github.com/seaweedfs/seaweedfs/pull/10816#discussion_r-index-sync-failure

## The gap

A durable write flushes the `.dat`, publishes the needle map row, then flushes the `.idx`. #10816 handled a failure of the first flush - the append comes back off the end, nothing was ever published - and quarantines the volume if that truncate cannot be done. It did not handle a failure of the second one. That path returned the error and carried on with the row live and the volume writable, which has two consequences:

- The handler answers 500 and skips replication, while the primary keeps serving the new needle out of its live map. So the primary holds a needle the replicas never saw, for a write the client was told had failed.
- If the unflushed row is lost on restart, the durable `.dat` tail is exactly the state `check_volume_data_integrity` cannot account for, and `load()` sets `no_write_or_delete` anyway - the outcome the `.idx` flush existed to prevent.

## Why quarantine rather than roll back

Taking the row back out means undoing published state on a disk that is already failing. It also cannot be done safely: `nm.delete` appends a tombstone through the same failing `.idx`, and truncating the `.dat` afterwards would leave an `.idx` row pointing past the end - worse than what we started with. Undoing published state through the ordinary map API is also what the accounting review on #10816 rejected.

So the volume stops taking writes, matching what #10816 already does when the post-failure truncate fails. Nothing more is appended past a record whose index is in doubt, and the master routes writes elsewhere once the volume heartbeats read only.

This does not make the replicas consistent - the primary still has a needle they lack. That divergence is inherent once the bytes are down and cannot be safely removed; what changes is that it stays bounded and shows up as a read-only volume rather than quietly accumulating.

## Test

`test_write_needle_failed_idx_sync_quarantines_volume` injects the index flush failure through a `#[cfg(test)]` seam alongside the existing `.dat` one, and asserts the volume goes read only and refuses the next write. I checked it fails without the quarantine. Full `cargo test` passes (456).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved durability for deduplicated writes by synchronizing both data and index updates.
  - If index synchronization fails, the volume now enters read-only mode and rejects subsequent writes.
  - Successfully written data is preserved when a later index synchronization step fails.
- **Tests**
  - Added coverage for synchronization failures, volume quarantine, preserved data, and subsequent write rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->