### PR TITLE
test: wait for the master to register the volume servers before failover tests run

### DIFF
--- a/test/fuse_failover/framework_test.go
+++ b/test/fuse_failover/framework_test.go
@@ -109,6 +109,7 @@ func startFailoverCluster(t testing.TB, numVolumes, numMounts int) *failoverClus
 		require.NoError(t, c.waitForMount(mp, 30*time.Second),
 			"mount %d not ready\n%s", i, c.tailLog(fmt.Sprintf("mount%d", i)))
 	}
+	require.NoError(t, c.WaitForVolumeServers(60*time.Second))
 	return c
 }
 
@@ -342,6 +343,62 @@ func (c *failoverCluster) WaitForHolders(vid uint32, count int, timeout time.Dur
 		}
 		time.Sleep(500 * time.Millisecond)
 	}
+}
+
+// WaitForVolumeServers blocks until the master's topology lists every volume
+// server. A volume server accepts connections well before the master knows it
+// exists: a lone master only elects itself once its bootstrap check expires,
+// and heartbeats sent before that are refused and retried with backoff, so
+// registration lands seconds after the process is up. Until it does the
+// topology has no data node at all, an assign fails with "no free volumes
+// left", and the mount reports that as ENOSPC instead of retrying.
+func (c *failoverCluster) WaitForVolumeServers(timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		registered := c.registeredVolumeServers()
+		var missing []string
+		for i := range c.volumePorts {
+			if address := c.VolumeServerAddress(i); !registered[address] {
+				missing = append(missing, address)
+			}
+		}
+		if len(missing) == 0 {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("volume servers %v not registered with the master within %v\n%s",
+				missing, timeout, c.MasterGet("/dir/status?pretty=y"))
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+// registeredVolumeServers is the set of volume server addresses the master
+// currently holds in its topology.
+func (c *failoverCluster) registeredVolumeServers() map[string]bool {
+	var status struct {
+		Topology struct {
+			DataCenters []struct {
+				Racks []struct {
+					DataNodes []struct {
+						Url string `json:"Url"`
+					} `json:"DataNodes"`
+				} `json:"Racks"`
+			} `json:"DataCenters"`
+		} `json:"Topology"`
+	}
+	if err := json.Unmarshal([]byte(c.MasterGet("/dir/status")), &status); err != nil {
+		return nil
+	}
+	registered := make(map[string]bool)
+	for _, dc := range status.Topology.DataCenters {
+		for _, rack := range dc.Racks {
+			for _, dn := range rack.DataNodes {
+				registered[dn.Url] = true
+			}
+		}
+	}
+	return registered
 }
 
 // volumeIndexOf maps a server address back to its index, or -1.

--- a/test/fuse_failover/volume_failover_test.go
+++ b/test/fuse_failover/volume_failover_test.go
@@ -190,7 +190,9 @@ func TestReadWithVolumeServerDown(t *testing.T) {
 		t.Logf("read %s (held by volume%d) with volume%d down in %v", name, victim, victim, elapsed)
 
 		require.NoError(t, c.StartVolume(victim))
-		time.Sleep(3 * time.Second) // let the master see the heartbeat again
+		// The next iteration picks its victim from the master's placement view,
+		// so wait for the restarted server to be in it again.
+		require.NoError(t, c.WaitForVolumeServers(60*time.Second))
 	}
 }
 


### PR DESCRIPTION
`TestLargeWriteWhileVolumeServerStops` failed on an unrelated PR with the write dying before any chaos had been applied:

```
upload data largefile: assign volume: rpc error: code = Unknown desc = failed to find writable volumes
for collection: replication:001 ttl: error: No writable volumes and no free volumes left
```

The master log from that run says why:

```
05:49:21.391  bootstrap check in 1.848416007s (peer index 0 of 1)
05:49:23.241  127.0.0.1:37775.35739 becomes leader.
05:49:24.102  assign ...: No writable volumes and no free volumes left
05:49:24.102  topo failed to pick 1 from  0 node candidates
05:49:24.102  create 6 volume, created 0: Not enough data nodes found!
05:49:26.598  added volume server 0: 127.0.0.1:37949
05:49:26.925  added volume server 0: 127.0.0.1:38503
05:49:27.205  added volume server 0: 127.0.0.1:37505
```

The harness took an open volume server port as readiness, but the master only learns of a volume server from its heartbeat. A lone master refuses heartbeats until its bootstrap check elects it, the servers back off and retry, and registration lands seconds after the ports answer. The test began writing at `05:49:24` into a topology with no data node in it at all, so the assign had nothing to grow onto. The mount classifies "no free volumes left" as ENOSPC and fails fast rather than retrying, so the write surfaced the error straight to the test.

Every test in the file runs in that window; the others just happen to start writing on the far side of it.

`startFailoverCluster` now waits for the master's topology to list every volume server before it returns, and `TestReadWithVolumeServerDown` waits for a restarted server to reappear in the topology instead of sleeping 3s, since its next iteration picks its victim from the master's placement view.

Reproduced the mechanism locally: the master spends 1.52s in the bootstrap check, becomes leader at +1.52s, and the volume servers register at +1.80s, all with their ports open from the start. The new wait was exercised against a live cluster in both directions -- it returns as soon as all three land, and on timeout it names the servers still missing and dumps the topology.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failover test reliability by waiting for restarted volume servers to re-register before continuing.
  * Added timeout handling with diagnostic status details when server registration does not complete.
  * Replaced fixed delays with readiness checks to reduce intermittent test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->