### PR TITLE
mount: use the kernel-resolved node id in Link, not the persisted attribute

### DIFF
--- a/weed/mount/weedfs_link.go
+++ b/weed/mount/weedfs_link.go
@@ -46,6 +46,17 @@ func (wfs *WFS) Link(cancel <-chan struct{}, in *fuse.LinkIn, name string, out *
 	}
 	oldParentPath, _ := oldEntryPath.DirAndName()
 
+	// The new link has to be reported with the node id the kernel already holds
+	// for the source, which is what makes the two names share one file.
+	// oldEntry.Attributes.Inode is not a substitute. It is a mount-runtime
+	// number that only entries created through a mount carry: entries written
+	// by the S3 API, WebDAV or a direct filer call persist inode 0, and the
+	// kernel rejects a LINK reply with NodeId 0 as EIO (invalid_nodeid). It is
+	// also the wrong key for inodeToPath, which is keyed by the numbers handed
+	// to the kernel rather than by the persisted attribute; Lookup's collision
+	// probe can move the two apart even for an entry that does carry one.
+	sourceInode := in.Oldnodeid
+
 	oldEntry, _, status := wfs.maybeLoadEntry(oldEntryPath)
 	if status != fuse.OK {
 		return status
@@ -176,16 +187,16 @@ func (wfs *WFS) Link(cancel <-chan struct{}, in *fuse.LinkIn, name string, out *
 		return fuse.EIO
 	}
 
-	wfs.inodeToPath.AddPath(oldEntry.Attributes.Inode, newEntryPath)
+	wfs.inodeToPath.AddPath(sourceInode, newEntryPath)
 
 	// Propagate the new HardLinkCounter to sibling cache entries and
 	// invalidate the kernel's inode attr cache. Without this, `stat` on any
 	// existing sibling link (other than the source we just wrote) returns
 	// the old nlink from the local metacache — pjdfstest link/00.t catches
 	// this after `link n1 n2` when it stats n0.
-	wfs.syncHardLinkSiblings(oldEntry.Attributes.Inode, oldEntry, oldEntryPath, newEntryPath)
+	wfs.syncHardLinkSiblings(sourceInode, oldEntry, oldEntryPath, newEntryPath)
 
-	wfs.outputPbEntry(out, oldEntry.Attributes.Inode, request.Entry)
+	wfs.outputPbEntry(out, sourceInode, request.Entry)
 
 	return fuse.OK
 }

--- a/weed/mount/weedfs_link_test.go
+++ b/weed/mount/weedfs_link_test.go
@@ -1,0 +1,143 @@
+package mount
+
+import (
+	"context"
+	"testing"
+
+	"github.com/seaweedfs/go-fuse/v2/fuse"
+	"github.com/seaweedfs/seaweedfs/weed/filer"
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+)
+
+// linkTestSource seeds the meta cache with an entry and registers it with
+// inodeToPath the way a kernel Lookup would, returning the node id the kernel
+// would then use as LinkIn.Oldnodeid.
+func linkTestSource(t *testing.T, wfs *WFS, name string, persistedInode uint64) (util.FullPath, uint64) {
+	t.Helper()
+
+	entry := &filer_pb.Entry{
+		Name: name,
+		Attributes: &filer_pb.FuseAttributes{
+			FileMode: 0o644,
+			FileSize: 12,
+			Inode:    persistedInode,
+			Crtime:   1,
+			Mtime:    1,
+			Uid:      99,
+			Gid:      100,
+		},
+	}
+	if err := wfs.metaCache.InsertEntry(context.Background(), filer.FromPbEntry("/", entry), 0); err != nil {
+		t.Fatalf("InsertEntry: %v", err)
+	}
+
+	fullPath := util.FullPath("/").Child(name)
+	inode := wfs.inodeToPath.Lookup(fullPath, entry.Attributes.Crtime, false, false, persistedInode, true)
+	if inode == 0 {
+		t.Fatal("Lookup handed out node id 0")
+	}
+	return fullPath, inode
+}
+
+func doLink(t *testing.T, wfs *WFS, oldNodeId uint64, name string) *fuse.EntryOut {
+	t.Helper()
+
+	out := &fuse.EntryOut{}
+	status := wfs.Link(make(chan struct{}), &fuse.LinkIn{
+		InHeader: fuse.InHeader{
+			NodeId: 1,
+			Caller: fuse.Caller{Owner: fuse.Owner{Uid: 99, Gid: 100}},
+		},
+		Oldnodeid: oldNodeId,
+	}, name, out)
+	if status != fuse.OK {
+		t.Fatalf("Link status = %v, want OK", status)
+	}
+	return out
+}
+
+// Entries written outside a mount (S3 API, WebDAV, a direct filer call) persist
+// Attributes.Inode == 0, because the inode is a mount-runtime number that only
+// lives in inodeToPath. Replying to LINK with NodeId 0 makes the kernel fail the
+// call with EIO (invalid_nodeid), which is what
+// https://github.com/seaweedfs/seaweedfs/issues/8404 reports. The reply has to
+// name the node id the kernel already holds for the source.
+func TestLinkReportsKernelNodeIdWhenEntryHasNoPersistedInode(t *testing.T) {
+	wfs, _ := newCreateTestWFS(t)
+
+	sourcePath, sourceInode := linkTestSource(t, wfs, "s3-uploaded.txt", 0)
+
+	out := doLink(t, wfs, sourceInode, "hardlink.txt")
+
+	if out.NodeId == 0 {
+		t.Fatal("Link replied with NodeId 0; the kernel rejects that with EIO")
+	}
+	if out.NodeId != sourceInode {
+		t.Fatalf("Link NodeId = %d, want the source node id %d", out.NodeId, sourceInode)
+	}
+	if out.Attr.Ino != sourceInode {
+		t.Fatalf("Link Attr.Ino = %d, want %d", out.Attr.Ino, sourceInode)
+	}
+	if out.Attr.Nlink != 2 {
+		t.Fatalf("Link Attr.Nlink = %d, want 2", out.Attr.Nlink)
+	}
+
+	// The new name must resolve to the same inode, or a later Lookup on it
+	// hands the kernel node id 0 and the link reads back as missing.
+	linkPath := util.FullPath("/hardlink.txt")
+	linkInode, found := wfs.inodeToPath.GetInode(linkPath)
+	if !found {
+		t.Fatal("new link was not registered in inodeToPath")
+	}
+	if linkInode != sourceInode {
+		t.Fatalf("new link inode = %d, want the source inode %d", linkInode, sourceInode)
+	}
+	if wfs.inodeToPath.HasInode(0) {
+		t.Fatal("inode 0 was registered in inodeToPath")
+	}
+
+	paths := wfs.inodeToPath.GetAllPaths(sourceInode)
+	if len(paths) != 2 {
+		t.Fatalf("inode %d has paths %v, want both %s and %s", sourceInode, paths, sourcePath, linkPath)
+	}
+
+	// The source still resolves, and it now carries a hard link id.
+	if _, status := wfs.inodeToPath.GetPath(sourceInode); status != fuse.OK {
+		t.Fatalf("GetPath(%d) = %v, want OK", sourceInode, status)
+	}
+	linked, _, status := wfs.maybeLoadEntry(sourcePath)
+	if status != fuse.OK {
+		t.Fatalf("reload source: %v", status)
+	}
+	if len(linked.HardLinkId) == 0 {
+		t.Fatal("source entry was not converted to hard link mode")
+	}
+	if linked.HardLinkCounter != 2 {
+		t.Fatalf("source HardLinkCounter = %d, want 2", linked.HardLinkCounter)
+	}
+}
+
+// A source created through the mount does carry a persisted inode. The reply
+// must keep naming the node id the kernel holds, which for this case is the
+// same number.
+func TestLinkReportsKernelNodeIdWhenEntryHasPersistedInode(t *testing.T) {
+	wfs, _ := newCreateTestWFS(t)
+
+	_, sourceInode := linkTestSource(t, wfs, "mount-created.txt", 8404)
+	if sourceInode != 8404 {
+		t.Fatalf("source node id = %d, want the persisted inode 8404", sourceInode)
+	}
+
+	out := doLink(t, wfs, sourceInode, "hardlink.txt")
+
+	if out.NodeId != sourceInode {
+		t.Fatalf("Link NodeId = %d, want %d", out.NodeId, sourceInode)
+	}
+	if out.Attr.Ino != sourceInode {
+		t.Fatalf("Link Attr.Ino = %d, want %d", out.Attr.Ino, sourceInode)
+	}
+	if linkInode, found := wfs.inodeToPath.GetInode(util.FullPath("/hardlink.txt")); !found || linkInode != sourceInode {
+		t.Fatalf("new link inode = %d (found=%v), want %d", linkInode, found, sourceInode)
+	}
+}

--- a/weed/mount/weedfs_link_test.go
+++ b/weed/mount/weedfs_link_test.go
@@ -141,3 +141,116 @@ func TestLinkReportsKernelNodeIdWhenEntryHasPersistedInode(t *testing.T) {
 		t.Fatalf("new link inode = %d (found=%v), want %d", linkInode, found, sourceInode)
 	}
 }
+
+// cachedLink returns what the mount would serve for path out of its own meta
+// cache, which is what a stat on that name reads before the kernel's attr
+// cache expires.
+func cachedLink(t *testing.T, wfs *WFS, path util.FullPath) *filer.Entry {
+	t.Helper()
+
+	entry, _, err := wfs.metaCache.FindEntry(context.Background(), path)
+	if err != nil {
+		t.Fatalf("FindEntry(%s): %v", path, err)
+	}
+	if entry == nil {
+		t.Fatalf("FindEntry(%s): not cached", path)
+	}
+	return entry
+}
+
+// A third link is the first case that reaches the body of
+// syncHardLinkSiblings: with two links the source alias and the name just
+// created are both in skipPaths, so the loop iterates over nothing. Three
+// links leave one name that no other part of Link() writes and that only the
+// sibling sync visits.
+//
+// The source is written outside a mount, so it persists Attributes.Inode 0,
+// the number Link() used to key the sync by. GetAllPaths(0) yields nothing,
+// which is what the second half of this test pins down: the sync has to be
+// keyed by the kernel node id, the number inodeToPath is indexed by.
+func TestLinkSyncsHardLinkSiblingsOnThirdLink(t *testing.T) {
+	wfs, _ := newCreateTestWFS(t)
+
+	sourcePath, sourceInode := linkTestSource(t, wfs, "s3-uploaded.txt", 0)
+
+	firstLinkPath := util.FullPath("/hardlink-1.txt")
+	doLink(t, wfs, sourceInode, "hardlink-1.txt")
+
+	// Two links so far: nothing has exercised the sibling loop yet, Link()
+	// wrote both of these names itself.
+	if counter := cachedLink(t, wfs, firstLinkPath).HardLinkCounter; counter != 2 {
+		t.Fatalf("after the first link, %s HardLinkCounter = %d, want 2", firstLinkPath, counter)
+	}
+
+	// Link() resolves its source through GetPath and skips that path plus the
+	// name it is about to create. Whatever is left over is the sibling loop's
+	// work.
+	skippedSource, status := wfs.inodeToPath.GetPath(sourceInode)
+	if status != fuse.OK {
+		t.Fatalf("GetPath(%d) = %v, want OK", sourceInode, status)
+	}
+	secondLinkPath := util.FullPath("/hardlink-2.txt")
+
+	doLink(t, wfs, sourceInode, "hardlink-2.txt")
+
+	paths := wfs.inodeToPath.GetAllPaths(sourceInode)
+	if len(paths) != 3 {
+		t.Fatalf("inode %d has paths %v, want %s, %s and %s",
+			sourceInode, paths, sourcePath, firstLinkPath, secondLinkPath)
+	}
+
+	// Guard against this test covering nothing: at least one name has to fall
+	// outside skipPaths, or the sibling loop is a no-op again and everything
+	// below only re-checks Link()'s own two writes.
+	var siblings []util.FullPath
+	for _, p := range paths {
+		if p == skippedSource || p == secondLinkPath {
+			continue
+		}
+		siblings = append(siblings, p)
+	}
+	if len(siblings) == 0 {
+		t.Fatalf("every path in %v is a skipPath (%s, %s); the sibling loop has no work to do",
+			paths, skippedSource, secondLinkPath)
+	}
+
+	// Every name of the file reports three links, the sibling included. A stale
+	// counter here is the pjdfstest link/00.t failure: stat on an older link
+	// still says nlink 2.
+	for _, p := range paths {
+		if counter := cachedLink(t, wfs, p).HardLinkCounter; counter != 3 {
+			t.Errorf("%s HardLinkCounter = %d, want 3", p, counter)
+		}
+	}
+
+	// Which inode the sync is keyed by, driven directly. Going through Link()
+	// cannot tell the two keys apart: the meta cache keeps one blob per hard
+	// link id (FilerStoreWrapper.setHardLink/maybeReadHardLink), so a read of
+	// any sibling returns the attributes of the last write to any of them,
+	// synced or not. Feeding the loop an authoritative counter that no other
+	// write has stored is what makes its work visible.
+	authoritative, _, status := wfs.maybeLoadEntry(sourcePath)
+	if status != fuse.OK {
+		t.Fatalf("reload source: %v", status)
+	}
+	if authoritative.Attributes.Inode != 0 {
+		t.Fatalf("source Attributes.Inode = %d, want 0: an entry written outside a mount carries no inode",
+			authoritative.Attributes.Inode)
+	}
+	authoritative.HardLinkCounter = 4
+
+	wfs.syncHardLinkSiblings(authoritative.Attributes.Inode, authoritative, skippedSource, secondLinkPath)
+	for _, p := range siblings {
+		if counter := cachedLink(t, wfs, p).HardLinkCounter; counter != 3 {
+			t.Errorf("keyed by the persisted inode the sync reached %s (counter %d), which it cannot: "+
+				"GetAllPaths(%d) has no paths", p, counter, authoritative.Attributes.Inode)
+		}
+	}
+
+	wfs.syncHardLinkSiblings(sourceInode, authoritative, skippedSource, secondLinkPath)
+	for _, p := range siblings {
+		if counter := cachedLink(t, wfs, p).HardLinkCounter; counter != 4 {
+			t.Errorf("%s HardLinkCounter = %d after the sibling sync, want 4", p, counter)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #8404.

## Problem

`weed/mount/weedfs_link.go`'s `Link()` used `oldEntry.Attributes.Inode` in three places: `inodeToPath.AddPath`, `syncHardLinkSiblings`, and the `outputPbEntry` call that fills the FUSE `LinkOut` reply's node id. `Attributes.Inode` is a persisted filer attribute, not the mount's own node id space, and for an entry that never went through the mount it can be 0. A `LinkOut` reply with `NodeId 0` is rejected by the kernel as EIO, which is the reported error.

`in.Oldnodeid` is available in the same function, already resolved by the kernel and already used to look up the source path (line 43). It is the correct value at all three sites regardless of what the filer happens to have stored, since `inodeToPath` is keyed by the node ids handed to the kernel, not by the persisted attribute, and the two can diverge (`Lookup`'s collision probe can move them apart even for an entry that does carry a stored inode).

## Second bug found while fixing the first

The old `AddPath(oldEntry.Attributes.Inode, newEntryPath)` call, when the attribute was 0, wrote `path2inode[newLink] = 0`. A LOOKUP reply with node id 0 means "negative dentry" (ENOENT) to the kernel, so within the same mount session, a later `Lookup` on the freshly created hardlink name would fail too, independent of the LINK reply itself. Fixed by the same change, since all three sites now consistently use the real node id.

As a side effect of the same root cause: under the old code the real inode's `nlookup` was never incremented for the new dentry even though the kernel holds a reference for it. A later FORGET could over-decrement and trip the `kernel forget over-decrement` guard in `inode_to_path.go`, dropping the inode early.

## Reproducing this

The steps in #8404 (upload with the S3 API, then `ln`) may not fail on current master. Since #9067 added `weed/filer/filer_inode.go` and #9724 reworked it, `Filer.CreateEntry` calls `ensureEntryInode` (`weed/filer/filer.go:268`), which fills in a non-zero `Attributes.Inode` for an entry that arrives without one, for a plain S3 upload that is `FullPath.AsInode(crtime)`. A file uploaded today therefore usually reaches `Link()` with the stored inode already equal to the node id the mount handed the kernel, and the old code happens to pick the right number.

That changed how easy the bug is to hit, not whether it is there. `ensureEntryInode` runs on create and on update (`filer.go:268` and `:482`), never on read, so an entry written before that code landed keeps `inode: 0` for as long as nothing rewrites it, and `ln` on it still returns EIO, which is the state the original report's `fs.meta.cat` dump shows. Any writer that reaches the store without going through `Filer.CreateEntry`/`UpdateEntry` leaves the same hole.

The added test reproduces the failure deterministically: reverting the three call sites makes `TestLinkReportsKernelNodeIdWhenEntryHasNoPersistedInode` fail with `Link replied with NodeId 0`.

## Scope checked and left alone

`Rename` and both `Unlink` call sites were checked for the same class of bug. Neither returns an `EntryOut`, so neither can produce this specific EIO. One of the two `Unlink` sites does have its own, separate precedence quirk (checks the persisted attribute before falling back to the live-resolved inode, the reverse of the other three call sites), but it degrades to a silent no-op on sibling nlink sync rather than an error, and is out of scope here.

## Testing

New `weed/mount/weedfs_link_test.go`, using the existing in-process gRPC test harness (`newCreateTestWFS`, already used by several other mount tests) to drive `Link()` over a real RPC path: one case for an entry with no persisted inode (the bug), one regression case for an entry that already has one. `go build ./weed/mount/...`, `go vet`, and `go test -race ./weed/mount/` are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hard-link handling to preserve the correct source-file identifier.
  * Synchronized hard-link metadata, paths, link counts, and filesystem responses.
  * Added validation to reject invalid zero identifiers.

* **Tests**
  * Added coverage for hard links with and without previously stored identifiers.
  * Added tests for linking files multiple times and keeping related hard-link metadata synchronized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->