### PR TITLE
server: 416 only when no requested range overlaps, with Content-Range, and the Rust mirror

### DIFF
--- a/seaweed-volume/src/server/handlers.rs
+++ b/seaweed-volume/src/server/handlers.rs
@@ -1589,11 +1589,14 @@ async fn get_or_head_handler_inner(
 }
 
 /// Handle HTTP Range requests. Returns 206 Partial Content or 416 Range Not Satisfiable.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 struct HttpRange {
     start: i64,
     length: i64,
 }
+
+// Returned when the first-byte-pos of every byte-range-spec is past the content size.
+const RANGE_NO_OVERLAP: &str = "invalid range: failed to overlap";
 
 fn parse_range_header(s: &str, size: i64) -> Result<Vec<HttpRange>, &'static str> {
     if s.is_empty() {
@@ -1604,6 +1607,7 @@ fn parse_range_header(s: &str, size: i64) -> Result<Vec<HttpRange>, &'static str
         return Err("invalid range");
     }
     let mut ranges = Vec::new();
+    let mut no_overlap = false;
     for part in s[PREFIX.len()..].split(',') {
         let part = part.trim();
         if part.is_empty() {
@@ -1627,8 +1631,12 @@ fn parse_range_header(s: &str, size: i64) -> Result<Vec<HttpRange>, &'static str
             r.length = size - r.start;
         } else {
             let i = start_str.parse::<i64>().map_err(|_| "invalid range")?;
-            if i > size || i < 0 {
+            if i < 0 {
                 return Err("invalid range");
+            }
+            if i >= size {
+                no_overlap = true;
+                continue;
             }
             r.start = i;
             if end_str.is_empty() {
@@ -1645,6 +1653,9 @@ fn parse_range_header(s: &str, size: i64) -> Result<Vec<HttpRange>, &'static str
             }
         }
         ranges.push(r);
+    }
+    if no_overlap && ranges.is_empty() {
+        return Err(RANGE_NO_OVERLAP);
     }
     Ok(ranges)
 }
@@ -1679,7 +1690,15 @@ fn handle_range_request(
     let total = data.len() as i64;
     let ranges = match parse_range_header(range_str, total) {
         Ok(r) => r,
-        Err(msg) => return range_error_response(headers, msg),
+        Err(msg) => {
+            if msg == RANGE_NO_OVERLAP {
+                headers.insert(
+                    "Content-Range",
+                    format!("bytes */{}", total).parse().unwrap(),
+                );
+            }
+            return range_error_response(headers, msg);
+        }
     };
 
     // Go's ProcessRangeRequest returns nil (empty body) for empty or oversized ranges
@@ -1762,7 +1781,15 @@ fn handle_range_request_from_source(
     let total = info.data_size as i64;
     let ranges = match parse_range_header(range_str, total) {
         Ok(r) => r,
-        Err(msg) => return range_error_response(headers, msg),
+        Err(msg) => {
+            if msg == RANGE_NO_OVERLAP {
+                headers.insert(
+                    "Content-Range",
+                    format!("bytes */{}", total).parse().unwrap(),
+                );
+            }
+            return range_error_response(headers, msg);
+        }
     };
 
     if ranges.is_empty() {
@@ -3910,6 +3937,25 @@ mod tests {
     fn test_parse_url_path_invalid() {
         assert!(parse_url_path("/invalid").is_none());
         assert!(parse_url_path("").is_none());
+    }
+
+    #[test]
+    fn test_parse_range_header_no_overlap() {
+        assert_eq!(
+            parse_range_header("bytes=10-", 10).unwrap_err(),
+            RANGE_NO_OVERLAP
+        );
+        assert_eq!(
+            parse_range_header("bytes=100-", 10).unwrap_err(),
+            RANGE_NO_OVERLAP
+        );
+        // 416 only when every range fails to overlap
+        let ranges = parse_range_header("bytes=10-,0-1", 10).unwrap();
+        assert_eq!(ranges.len(), 1);
+        assert_eq!((ranges[0].start, ranges[0].length), (0, 2));
+        // an end past the size is clamped, still satisfiable
+        let ranges = parse_range_header("bytes=5-100", 10).unwrap();
+        assert_eq!((ranges[0].start, ranges[0].length), (5, 5));
     }
 
     #[test]

--- a/seaweed-volume/src/server/handlers.rs
+++ b/seaweed-volume/src/server/handlers.rs
@@ -1595,7 +1595,7 @@ struct HttpRange {
     length: i64,
 }
 
-// Returned when the first-byte-pos of every byte-range-spec is past the content size.
+// Returned when the first-byte-pos of every byte-range-spec is at or past the content size.
 const RANGE_NO_OVERLAP: &str = "invalid range: failed to overlap";
 
 fn parse_range_header(s: &str, size: i64) -> Result<Vec<HttpRange>, &'static str> {

--- a/weed/server/common.go
+++ b/weed/server/common.go
@@ -316,6 +316,9 @@ func ProcessRangeRequest(r *http.Request, w http.ResponseWriter, totalSize int64
 	ranges, err := parseRange(rangeReq, totalSize)
 	if err != nil {
 		glog.Errorf("ProcessRangeRequest headers: %+v err: %v", w.Header(), err)
+		if err == errNoOverlap {
+			w.Header().Set("Content-Range", fmt.Sprintf("bytes */%d", totalSize))
+		}
 		http.Error(w, err.Error(), http.StatusRequestedRangeNotSatisfiable)
 		return fmt.Errorf("ProcessRangeRequest header: %w", err)
 	}

--- a/weed/server/common_test.go
+++ b/weed/server/common_test.go
@@ -117,17 +117,17 @@ func (c *countingReadCloser) Close() error {
 
 func TestProcessRangeRequestRanges(t *testing.T) {
 	data := []byte("0123456789")
-	serve := func(rangeHeader string) *httptest.ResponseRecorder {
-		r := httptest.NewRequest(http.MethodGet, "/test.txt", nil)
+	serve := func(rangeHeader string) (*httptest.ResponseRecorder, error) {
+		r := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/test.txt", nil)
 		r.Header.Set("Range", rangeHeader)
 		w := httptest.NewRecorder()
-		ProcessRangeRequest(r, w, int64(len(data)), "text/plain", func(offset int64, size int64) (filer.DoStreamContent, error) {
+		err := ProcessRangeRequest(r, w, int64(len(data)), "text/plain", func(offset int64, size int64) (filer.DoStreamContent, error) {
 			return func(writer io.Writer) error {
 				_, err := writer.Write(data[offset : offset+size])
 				return err
 			}, nil
 		})
-		return w
+		return w, err
 	}
 
 	tests := []struct {
@@ -143,7 +143,10 @@ func TestProcessRangeRequestRanges(t *testing.T) {
 		{"bytes=10-,0-1", http.StatusPartialContent, "bytes 0-1/10", "01"},
 	}
 	for _, tt := range tests {
-		w := serve(tt.rangeHeader)
+		w, err := serve(tt.rangeHeader)
+		if wantErr := tt.wantCode == http.StatusRequestedRangeNotSatisfiable; (err != nil) != wantErr {
+			t.Errorf("%s: error = %v, want an error only for 416", tt.rangeHeader, err)
+		}
 		if w.Code != tt.wantCode {
 			t.Errorf("%s: status %d, want %d", tt.rangeHeader, w.Code, tt.wantCode)
 		}

--- a/weed/server/common_test.go
+++ b/weed/server/common_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/filer"
 )
 
 func TestParseURL(t *testing.T) {
@@ -111,4 +113,45 @@ func (c *countingReadCloser) Read(p []byte) (int, error) {
 
 func (c *countingReadCloser) Close() error {
 	return nil
+}
+
+func TestProcessRangeRequestRanges(t *testing.T) {
+	data := []byte("0123456789")
+	serve := func(rangeHeader string) *httptest.ResponseRecorder {
+		r := httptest.NewRequest(http.MethodGet, "/test.txt", nil)
+		r.Header.Set("Range", rangeHeader)
+		w := httptest.NewRecorder()
+		ProcessRangeRequest(r, w, int64(len(data)), "text/plain", func(offset int64, size int64) (filer.DoStreamContent, error) {
+			return func(writer io.Writer) error {
+				_, err := writer.Write(data[offset : offset+size])
+				return err
+			}, nil
+		})
+		return w
+	}
+
+	tests := []struct {
+		rangeHeader string
+		wantCode    int
+		wantRange   string
+		wantBody    string
+	}{
+		{"bytes=0-1", http.StatusPartialContent, "bytes 0-1/10", "01"},
+		{"bytes=5-100", http.StatusPartialContent, "bytes 5-9/10", "56789"},
+		{"bytes=10-", http.StatusRequestedRangeNotSatisfiable, "bytes */10", ""},
+		{"bytes=100-", http.StatusRequestedRangeNotSatisfiable, "bytes */10", ""},
+		{"bytes=10-,0-1", http.StatusPartialContent, "bytes 0-1/10", "01"},
+	}
+	for _, tt := range tests {
+		w := serve(tt.rangeHeader)
+		if w.Code != tt.wantCode {
+			t.Errorf("%s: status %d, want %d", tt.rangeHeader, w.Code, tt.wantCode)
+		}
+		if got := w.Header().Get("Content-Range"); got != tt.wantRange {
+			t.Errorf("%s: Content-Range %q, want %q", tt.rangeHeader, got, tt.wantRange)
+		}
+		if tt.wantBody != "" && w.Body.String() != tt.wantBody {
+			t.Errorf("%s: body %q, want %q", tt.rangeHeader, w.Body.String(), tt.wantBody)
+		}
+	}
 }

--- a/weed/server/volume_server_handlers_helper.go
+++ b/weed/server/volume_server_handlers_helper.go
@@ -28,7 +28,7 @@ func (r httpRange) mimeHeader(contentType string, size int64) textproto.MIMEHead
 }
 
 // errNoOverlap is returned by parseRange if first-byte-pos of
-// all of the byte-range-spec values is greater than the content size.
+// all of the byte-range-spec values is at or beyond the content size.
 var errNoOverlap = errors.New("invalid range: failed to overlap")
 
 // parseRange parses a Range header string as per RFC 7233.

--- a/weed/server/volume_server_handlers_helper.go
+++ b/weed/server/volume_server_handlers_helper.go
@@ -27,7 +27,11 @@ func (r httpRange) mimeHeader(contentType string, size int64) textproto.MIMEHead
 	}
 }
 
-// parseRange parses a Range header string as per RFC 2616.
+// errNoOverlap is returned by parseRange if first-byte-pos of
+// all of the byte-range-spec values is greater than the content size.
+var errNoOverlap = errors.New("invalid range: failed to overlap")
+
+// parseRange parses a Range header string as per RFC 7233.
 func parseRange(s string, size int64) ([]httpRange, error) {
 	if s == "" {
 		return nil, nil // header not present
@@ -37,6 +41,7 @@ func parseRange(s string, size int64) ([]httpRange, error) {
 		return nil, errors.New("invalid range")
 	}
 	var ranges []httpRange
+	noOverlap := false
 	for _, ra := range strings.Split(s[len(b):], ",") {
 		ra = strings.TrimSpace(ra)
 		if ra == "" {
@@ -62,8 +67,14 @@ func parseRange(s string, size int64) ([]httpRange, error) {
 			r.length = size - r.start
 		} else {
 			i, err := strconv.ParseInt(start, 10, 64)
-			if err != nil || i >= size || i < 0 {
+			if err != nil || i < 0 {
 				return nil, errors.New("invalid range")
+			}
+			if i >= size {
+				// If the range begins after the size of the content,
+				// then it does not overlap.
+				noOverlap = true
+				continue
 			}
 			r.start = i
 			if end == "" {
@@ -81,6 +92,10 @@ func parseRange(s string, size int64) ([]httpRange, error) {
 			}
 		}
 		ranges = append(ranges, r)
+	}
+	if noOverlap && len(ranges) == 0 {
+		// The specified ranges did not overlap with the content.
+		return nil, errNoOverlap
 	}
 	return ranges, nil
 }


### PR DESCRIPTION
Fixes #10888. Follow-up to #10898, which landed the boundary check itself.

Rebased on top of #10898. What remains here, on top of the literal `i >= size` rejection:

- **Multi-range requests**: with the literal check, `bytes=10-,0-1` on a 10-byte file fails the whole request with 416 even though `0-1` is satisfiable. RFC 9110 wants 416 only when every range fails to overlap. This ports stdlib's noOverlap handling: a non-overlapping spec is skipped, and only when nothing survives does the request get 416. Verified byte-for-byte against Go 1.26's ServeContent.
- **`Content-Range: bytes */<size>` on the 416**, matching the S3 path and ServeContent.
- **The Rust volume server**, which carries the same stale check in `parse_range_header` and still returns 206 for `bytes=<size>-` — mirrored in the second commit.

The tests from #10898 pass unchanged (every start-past-size case still errors, via `errNoOverlap`); the new `TestProcessRangeRequestRanges` additionally pins the mixed-range 206, the 416 header, and end-clamping through the actual `ProcessRangeRequest` path.
