### PR TITLE
S3: commit GET status only after the first read succeeds

### DIFF
--- a/weed/s3api/s3api_local_read_fallback_test.go
+++ b/weed/s3api/s3api_local_read_fallback_test.go
@@ -166,7 +166,7 @@ func TestS3CachedReadFallsBackToRemote(t *testing.T) {
 		assert.Equal(t, int64(4), client.gotSize)
 	})
 
-	t.Run("a local-only object keeps the existing error", func(t *testing.T) {
+	t.Run("a local-only object gets a clean 500, not a broken 200 body", func(t *testing.T) {
 		client := &fakeStreamRemoteClient{data: content}
 		remote_storage.RemoteStorageClientMakers["faketest"] = &fakeStreamRemoteMaker{client: client}
 		s3a := newLocalReadFallbackServer(t, startStreamThroughFiler(t, "faketest-nofallback", nil))
@@ -180,6 +180,8 @@ func TestS3CachedReadFallsBackToRemote(t *testing.T) {
 		err := s3a.streamFromVolumeServers(w, r, local, "", "mybucket", "dir/obj.bin", "")
 
 		require.Error(t, err)
+		assert.Equal(t, http.StatusInternalServerError, w.Code, "the status must not be committed before the first read succeeds")
+		assert.Contains(t, w.Body.String(), "InternalError")
 		assert.Nil(t, client.gotLoc, "an object that is not remote-mounted has no remote to fall back to")
 	})
 
@@ -198,6 +200,52 @@ func TestS3CachedReadFallsBackToRemote(t *testing.T) {
 
 		require.Error(t, err)
 		assert.Nil(t, client.gotLoc, "a versioned read must not serve the unversioned remote object")
+	})
+}
+
+// the deferred status commit must be invisible on the success path: a readable
+// local object still streams with the same status and headers as before
+func TestS3LocalReadCommitsStatusOnFirstWrite(t *testing.T) {
+	content := []byte("0123456789")
+	newLocalServer := func(t *testing.T, name string) *S3ApiServer {
+		s3a := newLocalReadFallbackServer(t, startStreamThroughFiler(t, name, nil))
+		cache := chunk_cache.NewChunkCacheInMemory(16)
+		cache.SetChunk("1,0123456789ab", content)
+		s3a.readerCache = filer.NewReaderCache(8, cache, s3a.filerClient.GetLookupFileIdFunction(), s3a.filerClient)
+		return s3a
+	}
+	localEntry := func() *filer_pb.Entry {
+		local := cachedEntry(content)
+		local.RemoteEntry = nil
+		return local
+	}
+
+	t.Run("readable local object streams a 200", func(t *testing.T) {
+		s3a := newLocalServer(t, "faketest-localok")
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/mybucket/dir/obj.bin", nil)
+
+		err := s3a.streamFromVolumeServers(w, r, localEntry(), "", "mybucket", "dir/obj.bin", "")
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, content, w.Body.Bytes())
+		assert.Equal(t, "10", w.Header().Get("Content-Length"))
+	})
+
+	t.Run("readable range streams a 206 with range headers", func(t *testing.T) {
+		s3a := newLocalServer(t, "faketest-localrange")
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/mybucket/dir/obj.bin", nil)
+		r.Header.Set("Range", "bytes=2-5")
+
+		err := s3a.streamFromVolumeServers(w, r, localEntry(), "", "mybucket", "dir/obj.bin", "")
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusPartialContent, w.Code)
+		assert.Equal(t, content[2:6], w.Body.Bytes())
+		assert.Equal(t, "bytes 2-5/10", w.Header().Get("Content-Range"))
+		assert.Equal(t, "4", w.Header().Get("Content-Length"))
 	})
 }
 

--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -57,6 +57,23 @@ func (cw *countingWriter) Write(p []byte) (int, error) {
 	return n, err
 }
 
+// commitOnFirstWrite defers the status line until the first body write, so the
+// first read from the volume servers must succeed before the 200 is committed
+// and a missing needle still gets a clean 5xx instead of a broken 200 body.
+type commitOnFirstWrite struct {
+	w         io.Writer
+	commit    func()
+	committed bool
+}
+
+func (c *commitOnFirstWrite) Write(p []byte) (int, error) {
+	if !c.committed {
+		c.committed = true
+		c.commit()
+	}
+	return c.w.Write(p)
+}
+
 // adjustRangeForPart adjusts a client's Range header to absolute offsets within a part.
 // Parameters:
 //   - partStartOffset: the absolute start offset of the part in the object
@@ -1155,41 +1172,48 @@ func (s3a *S3ApiServer) streamFromVolumeServers(w http.ResponseWriter, r *http.R
 		}
 	}
 
-	// All validation and preparation successful - NOW set headers and write status
-	tHeaderSet := time.Now()
-	s3a.setResponseHeaders(w, r, entry, totalSize)
-
-	// Override/add range-specific headers if this is a range request
-	if isRangeRequest {
-		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", offset, offset+size-1, totalSize))
+	// Headers and status are committed on the first body write, once the first
+	// read from the volume servers has succeeded. The client sees the same wire
+	// timing either way -- the status line sits in the server's write buffer
+	// until body bytes arrive -- but a first read that fails now surfaces as a
+	// clean 5xx instead of a 200 with a broken body.
+	body := &commitOnFirstWrite{w: w, commit: func() {
+		tHeaderSet := time.Now()
+		s3a.setResponseHeaders(w, r, entry, totalSize)
+		if isRangeRequest {
+			w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", offset, offset+size-1, totalSize))
+		}
 		w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
-	} else {
-		w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
-	}
-	headerSetTime = time.Since(tHeaderSet)
-
-	// Now write status code (headers are all set, stream is ready)
-	if isRangeRequest {
-		w.WriteHeader(http.StatusPartialContent)
-	} else {
-		w.WriteHeader(http.StatusOK)
-	}
-
-	// Track time to first byte metric
-	TimeToFirstByte(r.Method, t0, r)
+		headerSetTime = time.Since(tHeaderSet)
+		if isRangeRequest {
+			w.WriteHeader(http.StatusPartialContent)
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+		TimeToFirstByte(r.Method, t0, r)
+	}}
 
 	// Stream directly to response with counting wrapper.
 	// ChunkReadAt's ReadAt is backed by in-memory prefetched chunk buffers, so
 	// io.CopyBuffer drains them as fast memcpys.
 	tStreamExec := time.Now()
 	glog.V(4).Infof("streamFromVolumeServers: starting chunk reader, offset=%d, size=%d", offset, size)
-	written, err := s3a.streamRangeToClient(w, r, reader, entry, bucket, object, offset, size, totalSize, versionId)
+	written, err := s3a.streamRangeToClient(body, r, reader, entry, bucket, object, offset, size, totalSize, versionId)
 	streamExecTime = time.Since(tStreamExec)
 	// Track traffic even on partial writes for accurate egress accounting
 	if written > 0 {
 		BucketTrafficSent(written, r)
 	}
 	if err != nil {
+		if !body.committed {
+			if isCanceledStreamingError(err) {
+				glog.V(3).Infof("streamFromVolumeServers: request canceled before first byte of %s/%s: %v", bucket, object, err)
+				return err
+			}
+			glog.Errorf("streamFromVolumeServers: first read of %s/%s failed: %v", bucket, object, err)
+			s3err.WriteErrorResponse(w, r, s3err.ErrInternalError)
+			return newStreamErrorWithResponse(err)
+		}
 		switch {
 		case isCanceledStreamingError(err):
 			// Client disconnected mid-stream (e.g. Nginx upstream timeout, browser cancel) - expected
@@ -1202,6 +1226,11 @@ func (s3a *S3ApiServer) streamFromVolumeServers(w http.ResponseWriter, r *http.R
 		}
 		// Streaming error after WriteHeader was called - response already partially written
 		return newStreamErrorWithResponse(err)
+	}
+	if !body.committed {
+		// a zero-length body never writes, so commit the empty response here
+		body.committed = true
+		body.commit()
 	}
 	glog.V(4).Infof("streamFromVolumeServers: streamFn completed successfully, wrote %d bytes", written)
 	return nil


### PR DESCRIPTION
Fixes #10924.

Since #9068 replaced the prefetch path with ChunkReadAt, streamFromVolumeServers wrote the 200/206 from filer metadata before the first byte had been fetched from a volume server. A missing or corrupted needle then surfaced mid-body: the client got a broken 200 instead of a 5xx, and SeaweedFS_s3_request_total recorded a success. The probeReadable check from #10367/#10837 only covered remote-mounted objects.

Rather than running the probe unconditionally, this defers the status commit to the first body write. The probe would have cost an extra volume round trip for range reads in random mode and only proves one byte; deferring the commit adds no read, no allocation, and no round trip anywhere, and the whole first copy buffer must be readable before the status is decided. It is also invisible on the wire: net/http buffers the status line until body bytes arrive, so successful responses are byte-for-byte identical with identical timing (verified against a live listener - a client sees nothing between WriteHeader and the first write either way).

A first read that fails now returns a clean InternalError before headers, and the metrics record the 5xx. Failures after the first buffer still truncate mid-body, which is inherent to streaming; the remote-mount splice from #10837 keeps covering that case where a remote copy exists. The 2s probe for remote-mounted objects stays, since it bounds the local attempt before falling back. TimeToFirstByte now measures to the first body byte instead of to the premature header write, so recorded TTFB gets more honest, not slower.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - S3 reads that fail before returning data now produce a proper server error instead of an incorrect successful response.
  - Successful local-object downloads continue to return correct status codes and range-related headers.
  - Empty responses are handled consistently when no body data is streamed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->