### PR TITLE
helm: install chart CI against an image tag that exists

### DIFF
--- a/.github/workflows/helm_ci.yml
+++ b/.github/workflows/helm_ci.yml
@@ -3,10 +3,10 @@ name: "helm: lint and test charts"
 on:
   push:
     branches: [ master ]
-    paths: ['k8s/**']
+    paths: ['k8s/**', '.github/workflows/helm_ci.yml']
   pull_request:
     branches: [ master ]
-    paths: ['k8s/**']
+    paths: ['k8s/**', '.github/workflows/helm_ci.yml']
 
 permissions:
   contents: read

--- a/.github/workflows/helm_ci.yml
+++ b/.github/workflows/helm_ci.yml
@@ -1549,11 +1549,32 @@ jobs:
 
           echo "All template rendering tests passed!"
 
+      - name: Resolve an image tag that is published
+        run: |
+          set -e
+          # A release bumps appVersion on master ~40 minutes before the container
+          # build publishes that tag, and this workflow runs on the bump commit.
+          # Install the last released image for the length of that window instead
+          # of failing on ImagePullBackOff.
+          IMAGE=$(helm template test k8s/charts/seaweedfs \
+            -s templates/master/master-statefulset.yaml | awk '$1 == "image:" {print $2; exit}')
+          REPO=${IMAGE%:*}
+          TAG=${IMAGE##*:}
+          if curl -sfL -o /dev/null "https://hub.docker.com/v2/repositories/$REPO/tags/$TAG"; then
+            echo "installing $IMAGE"
+          else
+            echo "$IMAGE is not published yet, installing $REPO:latest"
+            TAG=latest
+          fi
+          echo "IMAGE_TAG=$TAG" >> $GITHUB_ENV
+
       - name: Create kind cluster
         uses: helm/kind-action@v1.14.0
 
       - name: Run chart-testing (install)
-        run: ct install --target-branch ${{ github.event.repository.default_branch }} --all --chart-dirs k8s/charts
+        run: |
+          ct install --target-branch ${{ github.event.repository.default_branch }} --all --chart-dirs k8s/charts \
+            --helm-extra-set-args "--set=image.tag=$IMAGE_TAG"
 
       - name: Verify SFTP host key secret lifecycle
         run: |
@@ -1561,7 +1582,7 @@ jobs:
           CHART_DIR="k8s/charts/seaweedfs"
           NS="sftp-hostkey"
           SECRET="hk-seaweedfs-sftp-ssh-secret"
-          SFTP_ARGS="--set sftp.enabled=true --set master.enabled=false --set volume.enabled=false --set filer.enabled=false"
+          SFTP_ARGS="--set image.tag=$IMAGE_TAG --set sftp.enabled=true --set master.enabled=false --set volume.enabled=false --set filer.enabled=false"
           kubectl create namespace "$NS"
 
           echo "=== install generates a host key, upgrade keeps it ==="
@@ -1638,6 +1659,7 @@ jobs:
           # release if the hook Job does not finish, so a clean install is the
           # assertion.
           helm install np $CHART_DIR -n "$NS" --wait --timeout 8m \
+            --set image.tag=$IMAGE_TAG \
             --set s3.enabled=true \
             --set s3.createBuckets[0].name=testbucket \
             --set networkPolicy.enabled=true \

--- a/.github/workflows/helm_ci.yml
+++ b/.github/workflows/helm_ci.yml
@@ -1560,10 +1560,15 @@ jobs:
             -s templates/master/master-statefulset.yaml | awk '$1 == "image:" {print $2; exit}')
           REPO=${IMAGE%:*}
           TAG=${IMAGE##*:}
-          if curl -sfL -o /dev/null "https://hub.docker.com/v2/repositories/$REPO/tags/$TAG"; then
+          # Anything but a published tag installs latest, which between releases
+          # is the same digest as the chart's own appVersion, so a registry blip
+          # costs nothing while failing the job on one would cost a red build.
+          STATUS=$(curl -sSL --connect-timeout 5 --max-time 15 -o /dev/null \
+            -w '%{http_code}' "https://hub.docker.com/v2/repositories/$REPO/tags/$TAG" || true)
+          if [ "$STATUS" = 200 ]; then
             echo "installing $IMAGE"
           else
-            echo "$IMAGE is not published yet, installing $REPO:latest"
+            echo "$IMAGE is unavailable (HTTP ${STATUS:-none}), installing $REPO:latest"
             TAG=latest
           fi
           echo "IMAGE_TAG=$TAG" >> $GITHUB_ENV


### PR DESCRIPTION
The 4.44 chart CI run failed with ImagePullBackOff on `chrislusf/seaweedfs:4.44`: https://github.com/seaweedfs/seaweedfs/actions/runs/32560254977

The version bump lands `appVersion: "4.44"` on master and the tag push starts the container build at the same moment, but this workflow runs on the bump commit (it touches `k8s/**`) and finishes long before the image is published. `ct install` and the two later `helm install`s then wait on a tag that does not exist yet, so every release turns the chart CI red for the length of the container build.

Resolve the image before creating the cluster: keep the chart's own appVersion when Docker Hub already has it, and fall back to `latest` while it is still building. Normal runs are unchanged - the released appVersion is published, so it is still what gets installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Kubernetes deployment validation for changes affecting charts or deployment workflows.
  * Deployment checks now automatically use the appropriate published container image tag, with a safe fallback when unavailable.
  * Expanded lifecycle testing coverage, including installations with default-deny network policies.
  * Added bounded registry checks to make validation more predictable and reliable.
  * These updates provide more dependable pre-release verification of Kubernetes deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->