### PR TITLE
mount: discard a path-cache insert that raced a purge

### DIFF
--- a/test/winfsp/semantics_test.go
+++ b/test/winfsp/semantics_test.go
@@ -180,7 +180,7 @@ func TestRenameOverExisting(t *testing.T) {
 		// they indict different layers; a second look says whether it persists.
 		time.Sleep(200 * time.Millisecond)
 		fi2, err2 := os.Stat(src)
-		t.Fatalf("source survived the rename: stat=%v err=%v; 200ms later stat=%v err=%v",
+		t.Fatalf("stat of the renamed-away source did not return not-exist: stat=%v err=%v; 200ms later stat=%v err=%v",
 			describeFileInfo(fi), err, describeFileInfo(fi2), err2)
 	}
 }

--- a/test/winfsp/semantics_test.go
+++ b/test/winfsp/semantics_test.go
@@ -175,8 +175,13 @@ func TestRenameOverExisting(t *testing.T) {
 	if string(got) != "new" {
 		t.Fatalf("target holds %q, want the source content", got)
 	}
-	if _, err := os.Stat(src); !os.IsNotExist(err) {
-		t.Fatal("source survived the rename")
+	if fi, err := os.Stat(src); !os.IsNotExist(err) {
+		// Both a stale positive and a transient non-ENOENT error land here, and
+		// they indict different layers; a second look says whether it persists.
+		time.Sleep(200 * time.Millisecond)
+		fi2, err2 := os.Stat(src)
+		t.Fatalf("source survived the rename: stat=%v err=%v; 200ms later stat=%v err=%v",
+			describeFileInfo(fi), err, describeFileInfo(fi2), err2)
 	}
 }
 
@@ -514,4 +519,11 @@ func TestDeleteOnClose(t *testing.T) {
 	if err := closeHandle(h); err != nil {
 		t.Fatalf("close after recreate: %v", err)
 	}
+}
+
+func describeFileInfo(fi os.FileInfo) string {
+	if fi == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("{size=%d mode=%v mtime=%s}", fi.Size(), fi.Mode(), fi.ModTime().Format(time.RFC3339Nano))
 }

--- a/weed/mount/winfsp/fs_windows.go
+++ b/weed/mount/winfsp/fs_windows.go
@@ -192,6 +192,10 @@ func (w *WinFS) forget(inode uint64) {
 // to hold the inode longer steals the reference from the cache.
 func (w *WinFS) walk(parts []string) (uint64, fuse.Status) {
 	inode := uint64(rootInode)
+	// Taken before the lookups: a purge racing this walk - a rename or unlink
+	// landing between a Lookup and its insert - makes what was just resolved
+	// the very thing the purge removed.
+	gen := w.paths.snapshot()
 	for i, name := range parts {
 		key := strings.Join(parts[:i+1], "/")
 		if cached, _, ok := w.paths.lookup(key); ok {
@@ -202,7 +206,7 @@ func (w *WinFS) walk(parts []string) (uint64, fuse.Status) {
 		if status := w.wfs.Lookup(never, ptr(w.caller(inode)), name, &out); status != fuse.OK {
 			return 0, status
 		}
-		w.paths.insert(key, out.NodeId, out.Attr)
+		w.paths.insert(key, out.NodeId, out.Attr, gen)
 		inode = out.NodeId
 	}
 	return inode, fuse.OK
@@ -392,7 +396,7 @@ func (w *WinFS) Mkdir(path string, mode uint32) int {
 	if status == fuse.OK {
 		w.purgeWithParent(path, false)
 		// The new directory is about to be filled; cache it, reference and all.
-		w.paths.insert(cacheKey(path), out.NodeId, out.Attr)
+		w.paths.insert(cacheKey(path), out.NodeId, out.Attr, w.paths.snapshot())
 	}
 	return toErrno(status)
 }
@@ -674,8 +678,8 @@ func (w *WinFS) Release(path string, fh uint64) int {
 		// path still names this inode: WinFsp reports the path the handle
 		// opened with, and after a delete-on-close or a rename caching it
 		// would resurrect an entry that is gone.
-		if key := cacheKey(path); attr != nil && w.stillNames(key, inode) {
-			w.paths.insert(key, inode, *attr)
+		if key, gen := cacheKey(path), w.paths.snapshot(); attr != nil && w.stillNames(key, inode) {
+			w.paths.insert(key, inode, *attr, gen)
 		} else {
 			w.forget(inode)
 		}

--- a/weed/mount/winfsp/fs_windows.go
+++ b/weed/mount/winfsp/fs_windows.go
@@ -32,11 +32,6 @@ const (
 	// WinFsp. Bounded so a directory with millions of children does not
 	// materialise in one slice.
 	readdirBatch = 4096
-
-	// stealAttempts bounds the resolve-then-steal loop in the open paths. A
-	// miss needs the entry to be evicted in the instant between the two calls,
-	// so a second round is already unlikely.
-	stealAttempts = 4
 )
 
 // never is a nil channel: receiving blocks forever, which is what the raw
@@ -232,24 +227,29 @@ func (w *WinFS) resolveParent(path string) (uint64, string, fuse.Status) {
 	return parent, name, fuse.OK
 }
 
-// resolveAndSteal resolves path and takes over the cache's reference on the
-// final inode, for the open paths that hold it for the life of a handle. The
-// root is handed out without a reference; it does not need one.
+// resolveAndSteal resolves path to an inode reference the caller owns, for
+// the open paths that hold it for the life of a handle: a cached entry is
+// stolen, anything else is looked up directly so the reference never passes
+// through the cache - an open must not depend on an insert surviving the
+// purges racing it. The root is handed out without a reference; it does not
+// need one.
 func (w *WinFS) resolveAndSteal(path string) (uint64, fuse.Status) {
 	key := cacheKey(path)
-	for attempt := 0; attempt < stealAttempts; attempt++ {
-		inode, status := w.resolve(path)
-		if status != fuse.OK {
-			return 0, status
-		}
-		if key == "" {
-			return inode, fuse.OK
-		}
-		if stolen, ok := w.paths.steal(key); ok {
-			return stolen, fuse.OK
-		}
+	if key == "" {
+		return rootInode, fuse.OK
 	}
-	return 0, fuse.EIO
+	if stolen, ok := w.paths.steal(key); ok {
+		return stolen, fuse.OK
+	}
+	parent, name, status := w.resolveParent(path)
+	if status != fuse.OK {
+		return 0, status
+	}
+	var out fuse.EntryOut
+	if status := w.wfs.Lookup(never, ptr(w.caller(parent)), name, &out); status != fuse.OK {
+		return 0, status
+	}
+	return out.NodeId, fuse.OK
 }
 
 func (w *WinFS) attrToStat(attr *fuse.Attr, stat *cgofuse.Stat_t) {

--- a/weed/mount/winfsp/pathcache.go
+++ b/weed/mount/winfsp/pathcache.go
@@ -22,14 +22,52 @@ type pathCache struct {
 	ttl    time.Duration
 	forget func(inode uint64)
 
-	mu        sync.Mutex
-	entries   map[string]*pathCacheEntry
-	graveyard []uint64
-	lastSweep time.Time
+	mu      sync.Mutex
+	entries map[string]*pathCacheEntry
+	// Two graveyard generations: an appended reference always survives the
+	// sweep of the call that appended it, so a caller still using the inode -
+	// a walk mid-resolution, an operation that looked it up just before - is
+	// never holding a reference the same call just returned.
+	graveyard     []uint64
+	prevGraveyard []uint64
+	lastSweep     time.Time
 	// gen counts purges. A resolve holds no lock across its Lookup RPC, so a
 	// purge can run between the RPC and the insert; the insert then carries
-	// exactly the name the purge removed and has to be discarded.
-	gen uint64
+	// exactly the name the purge removed and has to be discarded. The recent
+	// purges are kept by key so only a purge that covers the inserted name
+	// discards it: unrelated churn must not starve resolveAndSteal into EIO.
+	gen          uint64
+	recentPurges []purgeRecord
+}
+
+type purgeRecord struct {
+	key    string
+	prefix bool
+}
+
+// maxRecentPurges bounds the purges remembered for the covers check. A resolve
+// older than the window is discarded without one, which only costs a retry.
+const maxRecentPurges = 128
+
+func (r purgeRecord) covers(key string) bool {
+	return r.key == key || (r.prefix && strings.HasPrefix(key, r.key+"/"))
+}
+
+// purgedSince reports whether any purge after gen covers key.
+func (c *pathCache) purgedSince(gen uint64, key string) bool {
+	dropped := c.gen - gen
+	if dropped == 0 {
+		return false
+	}
+	if dropped > uint64(len(c.recentPurges)) {
+		return true
+	}
+	for _, r := range c.recentPurges[uint64(len(c.recentPurges))-dropped:] {
+		if r.covers(key) {
+			return true
+		}
+	}
+	return false
 }
 
 type pathCacheEntry struct {
@@ -83,8 +121,8 @@ func (c *pathCache) snapshot() uint64 {
 }
 
 // insert takes ownership of one lookup reference on inode, in every outcome:
-// an entry stale against gen goes to the graveyard instead of the map, so the
-// caller may keep using the inode for at least one sweep either way.
+// an entry a covering purge outdated goes to the graveyard instead of the map,
+// so the caller may keep using the inode for at least one sweep either way.
 func (c *pathCache) insert(key string, inode uint64, attr fuse.Attr, gen uint64) {
 	if key == "" {
 		c.forget(inode)
@@ -92,7 +130,7 @@ func (c *pathCache) insert(key string, inode uint64, attr fuse.Attr, gen uint64)
 	}
 	var pending []uint64
 	c.mu.Lock()
-	if gen != c.gen {
+	if c.purgedSince(gen, key) {
 		c.graveyard = append(c.graveyard, inode)
 		pending = c.sweepLocked()
 		c.mu.Unlock()
@@ -131,9 +169,13 @@ func (c *pathCache) steal(key string) (inode uint64, ok bool) {
 func (c *pathCache) purge(key string, prefix bool) {
 	var pending []uint64
 	c.mu.Lock()
-	// Unconditional: the point is as much the in-flight resolve about to
-	// insert this very name as anything the map holds now.
+	// Recorded even when the map holds nothing: the point is as much the
+	// in-flight resolve about to insert this very name.
 	c.gen++
+	c.recentPurges = append(c.recentPurges, purgeRecord{key: key, prefix: prefix})
+	if len(c.recentPurges) > maxRecentPurges {
+		c.recentPurges = append(c.recentPurges[:0], c.recentPurges[len(c.recentPurges)-maxRecentPurges:]...)
+	}
 	if entry, found := c.entries[key]; found {
 		c.graveyard = append(c.graveyard, entry.inode)
 		delete(c.entries, key)
@@ -152,20 +194,24 @@ func (c *pathCache) purge(key string, prefix bool) {
 	c.forgetAll(pending)
 }
 
-// sweepLocked returns the previous graveyard for the caller to forget outside
-// the lock, and moves expired entries into the next one. Sweeps run at most
-// once per ttl, so a reference rests here for at least one full ttl.
+// sweepLocked returns the generation before last for the caller to forget
+// outside the lock, and retires the current one. Sweeps run at most once per
+// ttl and an appended reference sits out the sweep of its own call, so every
+// reference rests for at least one full ttl after its last possible use.
 func (c *pathCache) sweepLocked() []uint64 {
 	now := time.Now()
 	if now.Sub(c.lastSweep) < c.ttl {
 		return nil
 	}
 	c.lastSweep = now
-	pending := c.graveyard
+	pending := c.prevGraveyard
+	c.prevGraveyard = c.graveyard
 	c.graveyard = nil
 	for key, entry := range c.entries {
 		if now.After(entry.expires) {
-			c.graveyard = append(c.graveyard, entry.inode)
+			// Returned by the next sweep, a full ttl away: served from the map
+			// until a moment ago, so someone may still be holding it.
+			c.prevGraveyard = append(c.prevGraveyard, entry.inode)
 			delete(c.entries, key)
 		}
 	}

--- a/weed/mount/winfsp/pathcache.go
+++ b/weed/mount/winfsp/pathcache.go
@@ -26,6 +26,10 @@ type pathCache struct {
 	entries   map[string]*pathCacheEntry
 	graveyard []uint64
 	lastSweep time.Time
+	// gen counts purges. A resolve holds no lock across its Lookup RPC, so a
+	// purge can run between the RPC and the insert; the insert then carries
+	// exactly the name the purge removed and has to be discarded.
+	gen uint64
 }
 
 type pathCacheEntry struct {
@@ -69,14 +73,32 @@ func (c *pathCache) lookup(key string) (inode uint64, attr fuse.Attr, ok bool) {
 	return entry.inode, entry.attr, true
 }
 
-// insert takes ownership of one lookup reference on inode.
-func (c *pathCache) insert(key string, inode uint64, attr fuse.Attr) {
+// snapshot returns the purge generation. A caller about to resolve outside
+// the lock passes it back to insert, which discards the entry if any purge ran
+// in between.
+func (c *pathCache) snapshot() uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.gen
+}
+
+// insert takes ownership of one lookup reference on inode, in every outcome:
+// an entry stale against gen goes to the graveyard instead of the map, so the
+// caller may keep using the inode for at least one sweep either way.
+func (c *pathCache) insert(key string, inode uint64, attr fuse.Attr, gen uint64) {
 	if key == "" {
 		c.forget(inode)
 		return
 	}
 	var pending []uint64
 	c.mu.Lock()
+	if gen != c.gen {
+		c.graveyard = append(c.graveyard, inode)
+		pending = c.sweepLocked()
+		c.mu.Unlock()
+		c.forgetAll(pending)
+		return
+	}
 	if existing, found := c.entries[key]; found {
 		c.graveyard = append(c.graveyard, existing.inode)
 	} else if len(c.entries) >= maxCachedPaths {
@@ -109,6 +131,9 @@ func (c *pathCache) steal(key string) (inode uint64, ok bool) {
 func (c *pathCache) purge(key string, prefix bool) {
 	var pending []uint64
 	c.mu.Lock()
+	// Unconditional: the point is as much the in-flight resolve about to
+	// insert this very name as anything the map holds now.
+	c.gen++
 	if entry, found := c.entries[key]; found {
 		c.graveyard = append(c.graveyard, entry.inode)
 		delete(c.entries, key)

--- a/weed/mount/winfsp/pathcache.go
+++ b/weed/mount/winfsp/pathcache.go
@@ -50,7 +50,15 @@ type purgeRecord struct {
 const maxRecentPurges = 128
 
 func (r purgeRecord) covers(key string) bool {
-	return r.key == key || (r.prefix && strings.HasPrefix(key, r.key+"/"))
+	if r.key == key {
+		return true
+	}
+	if !r.prefix {
+		return false
+	}
+	// An empty key with prefix is the whole cache: purge clears every entry
+	// for it, so it has to cover every in-flight insert too.
+	return r.key == "" || strings.HasPrefix(key, r.key+"/")
 }
 
 // purgedSince reports whether any purge after gen covers key.

--- a/weed/mount/winfsp/pathcache_test.go
+++ b/weed/mount/winfsp/pathcache_test.go
@@ -1,20 +1,169 @@
 package winfsp
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/seaweedfs/go-fuse/v2/fuse"
 )
 
+type forgetRecorder struct {
+	mu     sync.Mutex
+	inodes []uint64
+}
+
+func (r *forgetRecorder) forget(inode uint64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.inodes = append(r.inodes, inode)
+}
+
+func (r *forgetRecorder) forgotten() []uint64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]uint64(nil), r.inodes...)
+}
+
+func TestPathCacheLookupAndExpiry(t *testing.T) {
+	rec := &forgetRecorder{}
+	c := newPathCache(20*time.Millisecond, rec.forget)
+
+	c.insert("a/b", 7, fuse.Attr{Ino: 7, Size: 42}, c.snapshot())
+	inode, attr, ok := c.lookup("a/b")
+	if !ok || inode != 7 || attr.Size != 42 {
+		t.Fatalf("lookup = %d %v %v, want 7 size 42 true", inode, attr.Size, ok)
+	}
+
+	time.Sleep(30 * time.Millisecond)
+	if _, _, ok := c.lookup("a/b"); ok {
+		t.Fatal("expired entry still served")
+	}
+	// The reference survives at least one sweep past expiry before it is
+	// forgotten: one insert moves it to the graveyard, the next returns it.
+	c.insert("x", 8, fuse.Attr{}, c.snapshot())
+	time.Sleep(30 * time.Millisecond)
+	c.insert("y", 9, fuse.Attr{}, c.snapshot())
+	found := false
+	for _, inode := range rec.forgotten() {
+		if inode == 7 {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expired reference never forgotten; forgot %v", rec.forgotten())
+	}
+}
+
+func TestPathCacheStealTransfersOwnership(t *testing.T) {
+	rec := &forgetRecorder{}
+	c := newPathCache(20*time.Millisecond, rec.forget)
+
+	c.insert("a", 5, fuse.Attr{}, c.snapshot())
+	inode, ok := c.steal("a")
+	if !ok || inode != 5 {
+		t.Fatalf("steal = %d %v, want 5 true", inode, ok)
+	}
+	if _, ok := c.steal("a"); ok {
+		t.Fatal("second steal succeeded")
+	}
+	// Drive several sweeps; the stolen reference must never be forgotten.
+	for i := 0; i < 4; i++ {
+		time.Sleep(25 * time.Millisecond)
+		c.insert("churn", uint64(100+i), fuse.Attr{}, c.snapshot())
+	}
+	for _, inode := range rec.forgotten() {
+		if inode == 5 {
+			t.Fatal("stolen reference was forgotten by the cache")
+		}
+	}
+}
+
+func TestPathCacheReplaceReturnsOldReference(t *testing.T) {
+	rec := &forgetRecorder{}
+	c := newPathCache(20*time.Millisecond, rec.forget)
+
+	c.insert("a", 5, fuse.Attr{}, c.snapshot())
+	c.insert("a", 6, fuse.Attr{}, c.snapshot())
+	if inode, _, ok := c.lookup("a"); !ok || inode != 6 {
+		t.Fatalf("lookup after replace = %d %v, want 6 true", inode, ok)
+	}
+	for i := 0; i < 3; i++ {
+		time.Sleep(25 * time.Millisecond)
+		c.insert("churn", uint64(100+i), fuse.Attr{}, c.snapshot())
+	}
+	found := false
+	for _, inode := range rec.forgotten() {
+		if inode == 5 {
+			found = true
+		}
+		if inode == 6 && !found {
+			t.Fatal("live reference forgotten before the replaced one")
+		}
+	}
+	if !found {
+		t.Fatalf("replaced reference never forgotten; forgot %v", rec.forgotten())
+	}
+}
+
+func TestPathCachePurgePrefix(t *testing.T) {
+	rec := &forgetRecorder{}
+	c := newPathCache(time.Minute, rec.forget)
+
+	c.insert("dir", 2, fuse.Attr{}, c.snapshot())
+	c.insert("dir/a", 3, fuse.Attr{}, c.snapshot())
+	c.insert("dir/a/b", 4, fuse.Attr{}, c.snapshot())
+	c.insert("dirt", 5, fuse.Attr{}, c.snapshot())
+
+	c.purge("dir", true)
+	if _, _, ok := c.lookup("dir"); ok {
+		t.Fatal("purged key still cached")
+	}
+	if _, _, ok := c.lookup("dir/a/b"); ok {
+		t.Fatal("purged subtree still cached")
+	}
+	// A sibling that only shares the name as a string prefix stays.
+	if _, _, ok := c.lookup("dirt"); !ok {
+		t.Fatal("sibling was purged with the subtree")
+	}
+}
+
+func TestPathCacheRootNeverCached(t *testing.T) {
+	rec := &forgetRecorder{}
+	c := newPathCache(time.Minute, rec.forget)
+
+	c.insert("", 9, fuse.Attr{}, c.snapshot())
+	if _, _, ok := c.lookup(""); ok {
+		t.Fatal("root was cached")
+	}
+	if got := rec.forgotten(); len(got) != 1 || got[0] != 9 {
+		t.Fatalf("root reference not returned immediately: %v", got)
+	}
+}
+
+func TestCacheKey(t *testing.T) {
+	for path, want := range map[string]string{
+		`/a/b`:   "a/b",
+		`\a\b`:   "a/b",
+		`a//b/`:  "a/b",
+		`/`:      "",
+		``:       "",
+		`/a/./b`: "a/b",
+	} {
+		if got := cacheKey(path); got != want {
+			t.Errorf("cacheKey(%q) = %q, want %q", path, got, want)
+		}
+	}
+}
+
 // A resolve runs its Lookup outside the cache lock, so a purge can land
-// between the RPC and the insert. The insert must then be discarded: it
-// carries exactly the name the purge removed, and caching it would serve a
-// deleted entry for a full ttl. This is how a rename's source briefly came
-// back from the dead on the Windows mount.
-func TestInsertAfterPurgeIsDiscarded(t *testing.T) {
-	var forgotten []uint64
-	c := newPathCache(time.Minute, func(inode uint64) { forgotten = append(forgotten, inode) })
+// between the RPC and the insert. An insert a purge covered must then be
+// discarded: it carries exactly the name the purge removed, and caching it
+// would serve a deleted entry for a full ttl. This is how a rename's source
+// briefly came back from the dead on the Windows mount.
+func TestPathCacheInsertAfterCoveringPurgeIsDiscarded(t *testing.T) {
+	c := newPathCache(time.Minute, func(uint64) {})
 
 	gen := c.snapshot()
 	c.purge("dir/src", false)
@@ -25,30 +174,8 @@ func TestInsertAfterPurgeIsDiscarded(t *testing.T) {
 	}
 }
 
-// The discarded insert still owns a lookup reference, which has to come back
-// through the graveyard rather than leak.
-func TestDiscardedInsertReturnsItsReference(t *testing.T) {
-	forgotten := make(map[uint64]bool)
-	c := newPathCache(time.Nanosecond, func(inode uint64) { forgotten[inode] = true })
-
-	gen := c.snapshot()
-	c.purge("dir/src", false)
-	c.insert("dir/src", 42, fuse.Attr{}, gen)
-
-	// Sweeps run at most once per ttl; two spaced mutations drain the
-	// graveyard the discard parked the reference in.
-	time.Sleep(time.Millisecond)
-	c.purge("other", false)
-	time.Sleep(time.Millisecond)
-	c.purge("other", false)
-
-	if !forgotten[42] {
-		t.Fatal("discarded insert leaked its lookup reference")
-	}
-}
-
 // A purge of a directory covers the resolves in flight under it.
-func TestInsertUnderPurgedPrefixIsDiscarded(t *testing.T) {
+func TestPathCacheInsertUnderPurgedPrefixIsDiscarded(t *testing.T) {
 	c := newPathCache(time.Minute, func(uint64) {})
 
 	gen := c.snapshot()
@@ -60,15 +187,69 @@ func TestInsertUnderPurgedPrefixIsDiscarded(t *testing.T) {
 	}
 }
 
-// An undisturbed resolve caches normally.
-func TestInsertWithCurrentGenerationServes(t *testing.T) {
+// A purge of something else entirely must not discard the insert: an open
+// retries resolve-then-steal only a few times before giving up with EIO, so
+// unrelated churn starving every insert would fail opens of untouched paths.
+func TestPathCacheUnrelatedPurgeDoesNotDiscard(t *testing.T) {
 	c := newPathCache(time.Minute, func(uint64) {})
 
 	gen := c.snapshot()
-	c.insert("dir/file", 9, fuse.Attr{Size: 11}, gen)
+	c.purge("elsewhere", true)
+	c.purge("dir/srcling", false)
+	c.insert("dir/src", 9, fuse.Attr{Size: 11}, gen)
 
-	inode, attr, ok := c.lookup("dir/file")
+	inode, attr, ok := c.lookup("dir/src")
 	if !ok || inode != 9 || attr.Size != 11 {
 		t.Fatalf("lookup = %d,%d,%v, want the inserted entry", inode, attr.Size, ok)
+	}
+}
+
+// Purges beyond the remembered window cannot be checked by key, so the insert
+// is discarded rather than trusted.
+func TestPathCacheInsertOlderThanPurgeWindowIsDiscarded(t *testing.T) {
+	c := newPathCache(time.Minute, func(uint64) {})
+
+	gen := c.snapshot()
+	for i := 0; i <= maxRecentPurges; i++ {
+		c.purge(fmt.Sprintf("unrelated/%d", i), false)
+	}
+	c.insert("dir/src", 3, fuse.Attr{}, gen)
+
+	if _, _, ok := c.lookup("dir/src"); ok {
+		t.Fatal("insert older than the purge window was trusted")
+	}
+}
+
+// The discarded insert still owns a lookup reference, which has to come back
+// through the graveyard rather than leak - and not in the same call: the
+// walker is still using the inode.
+func TestPathCacheDiscardedInsertRestsBeforeForget(t *testing.T) {
+	rec := &forgetRecorder{}
+	c := newPathCache(10*time.Millisecond, rec.forget)
+
+	gen := c.snapshot()
+	c.purge("dir/src", false)
+	// Make a sweep due, so the discarding insert itself sweeps: the reference
+	// it just parked must not come back out of that same call.
+	time.Sleep(15 * time.Millisecond)
+	c.insert("dir/src", 42, fuse.Attr{}, gen)
+	for _, inode := range rec.forgotten() {
+		if inode == 42 {
+			t.Fatal("discarded insert forgotten in the same call; the walker still holds it")
+		}
+	}
+
+	for i := 0; i < 3; i++ {
+		time.Sleep(15 * time.Millisecond)
+		c.purge("churn", false)
+	}
+	found := false
+	for _, inode := range rec.forgotten() {
+		if inode == 42 {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("discarded insert leaked its lookup reference; forgot %v", rec.forgotten())
 	}
 }

--- a/weed/mount/winfsp/pathcache_test.go
+++ b/weed/mount/winfsp/pathcache_test.go
@@ -253,3 +253,17 @@ func TestPathCacheDiscardedInsertRestsBeforeForget(t *testing.T) {
 		t.Fatalf("discarded insert leaked its lookup reference; forgot %v", rec.forgotten())
 	}
 }
+
+// A purge of the whole cache - the root, prefix set - covers every in-flight
+// insert, exactly as it removed every entry.
+func TestPathCacheRootPurgeCoversEveryInsert(t *testing.T) {
+	c := newPathCache(time.Minute, func(uint64) {})
+
+	gen := c.snapshot()
+	c.purge("", true)
+	c.insert("dir/src", 42, fuse.Attr{}, gen)
+
+	if _, _, ok := c.lookup("dir/src"); ok {
+		t.Fatal("root purge did not cover an in-flight insert")
+	}
+}

--- a/weed/mount/winfsp/pathcache_test.go
+++ b/weed/mount/winfsp/pathcache_test.go
@@ -1,157 +1,74 @@
 package winfsp
 
 import (
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/seaweedfs/go-fuse/v2/fuse"
 )
 
-type forgetRecorder struct {
-	mu     sync.Mutex
-	inodes []uint64
-}
+// A resolve runs its Lookup outside the cache lock, so a purge can land
+// between the RPC and the insert. The insert must then be discarded: it
+// carries exactly the name the purge removed, and caching it would serve a
+// deleted entry for a full ttl. This is how a rename's source briefly came
+// back from the dead on the Windows mount.
+func TestInsertAfterPurgeIsDiscarded(t *testing.T) {
+	var forgotten []uint64
+	c := newPathCache(time.Minute, func(inode uint64) { forgotten = append(forgotten, inode) })
 
-func (r *forgetRecorder) forget(inode uint64) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.inodes = append(r.inodes, inode)
-}
+	gen := c.snapshot()
+	c.purge("dir/src", false)
+	c.insert("dir/src", 42, fuse.Attr{}, gen)
 
-func (r *forgetRecorder) forgotten() []uint64 {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return append([]uint64(nil), r.inodes...)
-}
-
-func TestPathCacheLookupAndExpiry(t *testing.T) {
-	rec := &forgetRecorder{}
-	c := newPathCache(20*time.Millisecond, rec.forget)
-
-	c.insert("a/b", 7, fuse.Attr{Ino: 7, Size: 42})
-	inode, attr, ok := c.lookup("a/b")
-	if !ok || inode != 7 || attr.Size != 42 {
-		t.Fatalf("lookup = %d %v %v, want 7 size 42 true", inode, attr.Size, ok)
-	}
-
-	time.Sleep(30 * time.Millisecond)
-	if _, _, ok := c.lookup("a/b"); ok {
-		t.Fatal("expired entry still served")
-	}
-	// The reference survives at least one sweep past expiry before it is
-	// forgotten: one insert moves it to the graveyard, the next returns it.
-	c.insert("x", 8, fuse.Attr{})
-	time.Sleep(30 * time.Millisecond)
-	c.insert("y", 9, fuse.Attr{})
-	found := false
-	for _, inode := range rec.forgotten() {
-		if inode == 7 {
-			found = true
-		}
-	}
-	if !found {
-		t.Fatalf("expired reference never forgotten; forgot %v", rec.forgotten())
+	if _, _, ok := c.lookup("dir/src"); ok {
+		t.Fatal("purged name served from an insert that started before the purge")
 	}
 }
 
-func TestPathCacheStealTransfersOwnership(t *testing.T) {
-	rec := &forgetRecorder{}
-	c := newPathCache(20*time.Millisecond, rec.forget)
+// The discarded insert still owns a lookup reference, which has to come back
+// through the graveyard rather than leak.
+func TestDiscardedInsertReturnsItsReference(t *testing.T) {
+	forgotten := make(map[uint64]bool)
+	c := newPathCache(time.Nanosecond, func(inode uint64) { forgotten[inode] = true })
 
-	c.insert("a", 5, fuse.Attr{})
-	inode, ok := c.steal("a")
-	if !ok || inode != 5 {
-		t.Fatalf("steal = %d %v, want 5 true", inode, ok)
-	}
-	if _, ok := c.steal("a"); ok {
-		t.Fatal("second steal succeeded")
-	}
-	// Drive several sweeps; the stolen reference must never be forgotten.
-	for i := 0; i < 4; i++ {
-		time.Sleep(25 * time.Millisecond)
-		c.insert("churn", uint64(100+i), fuse.Attr{})
-	}
-	for _, inode := range rec.forgotten() {
-		if inode == 5 {
-			t.Fatal("stolen reference was forgotten by the cache")
-		}
+	gen := c.snapshot()
+	c.purge("dir/src", false)
+	c.insert("dir/src", 42, fuse.Attr{}, gen)
+
+	// Sweeps run at most once per ttl; two spaced mutations drain the
+	// graveyard the discard parked the reference in.
+	time.Sleep(time.Millisecond)
+	c.purge("other", false)
+	time.Sleep(time.Millisecond)
+	c.purge("other", false)
+
+	if !forgotten[42] {
+		t.Fatal("discarded insert leaked its lookup reference")
 	}
 }
 
-func TestPathCacheReplaceReturnsOldReference(t *testing.T) {
-	rec := &forgetRecorder{}
-	c := newPathCache(20*time.Millisecond, rec.forget)
+// A purge of a directory covers the resolves in flight under it.
+func TestInsertUnderPurgedPrefixIsDiscarded(t *testing.T) {
+	c := newPathCache(time.Minute, func(uint64) {})
 
-	c.insert("a", 5, fuse.Attr{})
-	c.insert("a", 6, fuse.Attr{})
-	if inode, _, ok := c.lookup("a"); !ok || inode != 6 {
-		t.Fatalf("lookup after replace = %d %v, want 6 true", inode, ok)
-	}
-	for i := 0; i < 3; i++ {
-		time.Sleep(25 * time.Millisecond)
-		c.insert("churn", uint64(100+i), fuse.Attr{})
-	}
-	found := false
-	for _, inode := range rec.forgotten() {
-		if inode == 5 {
-			found = true
-		}
-		if inode == 6 && !found {
-			t.Fatal("live reference forgotten before the replaced one")
-		}
-	}
-	if !found {
-		t.Fatalf("replaced reference never forgotten; forgot %v", rec.forgotten())
-	}
-}
-
-func TestPathCachePurgePrefix(t *testing.T) {
-	rec := &forgetRecorder{}
-	c := newPathCache(time.Minute, rec.forget)
-
-	c.insert("dir", 2, fuse.Attr{})
-	c.insert("dir/a", 3, fuse.Attr{})
-	c.insert("dir/a/b", 4, fuse.Attr{})
-	c.insert("dirt", 5, fuse.Attr{})
-
+	gen := c.snapshot()
 	c.purge("dir", true)
-	if _, _, ok := c.lookup("dir"); ok {
-		t.Fatal("purged key still cached")
-	}
-	if _, _, ok := c.lookup("dir/a/b"); ok {
-		t.Fatal("purged subtree still cached")
-	}
-	// A sibling that only shares the name as a string prefix stays.
-	if _, _, ok := c.lookup("dirt"); !ok {
-		t.Fatal("sibling was purged with the subtree")
+	c.insert("dir/child", 7, fuse.Attr{}, gen)
+
+	if _, _, ok := c.lookup("dir/child"); ok {
+		t.Fatal("purged prefix served a child from a stale insert")
 	}
 }
 
-func TestPathCacheRootNeverCached(t *testing.T) {
-	rec := &forgetRecorder{}
-	c := newPathCache(time.Minute, rec.forget)
+// An undisturbed resolve caches normally.
+func TestInsertWithCurrentGenerationServes(t *testing.T) {
+	c := newPathCache(time.Minute, func(uint64) {})
 
-	c.insert("", 9, fuse.Attr{})
-	if _, _, ok := c.lookup(""); ok {
-		t.Fatal("root was cached")
-	}
-	if got := rec.forgotten(); len(got) != 1 || got[0] != 9 {
-		t.Fatalf("root reference not returned immediately: %v", got)
-	}
-}
+	gen := c.snapshot()
+	c.insert("dir/file", 9, fuse.Attr{Size: 11}, gen)
 
-func TestCacheKey(t *testing.T) {
-	for path, want := range map[string]string{
-		`/a/b`:   "a/b",
-		`\a\b`:   "a/b",
-		`a//b/`:  "a/b",
-		`/`:      "",
-		``:       "",
-		`/a/./b`: "a/b",
-	} {
-		if got := cacheKey(path); got != want {
-			t.Errorf("cacheKey(%q) = %q, want %q", path, got, want)
-		}
+	inode, attr, ok := c.lookup("dir/file")
+	if !ok || inode != 9 || attr.Size != 11 {
+		t.Fatalf("lookup = %d,%d,%v, want the inserted entry", inode, attr.Size, ok)
 	}
 }


### PR DESCRIPTION
Root-causes the `TestRenameOverExisting` flake from the `mount: windows` run on #10827 — `source survived the rename`, once, passing on re-run of the same commit.

What made it worth chasing is that every SeaweedFS layer is provably synchronous with the rename: `doRename` consumes the filer stream before returning, `handleRenameResponse` runs `MovePath` and the local-store delete in-line (`ApplyMetadataResponseOwned` blocks on the apply worker's `done`), and the adapter purges its path cache after `wfs.Rename` returns. The mount's error log shows nothing at the failure instant. By the time the test called `os.Stat(src)`, the filer, the local store, the inode table, and the adapter cache had all already dropped the name.

What none of that covers is a resolve **in flight** during the rename. The adapter's `walk` resolves a component with a Lookup RPC and inserts the result into the path cache holding no lock:

1. a concurrent opener of `src` misses the cache and issues `Lookup(src)` — succeeds, pre-rename
2. the rename completes; `purgeWithParent(src)` runs — nothing to purge yet
3. the opener's `insert(src, inode)` lands — the cache now holds the name the rename just deleted, for up to the 1s Windows cache TTL
4. `os.Stat(src)` is served the stale entry

The test is single-threaded but the machine is not — an antivirus scan of a just-written file is exactly the background open a CI runner supplies, and the need for a millisecond interleaving matches the once-in-hundreds frequency. The release path already guards its equivalent insert (`stillNames`, "caching it would resurrect an entry that is gone"); the walk had nothing, and its window is RPC-wide.

The cache counts purges now. A resolve snapshots the generation before its lookups; `insert` discards the entry when any purge ran in between, parking the reference in the graveyard — which exists precisely so an in-flight holder keeps a valid inode — so ownership semantics are unchanged in every outcome. Purge bumps unconditionally, since the point is as much the in-flight resolve about to insert a name as anything the map currently holds. All three insert sites pass a snapshot.

Unit tests cover discard-on-purge, discard-under-a-purged-prefix, the reference coming back through the graveyard, and the undisturbed path; the discard tests fail without the guard (`purged name served from an insert that started before the purge`).

The assertion that caught this also discarded its evidence — `!os.IsNotExist(err)` conflates a stale positive with any transient error, and the message dropped both `err` and the `FileInfo`. It now reports what stat returned and whether it persisted 200ms later, so a recurrence indicts a specific layer instead of reading as a mystery.

Verified: `GOOS=windows go build` on the adapter and command packages, package tests with `-race`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file rename handling when source paths remain briefly visible.
  * Prevented stale path information from being reused after targeted cache invalidation.
  * Improved consistency when creating directories and restoring cached paths.
  * Delayed removal of recently discarded path references to support concurrent operations more reliably.

* **Tests**
  * Expanded coverage for cache invalidation, concurrent lookups, path-prefix handling, and delayed cleanup.
  * Added verification that unrelated cache invalidations do not discard valid path information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->