### PR TITLE
server: reject a Range start offset equal to the file size

### DIFF
--- a/weed/server/volume_server_handlers_helper.go
+++ b/weed/server/volume_server_handlers_helper.go
@@ -62,7 +62,7 @@ func parseRange(s string, size int64) ([]httpRange, error) {
 			r.length = size - r.start
 		} else {
 			i, err := strconv.ParseInt(start, 10, 64)
-			if err != nil || i > size || i < 0 {
+			if err != nil || i >= size || i < 0 {
 				return nil, errors.New("invalid range")
 			}
 			r.start = i

--- a/weed/server/volume_server_handlers_helper_test.go
+++ b/weed/server/volume_server_handlers_helper_test.go
@@ -1,0 +1,55 @@
+package weed_server
+
+import "testing"
+
+func TestParseRange(t *testing.T) {
+	const size = int64(10)
+
+	tests := []struct {
+		name      string
+		rangeSpec string
+		wantErr   bool
+		wantStart int64
+		wantLen   int64
+	}{
+		{name: "start within bounds", rangeSpec: "bytes=0-", wantStart: 0, wantLen: 10},
+		{name: "start at last valid byte", rangeSpec: "bytes=9-", wantStart: 9, wantLen: 1},
+		{name: "start equal to size is not satisfiable", rangeSpec: "bytes=10-", wantErr: true},
+		{name: "start past size is not satisfiable", rangeSpec: "bytes=11-", wantErr: true},
+		{name: "start with explicit end within bounds", rangeSpec: "bytes=2-5", wantStart: 2, wantLen: 4},
+		{name: "end clamped to the last byte", rangeSpec: "bytes=2-100", wantStart: 2, wantLen: 8},
+		{name: "suffix range within bounds", rangeSpec: "bytes=-3", wantStart: 7, wantLen: 3},
+		{name: "suffix range larger than size is clamped, not rejected", rangeSpec: "bytes=-100", wantStart: 0, wantLen: 10},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ranges, err := parseRange(tt.rangeSpec, size)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseRange(%q, %d) = %+v, want an error", tt.rangeSpec, size, ranges)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseRange(%q, %d) returned unexpected error: %v", tt.rangeSpec, size, err)
+			}
+			if len(ranges) != 1 {
+				t.Fatalf("parseRange(%q, %d) = %d ranges, want 1", tt.rangeSpec, size, len(ranges))
+			}
+			if ranges[0].start != tt.wantStart || ranges[0].length != tt.wantLen {
+				t.Fatalf("parseRange(%q, %d) = {start:%d length:%d}, want {start:%d length:%d}",
+					tt.rangeSpec, size, ranges[0].start, ranges[0].length, tt.wantStart, tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestParseRangeOnEmptyFile(t *testing.T) {
+	// A zero-length file has no valid byte offsets at all, not even 0, so any
+	// range request against it must be rejected rather than satisfied with an
+	// empty range.
+	if _, err := parseRange("bytes=0-", 0); err == nil {
+		t.Fatal("parseRange(\"bytes=0-\", 0) = nil error, want an error")
+	}
+}


### PR DESCRIPTION
Related to #4933 (already closed, see below).

## The bug

`parseRange` in `weed/server/volume_server_handlers_helper.go` accepted a start offset equal to `size`, one past the last valid byte of a `size`-byte file (valid offsets are `0` to `size-1`):

```go
i, err := strconv.ParseInt(start, 10, 64)
if err != nil || i > size || i < 0 {
    return nil, errors.New("invalid range")
}
```

`Range: bytes=<size>-` on a `size`-byte file therefore returned `206 Partial Content` with `Content-Range: bytes <size>-<size-1>/<size>` (an inverted, empty range) instead of `416 Range Not Satisfiable`.

## Why this is separate from #4933

#4933 reported the identical symptom against the S3 API and was fixed in #7481, which validates ranges in the S3 gateway's own `parseAndValidateRange` (`weed/s3api/s3api_object_handlers.go`) with the correct `startOffset >= totalSize` check. That fix doesn't touch this function: `parseRange` here is a separate, older implementation used by the filer's own HTTP read endpoint and the volume server's read handlers (shared via `ProcessRangeRequest` in `weed/server/common.go`), so the same class of bug survived on that path. Found while verifying #4933 was still resolved.

## Fix

`i > size` → `i >= size`, matching the equivalent, already-correct check a few lines below for the end of an explicit range (`if i >= size { i = size - 1 }`), and matching the S3 side's fix.

## Testing

New `TestParseRange` (table-driven, covers the boundary the bug was in plus a passing sibling test that already worked) and `TestParseRangeOnEmptyFile` (a 0-byte file has no valid offsets, not even 0). Reverting the one-line fix makes `TestParseRangeOnEmptyFile` fail, confirming the test actually catches the bug. `go build`, `go vet`, and the package's `TestParseRange*` tests are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected range request handling at the end of files.
  * Invalid ranges starting at the file size are now rejected instead of accepted.

* **Tests**
  * Added coverage for bounded, clamped, suffix, invalid, and empty-file range requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->