### PR TITLE
helm: expose loadBalancerClass, loadBalancerIP, loadBalancerSourceRanges on services

### DIFF
--- a/k8s/charts/seaweedfs/templates/admin/admin-service.yaml
+++ b/k8s/charts/seaweedfs/templates/admin/admin-service.yaml
@@ -21,6 +21,7 @@ spec:
   {{- $nodePorts = .Values.admin.service.nodePorts | default dict }}
   {{- end }}
   type: {{ $serviceType }}
+  {{- include "seaweedfs.service.loadBalancerFields" .Values.admin.service }}
   ports:
   - name: "http"
     port: {{ .Values.admin.port }}

--- a/k8s/charts/seaweedfs/templates/all-in-one/all-in-one-service.yml
+++ b/k8s/charts/seaweedfs/templates/all-in-one/all-in-one-service.yml
@@ -21,6 +21,7 @@ spec:
   {{- $nodePorts = .Values.allInOne.service.nodePorts | default dict }}
   {{- end }}
   type: {{ $serviceType }}
+  {{- include "seaweedfs.service.loadBalancerFields" .Values.allInOne.service }}
   internalTrafficPolicy: {{ .Values.allInOne.service.internalTrafficPolicy | default "Cluster" }}
   {{- if and (semverCompare ">=1.31-0" .Capabilities.KubeVersion.GitVersion) .Values.allInOne.s3.trafficDistribution }}
   trafficDistribution: {{ include "seaweedfs.trafficDistribution" (dict "value" .Values.allInOne.s3.trafficDistribution "Capabilities" .Capabilities) }}

--- a/k8s/charts/seaweedfs/templates/s3/s3-service.yaml
+++ b/k8s/charts/seaweedfs/templates/s3/s3-service.yaml
@@ -21,6 +21,7 @@ spec:
   {{- $nodePorts = .Values.s3.service.nodePorts | default dict }}
   {{- end }}
   type: {{ $serviceType }}
+  {{- include "seaweedfs.service.loadBalancerFields" .Values.s3.service }}
   internalTrafficPolicy: {{ .Values.s3.internalTrafficPolicy | default "Cluster" }}
   {{- $td := .Values.s3.trafficDistribution | default .Values.filer.s3.trafficDistribution }}
   {{- if and (semverCompare ">=1.31-0" .Capabilities.KubeVersion.GitVersion) $td }}

--- a/k8s/charts/seaweedfs/templates/sftp/sftp-service.yaml
+++ b/k8s/charts/seaweedfs/templates/sftp/sftp-service.yaml
@@ -21,6 +21,7 @@ spec:
   {{- $nodePorts = .Values.sftp.service.nodePorts | default dict }}
   {{- end }}
   type: {{ $serviceType }}
+  {{- include "seaweedfs.service.loadBalancerFields" .Values.sftp.service }}
   internalTrafficPolicy: {{ .Values.sftp.internalTrafficPolicy | default "Cluster" }}
   ports:
   - name: "swfs-sftp"

--- a/k8s/charts/seaweedfs/templates/shared/_helpers.tpl
+++ b/k8s/charts/seaweedfs/templates/shared/_helpers.tpl
@@ -548,3 +548,23 @@ true
 {{- and (eq .value "PreferClose") (semverCompare ">=1.35-0" .Capabilities.KubeVersion.GitVersion) | ternary "PreferSameZone" .value -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Render LoadBalancer-specific service fields (loadBalancerClass, loadBalancerIP,
+loadBalancerSourceRanges), only when the service type is LoadBalancer.
+Usage: {{ include "seaweedfs.service.loadBalancerFields" .Values.s3.service }}
+*/}}
+{{- define "seaweedfs.service.loadBalancerFields" -}}
+{{- if eq (.type | default "ClusterIP") "LoadBalancer" }}
+{{- with .loadBalancerClass }}
+  loadBalancerClass: {{ . }}
+{{- end }}
+{{- with .loadBalancerIP }}
+  loadBalancerIP: {{ . }}
+{{- end }}
+{{- with .loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -1184,6 +1184,10 @@ s3:
   # Service settings
   service:
     type: ClusterIP
+    # used only when type is LoadBalancer
+    loadBalancerClass: ""
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
     # fixed nodePorts, used only when type is NodePort or LoadBalancer
     nodePorts:
       http: null
@@ -1288,6 +1292,10 @@ sftp:
   # Service settings
   service:
     type: ClusterIP
+    # used only when type is LoadBalancer
+    loadBalancerClass: ""
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
     # fixed nodePorts, used only when type is NodePort or LoadBalancer
     nodePorts:
       sftp: null
@@ -1430,6 +1438,10 @@ admin:
   service:
     type: ClusterIP
     annotations: {}
+    # used only when type is LoadBalancer
+    loadBalancerClass: ""
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
     # fixed nodePorts, used only when type is NodePort or LoadBalancer
     nodePorts:
       http: null
@@ -1654,6 +1666,10 @@ allInOne:
     annotations: {}  # Annotations for the service
     type: ClusterIP  # Service type (ClusterIP, NodePort, LoadBalancer)
     internalTrafficPolicy: Cluster  # Internal traffic policy
+    # used only when type is LoadBalancer
+    loadBalancerClass: ""
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
     # fixed nodePorts, used only when type is NodePort or LoadBalancer
     nodePorts:
       master: null


### PR DESCRIPTION
Fixes #10914.

The chart's Services only exposed `service.type` and `service.nodePorts`, so on GKE and similar you could not pin a reserved static IP (`loadBalancerClass` + provider annotation) or restrict source CIDRs on a chart-managed LoadBalancer Service.

This adds `loadBalancerClass`, `loadBalancerIP`, and `loadBalancerSourceRanges` to the `service` block of every Service that honors `service.type`: s3 (also used for filer s3), sftp, admin, and all-in-one. A shared helper renders them only when `service.type` is `LoadBalancer`, so leftover values on a ClusterIP/NodePort service never produce an invalid manifest, and the default rendering is byte-identical to before.

Verified with `helm template`: defaults unchanged, all three fields render on all four services when set with `type: LoadBalancer`, nothing renders when the type is ClusterIP or NodePort. `helm lint` passes with every `ci/` values file, and the rendered manifests pass `kubectl apply --dry-run=client`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable load balancer settings for S3, SFTP, Admin, and All-in-One services.
  * Supports specifying a load balancer class, IP address, and source address ranges.
  * These settings are applied when a service uses the `LoadBalancer` type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->