### PR TITLE
ci: call the apt helper from the workflow's working directory

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -64,7 +64,7 @@ jobs:
         sudo rm -f /etc/apt/sources.list.d/azure-cli.list /etc/apt/sources.list.d/microsoft-prod.list
         # Same helper the e2e image installs through: the runner's own list is
         # azure-only too, and an outage there fails this step outright.
-        sudo docker/apt-install fuse
+        sudo ./apt-install fuse
         
         # Verify FUSE installation
         echo "FUSE version: $(fusermount --version 2>&1 || echo 'fusermount not found')"


### PR DESCRIPTION
Fixes a break I introduced in #10831. Every `FUSE Mount` run since it merged fails immediately:

```
sudo: docker/apt-install: command not found
##[error]Process completed with exit code 1
```

`e2e.yml` sets `defaults.run.working-directory: docker`, which I missed, so `sudo docker/apt-install` resolved to `docker/docker/apt-install`. Reproduced and verified from that working directory:

```
cwd=/repo/docker
--- old form:  sh: 1: docker/apt-install: not found
--- new form:  Get:1 http://ports.ubuntu.com/ubuntu-ports jammy InRelease [270 kB]
```

Worth merging ahead of the mount PRs — it blocks `FUSE Mount` on anything touching `weed/**` or `docker/**`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated end-to-end test setup to use the standard FUSE installation helper, improving workflow reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->