### PR TITLE
test: wait for volume server registration in the FUSE DLM harness

### DIFF
--- a/test/fuse_dlm/framework_test.go
+++ b/test/fuse_dlm/framework_test.go
@@ -90,6 +90,8 @@ func startDLMTestCluster(t testing.TB) *dlmTestCluster {
 	require.NoError(t, c.startVolume(configDir))
 	require.NoError(t, c.waitForTCP(fmt.Sprintf("127.0.0.1:%d", c.volumePort), 30*time.Second),
 		"volume not ready\n%s", c.tailLog("volume"))
+	require.NoError(t, c.waitForVolumeRegistered(30*time.Second),
+		"volume server registration\n%s", c.tailLog("master"))
 
 	// Start 2 filers
 	for i := 0; i < 2; i++ {
@@ -346,6 +348,44 @@ func (c *dlmTestCluster) waitForFilerCount(expected int, timeout time.Duration) 
 		time.Sleep(200 * time.Millisecond)
 	}
 	return fmt.Errorf("timed out waiting for %d filers in group %q", expected, filerGroup)
+}
+
+// waitForVolumeRegistered waits until the volume server shows up in the master
+// topology with its slots reported. An open volume port only means the process
+// is listening: until the master has elected itself and accepted a heartbeat,
+// an assign fails and the first write on a fresh mount surfaces it as ENOSPC.
+func (c *dlmTestCluster) waitForVolumeRegistered(timeout time.Duration) error {
+	addr := fmt.Sprintf("127.0.0.1:%d", c.masterGrpcPort)
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	client := master_pb.NewSeaweedClient(conn)
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		resp, err := client.VolumeList(ctx, &master_pb.VolumeListRequest{})
+		cancel()
+		if err == nil && resp.TopologyInfo != nil {
+			var slots int64
+			for _, dc := range resp.TopologyInfo.DataCenterInfos {
+				for _, rack := range dc.RackInfos {
+					for _, dn := range rack.DataNodeInfos {
+						for _, disk := range dn.DiskInfos {
+							slots += disk.MaxVolumeCount
+						}
+					}
+				}
+			}
+			if slots > 0 {
+				return nil
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	return fmt.Errorf("volume server not registered with the master within %v", timeout)
 }
 
 // waitForLockRingConverged verifies that both filers have a consistent view of


### PR DESCRIPTION
The FUSE DLM harness waits for the master and volume TCP ports, filer registration, lock-ring convergence, and the mounts — but never for the volume server to be registered in the master topology. The first write on a fresh mount needs a volume assign, and until the master has elected itself and accepted a volume heartbeat that assign fails, which the mount surfaces to the test as ENOSPC.

Both runs of the workflow on #10885 hit exactly this: the failing run's timeline shows the cluster processes spawning at 06:08:47-49 and `TestDLMConcurrentWritersSameFile` getting `no space left on device` at 06:08:49.99 — writes began 1-3 seconds after master start, racing the ~2s leader election, and the uploaded volume.log shows the heartbeat being rejected with `raft.Server: Not current leader`. The PR itself only touches the mount Link path; the race is the harness's.

Fix mirrors what test/master_cold_start already does: poll the master until the topology reports a data node with volume slots, which transitively waits out leader election too. Verified locally against a live cluster that the wait passes once the volume server registers (the FUSE mounts themselves need Linux, so the full suite runs here in CI).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cluster startup reliability by waiting for the volume server to register and report available capacity before proceeding.
  * Added timeout handling to prevent startup checks from waiting indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->