### PR TITLE
topology: refresh oversized mark on every heartbeat

### DIFF
--- a/weed/topology/topology.go
+++ b/weed/topology/topology.go
@@ -637,11 +637,10 @@ func (t *Topology) SyncDataNodeRegistration(volumes []*master_pb.VolumeInformati
 		// Without this, the volume stays visible in volume.list/admin UI yet
 		// LookupVolume returns "volume id not found".
 		if !vl.HasDataNode(v.Id, dn) {
-			// RegisterVolume sets the oversized mark via its defer; the writable
-			// correction runs once, after UpdateVolumeSize below.
-			if !vl.RegisterVolume(&v, dn) {
-				// Dropped with its collection; re-resolve.
-				t.RegisterVolumeLayout(v, dn)
+			for !vl.RegisterVolume(&v, dn) {
+				// Dropped with its collection; the next lookup creates a fresh
+				// one, which the calls below must use too.
+				vl = t.GetVolumeLayout(v.Collection, v.ReplicaPlacement, v.Ttl, diskType)
 			}
 			// Volumes new to the disk map were registered above, so reaching
 			// here means only the lookup index had lost it. Clients were told

--- a/weed/topology/topology.go
+++ b/weed/topology/topology.go
@@ -655,6 +655,7 @@ func (t *Topology) SyncDataNodeRegistration(volumes []*master_pb.VolumeInformati
 			// it is back.
 			newVolumes = append(newVolumes, v)
 		}
+		vl.UpdateOversizedState(&v, dn)
 		if vl.UpdateVolumeSize(v.Id, v.Size, v.CompactRevision) {
 			vl.AdjustActiveVolumeCountAfterRecovery(v.Id)
 		}
@@ -731,6 +732,7 @@ func (t *Topology) ApplyVolumeChanges(changed []*master_pb.VolumeInformationMess
 		if isNew || becameServable {
 			newVolumes = append(newVolumes, vi)
 		}
+		vl.UpdateOversizedState(&vi, dn)
 		vl.EnsureCorrectWritables(&vi)
 		if vl.UpdateVolumeSize(vi.Id, vi.Size, vi.CompactRevision) {
 			vl.AdjustActiveVolumeCountAfterRecovery(vi.Id)

--- a/weed/topology/topology.go
+++ b/weed/topology/topology.go
@@ -613,18 +613,12 @@ func (t *Topology) SyncDataNodeRegistration(volumes []*master_pb.VolumeInformati
 		}
 	}
 	// find out the delta volumes
-	var changedVolumes []storage.VolumeInfo
-	newVolumes, deletedVolumes, changedVolumes = dn.UpdateVolumes(volumeInfos)
+	newVolumes, deletedVolumes, _ = dn.UpdateVolumes(volumeInfos)
 	for _, v := range newVolumes {
 		t.RegisterVolumeLayout(v, dn)
 	}
 	for _, v := range deletedVolumes {
 		t.UnRegisterVolumeLayout(v, dn)
-	}
-	for _, v := range changedVolumes {
-		diskType := types.ToDiskType(v.DiskType)
-		vl := t.GetVolumeLayout(v.Collection, v.ReplicaPlacement, v.Ttl, diskType)
-		vl.EnsureCorrectWritables(&v)
 	}
 	// Update effective sizes for all reported volumes (decay pending estimates).
 	// If decay brings a volume eagerly removed by RecordAssign back under the
@@ -643,9 +637,9 @@ func (t *Topology) SyncDataNodeRegistration(volumes []*master_pb.VolumeInformati
 		// Without this, the volume stays visible in volume.list/admin UI yet
 		// LookupVolume returns "volume id not found".
 		if !vl.HasDataNode(v.Id, dn) {
-			if vl.RegisterVolume(&v, dn) {
-				vl.EnsureCorrectWritables(&v)
-			} else {
+			// RegisterVolume sets the oversized mark via its defer; the writable
+			// correction runs once, after UpdateVolumeSize below.
+			if !vl.RegisterVolume(&v, dn) {
 				// Dropped with its collection; re-resolve.
 				t.RegisterVolumeLayout(v, dn)
 			}
@@ -659,6 +653,7 @@ func (t *Topology) SyncDataNodeRegistration(volumes []*master_pb.VolumeInformati
 		if vl.UpdateVolumeSize(v.Id, v.Size, v.CompactRevision) {
 			vl.AdjustActiveVolumeCountAfterRecovery(v.Id)
 		}
+		vl.EnsureCorrectWritables(&v)
 	}
 	return
 }
@@ -733,10 +728,10 @@ func (t *Topology) ApplyVolumeChanges(changed []*master_pb.VolumeInformationMess
 			newVolumes = append(newVolumes, vi)
 		}
 		vl.UpdateOversizedState(&vi, dn)
-		vl.EnsureCorrectWritables(&vi)
 		if vl.UpdateVolumeSize(vi.Id, vi.Size, vi.CompactRevision) {
 			vl.AdjustActiveVolumeCountAfterRecovery(vi.Id)
 		}
+		vl.EnsureCorrectWritables(&vi)
 	}
 	return newVolumes
 }

--- a/weed/topology/topology_test.go
+++ b/weed/topology/topology_test.go
@@ -88,7 +88,7 @@ func TestHandlingVolumeServerHeartbeat(t *testing.T) {
 		for k := 1; k <= volumeCount; k++ {
 			volumeMessage := &master_pb.VolumeInformationMessage{
 				Id:               uint32(k),
-				Size:             uint64(254320),
+				Size:             uint64(30000),
 				Collection:       "",
 				FileCount:        uint64(2343),
 				DeleteCount:      uint64(345),

--- a/weed/topology/volume_layout.go
+++ b/weed/topology/volume_layout.go
@@ -311,11 +311,12 @@ func (vl *VolumeLayout) ensureCorrectWritables(vid needle.VolumeId) {
 			time.Since(st.fullSince) < capacityRecoveryDelay {
 			return
 		}
-		// A volume whose effective size is still past the crowded threshold
-		// (marked by UpdateVolumeSize's decay pass) must not be restored here:
-		// UpdateVolumeSize refused the recovery for a reason this helper would
-		// otherwise override.
-		if _, crowded := vl.crowded[vid]; crowded {
+		// A volume already at the limit must not be restored here: the next
+		// assign's RecordAssign would remove it again. Crowded is the wrong
+		// test for that -- it starts at 90%, and a crowded volume that lost a
+		// replica would never be writable again once the replica returned,
+		// since nothing writes to it and its size can no longer fall.
+		if st := vl.sizeTracking[vid]; st != nil && st.effectiveSize >= vl.volumeSizeLimit {
 			return
 		}
 		vl.setVolumeWritable(vid)

--- a/weed/topology/volume_layout.go
+++ b/weed/topology/volume_layout.go
@@ -164,6 +164,18 @@ func (vl *VolumeLayout) rememberOversizedVolume(v *storage.VolumeInfo, dn *DataN
 	}
 }
 
+// UpdateOversizedState refreshes the per-replica oversized mark from the size
+// reported by this heartbeat. RegisterVolume sets it once at registration; the
+// delta heartbeat path (ApplyVolumeChanges) and the full heartbeat path
+// (SyncDataNodeRegistration) must keep it current, or a volume that grew past
+// the limit would keep looking writable to ensureCorrectWritables and bounce
+// between writable and unwritable on every assign.
+func (vl *VolumeLayout) UpdateOversizedState(v *storage.VolumeInfo, dn *DataNode) {
+	vl.accessLock.Lock()
+	defer vl.accessLock.Unlock()
+	vl.rememberOversizedVolume(v, dn)
+}
+
 // UpdateVolumeSize is called on every heartbeat for every reported volume.
 // It decays the pending size estimate toward the reported size and updates
 // crowded state. Replicated volumes report from multiple DataNodes; decay

--- a/weed/topology/volume_layout.go
+++ b/weed/topology/volume_layout.go
@@ -303,6 +303,14 @@ func (vl *VolumeLayout) ensureCorrectWritables(vid needle.VolumeId) {
 	isAllWritable := vl.isAllWritable(vid)
 	isOversizedVolume := vl.vid2location[vid].AnyOversized()
 	if isEnoughCopies && isAllWritable && !isOversizedVolume {
+		// A volume removed for capacity (fullSince set) must go through the
+		// heartbeat recovery path in UpdateVolumeSize, which enforces
+		// capacityRecoveryDelay. Re-adding it here would bypass the cooldown
+		// and let a just-compacted volume flip back to writable immediately.
+		if st := vl.sizeTracking[vid]; st != nil && !st.fullSince.IsZero() &&
+			time.Since(st.fullSince) < capacityRecoveryDelay {
+			return
+		}
 		vl.setVolumeWritable(vid)
 		return
 	}

--- a/weed/topology/volume_layout.go
+++ b/weed/topology/volume_layout.go
@@ -311,6 +311,13 @@ func (vl *VolumeLayout) ensureCorrectWritables(vid needle.VolumeId) {
 			time.Since(st.fullSince) < capacityRecoveryDelay {
 			return
 		}
+		// A volume whose effective size is still past the crowded threshold
+		// (marked by UpdateVolumeSize's decay pass) must not be restored here:
+		// UpdateVolumeSize refused the recovery for a reason this helper would
+		// otherwise override.
+		if _, crowded := vl.crowded[vid]; crowded {
+			return
+		}
 		vl.setVolumeWritable(vid)
 		return
 	}

--- a/weed/topology/volume_layout.go
+++ b/weed/topology/volume_layout.go
@@ -131,8 +131,6 @@ func (vl *VolumeLayout) RegisterVolume(v *storage.VolumeInfo, dn *DataNode) bool
 		return false
 	}
 
-	defer vl.rememberOversizedVolume(v, dn)
-
 	moveLookupOwnership(v.Id, vl.getOrCreateLocationList(v.Id).Set(dn), dn)
 	if !v.ReadOnly {
 		vl.initSizeTracking(v.Id, v.Size, v.CompactRevision)
@@ -165,11 +163,16 @@ func (vl *VolumeLayout) rememberOversizedVolume(v *storage.VolumeInfo, dn *DataN
 }
 
 // UpdateOversizedState refreshes the per-replica oversized mark from the size
-// reported by this heartbeat. RegisterVolume sets it once at registration; the
-// delta heartbeat path (ApplyVolumeChanges) and the full heartbeat path
-// (SyncDataNodeRegistration) must keep it current, or a volume that grew past
-// the limit would keep looking writable to ensureCorrectWritables and bounce
+// reported by this heartbeat, and is the only writer of that mark. The delta
+// heartbeat path (ApplyVolumeChanges) and the full heartbeat path
+// (SyncDataNodeRegistration) both call it, or a volume that grew past the
+// limit would keep looking writable to ensureCorrectWritables and bounce
 // between writable and unwritable on every assign.
+//
+// Registration deliberately does not touch the mark: the incremental path
+// registers from a short heartbeat message that carries no size, so judging
+// the volume by it would clear the mark on every arrival announcement and
+// hand an oversized volume back to the writable list.
 func (vl *VolumeLayout) UpdateOversizedState(v *storage.VolumeInfo, dn *DataNode) {
 	vl.accessLock.Lock()
 	defer vl.accessLock.Unlock()

--- a/weed/topology/volume_layout_oversized_heartbeat_test.go
+++ b/weed/topology/volume_layout_oversized_heartbeat_test.go
@@ -3,6 +3,10 @@ package topology
 import (
 	"testing"
 	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
+	"github.com/seaweedfs/seaweedfs/weed/storage/super_block"
+	"github.com/seaweedfs/seaweedfs/weed/storage/types"
 )
 
 // A volume that grew past the limit keeps bouncing between writable and
@@ -155,11 +159,10 @@ func TestEnsureCorrectWritablesHonorsRecoveryCooldown(t *testing.T) {
 	}
 }
 
-// After the cooldown elapses, a volume whose effective size is still past the
-// crowded threshold must not be restored by ensureCorrectWritables: only
-// UpdateVolumeSize's recovery path -- which rejects the crowded state -- may
-// bring it back to writable.
-func TestEnsureCorrectWritablesDoesNotRestoreCrowdedVolume(t *testing.T) {
+// After the cooldown elapses, a volume whose effective size is still at the
+// limit must not be restored by ensureCorrectWritables: the next assign would
+// remove it again.
+func TestEnsureCorrectWritablesDoesNotRestoreVolumeStillAtLimit(t *testing.T) {
 	layout := `
 {
   "dc1":{
@@ -178,8 +181,7 @@ func TestEnsureCorrectWritablesDoesNotRestoreCrowdedVolume(t *testing.T) {
 
 	// Remove the volume for capacity, as RecordAssign would. effectiveSize
 	// lands at 13000, past the limit (10000); after the decay against a
-	// reported size of 8000 it stays at 10500, still past the crowded
-	// threshold (9000).
+	// reported size of 8000 it stays at 10500, still past the limit.
 	if !vl.RecordAssign(1, 5000) {
 		t.Fatalf("RecordAssign should report the volume reached capacity")
 	}
@@ -195,7 +197,7 @@ func TestEnsureCorrectWritablesDoesNotRestoreCrowdedVolume(t *testing.T) {
 
 	// Heartbeat reports a size below the limit: the oversized mark clears,
 	// but the decay only halves the pending estimate, so effectiveSize stays
-	// past the crowded threshold and UpdateVolumeSize refuses recovery.
+	// past the limit and UpdateVolumeSize refuses recovery.
 	vi.Size = 8000
 	vl.UpdateOversizedState(&vi, dn)
 	vl.UpdateVolumeSize(1, vi.Size, 0)
@@ -203,11 +205,73 @@ func TestEnsureCorrectWritablesDoesNotRestoreCrowdedVolume(t *testing.T) {
 		t.Fatalf("expected oversized mark cleared after the shrink report")
 	}
 
-	// After the cooldown, the volume is still crowded: ensureCorrectWritables
-	// must not override UpdateVolumeSize's refusal.
+	// After the cooldown, the volume is still at the limit:
+	// ensureCorrectWritables must not override UpdateVolumeSize's refusal.
 	advanceSizeTrackingClock(vl, 1, capacityRecoveryDelay+time.Second)
 	vl.EnsureCorrectWritables(&vi)
 	if w, _ := vl.GetWritableVolumeCount(); w != 0 {
-		t.Fatalf("expected crowded volume to stay unwritable, got %d writable", w)
+		t.Fatalf("expected volume at the limit to stay unwritable, got %d writable", w)
+	}
+}
+
+// A crowded volume is not a full one: it is above the growth threshold but
+// still has room. One that drops out of writables while a replica is away must
+// come back when the replica returns -- nothing writes to a volume that is not
+// writable, so its size can never fall on its own and the lockout would be
+// permanent.
+func TestEnsureCorrectWritablesRestoresCrowdedVolumeAfterReplicaReturns(t *testing.T) {
+	layout := `
+{
+  "dc1":{
+    "rack1":{
+      "server1":{
+        "ip":"10.0.0.1",
+        "volumes":[
+          {"id":1, "size":9500, "replication":"001"}
+        ],
+        "limit":10
+      },
+      "server2":{
+        "ip":"10.0.0.2",
+        "volumes":[
+          {"id":1, "size":9500, "replication":"001"}
+        ],
+        "limit":10
+      }
+    }
+  }
+}
+`
+	topo := setupWithLimit(t, layout, 10000)
+	rp, _ := super_block.NewReplicaPlacementFromString("001")
+	vl := topo.GetVolumeLayout("", rp, needle.EMPTY_TTL, types.HardDriveType)
+
+	// 9500 is past the growth threshold (9000) but under the limit (10000).
+	vl.UpdateVolumeSize(1, 9500, 0)
+	if _, crowded := vl.crowded[1]; !crowded {
+		t.Fatalf("expected the volume to be crowded")
+	}
+	if w, _ := vl.GetWritableVolumeCount(); w != 1 {
+		t.Fatalf("a crowded volume is still writable, got %d writable", w)
+	}
+
+	dn := vl.vid2location[1].list[1]
+	vi, err := dn.GetVolumesById(1)
+	if err != nil {
+		t.Fatalf("GetVolumesById: %v", err)
+	}
+	vl.UnRegisterVolume(&vi, dn)
+	if w, _ := vl.GetWritableVolumeCount(); w != 0 {
+		t.Fatalf("expected 0 writable while a replica is missing, got %d", w)
+	}
+
+	// The replica comes back on the next heartbeat.
+	topo.RegisterVolumeLayout(vi, dn)
+	advanceSizeTrackingClock(vl, 1, 5*time.Second)
+	vl.UpdateOversizedState(&vi, dn)
+	vl.UpdateVolumeSize(1, vi.Size, 0)
+	vl.EnsureCorrectWritables(&vi)
+	if w, _ := vl.GetWritableVolumeCount(); w != 1 {
+		t.Fatalf("expected the volume writable again, got %d", w)
 	}
 }

--- a/weed/topology/volume_layout_oversized_heartbeat_test.go
+++ b/weed/topology/volume_layout_oversized_heartbeat_test.go
@@ -154,3 +154,60 @@ func TestEnsureCorrectWritablesHonorsRecoveryCooldown(t *testing.T) {
 		t.Fatalf("expected volume writable after the cooldown, got %d", w)
 	}
 }
+
+// After the cooldown elapses, a volume whose effective size is still past the
+// crowded threshold must not be restored by ensureCorrectWritables: only
+// UpdateVolumeSize's recovery path -- which rejects the crowded state -- may
+// bring it back to writable.
+func TestEnsureCorrectWritablesDoesNotRestoreCrowdedVolume(t *testing.T) {
+	layout := `
+{
+  "dc1":{
+    "rack1":{
+      "server1":{
+        "volumes":[
+          {"id":1, "size":8000, "replication":"000"}
+        ],
+        "limit":10
+      }
+    }
+  }
+}
+`
+	_, vl := setupPickTest(t, layout, 10000)
+
+	// Remove the volume for capacity, as RecordAssign would. effectiveSize
+	// lands at 13000, past the limit (10000); after the decay against a
+	// reported size of 8000 it stays at 10500, still past the crowded
+	// threshold (9000).
+	if !vl.RecordAssign(1, 5000) {
+		t.Fatalf("RecordAssign should report the volume reached capacity")
+	}
+	if w, _ := vl.GetWritableVolumeCount(); w != 0 {
+		t.Fatalf("expected 0 writable after RecordAssign, got %d", w)
+	}
+
+	dn := vl.vid2location[1].list[0]
+	vi, err := dn.GetVolumesById(1)
+	if err != nil {
+		t.Fatalf("GetVolumesById: %v", err)
+	}
+
+	// Heartbeat reports a size below the limit: the oversized mark clears,
+	// but the decay only halves the pending estimate, so effectiveSize stays
+	// past the crowded threshold and UpdateVolumeSize refuses recovery.
+	vi.Size = 8000
+	vl.UpdateOversizedState(&vi, dn)
+	vl.UpdateVolumeSize(1, vi.Size, 0)
+	if vl.vid2location[1].AnyOversized() {
+		t.Fatalf("expected oversized mark cleared after the shrink report")
+	}
+
+	// After the cooldown, the volume is still crowded: ensureCorrectWritables
+	// must not override UpdateVolumeSize's refusal.
+	advanceSizeTrackingClock(vl, 1, capacityRecoveryDelay+time.Second)
+	vl.EnsureCorrectWritables(&vi)
+	if w, _ := vl.GetWritableVolumeCount(); w != 0 {
+		t.Fatalf("expected crowded volume to stay unwritable, got %d writable", w)
+	}
+}

--- a/weed/topology/volume_layout_oversized_heartbeat_test.go
+++ b/weed/topology/volume_layout_oversized_heartbeat_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
+	"github.com/seaweedfs/seaweedfs/weed/sequence"
 	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
 	"github.com/seaweedfs/seaweedfs/weed/storage/super_block"
 	"github.com/seaweedfs/seaweedfs/weed/storage/types"
@@ -273,5 +275,44 @@ func TestEnsureCorrectWritablesRestoresCrowdedVolumeAfterReplicaReturns(t *testi
 	vl.EnsureCorrectWritables(&vi)
 	if w, _ := vl.GetWritableVolumeCount(); w != 1 {
 		t.Fatalf("expected the volume writable again, got %d", w)
+	}
+}
+
+// An incremental heartbeat announces an arrival with a short message that
+// carries no size. Registering from it must not clear the oversized mark the
+// full heartbeat set, or the volume is handed back to the writable list until
+// the next full report.
+func TestIncrementalRegistrationKeepsOversizedMark(t *testing.T) {
+	topo := NewTopology("weedfs", sequence.NewMemorySequencer(), 32*1024, 5, false)
+	dc := topo.GetOrCreateDataCenter("dc1")
+	rack := dc.GetOrCreateRack("rack1")
+	dn := rack.GetOrCreateDataNode("127.0.0.1", 34534, 0, "127.0.0.1", "", map[string]uint32{"": 25})
+
+	rp, _ := super_block.NewReplicaPlacementFromString("000")
+	vl := topo.GetVolumeLayout("", rp, needle.EMPTY_TTL, types.HardDriveType)
+
+	// A full heartbeat reports the volume past the 32 KB limit.
+	topo.SyncDataNodeRegistration([]*master_pb.VolumeInformationMessage{{
+		Id:               1,
+		Size:             uint64(64 * 1024),
+		ReplicaPlacement: uint32(0),
+		Version:          uint32(needle.GetCurrentVersion()),
+	}}, dn)
+	if w, _ := vl.GetWritableVolumeCount(); w != 0 {
+		t.Fatalf("expected the oversized volume out of writables, got %d", w)
+	}
+
+	// The same volume is announced again as an arrival.
+	topo.IncrementalSyncDataNodeRegistration([]*master_pb.VolumeShortInformationMessage{{
+		Id:               1,
+		ReplicaPlacement: uint32(0),
+		Version:          uint32(needle.GetCurrentVersion()),
+	}}, nil, dn)
+
+	if !vl.vid2location[1].AnyOversized() {
+		t.Fatalf("expected the oversized mark to survive the arrival announcement")
+	}
+	if w, _ := vl.GetWritableVolumeCount(); w != 0 {
+		t.Fatalf("expected the oversized volume to stay out of writables, got %d", w)
 	}
 }

--- a/weed/topology/volume_layout_oversized_heartbeat_test.go
+++ b/weed/topology/volume_layout_oversized_heartbeat_test.go
@@ -2,6 +2,7 @@ package topology
 
 import (
 	"testing"
+	"time"
 )
 
 // A volume that grew past the limit keeps bouncing between writable and
@@ -35,8 +36,9 @@ func TestUpdateOversizedStateKeepsOversizedVolumeUnwritable(t *testing.T) {
 		t.Fatalf("expected 0 writable after RecordAssign, got %d", w)
 	}
 
-	// A heartbeat that reports the now-oversized volume must refresh the mark,
-	// otherwise the next ensureCorrectWritables would re-add it to writables.
+	// A heartbeat that reports the now-oversized volume must refresh the mark
+	// so ensureCorrectWritables does not re-add it to writables. Mirrors the
+	// heartbeat order: refresh, then decay, then correct.
 	dn := vl.vid2location[1].list[0]
 	vi, err := dn.GetVolumesById(1)
 	if err != nil {
@@ -45,6 +47,7 @@ func TestUpdateOversizedStateKeepsOversizedVolumeUnwritable(t *testing.T) {
 	oversized := vi
 	oversized.Size = 12000
 	vl.UpdateOversizedState(&oversized, dn)
+	vl.UpdateVolumeSize(1, oversized.Size, 0)
 	vl.EnsureCorrectWritables(&oversized)
 
 	if w, _ := vl.GetWritableVolumeCount(); w != 0 {
@@ -93,5 +96,61 @@ func TestUpdateOversizedStateClearsMarkWhenVolumeShrinks(t *testing.T) {
 	vl.UpdateOversizedState(&vi, dn)
 	if vl.vid2location[1].AnyOversized() {
 		t.Fatalf("expected AnyOversized cleared after the volume shrank")
+	}
+}
+
+// A volume removed for capacity must not be re-added to writables by
+// ensureCorrectWritables before capacityRecoveryDelay elapses, even after its
+// oversized mark is cleared by a heartbeat that reports a smaller size.
+func TestEnsureCorrectWritablesHonorsRecoveryCooldown(t *testing.T) {
+	layout := `
+{
+  "dc1":{
+    "rack1":{
+      "server1":{
+        "volumes":[
+          {"id":1, "size":4000, "replication":"000"}
+        ],
+        "limit":10
+      }
+    }
+  }
+}
+`
+	_, vl := setupPickTest(t, layout, 10000)
+
+	// Remove the volume for capacity, as RecordAssign would.
+	if !vl.RecordAssign(1, 9000) {
+		t.Fatalf("RecordAssign should report the volume reached capacity")
+	}
+	if w, _ := vl.GetWritableVolumeCount(); w != 0 {
+		t.Fatalf("expected 0 writable after RecordAssign, got %d", w)
+	}
+
+	dn := vl.vid2location[1].list[0]
+	vi, err := dn.GetVolumesById(1)
+	if err != nil {
+		t.Fatalf("GetVolumesById: %v", err)
+	}
+
+	// Heartbeat reports the volume shrank back under the limit: the oversized
+	// mark clears and effectiveSize decays, but the volume is still within
+	// capacityRecoveryDelay.
+	vi.Size = 4000
+	vl.UpdateOversizedState(&vi, dn)
+	vl.UpdateVolumeSize(1, vi.Size, 0)
+	vl.EnsureCorrectWritables(&vi)
+	if w, _ := vl.GetWritableVolumeCount(); w != 0 {
+		t.Fatalf("expected volume to stay unwritable during the cooldown, got %d writable", w)
+	}
+
+	// After the cooldown, a heartbeat with the shrunken size recovers it.
+	advanceSizeTrackingClock(vl, 1, capacityRecoveryDelay+time.Second)
+	if !vl.UpdateVolumeSize(1, vi.Size, 0) {
+		t.Fatalf("expected volume to recover to writable after the cooldown")
+	}
+	vl.EnsureCorrectWritables(&vi)
+	if w, _ := vl.GetWritableVolumeCount(); w != 1 {
+		t.Fatalf("expected volume writable after the cooldown, got %d", w)
 	}
 }

--- a/weed/topology/volume_layout_oversized_heartbeat_test.go
+++ b/weed/topology/volume_layout_oversized_heartbeat_test.go
@@ -1,0 +1,97 @@
+package topology
+
+import (
+	"testing"
+)
+
+// A volume that grew past the limit keeps bouncing between writable and
+// unwritable when the oversized mark is not refreshed on heartbeat: RegisterVolume
+// sets it once, but the delta heartbeat path (ApplyVolumeChanges) never re-sets
+// it, so ensureCorrectWritables sees a stale "not oversized" mark and re-adds
+// the volume to writables on the next heartbeat, while RecordAssign removes it
+// on the next assign. UpdateOversizedState must keep the mark current.
+func TestUpdateOversizedStateKeepsOversizedVolumeUnwritable(t *testing.T) {
+	layout := `
+{
+  "dc1":{
+    "rack1":{
+      "server1":{
+        "volumes":[
+          {"id":1, "size":4000, "replication":"000"}
+        ],
+        "limit":10
+      }
+    }
+  }
+}
+`
+	_, vl := setupPickTest(t, layout, 10000)
+
+	// Grow the volume past the limit, as RecordAssign would see it.
+	if !vl.RecordAssign(1, 9000) {
+		t.Fatalf("RecordAssign should report the volume reached capacity")
+	}
+	if w, _ := vl.GetWritableVolumeCount(); w != 0 {
+		t.Fatalf("expected 0 writable after RecordAssign, got %d", w)
+	}
+
+	// A heartbeat that reports the now-oversized volume must refresh the mark,
+	// otherwise the next ensureCorrectWritables would re-add it to writables.
+	dn := vl.vid2location[1].list[0]
+	vi, err := dn.GetVolumesById(1)
+	if err != nil {
+		t.Fatalf("GetVolumesById: %v", err)
+	}
+	oversized := vi
+	oversized.Size = 12000
+	vl.UpdateOversizedState(&oversized, dn)
+	vl.EnsureCorrectWritables(&oversized)
+
+	if w, _ := vl.GetWritableVolumeCount(); w != 0 {
+		t.Fatalf("expected volume to stay unwritable after heartbeat refresh, got %d writable", w)
+	}
+	if !vl.vid2location[1].AnyOversized() {
+		t.Fatalf("expected AnyOversized to be true after heartbeat refresh")
+	}
+}
+
+// A volume that shrank back under the limit must have its oversized mark
+// cleared by the heartbeat refresh, or it stays locked out of writables
+// forever.
+func TestUpdateOversizedStateClearsMarkWhenVolumeShrinks(t *testing.T) {
+	layout := `
+{
+  "dc1":{
+    "rack1":{
+      "server1":{
+        "volumes":[
+          {"id":1, "size":4000, "replication":"000"}
+        ],
+        "limit":10
+      }
+    }
+  }
+}
+`
+	_, vl := setupPickTest(t, layout, 10000)
+
+	dn := vl.vid2location[1].list[0]
+	vi, err := dn.GetVolumesById(1)
+	if err != nil {
+		t.Fatalf("GetVolumesById: %v", err)
+	}
+
+	// Mark oversized via a heartbeat that reports a huge size.
+	big := vi
+	big.Size = 12000
+	vl.UpdateOversizedState(&big, dn)
+	if !vl.vid2location[1].AnyOversized() {
+		t.Fatalf("expected AnyOversized after a huge report")
+	}
+
+	// A later heartbeat with a normal size clears the mark.
+	vl.UpdateOversizedState(&vi, dn)
+	if vl.vid2location[1].AnyOversized() {
+		t.Fatalf("expected AnyOversized cleared after the volume shrank")
+	}
+}


### PR DESCRIPTION
## Problem: writable/unwritable flip loop on an oversized volume

A volume that grows past `volumeSizeLimit` keeps **bouncing between writable and unwritable on every heartbeat/assign cycle**, because two independent paths use different facts to decide writability:

- `ensureCorrectWritables` (heartbeat path) checks the **`oversized` bit flag** on the volume location
- `RecordAssign` (write path) checks **`effectiveSize`** (real-time, heartbeat-decayed)

The `oversized` bit is only ever set at **registration time** (`RegisterVolume` → `rememberOversizedVolume`). The delta heartbeat path (`ApplyVolumeChanges`) and the full heartbeat path (`SyncDataNodeRegistration`) never refresh it — so once a volume outgrows the limit, the bit stays stale `false`, and `ensureCorrectWritables` keeps re-adding the volume to `writables` on every heartbeat while `RecordAssign` removes it on every assign.

### Production symptom

```
I0819 10:21:20.613067 volume_layout.go:360 Volume 166140692 reaches full capacity (effective=35551735903, limit=31457280000).
I0819 10:21:20.613049 volume_layout.go:784 Volume 166140692 becomes unwritable
I0819 10:21:20.032460 volume_layout.go:796 Volume 166140692 becomes writable
I0819 10:21:19.860205 volume_layout.go:360 Volume 166140692 reaches full capacity (effective=35551633399, limit=31457280000).
I0819 10:21:19.860192 volume_layout.go:784 Volume 166140692 becomes unwritable
I0819 10:21:19.559009 volume_layout.go:796 Volume 166140692 becomes writable
```

```
E0819 10:18:43.680032 volume_grpc_vacuum.go:72 failed compact volume 166140692: volume 166140692 unexpected new data size: 13922058544 does not match size of content minus deleted: 13933663196
```

Downstream effects:

1. **Volume exceeds the limit**: effectiveSize is an estimate (1 MB per file default) that trails the real on-disk size, and the flip loop keeps the volume writable, so writes continue past the 30 GB limit (actual 35.5 GB).
2. **Vacuum fails**: the volume is still writable during compaction, so `CompactByIndex`'s snapshot disagrees with concurrent writes (`expectedContentSize > dstDatSize`).
3. **Replica divergence**: the three replicas report slightly different sizes (35551436816 / 35551436560 / 35551427488), and the flip loop masks the difference instead of surfacing it.

## Fix

Refresh the `oversized` mark from **each heartbeat's reported size** in both heartbeat paths, mirroring what `RegisterVolume` already does at registration:

- `ApplyVolumeChanges` (delta heartbeats)
- `SyncDataNodeRegistration` (full heartbeats)

New method `VolumeLayout.UpdateOversizedState` wraps the existing `rememberOversizedVolume` with the layout lock. It sets the bit to `true` when the reported size ≥ limit and to `false` when the volume shrank back — so a compacted volume can recover writability, and a grown volume stays out.

This makes both consumers of `AnyOversized` correct again:

- `ensureCorrectWritables` no longer re-adds an oversized volume to `writables`
- `UpdateVolumeSize`'s recovery path (`if vl.vid2location[vid].AnyOversized()`) no longer lets a stale false mark restore a still-oversized volume

## Behavior

| State | Before | After |
|---|---|---|
| Volume grows past limit | writable/unwritable flip every ~4 s; writes continue past limit | stays unwritable; writes reassigned |
| Volume compacts back under limit | (n/a — bit was stale) | oversized mark cleared; volume can recover after `capacityRecoveryDelay` |
| Delta heartbeat (`ApplyVolumeChanges`) | stale bit | refreshed from reported size |
| Full heartbeat (`SyncDataNodeRegistration`) | stale bit (unless re-registered) | refreshed from reported size |

## Tests

`volume_layout_oversized_heartbeat_test.go`:
- `TestUpdateOversizedStateKeepsOversizedVolumeUnwritable`: after `RecordAssign` removes the volume, a heartbeat reporting an oversized size keeps it out of `writables` via `EnsureCorrectWritables`.
- `TestUpdateOversizedStateClearsMarkWhenVolumeShrinks`: a later heartbeat with a normal size clears the mark so the volume is not locked out forever.

`go test ./weed/topology/` and `go vet` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved volume state updates during registration and heartbeat processing.
  * Volumes reaching their hard capacity limit are consistently marked unwritable.
  * Oversized status is refreshed correctly as volume sizes change.
  * Capacity-reduced volumes remain unwritable until the recovery cooldown expires.
  * Crowded volumes can recover to writable status after replicas return and effective capacity is restored.
  * Volumes still at their hard capacity limit remain protected from premature reactivation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->