### PR TITLE
release: cut the whole release from the version bump workflow

### DIFF
--- a/.github/workflows/release_version_bump.yml
+++ b/.github/workflows/release_version_bump.yml
@@ -1,4 +1,17 @@
-name: "release: bump version"
+name: "release: bump version and cut the release"
+
+# One entry point for a SeaweedFS release:
+#   1. bump MAJOR/MINOR in constants.go and the Helm Chart.yaml, commit to master
+#   2. push the <appVersion> tag, which fans out to the workflows that trigger on
+#      `push: tags` (binaries_release*, container_release_unified, helm_manual_release)
+#   3. create the GitHub release, with GitHub's generated notes
+#   4. dispatch "Prepare release" in seaweedfs-csi-driver and seaweedfs-operator,
+#      which pick up the new master through `go get -u`, and wait for both
+#
+# Events raised by the default GITHUB_TOKEN do not start other workflows, and it
+# cannot reach the other two repositories at all. Add a repo secret RELEASE_PAT
+# with `contents: write` here and `actions: write` on the csi-driver and operator
+# repos. Without it the tag is still pushed, but nothing downstream of it runs.
 
 on:
   workflow_dispatch:
@@ -14,15 +27,37 @@ on:
         description: "Explicit MAJOR.MINOR to set, e.g. 4.36 (overrides 'bump')"
         type: string
         required: false
+      downstream:
+        description: "Also release the CSI driver and the operator"
+        type: boolean
+        default: true
+      dry_run:
+        description: "Show the version bump, but change nothing"
+        type: boolean
+        default: false
 
 permissions:
   contents: write
 
 jobs:
-  bump-version:
+  release:
     runs-on: ubuntu-latest
+    outputs:
+      app_version: ${{ steps.compute.outputs.app_version }}
+      sha: ${{ steps.tag.outputs.sha }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Check the release token
+        env:
+          HAS_PAT: ${{ secrets.RELEASE_PAT != '' }}
+        run: |
+          if [ "$HAS_PAT" != "true" ]; then
+            echo "::warning::RELEASE_PAT is not set. The tag will be pushed with GITHUB_TOKEN, so the binary, container and helm workflows will not start on their own."
+          fi
 
       - name: Compute new version
         id: compute
@@ -99,17 +134,88 @@ jobs:
           sed -i -E "s/^version:.*/version: ${CHART_VERSION}/" "$CHART"
           cat "$CHART"
 
-      - name: Commit and push
+      - name: Commit, and push the tag
+        id: tag
         env:
-          APP_VERSION: ${{ steps.compute.outputs.app_version }}
+          TAG: ${{ steps.compute.outputs.app_version }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -euo pipefail
-          if git diff --quiet; then
-            echo "No version change to commit."
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "::error::Tag ${TAG} already exists."
+            exit 1
+          fi
+          if [ "$DRY_RUN" = "true" ]; then
+            git --no-pager diff --stat
+            echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add weed/util/version/constants.go k8s/charts/seaweedfs/Chart.yaml
-          git commit -m "${APP_VERSION}"
-          git push
+          if git diff --quiet; then
+            echo "::warning::Version files are already at ${TAG}; tagging the current HEAD."
+          else
+            git add weed/util/version/constants.go k8s/charts/seaweedfs/Chart.yaml
+            git commit -m "${TAG}"
+            git push
+          fi
+
+          # Push the tag with git so the `push: tags` triggers fire. Creating the
+          # tag through the release API alone would only emit a `create` event.
+          git tag "$TAG"
+          git push origin "$TAG"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Create the release
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.compute.outputs.app_version }}
+        run: gh release create "$TAG" --title "$TAG" --generate-notes --verify-tag
+
+  downstream:
+    needs: release
+    if: ${{ inputs.downstream && !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - repo: seaweedfs/seaweedfs-csi-driver
+            workflow: prepare_release.yaml
+          - repo: seaweedfs/seaweedfs-operator
+            workflow: prepare_release.yml
+    steps:
+      - name: Release ${{ matrix.repo }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          REPO: ${{ matrix.repo }}
+          WORKFLOW: ${{ matrix.workflow }}
+          SHA: ${{ needs.release.outputs.sha }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::error::RELEASE_PAT with actions:write on ${REPO} is required to release it"
+            exit 1
+          fi
+
+          # Have the module proxy fetch the release commit, so the `go get -u` in
+          # the dispatched workflow resolves to it rather than to a cached tip.
+          curl -sf "https://proxy.golang.org/github.com/seaweedfs/seaweedfs/@v/${SHA}.info" || true
+
+          BEFORE=$(gh run list -R "$REPO" --workflow "$WORKFLOW" --limit 1 --json databaseId --jq '.[0].databaseId // 0')
+          gh workflow run -R "$REPO" "$WORKFLOW" --ref master -f bump=patch -f update_seaweedfs=true
+
+          for _ in $(seq 24); do
+            sleep 5
+            RUN=$(gh run list -R "$REPO" --workflow "$WORKFLOW" --limit 1 --json databaseId --jq '.[0].databaseId // 0')
+            [ "$RUN" != "$BEFORE" ] && break
+          done
+          if [ "$RUN" = "$BEFORE" ]; then
+            echo "::error::${REPO} did not start a run for ${WORKFLOW}"
+            exit 1
+          fi
+
+          echo "watching https://github.com/${REPO}/actions/runs/${RUN}"
+          gh run watch "$RUN" -R "$REPO" --exit-status

--- a/.github/workflows/release_version_bump.yml
+++ b/.github/workflows/release_version_bump.yml
@@ -36,18 +36,18 @@ on:
         type: boolean
         default: false
 
-permissions:
-  contents: write
-
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       app_version: ${{ steps.compute.outputs.app_version }}
       sha: ${{ steps.tag.outputs.sha }}
     steps:
       - uses: actions/checkout@v7
         with:
+          ref: master
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
 
@@ -178,6 +178,7 @@ jobs:
     needs: release
     if: ${{ inputs.downstream && !inputs.dry_run }}
     runs-on: ubuntu-latest
+    permissions: {}
     strategy:
       fail-fast: false
       matrix:
@@ -193,6 +194,7 @@ jobs:
           REPO: ${{ matrix.repo }}
           WORKFLOW: ${{ matrix.workflow }}
           SHA: ${{ needs.release.outputs.sha }}
+          MODULE: github.com/seaweedfs/seaweedfs
         run: |
           set -euo pipefail
           if [ -z "${GH_TOKEN}" ]; then
@@ -200,22 +202,36 @@ jobs:
             exit 1
           fi
 
-          # Have the module proxy fetch the release commit, so the `go get -u` in
-          # the dispatched workflow resolves to it rather than to a cached tip.
-          curl -sf "https://proxy.golang.org/github.com/seaweedfs/seaweedfs/@v/${SHA}.info" || true
+          # The dispatched workflow pins seaweedfs with `go get -u ...@latest`, so
+          # wait until the proxy serves the release commit as the tip. Asking for
+          # the commit by name is what makes the proxy fetch it.
+          for _ in $(seq 30); do
+            curl -sf "https://proxy.golang.org/${MODULE}/@v/${SHA}.info" >/dev/null || true
+            TIP=$(curl -sf "https://proxy.golang.org/${MODULE}/@latest" | jq -r '.Origin.Hash // ""' || true)
+            [ "$TIP" = "$SHA" ] && break
+            sleep 10
+          done
+          if [ "$TIP" != "$SHA" ]; then
+            echo "::error::the module proxy still serves ${TIP} as the tip, so ${REPO} would pin a pre-release commit. Run ${WORKFLOW} there once it catches up."
+            exit 1
+          fi
 
-          BEFORE=$(gh run list -R "$REPO" --workflow "$WORKFLOW" --limit 1 --json databaseId --jq '.[0].databaseId // 0')
+          runs() { gh api "repos/${REPO}/actions/workflows/${WORKFLOW}/runs?per_page=50" --jq '[.workflow_runs[].id]'; }
+
+          BEFORE=$(runs)
           gh workflow run -R "$REPO" "$WORKFLOW" --ref master -f bump=patch -f update_seaweedfs=true
 
           for _ in $(seq 24); do
             sleep 5
-            RUN=$(gh run list -R "$REPO" --workflow "$WORKFLOW" --limit 1 --json databaseId --jq '.[0].databaseId // 0')
-            [ "$RUN" != "$BEFORE" ] && break
+            NEW=$(runs | jq -c --argjson before "$BEFORE" '. - $before')
+            [ "$(jq length <<<"$NEW")" -gt 0 ] && break
           done
-          if [ "$RUN" = "$BEFORE" ]; then
-            echo "::error::${REPO} did not start a run for ${WORKFLOW}"
-            exit 1
-          fi
+          case "$(jq length <<<"$NEW")" in
+            0) echo "::error::${REPO} did not start a run for ${WORKFLOW}"; exit 1 ;;
+            1) ;;
+            *) echo "::error::${REPO} started more than one run of ${WORKFLOW}; cannot tell which one is ours: ${NEW}"; exit 1 ;;
+          esac
+          RUN=$(jq -r '.[0]' <<<"$NEW")
 
           echo "watching https://github.com/${REPO}/actions/runs/${RUN}"
           gh run watch "$RUN" -R "$REPO" --exit-status

--- a/.github/workflows/release_version_bump.yml
+++ b/.github/workflows/release_version_bump.yml
@@ -216,22 +216,21 @@ jobs:
             exit 1
           fi
 
-          runs() { gh api "repos/${REPO}/actions/workflows/${WORKFLOW}/runs?per_page=50" --jq '[.workflow_runs[].id]'; }
+          # Wait on the release the dispatched workflow publishes, not on the run
+          # that publishes it: a dispatch cannot be told apart from a concurrent
+          # one through the API, and the release is what we are here for.
+          released() { gh api "repos/${REPO}/releases?per_page=30" --jq '[.[].tag_name]'; }
 
-          BEFORE=$(runs)
+          BEFORE=$(released)
           gh workflow run -R "$REPO" "$WORKFLOW" --ref master -f bump=patch -f update_seaweedfs=true
 
-          for _ in $(seq 24); do
-            sleep 5
-            NEW=$(runs | jq -c --argjson before "$BEFORE" '. - $before')
+          for _ in $(seq 80); do
+            sleep 15
+            NEW=$(released | jq -c --argjson before "$BEFORE" '. - $before')
             [ "$(jq length <<<"$NEW")" -gt 0 ] && break
           done
-          case "$(jq length <<<"$NEW")" in
-            0) echo "::error::${REPO} did not start a run for ${WORKFLOW}"; exit 1 ;;
-            1) ;;
-            *) echo "::error::${REPO} started more than one run of ${WORKFLOW}; cannot tell which one is ours: ${NEW}"; exit 1 ;;
-          esac
-          RUN=$(jq -r '.[0]' <<<"$NEW")
-
-          echo "watching https://github.com/${REPO}/actions/runs/${RUN}"
-          gh run watch "$RUN" -R "$REPO" --exit-status
+          if [ "$(jq length <<<"$NEW")" -eq 0 ]; then
+            echo "::error::${REPO} published no release within 20 minutes; see https://github.com/${REPO}/actions/workflows/${WORKFLOW}"
+            exit 1
+          fi
+          echo "${REPO} released $(jq -r 'join(", ")' <<<"$NEW")"


### PR DESCRIPTION
The bump workflow stopped after pushing the version commit; everything after
that was manual — create the release, then run "Prepare release" in the
csi-driver and the operator.

It now does the whole thing:

- bump `constants.go` and the chart, commit to master (unchanged)
- push the `<appVersion>` tag, which is what starts `binaries_release*`,
  `container_release_unified` and `helm_manual_release`
- create the release with GitHub's generated notes
- dispatch `prepare_release` in seaweedfs-csi-driver and seaweedfs-operator,
  and wait for both

Two new inputs: `downstream` to skip the other two repositories, and `dry_run`
to see the computed version and the diff without changing anything.

Both the tag push and the cross-repository dispatch need the `RELEASE_PAT`
secret — the default `GITHUB_TOKEN` raises no events that start workflows, and
cannot reach the other repositories at all. Without it the release still
happens, with a warning, but nothing downstream of it runs.

The downstream workflows resolve seaweedfs through `go get -u ...@latest`, so
this asks the module proxy for the release commit before dispatching them to
narrow the window where they would pick up the previous tip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the release workflow to create version updates, tags, and releases automatically.
  * Added dry-run and optional downstream-release controls.
  * Added coordination with related driver and operator releases.
  * Added release version and commit information to workflow outputs.
* **Bug Fixes**
  * Prevents releases when the target tag already exists.
  * Confirms downstream releases are newly published before completion.
  * Provides a warning when release authentication is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->