### PR TITLE
ci: install the runner's own packages through the mirror fallback too

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -61,13 +61,10 @@ jobs:
 
     - name: Install dependencies
       run: |
-        # Use faster mirrors and install with timeout
         sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
-        echo "deb http://azure.archive.ubuntu.com/ubuntu/ $(lsb_release -cs) main restricted universe multiverse" | sudo tee /etc/apt/sources.list
-        echo "deb http://azure.archive.ubuntu.com/ubuntu/ $(lsb_release -cs)-updates main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
-        
-        sudo apt-get update --fix-missing
-        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends fuse
+        # Same helper the e2e image installs through: the runner's own list is
+        # azure-only too, and an outage there fails this step outright.
+        sudo docker/apt-install fuse
         
         # Verify FUSE installation
         echo "FUSE version: $(fusermount --version 2>&1 || echo 'fusermount not found')"

--- a/docker/apt-install
+++ b/docker/apt-install
@@ -8,7 +8,9 @@ set -e
 [ -f /etc/apt/sources.list.orig ] || cp /etc/apt/sources.list /etc/apt/sources.list.orig
 
 for mirror in azure.archive.ubuntu.com archive.ubuntu.com; do
-	sed "s|http://archive\.ubuntu\.com/ubuntu|http://$mirror/ubuntu|g; s|http://security\.ubuntu\.com/ubuntu|http://$mirror/ubuntu|g" \
+	# Any archive host, so this works whether the pristine list came from the
+	# base image (archive.ubuntu.com) or a CI runner (azure.archive.ubuntu.com).
+	sed "s|http://[a-z0-9.]*archive\.ubuntu\.com/ubuntu|http://$mirror/ubuntu|g; s|http://security\.ubuntu\.com/ubuntu|http://$mirror/ubuntu|g" \
 		/etc/apt/sources.list.orig > /etc/apt/sources.list
 	if apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=15 update && \
 		DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=15 install -y \


### PR DESCRIPTION
Follow-up to #10828, which fixed the image builds but not the runner.

`FUSE Mount` failed again on #10822 after #10828 merged, in a different place — the workflow's own `Install dependencies` step, on the runner rather than inside a container:

```
Err:1 http://azure.archive.ubuntu.com/ubuntu jammy/universe amd64 libfuse2
  Unable to connect to azure.archive.ubuntu.com:http:
E: Unable to fetch some archives
##[error]Process completed with exit code 100
```

`e2e.yml` overwrites the runner's `sources.list` with two azure-only lines and installs `fuse` from it, so it is the same single point of failure as the Dockerfile was, in workflow form. The image-side fallback cannot help there.

This installs through the same helper, and widens its rewrite to match any archive host so it works whether the pristine list came from the base image (`archive.ubuntu.com`) or from a CI runner (`azure.archive.ubuntu.com`). Keeping the runner's own list also restores the `-security` and `-backports` pockets, which the hand-written two-line replacement dropped.

Verified against the outage itself rather than a simulation: with the pristine list pointed at Azure, the build logged

```
apt: azure.archive.ubuntu.com unreachable, trying the next mirror
Setting up curl (7.81.0-1ubuntu1.25) ...
```

after Azure timed out for real, and installed from `archive.ubuntu.com`.

Scope note: 13 other workflows `apt-get install` on the runner against GitHub's default (also azure) list. They did not fail in this window, so I left them alone rather than churning every workflow blind — they can adopt the same one-line call if they start failing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ubuntu package source handling across regional archive mirrors.
  * Updated end-to-end test setup to install FUSE more reliably.
  * Removed reliance on Azure-specific package mirrors during environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->