### PR TITLE
Add monitoring label to filer servicemonitor

### DIFF
--- a/k8s/charts/seaweedfs/templates/filer/filer-service-client.yaml
+++ b/k8s/charts/seaweedfs/templates/filer/filer-service-client.yaml
@@ -10,9 +10,6 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: filer
-{{- if .Values.filer.metricsPort }}
-    monitoring: "true"
-{{- end }}
 {{- if .Values.filer.annotations }}
   annotations:
     {{- toYaml .Values.filer.annotations | nindent 4 }}

--- a/k8s/charts/seaweedfs/templates/filer/filer-service.yaml
+++ b/k8s/charts/seaweedfs/templates/filer/filer-service.yaml
@@ -10,6 +10,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: filer
+{{- if .Values.filer.metricsPort }}
+    monitoring: "true"
+{{- end }}
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 {{- if .Values.filer.annotations }}

--- a/k8s/charts/seaweedfs/templates/filer/filer-servicemonitor.yaml
+++ b/k8s/charts/seaweedfs/templates/filer/filer-servicemonitor.yaml
@@ -30,6 +30,7 @@ spec:
       app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: filer
+      monitoring: "true"
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
# What problem are we solving?
The filer pods are being double-scraped due to 2 services pointing to the same pods. Fixing https://github.com/seaweedfs/seaweedfs/issues/10836


# How are we solving the problem?
Adding monitoring: "true" to the label selector for the filer service monitor. This label is already present in [filer-service-client](https://github.com/seaweedfs/seaweedfs/blob/master/k8s/charts/seaweedfs/templates/filer/filer-service-client.yaml#L14)

# How is the PR tested?
Rendered the `seaweedfs` chart locally with `helm template` before/after the change and confirmed:
- The filer `ServiceMonitor`'s `spec.selector.matchLabels` now includes `monitoring: "true"`, matching only `<release>-filer-client` (which already carries this label) instead of matching both `<release>-filer` and `<release>-filer-client`.
- `<release>-filer` (the headless service without `monitoring: "true"`) is no longer selected by the ServiceMonitor.


# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enabled monitoring discovery for the filer service, allowing supported monitoring systems to collect its metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->