### PR TITLE
helm: render the mysql secret and env only for the mysql filer store

### DIFF
--- a/.github/workflows/helm_ci.yml
+++ b/.github/workflows/helm_ci.yml
@@ -482,6 +482,41 @@ jobs:
             --set filer.s3.enableAuth=true > /tmp/filer-s3.yaml
           echo "Filer S3 gateway renders correctly"
           
+          echo "=== Testing the mysql filer store gates its secret and env ==="
+          helm template test $CHART_DIR \
+            --set-string filer.extraEnvironmentVars.WEED_MONGODB_ENABLED=true \
+            --set-string filer.extraEnvironmentVars.WEED_LEVELDB2_ENABLED=false > /tmp/filer-mongodb.yaml
+          ! grep -q "db-secret" /tmp/filer-mongodb.yaml
+          ! grep -q "WEED_MYSQL" /tmp/filer-mongodb.yaml
+          grep -q "name: WEED_MONGODB_ENABLED" /tmp/filer-mongodb.yaml
+          helm template test $CHART_DIR \
+            --set-string filer.extraEnvironmentVars.WEED_MYSQL_ENABLED=true > /tmp/filer-mysql.yaml
+          grep -q "name: test-seaweedfs-db-secret" /tmp/filer-mysql.yaml
+          grep -q "name: WEED_MYSQL_USERNAME" /tmp/filer-mysql.yaml
+          grep -q "name: WEED_MYSQL_PASSWORD" /tmp/filer-mysql.yaml
+          grep -q "name: WEED_MYSQL_HOSTNAME" /tmp/filer-mysql.yaml
+          # Secret-backed keys follow the same rule as the plain ones.
+          helm template test $CHART_DIR \
+            --set filer.secretExtraEnvironmentVars.WEED_MYSQL_PASSWORD.secretKeyRef.name=db \
+            --set filer.secretExtraEnvironmentVars.WEED_MYSQL_PASSWORD.secretKeyRef.key=password > /tmp/filer-mysql-off-secret.yaml
+          ! grep -q "WEED_MYSQL" /tmp/filer-mysql-off-secret.yaml
+          helm template test $CHART_DIR \
+            --set-string filer.extraEnvironmentVars.WEED_MYSQL_ENABLED=true \
+            --set filer.secretExtraEnvironmentVars.WEED_MYSQL_PASSWORD.secretKeyRef.name=db \
+            --set filer.secretExtraEnvironmentVars.WEED_MYSQL_PASSWORD.secretKeyRef.key=password > /tmp/filer-mysql-on-secret.yaml
+          grep -A 4 -- "- name: WEED_MYSQL_PASSWORD$" /tmp/filer-mysql-on-secret.yaml | grep -q "name: db"
+          # A flag the chart cannot read counts as selected, not as off.
+          helm template test $CHART_DIR \
+            --set filer.secretExtraEnvironmentVars.WEED_MYSQL_ENABLED.secretKeyRef.name=store \
+            --set filer.secretExtraEnvironmentVars.WEED_MYSQL_ENABLED.secretKeyRef.key=enabled > /tmp/filer-mysql-secret.yaml
+          grep -q "name: test-seaweedfs-db-secret" /tmp/filer-mysql-secret.yaml
+          grep -q "name: WEED_MYSQL_HOSTNAME" /tmp/filer-mysql-secret.yaml
+          helm template test $CHART_DIR \
+            --set-string filer.extraEnvironmentVars.WEED_MYSQL2_HOSTNAME=other > /tmp/filer-mysql2.yaml
+          grep -q "name: WEED_MYSQL2_HOSTNAME" /tmp/filer-mysql2.yaml
+          ! grep -q "WEED_MYSQL_" /tmp/filer-mysql2.yaml
+          echo "The mysql secret and env follow the selected filer store"
+
           echo "=== Testing SFTP enabled ==="
           helm template test $CHART_DIR --set sftp.enabled=true > /tmp/sftp.yaml
           grep -q "seaweedfs-sftp" /tmp/sftp.yaml

--- a/k8s/charts/seaweedfs/README.md
+++ b/k8s/charts/seaweedfs/README.md
@@ -22,8 +22,8 @@ helm install --values=values.yaml seaweedfs seaweedfs/seaweedfs
 ## Info:
 * master/filer/volume are stateful sets with anti-affinity on the hostname,
 so your deployment will be spread/HA.
-* chart is using memsql(mysql) as the filer backend to enable HA (multiple filer instances) and backup/HA memsql can provide.
-* mysql user/password are created in a k8s secret (default: `<release>-seaweedfs-db-secret`) and injected to the filer with ENV.
+* leveldb2 is the default filer backend; a mysql-compatible database (memsql, ...) enables HA (multiple filer instances) and the backup/HA it can provide.
+* with `filer.extraEnvironmentVars.WEED_MYSQL_ENABLED` set to `"true"`, mysql user/password are created in a k8s secret (default: `<release>-seaweedfs-db-secret`) and injected to the filer with ENV. On any other store neither the secret nor the `WEED_MYSQL_*` env, plain or secret-backed, is rendered.
 * cert config exists and can be enabled, but not been tested, requires cert-manager to be installed.
 
 ## Prerequisites

--- a/k8s/charts/seaweedfs/templates/filer/filer-statefulset.yaml
+++ b/k8s/charts/seaweedfs/templates/filer/filer-statefulset.yaml
@@ -92,6 +92,7 @@ spec:
           image: {{ template "seaweedfs.filer.image" . }}
           imagePullPolicy: {{ default "IfNotPresent" .Values.global.seaweedfs.imagePullPolicy }}
           env:
+            {{- $mysqlEnabled := include "seaweedfs.filer.mysqlEnabled" . }}
             - name: POD_IP
               valueFrom:
                 fieldRef:
@@ -104,6 +105,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- if $mysqlEnabled }}
             - name: WEED_MYSQL_USERNAME
               valueFrom:
                 secretKeyRef:
@@ -116,6 +118,7 @@ spec:
                   name: {{ include "seaweedfs.fullname" . }}-db-secret
                   key: password
                   optional: true
+            {{- end }}
             - name: SEAWEEDFS_FULLNAME
               value: "{{ include "seaweedfs.fullname" . }}"
             {{- if and .Values.filer.s3.enabled .Values.filer.s3.enableAuth }}
@@ -123,6 +126,13 @@ spec:
             {{- end }}
             {{- $mergedExtraEnvironmentVars := dict }}
             {{- include "seaweedfs.mergeExtraEnvironmentVars" (dict "global" .Values.global.seaweedfs "component" .Values.filer "target" $mergedExtraEnvironmentVars) }}
+            {{- if not $mysqlEnabled }}
+            {{- range $key := keys $mergedExtraEnvironmentVars }}
+            {{- if hasPrefix "WEED_MYSQL_" $key }}
+            {{- $_ := unset $mergedExtraEnvironmentVars $key }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
             {{- range $key := keys $mergedExtraEnvironmentVars | sortAlpha }}
             {{- $value := index $mergedExtraEnvironmentVars $key }}
             - name: {{ $key }}
@@ -135,8 +145,10 @@ spec:
             {{- end }}
             {{- if .Values.filer.secretExtraEnvironmentVars }}
             {{- range $key, $value := .Values.filer.secretExtraEnvironmentVars }}
+            {{- if or $mysqlEnabled (not (hasPrefix "WEED_MYSQL_" $key)) }}
             - name: {{ $key }}
               valueFrom: {{ toYaml $value | nindent 16 }}
+            {{- end }}
             {{- end }}
             {{- end }}
           command:

--- a/k8s/charts/seaweedfs/templates/shared/_helpers.tpl
+++ b/k8s/charts/seaweedfs/templates/shared/_helpers.tpl
@@ -76,6 +76,18 @@ Inject extra environment vars in the format key:value, if populated
 {{- end }}
 {{- end -}}
 
+{{/* Whether the mysql filer store is selected; a flag the chart cannot read counts as selected. */}}
+{{- define "seaweedfs.filer.mysqlEnabled" -}}
+{{- $merged := dict -}}
+{{- $_ := include "seaweedfs.mergeExtraEnvironmentVars" (dict "global" .Values.global.seaweedfs "component" .Values.filer "target" $merged) -}}
+{{- $enabled := index $merged "WEED_MYSQL_ENABLED" -}}
+{{- if or (kindIs "map" $enabled) (hasKey (.Values.filer.secretExtraEnvironmentVars | default dict) "WEED_MYSQL_ENABLED") -}}
+true
+{{- else if and $enabled (eq (lower (toString $enabled)) "true") -}}
+true
+{{- end -}}
+{{- end -}}
+
 {{/* Return the proper filer image */}}
 {{- define "seaweedfs.filer.image" -}}
 {{- if .Values.filer.imageOverride -}}

--- a/k8s/charts/seaweedfs/templates/shared/secret-seaweedfs-db.yaml
+++ b/k8s/charts/seaweedfs/templates/shared/secret-seaweedfs-db.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.filer.enabled }}
+{{- if and .Values.filer.enabled (include "seaweedfs.filer.mysqlEnabled" .) }}
 apiVersion: v1
 kind: Secret
 type: Opaque

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -897,6 +897,7 @@ filer:
 
   # extraEnvVars is a list of extra environment variables to set with the stateful set.
   extraEnvironmentVars:
+    # the WEED_MYSQL_* keys and the db credential secret only render while this is "true"
     WEED_MYSQL_ENABLED: "false"
     WEED_MYSQL_HOSTNAME: "mysql-db-host"
     WEED_MYSQL_PORT: "3306"


### PR DESCRIPTION
Fixes #10869.

`templates/shared/secret-seaweedfs-db.yaml` and the filer's `WEED_MYSQL_USERNAME` / `WEED_MYSQL_PASSWORD` env were gated on `filer.enabled` alone. A filer on mongodb, redis, postgres or the default leveldb2 therefore got:

- a generated mysql credential secret it never reads, and `helm.sh/resource-policy: keep` means it stays in the namespace forever,
- `WEED_MYSQL_HOSTNAME=mysql-db-host` and the rest of the mysql block as dead env pointing at a host that does not exist.

## Change

`seaweedfs.filer.mysqlEnabled` resolves the selected store from the merged global + filer `extraEnvironmentVars`, the same merge the statefulset already renders env from, and everything mysql-specific hangs off it: the secret, the two credential env vars, and the `WEED_MYSQL_*` keys in the filer's env, plain and secret-backed alike.

Precedence follows the merge, so a filer value overrides a global one exactly as the rendered env does. An enable flag the chart cannot read - a `valueFrom` dict, or a key in `secretExtraEnvironmentVars` - counts as selected rather than off, so a filer that really is on mysql never loses its config. `WEED_MYSQL2_*` is a separate store and is untouched, and no other store's env is touched at all.

No values were removed: with `WEED_MYSQL_ENABLED: "true"` the render is byte-identical to before.

## Rendered

default install (leveldb2):
```
env: [... WEED_LEVELDB2_ENABLED]
no test-seaweedfs-db-secret
```

`--set-string filer.extraEnvironmentVars.WEED_MYSQL_ENABLED=true`:
```
env: [WEED_MYSQL_USERNAME, WEED_MYSQL_PASSWORD, WEED_LEVELDB2_ENABLED,
      WEED_MYSQL_CONNECTION_MAX_IDLE, ... WEED_MYSQL_HOSTNAME, WEED_MYSQL_PORT]
Secret test-seaweedfs-db-secret
```

## Upgrades

The secret is a `pre-install` hook with `resource-policy: keep`, so it was never part of the release manifest and an upgrade leaves any already-created one in place. A non-mysql install that wants it gone deletes it once by hand; no new one is created.

## Tests

`helm_ci.yml` gains a block covering the issue's mongodb repro, the mysql-on render, secret-backed keys in both directions, the unreadable-flag case, and `WEED_MYSQL2_*`. The whole "Verify template rendering" step and `helm lint` against `ci/*.yaml` and `openshift-values.yaml` pass locally.