### PR TITLE
admin: keep the copy confirmation in front of the access key modal

### DIFF
--- a/weed/admin/static/js/admin.js
+++ b/weed/admin/static/js/admin.js
@@ -634,7 +634,7 @@ function formatDate(date) {
 function adminCopyToClipboard(text) {
     if (navigator.clipboard && navigator.clipboard.writeText) {
         navigator.clipboard.writeText(text).then(() => {
-            showAlert('Copied to clipboard!', 'success');
+            showToast('Copied to clipboard!');
         }).catch(err => {
             console.error('Failed to copy text: ', err);
             fallbackCopyText(text);
@@ -660,7 +660,7 @@ function fallbackCopyText(text) {
     try {
         const successful = document.execCommand('copy');
         if (successful) {
-            showAlert('Copied to clipboard!', 'success');
+            showToast('Copied to clipboard!');
         } else {
             showAlert('Failed to copy to clipboard', 'danger');
         }
@@ -2265,11 +2265,11 @@ function copyFromInput(inputId) {
         try {
             const successful = document.execCommand('copy');
             if (successful) {
-                showAlert('Copied to clipboard!', 'success');
+                showToast('Copied to clipboard!');
             } else {
                 // Try modern clipboard API as fallback
                 navigator.clipboard.writeText(input.value).then(() => {
-                    showAlert('Copied to clipboard!', 'success');
+                    showToast('Copied to clipboard!');
                 }).catch(() => {
                     showAlert('Failed to copy', 'danger');
                 });
@@ -2277,7 +2277,7 @@ function copyFromInput(inputId) {
         } catch (err) {
             // Try modern clipboard API as fallback
             navigator.clipboard.writeText(input.value).then(() => {
-                showAlert('Copied to clipboard!', 'success');
+                showToast('Copied to clipboard!');
             }).catch(() => {
                 showAlert('Failed to copy', 'danger');
             });

--- a/weed/admin/static/js/modal-alerts.js
+++ b/weed/admin/static/js/modal-alerts.js
@@ -290,6 +290,40 @@
         return text.replace(/[&<>"']/g, function (m) { return map[m]; });
     }
 
+    // Bootstrap gives every modal and backdrop the same z-index, so a modal
+    // opened while another one is showing paints behind it and cannot be
+    // clicked. Lift each nested modal, and its backdrop, above what is already
+    // on screen.
+    const MODAL_Z_INDEX = 1055;
+    const MODAL_Z_INDEX_STEP = 20;
+
+    document.addEventListener('show.bs.modal', function (event) {
+        const depth = document.querySelectorAll('.modal.show').length;
+        if (depth === 0) {
+            return;
+        }
+
+        const zIndex = MODAL_Z_INDEX + depth * MODAL_Z_INDEX_STEP;
+        event.target.style.zIndex = zIndex;
+
+        // Bootstrap only creates the backdrop after this event returns.
+        setTimeout(function () {
+            const backdrops = document.querySelectorAll('.modal-backdrop');
+            const backdrop = backdrops[backdrops.length - 1];
+            if (backdrop) {
+                backdrop.style.zIndex = zIndex - 1;
+            }
+        }, 0);
+    });
+
+    document.addEventListener('hidden.bs.modal', function (event) {
+        event.target.style.zIndex = '';
+        // Closing any modal releases the scroll lock the others still need.
+        if (document.querySelector('.modal.show')) {
+            document.body.classList.add('modal-open');
+        }
+    });
+
     // Auto-initialize on DOMContentLoaded
     if (document.readyState === 'loading') {
         document.addEventListener('DOMContentLoaded', ensureModalsExist);

--- a/weed/admin/static/js/modal-alerts.js
+++ b/weed/admin/static/js/modal-alerts.js
@@ -169,6 +169,36 @@
     };
 
     /**
+     * Show a transient message that does not have to be dismissed
+     * @param {string} message - The message to display
+     * @param {string} type - Bootstrap contextual color, defaults to 'success'
+     */
+    window.showToast = function (message, type) {
+        let container = document.getElementById('globalToastContainer');
+        if (!container) {
+            container = document.createElement('div');
+            container.id = 'globalToastContainer';
+            container.className = 'toast-container position-fixed top-0 end-0 p-3';
+            // Above any modal, however deeply they are stacked.
+            container.style.zIndex = '9999';
+            document.body.appendChild(container);
+        }
+
+        const toast = document.createElement('div');
+        toast.className = 'toast align-items-center text-white bg-' + (type || 'success') + ' border-0';
+        toast.setAttribute('role', 'alert');
+        toast.innerHTML = '<div class="d-flex"><div class="toast-body">' + escapeHtml(message) + '</div>' +
+            '<button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button></div>';
+        container.appendChild(toast);
+
+        toast.addEventListener('hidden.bs.toast', function () {
+            toast.remove();
+        });
+
+        new bootstrap.Toast(toast, { delay: 3000 }).show();
+    };
+
+    /**
      * Show a confirmation dialog using Bootstrap modal
      * @param {string} message - The confirmation message
      * @param {function} onConfirm - Callback function if user confirms


### PR DESCRIPTION
Fixes #10855.

On the object store users page, `Manage Access Keys` opens a modal, `View Secret` opens a second one on top of it, and each copy button then raised `Copied to clipboard!` as a third. Bootstrap gives every modal and every backdrop the same z-index, so that third modal painted behind the access key details modal, and because the details modal sat on top of it there was nothing to click to dismiss it.

Two commits:

- Nested modals now get a z-index above the ones already open, and so do the backdrops Bootstrap creates for them. Closing one also puts back the `modal-open` scroll lock that Bootstrap drops as soon as any modal hides, which the modals still underneath need. This applies to every stacked modal in the admin UI, not just this flow.
- Clipboard confirmations are toasts rather than modals. The details modal has three copy buttons; a modal meant three dismissals before the credentials were readable again. Copy failures stay as modals.

Verified in headless Chrome against the real `bootstrap.bundle.min.js` and `modal-alerts.js`, driving the same modal-on-modal-on-alert sequence. Before, `elementFromPoint` over the alert's OK button returned the details modal and all three modals reported z-index 1055. After, the modals report 1055/1075/1095, the OK button is the element at its own coordinates, and the scroll lock survives closing the top modal. With the toast, the details modal stays interactive and the toast auto-dismisses with no DOM left behind.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added brief, auto-dismissing toast notifications for successful clipboard actions.
  * Added support for displaying multiple nested modal dialogs with correct layering and page scroll behavior.

* **Bug Fixes**
  * Improved notification presentation for clipboard copy results while preserving existing failure messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->