### PR TITLE
mini: reserve the admin gRPC port instead of binding it late

### DIFF
--- a/weed/admin/dash/admin_server.go
+++ b/weed/admin/dash/admin_server.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"sort"
 	"strings"
@@ -1589,13 +1590,13 @@ func (as *AdminServer) GetConfigInfo(w http.ResponseWriter, r *http.Request) {
 }
 
 // StartWorkerGrpcServer starts the worker gRPC server
-func (s *AdminServer) StartWorkerGrpcServer(grpcPort int) error {
+func (s *AdminServer) StartWorkerGrpcServer(grpcPort int, listener net.Listener) error {
 	if s.workerGrpcServer != nil {
 		return fmt.Errorf("worker gRPC server is already running")
 	}
 
 	s.workerGrpcServer = NewWorkerGrpcServer(s)
-	return s.workerGrpcServer.StartWithTLS(grpcPort)
+	return s.workerGrpcServer.StartWithTLS(grpcPort, listener)
 }
 
 // StopWorkerGrpcServer stops the worker gRPC server

--- a/weed/admin/dash/worker_grpc_server.go
+++ b/weed/admin/dash/worker_grpc_server.go
@@ -83,16 +83,19 @@ func NewWorkerGrpcServer(adminServer *AdminServer) *WorkerGrpcServer {
 	}
 }
 
-// StartWithTLS starts the gRPC server on the specified port with optional TLS
-func (s *WorkerGrpcServer) StartWithTLS(port int) error {
+// StartWithTLS starts the gRPC server on the specified port with optional TLS.
+// A caller that already holds the port passes its listener instead.
+func (s *WorkerGrpcServer) StartWithTLS(port int, listener net.Listener) error {
 	if s.running {
 		return fmt.Errorf("worker gRPC server is already running")
 	}
 
-	// Create listener
-	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
-	if err != nil {
-		return fmt.Errorf("failed to listen on port %d: %v", port, err)
+	if listener == nil {
+		var err error
+		listener, err = net.Listen("tcp", fmt.Sprintf(":%d", port))
+		if err != nil {
+			return fmt.Errorf("failed to listen on port %d: %v", port, err)
+		}
 	}
 
 	// Create gRPC server with optional TLS

--- a/weed/command/admin.go
+++ b/weed/command/admin.go
@@ -59,6 +59,11 @@ type AdminOptions struct {
 	debugPort        *int
 	cpuProfile       *string
 	memProfile       *string
+
+	// workerGrpcListener, when set, is a listener already bound to grpcPort by
+	// the caller. `weed mini` reserves the port this way because the admin
+	// binds it only after every other service is up.
+	workerGrpcListener net.Listener
 }
 
 func init() {
@@ -406,7 +411,7 @@ func startAdminServer(ctx context.Context, options AdminOptions, enableUI bool, 
 	}
 
 	// Start worker gRPC server for worker connections
-	err = adminServer.StartWorkerGrpcServer(*options.grpcPort)
+	err = adminServer.StartWorkerGrpcServer(*options.grpcPort, options.workerGrpcListener)
 	if err != nil {
 		return fmt.Errorf("failed to start worker gRPC server: %w", err)
 	}

--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -1630,6 +1630,9 @@ func startMiniAdminWithWorker(allServicesReady chan struct{}) {
 	if miniProgressBoard != nil {
 		miniProgressBoard.starting("Admin")
 	}
+	// Snapshot the options, and with them the reserved listener, so a later
+	// in-process run cannot swap either out from under this goroutine.
+	adminOptions := miniAdminOptions
 	done := trackMiniClient()
 	go func() {
 		defer done()
@@ -1645,13 +1648,13 @@ func startMiniAdminWithWorker(allServicesReady chan struct{}) {
 				lancePort = *miniS3Options.portLance
 			}
 		}
-		if err := startAdminServer(ctx, miniAdminOptions, *miniEnableAdminUI, icebergPort, lancePort, urlPrefix); err != nil {
+		if err := startAdminServer(ctx, adminOptions, *miniEnableAdminUI, icebergPort, lancePort, urlPrefix); err != nil {
 			glog.Errorf("Admin server error: %v", err)
 		}
 		// A no-op once the admin took it over and shut it down; it matters when
 		// startAdminServer bailed out before that.
-		if miniAdminOptions.workerGrpcListener != nil {
-			miniAdminOptions.workerGrpcListener.Close()
+		if adminOptions.workerGrpcListener != nil {
+			adminOptions.workerGrpcListener.Close()
 		}
 	}()
 

--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -942,6 +942,17 @@ func ensureAllPortsAvailableOnIP(bindIp string) error {
 	// All gRPC port handling (calculation, validation, and assignment) is performed exclusively in initializeGrpcPortsOnIP
 	initializeGrpcPortsOnIP(bindIp)
 
+	// Every other service binds within a moment of this check, but the admin
+	// waits for all of them first. The admin gRPC port sits inside the Linux
+	// ephemeral range, so during that gap one of the cluster's own outgoing
+	// connections can take it and the admin then dies on bind. Hold a listener
+	// from here and hand it to the admin instead of re-binding later.
+	if listener, err := net.Listen("tcp", fmt.Sprintf(":%d", *miniAdminOptions.grpcPort)); err != nil {
+		glog.Warningf("Could not reserve Admin gRPC port %d: %v", *miniAdminOptions.grpcPort, err)
+	} else {
+		miniAdminOptions.workerGrpcListener = listener
+	}
+
 	// Log the final port configuration
 	icebergPortStr := "disabled"
 	if miniS3Options.portIceberg != nil && *miniS3Options.portIceberg > 0 {
@@ -1633,6 +1644,11 @@ func startMiniAdminWithWorker(allServicesReady chan struct{}) {
 		}
 		if err := startAdminServer(ctx, miniAdminOptions, *miniEnableAdminUI, icebergPort, lancePort, urlPrefix); err != nil {
 			glog.Errorf("Admin server error: %v", err)
+		}
+		// A no-op once the admin took it over and shut it down; it matters when
+		// startAdminServer bailed out before that.
+		if miniAdminOptions.workerGrpcListener != nil {
+			miniAdminOptions.workerGrpcListener.Close()
 		}
 	}()
 

--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -946,7 +946,10 @@ func ensureAllPortsAvailableOnIP(bindIp string) error {
 	// waits for all of them first. The admin gRPC port sits inside the Linux
 	// ephemeral range, so during that gap one of the cluster's own outgoing
 	// connections can take it and the admin then dies on bind. Hold a listener
-	// from here and hand it to the admin instead of re-binding later.
+	// from here and hand it to the admin instead of re-binding later. Clear
+	// first: an in-process rerun would otherwise inherit the closed listener
+	// of the previous run and only find out inside Serve.
+	miniAdminOptions.workerGrpcListener = nil
 	if listener, err := net.Listen("tcp", fmt.Sprintf(":%d", *miniAdminOptions.grpcPort)); err != nil {
 		glog.Warningf("Could not reserve Admin gRPC port %d: %v", *miniAdminOptions.grpcPort, err)
 	} else {


### PR DESCRIPTION
# What problem are we solving?

A lifecycle job failed on an unrelated PR with the admin never coming up:

```
E0824 19:26:29 mini.go:1635 Admin server error: failed to start worker gRPC server:
  failed to listen on port 33646: listen tcp :33646: bind: address already in use
  Admin        stopped   0.2s
```

No admin means no worker registers, so `TestLifecycleAdminDispatchSucceedsWithCustomFilerGrpcPort` then fails 30s later on "admin never reported an s3_lifecycle-capable worker". One of nineteen lifecycle shards, nothing else in the run.

`ensureAllPortsAvailableOnIP` finalizes every port up front by probing with a throwaway listener, then closes it. Master, filer, volume, S3 and WebDAV bind about 200ms later, but the admin waits for all of them and binds its worker gRPC port roughly two seconds in. That port defaults to the admin http port + 10000, i.e. 33646, which sits inside the default Linux ephemeral range 32768-60999 — so during the gap one of the cluster's own outgoing gRPC dials can take 33646 as its local source port and the admin's bind fails.

# How are we solving the problem?

Keep the listener the availability check already opens on the finalized admin gRPC port, and hand it to the admin instead of re-binding later. `StartWorkerGrpcServer` and `StartWithTLS` take a listener and bind it themselves only when it is nil, so standalone `weed admin` is unchanged.

Not touched: master, filer, volume and S3 have the same check-then-bind-later gap, ~200ms wide rather than ~2s. Passing listeners into those servers is a much larger change.

# How is the PR tested?

```bash
go build ./...
go test ./weed/admin/dash/... ./weed/command/...
```

Timed when the admin gRPC port starts listening, on a shifted port set so a stray local process could not answer for it:

```
baseline (master):  34646 listening after 1.46s
this branch:        34646 listening after 0.46s
```

The reservation now lands during port finalization, before any service starts and therefore before the first outbound dial, which closes the window.

`test/s3/lifecycle` `TestLifecycleAdminDispatchSucceedsWithCustomFilerGrpcPort` was also run locally on this branch and on master: the admin comes up and dispatches on both (`detected_count:1 executed_count:1 success_count:1`), and both then fail identically on the final HeadObject check — a pre-existing local macOS issue, not a regression.

# Checks
- [X] I have added unit tests if possible.
- [X] I will add related wiki document changes and link to this PR after merging.
- [X] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [X] I have reviewed every line of code.
- [X] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup reliability for the administrative gRPC service by reserving its port before services launch.
  * Reduced the likelihood of port conflicts and startup failures.
  * Ensured reserved ports are properly released if startup does not complete.
  * Improved reliability when restarting the service within the same process by resetting previously reserved ports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->