### PR TITLE
ci: fall through to another Ubuntu mirror when one is unreachable

### DIFF
--- a/docker/Dockerfile.e2e
+++ b/docker/Dockerfile.e2e
@@ -2,25 +2,21 @@ FROM ubuntu:22.04
 
 LABEL author="Chris Lu"
 
-# Use Azure's Ubuntu mirror — much faster than archive.ubuntu.com from GitHub-hosted runners,
-# which have been hanging long enough on Ign:/retry to trip the 10-min step timeout.
 # Note: This e2e test image intentionally runs as root for simplicity and compatibility.
 # Production images (Dockerfile.go_build) use proper user isolation with su-exec.
 # For testing purposes, running as root avoids permission complexities and dependency
 # on Alpine-specific tools like su-exec (not available in Ubuntu repos).
-RUN sed -i 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g; s|http://security.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list && \
-    apt-get -o Acquire::http::Timeout=15 update && \
-    DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::http::Timeout=15 install -y \
-    --no-install-recommends \
-    --no-install-suggests \
-    curl \
-    fio \
-    fuse \
-    ca-certificates \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /tmp/* \
-    && rm -rf /var/tmp/*
+
+# apt-install prefers Azure's mirror, which archive.ubuntu.com is slow enough from
+# GitHub-hosted runners to justify, and falls through to archive.ubuntu.com when
+# Azure is unreachable - which it periodically is, and Acquire::Retries against a
+# single mirror just retries a dead host. Images built FROM this one install
+# through it for the same reason.
+COPY apt-install /usr/local/bin/apt-install
+RUN chmod +x /usr/local/bin/apt-install && \
+    apt-install curl fio fuse ca-certificates && \
+    rm -rf /tmp/* /var/tmp/*
+
 RUN mkdir -p /etc/seaweedfs /data/filerldb2
 
 COPY ./weed /usr/bin/

--- a/docker/apt-install
+++ b/docker/apt-install
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Install packages, falling through to the next Ubuntu mirror when one is
+# unreachable. See docker/Dockerfile.e2e.
+set -e
+
+# Every rewrite starts from the pristine list, so a mirror that just failed does
+# not become the pattern the next rewrite has to match.
+[ -f /etc/apt/sources.list.orig ] || cp /etc/apt/sources.list /etc/apt/sources.list.orig
+
+for mirror in azure.archive.ubuntu.com archive.ubuntu.com; do
+	sed "s|http://archive\.ubuntu\.com/ubuntu|http://$mirror/ubuntu|g; s|http://security\.ubuntu\.com/ubuntu|http://$mirror/ubuntu|g" \
+		/etc/apt/sources.list.orig > /etc/apt/sources.list
+	if apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=15 update && \
+		DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=15 install -y \
+			--no-install-recommends --no-install-suggests "$@"; then
+		apt-get clean
+		rm -rf /var/lib/apt/lists/*
+		exit 0
+	fi
+	echo "apt: $mirror unreachable, trying the next mirror" >&2
+done
+
+exit 1

--- a/test/pjdfstest/Dockerfile
+++ b/test/pjdfstest/Dockerfile
@@ -1,17 +1,12 @@
 FROM chrislusf/seaweedfs:e2e
 
-RUN apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 update && \
-    DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 install -y \
-    --no-install-recommends \
-    --no-install-suggests \
+RUN apt-install \
     autoconf \
     automake \
     build-essential \
     git \
     libtap-harness-archive-perl \
-    perl \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    perl
 
 ARG PJDFSTEST_REPO=https://github.com/sanwan/pjdfstest.git
 ARG PJDFSTEST_REF=d25636a227606f8960e5179741d8f4ad7030ef41

--- a/test/samba/Dockerfile
+++ b/test/samba/Dockerfile
@@ -1,14 +1,9 @@
 FROM chrislusf/seaweedfs:e2e
 
-RUN apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 update && \
-    DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 install -y \
-    --no-install-recommends \
-    --no-install-suggests \
+RUN apt-install \
     samba \
     smbclient \
-    python3-minimal \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    python3-minimal
 
 COPY smb.conf.template /smb.conf.template
 COPY smb_tests.sh /smb_tests.sh


### PR DESCRIPTION
Two workflows lost runs to the same thing tonight — `pjdfstest` on #10822 and `samba-integration` on #10827 — both with every package failing identically:

```
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/... Unable to connect to azure.archive.ubuntu.com:80
ERROR: failed to build: ... exit code: 100
```

`docker/Dockerfile.e2e` rewrites both `archive` and `security` to `azure.archive.ubuntu.com` and nothing else, and `test/samba/Dockerfile` and `test/pjdfstest/Dockerfile` are `FROM chrislusf/seaweedfs:e2e`, so they inherit that list. When Azure is unreachable the build has nowhere to go: `Acquire::Retries=5` just retries a dead host for ~90s and then apt exits 100, before a single test runs.

Azure was pinned for a good reason — the comment records `archive.ubuntu.com` hanging long enough from GitHub runners to trip the step timeout — so this keeps it preferred rather than reverting it. Installs go through a small helper that walks a mirror list, rewriting from a pristine copy of `sources.list` each time so a mirror that just failed does not become the pattern the next rewrite has to match.

Verified both paths against a real `docker build`:

- normal: installs from Azure, image builds.
- fallback, first entry pointed at an unroutable host: `apt: blackhole.invalid unreachable, trying the next mirror`, then `Setting up curl ...` from `archive.ubuntu.com`, image builds.

The first version of the helper failed that second test — it sed'd the live `sources.list` in place, so once the first pass had written a hostname the second pass's pattern no longer matched it and the fallback never took effect. Hence starting from `sources.list.orig`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved container build setup for end-to-end, filesystem, and Samba test environments.
  * Dependency installation now uses consistent retry, timeout, and mirror-fallback behavior.
  * Reduced unnecessary package recommendations and cleaned package caches after successful installation.
  * Preserved compatibility across configured Ubuntu package mirrors, improving resilience when a mirror is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->