### PR TITLE
s3: allow-unordered is a listing parameter, not an unimplemented subresource

### DIFF
--- a/weed/s3api/s3api_bucket_handlers_misc.go
+++ b/weed/s3api/s3api_bucket_handlers_misc.go
@@ -177,7 +177,7 @@ var listObjectsQueryParams = map[string]bool{
 	"prefix": true, "delimiter": true, "marker": true, "max-keys": true,
 	"encoding-type": true, "list-type": true, "continuation-token": true,
 	"start-after": true, "fetch-owner": true, "expected-bucket-owner": true,
-	"x-id": true,
+	"allow-unordered": true, "x-id": true,
 	// SigV2 presigned URLs.
 	"AWSAccessKeyId": true, "Signature": true, "Expires": true,
 }

--- a/weed/s3api/s3api_bucket_subresource_routing_test.go
+++ b/weed/s3api/s3api_bucket_subresource_routing_test.go
@@ -18,6 +18,11 @@ func TestUnroutedBucketSubresource(t *testing.T) {
 		"list-type=2&continuation-token=x",
 		"delimiter=/&encoding-type=url",
 		"x-id=ListObjectsV2",
+		// The listing handlers read allow-unordered and validate it against
+		// delimiter, so the guard has to let it through to them.
+		"allow-unordered=true",
+		"allow-unordered=true&max-keys=1000",
+		"list-type=2&allow-unordered=true",
 		"prefix=a&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=deadbeef&X-Amz-Expires=900",
 		"AWSAccessKeyId=key&Signature=sig&Expires=1700000000",
 	} {


### PR DESCRIPTION
# What problem are we solving?

`test_bucket_list_unordered` and `test_bucket_listv2_unordered` fail in the Ceph
s3-tests suite on master, so `Basic S3 tests (KV store)` and `(SQL store)` are
red on every PR.

The cause is the guard that stops a bucket GET carrying an unimplemented
subresource from being answered with a bucket listing. Its list of known listing
parameters is missing `allow-unordered`, so the request is treated as a
subresource nothing routes and answered `501 NotImplemented` — for a parameter
the listing handlers already read and already validate against `delimiter`
(`s3api_object_handlers_list.go`, both V1 and V2).

```
$ curl "http://localhost:8333/bucket?allow-unordered=true"
<Error><Code>NotImplemented</Code>...
```

# How are we solving the problem?

Adding `allow-unordered` to the parameter list, so the guard hands the request to
the listing handler that implements it.

# How is the PR tested?

`TestUnroutedBucketSubresource` gains the three shapes a client sends it
(`allow-unordered=true` alone, with `max-keys`, and with `list-type=2`). Reverting
the one-line change fails all three. The two Ceph tests are what this is really
for; they run in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * S3 object listing requests now support the `allow-unordered` query parameter.
  * This option works alongside pagination and list-type parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->