### PR TITLE
Build the Rust worker against the protoc that ships with the build

### DIFF
--- a/.github/workflows/container_dev.yml
+++ b/.github/workflows/container_dev.yml
@@ -49,11 +49,6 @@ jobs:
           # Disable glibc fortify source — its __memcpy_chk etc. symbols don't exist in musl
           echo "CFLAGS_aarch64_unknown_linux_musl=-U_FORTIFY_SOURCE" >> "$GITHUB_ENV"
 
-      # lance's build scripts compile their own protos, and unlike seaweed-volume
-      # they do not vendor a protoc to do it with.
-      - name: Install protoc
-        run: sudo apt-get install -y protobuf-compiler
-
       - name: Cache cargo registry and target
         uses: actions/cache@v6
         with:
@@ -65,6 +60,21 @@ jobs:
           key: rust-docker-dev-${{ matrix.target }}-${{ hashFiles('seaweed-volume/Cargo.lock', 'seaweed-worker/Cargo.lock') }}
           restore-keys: |
             rust-docker-dev-${{ matrix.target }}-
+
+      # lance's build scripts compile their own protos and look for a protoc.
+      # Point them at the one protoc-bin-vendored ships, which seaweed-worker's
+      # own build already uses, so no job depends on a system package and every
+      # build sees the same version.
+      - name: Use the vendored protoc
+        run: |
+          cd seaweed-worker
+          cargo fetch
+          # The version from the lock, not whatever else a restored cache holds.
+          version=$(awk '/^name = "protoc-bin-vendored-linux-x86_64"$/{found=1; next} found && /^version = /{gsub(/"/,"",$3); print $3; exit}' Cargo.lock)
+          test -n "$version" || { echo "protoc-bin-vendored-linux-x86_64 is not in Cargo.lock" >&2; exit 1; }
+          protoc=$(find ~/.cargo/registry/src -path "*protoc-bin-vendored-linux-x86_64-$version/bin/protoc" | head -1)
+          test -x "$protoc" || { echo "no vendored protoc $version in the registry" >&2; exit 1; }
+          echo "PROTOC=$protoc" >> "$GITHUB_ENV"
 
       - name: Build normal variant
         env:

--- a/.github/workflows/container_latest.yml
+++ b/.github/workflows/container_latest.yml
@@ -93,11 +93,6 @@ jobs:
           # Disable glibc fortify source — its __memcpy_chk etc. symbols don't exist in musl
           echo "CFLAGS_aarch64_unknown_linux_musl=-U_FORTIFY_SOURCE" >> "$GITHUB_ENV"
 
-      # lance's build scripts compile their own protos, and unlike seaweed-volume
-      # they do not vendor a protoc to do it with.
-      - name: Install protoc
-        run: sudo apt-get install -y protobuf-compiler
-
       - name: Cache cargo registry and target
         uses: actions/cache@v6
         with:
@@ -109,6 +104,21 @@ jobs:
           key: rust-docker-${{ matrix.target }}-${{ hashFiles('seaweed-volume/Cargo.lock', 'seaweed-worker/Cargo.lock') }}
           restore-keys: |
             rust-docker-${{ matrix.target }}-
+
+      # lance's build scripts compile their own protos and look for a protoc.
+      # Point them at the one protoc-bin-vendored ships, which seaweed-worker's
+      # own build already uses, so no job depends on a system package and every
+      # build sees the same version.
+      - name: Use the vendored protoc
+        run: |
+          cd seaweed-worker
+          cargo fetch
+          # The version from the lock, not whatever else a restored cache holds.
+          version=$(awk '/^name = "protoc-bin-vendored-linux-x86_64"$/{found=1; next} found && /^version = /{gsub(/"/,"",$3); print $3; exit}' Cargo.lock)
+          test -n "$version" || { echo "protoc-bin-vendored-linux-x86_64 is not in Cargo.lock" >&2; exit 1; }
+          protoc=$(find ~/.cargo/registry/src -path "*protoc-bin-vendored-linux-x86_64-$version/bin/protoc" | head -1)
+          test -x "$protoc" || { echo "no vendored protoc $version in the registry" >&2; exit 1; }
+          echo "PROTOC=$protoc" >> "$GITHUB_ENV"
 
       - name: Build large-disk variant
         env:

--- a/.github/workflows/container_release_unified.yml
+++ b/.github/workflows/container_release_unified.yml
@@ -77,11 +77,6 @@ jobs:
           # Disable glibc fortify source — its __memcpy_chk etc. symbols don't exist in musl
           echo "CFLAGS_aarch64_unknown_linux_musl=-U_FORTIFY_SOURCE" >> "$GITHUB_ENV"
 
-      # lance's build scripts compile their own protos, and unlike seaweed-volume
-      # they do not vendor a protoc to do it with.
-      - name: Install protoc
-        run: sudo apt-get install -y protobuf-compiler
-
       - name: Cache cargo registry and target
         uses: actions/cache@v6
         with:
@@ -93,6 +88,21 @@ jobs:
           key: rust-docker-${{ matrix.target }}-${{ hashFiles('seaweed-volume/Cargo.lock', 'seaweed-worker/Cargo.lock') }}
           restore-keys: |
             rust-docker-${{ matrix.target }}-
+
+      # lance's build scripts compile their own protos and look for a protoc.
+      # Point them at the one protoc-bin-vendored ships, which seaweed-worker's
+      # own build already uses, so no job depends on a system package and every
+      # build sees the same version.
+      - name: Use the vendored protoc
+        run: |
+          cd seaweed-worker
+          cargo fetch
+          # The version from the lock, not whatever else a restored cache holds.
+          version=$(awk '/^name = "protoc-bin-vendored-linux-x86_64"$/{found=1; next} found && /^version = /{gsub(/"/,"",$3); print $3; exit}' Cargo.lock)
+          test -n "$version" || { echo "protoc-bin-vendored-linux-x86_64 is not in Cargo.lock" >&2; exit 1; }
+          protoc=$(find ~/.cargo/registry/src -path "*protoc-bin-vendored-linux-x86_64-$version/bin/protoc" | head -1)
+          test -x "$protoc" || { echo "no vendored protoc $version in the registry" >&2; exit 1; }
+          echo "PROTOC=$protoc" >> "$GITHUB_ENV"
 
       - name: Build large-disk variant
         env:

--- a/.github/workflows/rust-worker-tests.yml
+++ b/.github/workflows/rust-worker-tests.yml
@@ -36,11 +36,6 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      # lance's build scripts compile their own protos, and unlike seaweed-volume
-      # they do not vendor a protoc to do it with.
-      - name: Install protoc
-        run: sudo apt-get install -y protobuf-compiler
-
       # cargo tracks its own inputs but not the runner's C toolchain, so a cached
       # target/ can carry C objects built against a different glibc than we link against.
       - name: Fingerprint build toolchain
@@ -57,6 +52,21 @@ jobs:
           key: rust-worker-${{ steps.toolchain.outputs.fingerprint }}-${{ hashFiles('seaweed-worker/Cargo.lock') }}
           restore-keys: |
             rust-worker-${{ steps.toolchain.outputs.fingerprint }}-
+
+      # lance's build scripts compile their own protos and look for a protoc.
+      # Point them at the one protoc-bin-vendored ships, which seaweed-worker's
+      # own build already uses, so no job depends on a system package and every
+      # build sees the same version.
+      - name: Use the vendored protoc
+        run: |
+          cd seaweed-worker
+          cargo fetch
+          # The version from the lock, not whatever else a restored cache holds.
+          version=$(awk '/^name = "protoc-bin-vendored-linux-x86_64"$/{found=1; next} found && /^version = /{gsub(/"/,"",$3); print $3; exit}' Cargo.lock)
+          test -n "$version" || { echo "protoc-bin-vendored-linux-x86_64 is not in Cargo.lock" >&2; exit 1; }
+          protoc=$(find ~/.cargo/registry/src -path "*protoc-bin-vendored-linux-x86_64-$version/bin/protoc" | head -1)
+          test -x "$protoc" || { echo "no vendored protoc $version in the registry" >&2; exit 1; }
+          echo "PROTOC=$protoc" >> "$GITHUB_ENV"
 
       # The release profile is what ships, and it is where the release and the
       # container builds would otherwise discover a break for the first time.

--- a/.github/workflows/rust_binaries_release.yml
+++ b/.github/workflows/rust_binaries_release.yml
@@ -152,11 +152,6 @@ jobs:
           sudo apt-get install -y gcc-aarch64-linux-gnu
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
 
-      # lance's build scripts compile their own protos, and unlike seaweed-volume
-      # they do not vendor a protoc to do it with.
-      - name: Install protoc
-        run: sudo apt-get install -y protobuf-compiler
-
       - name: Cache cargo registry and target
         uses: actions/cache@v6
         with:
@@ -167,6 +162,21 @@ jobs:
           key: rust-worker-release-${{ matrix.target }}-${{ hashFiles('seaweed-worker/Cargo.lock') }}
           restore-keys: |
             rust-worker-release-${{ matrix.target }}-
+
+      # lance's build scripts compile their own protos and look for a protoc.
+      # Point them at the one protoc-bin-vendored ships, which seaweed-worker's
+      # own build already uses, so no job depends on a system package and every
+      # build sees the same version.
+      - name: Use the vendored protoc
+        run: |
+          cd seaweed-worker
+          cargo fetch
+          # The version from the lock, not whatever else a restored cache holds.
+          version=$(awk '/^name = "protoc-bin-vendored-linux-x86_64"$/{found=1; next} found && /^version = /{gsub(/"/,"",$3); print $3; exit}' Cargo.lock)
+          test -n "$version" || { echo "protoc-bin-vendored-linux-x86_64 is not in Cargo.lock" >&2; exit 1; }
+          protoc=$(find ~/.cargo/registry/src -path "*protoc-bin-vendored-linux-x86_64-$version/bin/protoc" | head -1)
+          test -x "$protoc" || { echo "no vendored protoc $version in the registry" >&2; exit 1; }
+          echo "PROTOC=$protoc" >> "$GITHUB_ENV"
 
       - name: Build the Rust maintenance worker
         run: |

--- a/seaweed-worker/Cargo.lock
+++ b/seaweed-worker/Cargo.lock
@@ -4667,6 +4667,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "protoc-bin-vendored"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c381df33c98266b5f08186583660090a4ffa0889e76c7e9a5e175f645a67fa"
+dependencies = [
+ "protoc-bin-vendored-linux-aarch_64",
+ "protoc-bin-vendored-linux-ppcle_64",
+ "protoc-bin-vendored-linux-s390_64",
+ "protoc-bin-vendored-linux-x86_32",
+ "protoc-bin-vendored-linux-x86_64",
+ "protoc-bin-vendored-macos-aarch_64",
+ "protoc-bin-vendored-macos-x86_64",
+ "protoc-bin-vendored-win32",
+]
+
+[[package]]
+name = "protoc-bin-vendored-linux-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c350df4d49b5b9e3ca79f7e646fde2377b199e13cfa87320308397e1f37e1a4c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-ppcle_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55a63e6c7244f19b5c6393f025017eb5d793fd5467823a099740a7a4222440c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-s390_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dba5565db4288e935d5330a07c264a4ee8e4a5b4a4e6f4e83fad824cc32f3b0"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8854774b24ee28b7868cd71dccaae8e02a2365e67a4a87a6cd11ee6cdbdf9cf5"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38b07546580df720fa464ce124c4b03630a6fb83e05c336fea2a241df7e5d78"
+
+[[package]]
+name = "protoc-bin-vendored-macos-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89278a9926ce312e51f1d999fee8825d324d603213344a9a706daa009f1d8092"
+
+[[package]]
+name = "protoc-bin-vendored-macos-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81745feda7ccfb9471d7a4de888f0652e806d5795b61480605d4943176299756"
+
+[[package]]
+name = "protoc-bin-vendored-win32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
+
+[[package]]
 name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5379,6 +5443,7 @@ dependencies = [
  "prometheus",
  "prost 0.13.5",
  "prost-types 0.13.5",
+ "protoc-bin-vendored",
  "tokio",
  "tokio-stream",
  "tonic",

--- a/seaweed-worker/README.md
+++ b/seaweed-worker/README.md
@@ -12,6 +12,17 @@ one.
 `core` knows nothing about any job. A second worker is a new crate beside
 `lance` that depends on it, not a fork of the protocol.
 
+## Building
+
+`core` compiles `plugin.proto` with the protoc that protoc-bin-vendored ships,
+the way seaweed-volume does, so it needs no system install.
+
+The lance crates compile protos of their own, in their own build-script
+processes, which nothing our build script sets can reach. They need a protoc of
+their own: either one on PATH — `brew install protobuf`, `apt install
+protobuf-compiler` — or `PROTOC` naming one. CI points it at the vendored
+binary for the runner's platform, resolved from the version in `Cargo.lock`.
+
 ## Running
 
     cargo run -p weed-lance-worker -- --admin 127.0.0.1:23646

--- a/seaweed-worker/crates/core/Cargo.toml
+++ b/seaweed-worker/crates/core/Cargo.toml
@@ -21,3 +21,7 @@ tracing.workspace = true
 
 [build-dependencies]
 tonic-build.workspace = true
+# Ships protoc with the build so neither CI nor a developer needs a system
+# install, and so the version is pinned rather than whatever the platform's
+# package manager happens to carry. The same crate seaweed-volume uses.
+protoc-bin-vendored = "3"

--- a/seaweed-worker/crates/core/build.rs
+++ b/seaweed-worker/crates/core/build.rs
@@ -1,4 +1,12 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Use the protoc that ships with protoc-bin-vendored rather than a system
+    // one, so the build needs no package manager and always sees the same
+    // version. An explicit PROTOC still wins, for packagers supplying their own
+    // and for the lance crates, whose own build scripts read the same variable.
+    if std::env::var_os("PROTOC").is_none() {
+        std::env::set_var("PROTOC", protoc_bin_vendored::protoc_bin_path()?);
+    }
+
     // Compiled straight out of the Go tree, the way seaweed-volume already reads
     // filer.proto, so the contract cannot drift from a vendored copy.
     tonic_build::configure()


### PR DESCRIPTION
Follow-up to #10879, which installed `protobuf-compiler` in every job that
builds the worker. That worked, but seaweed-volume already solved this problem
the other way: `protoc-bin-vendored` carries the binary, so the build needs no
package manager and every build — CI's and a developer's — sees the same
version.

The worker now does the same. `seaweed-worker-core`'s build script sets `PROTOC`
from the vendored crate unless one is already set, exactly as
`seaweed-volume/build.rs` does.

That alone is not enough, and the reason is worth writing down: the crates that
actually failed the build are lance's, not ours. `lance-encoding`,
`lance-file`, `lance-index`, `lance-table` and `lance-datafusion` each compile
protos of their own, in their own build-script processes, so an environment
variable our build script sets is invisible to them. What they do read is
`PROTOC` from the job environment — so CI points that at the same binary
protoc-bin-vendored has already put in the registry, and no job installs a
system package.

Lance's own answer to this, the `protoc` feature, was the other candidate. It
pulls in `protobuf-src`, which compiles protobuf from C++ source, and the
top-level `lance` crate does not forward it to `lance-datafusion` — so it would
have meant an unused direct dependency declared purely to flip a feature, plus a
C++ build in the middle of an aarch64-musl cross-compile that no PR check would
ever exercise. The vendored binary is a host tool, which is what a protoc needs
to be.

Verified locally, both directions, with protoc removed from `PATH` and
`lance-encoding` cleaned so its build script had to run again: without `PROTOC`
the build fails exactly as CI did, and with `PROTOC` pointing at the vendored
binary it compiles through lance-encoding and lance to a finished
`weed-worker`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build Improvements**
  * Builds now use a consistent, bundled Protocol Buffers compiler instead of relying on system-installed tooling.
  * Developers can still provide their own compiler through the existing `PROTOC` setting.
  * Build workflows now verify the compiler is available and executable before continuing.

* **Documentation**
  * Added build instructions covering bundled and externally supplied compiler options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->