### PR TITLE
ci: stop installing FUSE headers nothing links against

### DIFF
--- a/.github/workflows/fuse-dlm-integration.yml
+++ b/.github/workflows/fuse-dlm-integration.yml
@@ -40,10 +40,11 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Install FUSE dependencies
+      - name: Configure FUSE
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libfuse3-dev
+          # Nothing to install: fuse3 ships fusermount3 and is pre-installed,
+          # and go-fuse is pure Go, so the libfuse headers were never linked
+          # against.
           echo 'user_allow_other' | sudo tee -a /etc/fuse.conf
           sudo chmod 644 /etc/fuse.conf
 

--- a/.github/workflows/fuse-failover.yml
+++ b/.github/workflows/fuse-failover.yml
@@ -47,10 +47,11 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Install FUSE dependencies
+      - name: Configure FUSE
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libfuse3-dev
+          # Nothing to install: fuse3 ships fusermount3 and is pre-installed,
+          # and go-fuse is pure Go, so the libfuse headers were never linked
+          # against.
           echo 'user_allow_other' | sudo tee -a /etc/fuse.conf
           sudo chmod 644 /etc/fuse.conf
 

--- a/.github/workflows/fuse-integration.yml
+++ b/.github/workflows/fuse-integration.yml
@@ -38,12 +38,10 @@ jobs:
       with:
         go-version-file: 'go.mod'
 
-    - name: Install FUSE and dependencies
+    - name: Configure FUSE
       run: |
-        sudo apt-get update
-        # fuse3 is pre-installed on ubuntu-22.04 runners and conflicts
-        # with the legacy fuse package, so only install the dev headers.
-        sudo apt-get install -y libfuse3-dev
+        # Nothing to install: fuse3 ships fusermount3 and is pre-installed, and
+        # go-fuse is pure Go, so the libfuse headers were never linked against.
         # Allow non-root FUSE mounts with allow_other
         echo 'user_allow_other' | sudo tee -a /etc/fuse.conf
         sudo chmod 644 /etc/fuse.conf

--- a/.github/workflows/fuse-p2p-integration.yml
+++ b/.github/workflows/fuse-p2p-integration.yml
@@ -46,10 +46,11 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Install FUSE dependencies
+      - name: Configure FUSE
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libfuse3-dev
+          # Nothing to install: fuse3 ships fusermount3 and is pre-installed,
+          # and go-fuse is pure Go, so the libfuse headers were never linked
+          # against.
           echo 'user_allow_other' | sudo tee -a /etc/fuse.conf
           sudo chmod 644 /etc/fuse.conf
 


### PR DESCRIPTION
Both jobs on #10822 that hung today were stuck in apt: `FUSE Volume Server Failover` on `Install FUSE dependencies`, and `pjdfstest` on its image build. This is the first half of that — the runner-side install turns out to be unnecessary.

Four workflows run `apt-get install -y libfuse3-dev` before every FUSE job. Nothing links it:

- go-fuse implements the FUSE protocol in pure Go — no `"C"` import anywhere in `go-fuse/v2@v2.9.4/fuse`, and no `#cgo` in the tree references fuse.
- The jobs build `go build ./weed` and run `go test`; the headers are compile-time only and no compiler opens them.
- It does not even provide the binary the mount execs. `libfuse3-dev` depends on `libfuse3-3`; `fusermount3` ships in `fuse3`, which is only *Suggested*:

```
$ apt-cache depends libfuse3-dev
  Depends: libfuse3-3
  Suggests: fuse3
```

`fuse3` is pre-installed on the runner image — `fuse-integration.yml` already carried a comment saying so, and `.github/actions/fix-fusermount-setuid` hard-fails when `fusermount3` is missing from PATH, which it never has been.

So the step downloaded a dev package to satisfy nothing, and it is the step that hangs whenever the Ubuntu mirror goes slow. Writing `/etc/fuse.conf` is all that is left. If the assumption ever breaks, the setuid-repair step fails loudly with `no fusermount3 in PATH` rather than failing mysteriously later.

The container side (pjdfstest, samba) is separate — those images do need their packages, and the answer there is caching or a prebuilt image rather than deletion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated FUSE-related integration and failover workflows to use preinstalled FUSE 3 tooling.
  * Removed unnecessary dependency installation steps while preserving FUSE permissions and configuration.
  * Continued support for the pure-Go FUSE implementation without requiring linked libfuse development headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->