### PR TITLE
test: keep per-test log directories in the FUSE DLM harness

### DIFF
--- a/test/fuse_dlm/framework_test.go
+++ b/test/fuse_dlm/framework_test.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"testing"
@@ -261,7 +262,10 @@ func (c *dlmTestCluster) tailLog(name string) string {
 }
 
 func (c *dlmTestCluster) copyLogsForCI() {
-	ciLogDir := "/tmp/seaweedfs-fuse-dlm-logs"
+	// One subdirectory per test: a flat layout lets every teardown overwrite
+	// the previous test's logs, so the CI artifact only ever shows the last
+	// cluster, never the failing one.
+	ciLogDir := filepath.Join("/tmp/seaweedfs-fuse-dlm-logs", strings.ReplaceAll(c.t.Name(), "/", "_"))
 	os.MkdirAll(ciLogDir, 0755)
 	logsDir := filepath.Join(c.baseDir, "logs")
 	entries, err := os.ReadDir(logsDir)


### PR DESCRIPTION
Each teardown copied its logs into the same flat directory, so the CI artifact only ever showed the last test's cluster, never the failing one. One subdirectory per test fixes that. Also the control arm of the DLM investigation on #10885: this branch is master plus only this harness change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test log organization by storing each test’s logs in a separate directory.
  * Prevented log files from different tests from being mixed together, making troubleshooting easier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->