### PR TITLE
s3: log each request at -v=2

### DIFF
--- a/weed/s3api/auth_signature_v2.go
+++ b/weed/s3api/auth_signature_v2.go
@@ -68,11 +68,11 @@ func (iam *IdentityAccessManagement) isReqAuthenticatedV2(r *http.Request) (*Ide
 	return iam.doesPresignV2SignatureMatch(r)
 }
 
-func (iam *IdentityAccessManagement) doesPolicySignatureV2Match(formValues http.Header) s3err.ErrorCode {
+func (iam *IdentityAccessManagement) doesPolicySignatureV2Match(formValues http.Header) (*Identity, s3err.ErrorCode) {
 
 	accessKey := formValues.Get("AWSAccessKeyId")
 	if accessKey == "" {
-		return s3err.ErrMissingFields
+		return nil, s3err.ErrMissingFields
 	}
 
 	identity, cred, found := iam.lookupByAccessKey(accessKey)
@@ -85,35 +85,35 @@ func (iam *IdentityAccessManagement) doesPolicySignatureV2Match(formValues http.
 		glog.Warningf("InvalidAccessKeyId (V2 POST): attempted key '%s' not found. Available keys: %d, Auth enabled: %v",
 			accessKey, availableKeyCount, iam.isAuthEnabled)
 
-		return s3err.ErrInvalidAccessKeyID
+		return nil, s3err.ErrInvalidAccessKeyID
 	}
 
 	// Check service account expiration
 	if cred.isCredentialExpired() {
 		glog.V(2).Infof("Service account credential %s has expired (expiration: %d, now: %d)",
 			accessKey, cred.Expiration, time.Now().Unix())
-		return s3err.ErrAccessDenied
+		return nil, s3err.ErrAccessDenied
 	}
 
 	bucket := formValues.Get("bucket")
 	if !identity.CanDo(s3_constants.ACTION_WRITE, bucket, "") {
-		return s3err.ErrAccessDenied
+		return nil, s3err.ErrAccessDenied
 	}
 
 	policy := formValues.Get("Policy")
 	if policy == "" {
-		return s3err.ErrMissingFields
+		return nil, s3err.ErrMissingFields
 	}
 
 	signature := formValues.Get("Signature")
 	if signature == "" {
-		return s3err.ErrMissingFields
+		return nil, s3err.ErrMissingFields
 	}
 
 	if !compareSignatureV2(signature, calculateSignatureV2(policy, cred.SecretKey)) {
-		return s3err.ErrSignatureDoesNotMatch
+		return nil, s3err.ErrSignatureDoesNotMatch
 	}
-	return s3err.ErrNone
+	return identity, s3err.ErrNone
 }
 
 // doesSignV2Match - Verify authorization header with calculated header in accordance with

--- a/weed/s3api/auth_signature_v4.go
+++ b/weed/s3api/auth_signature_v4.go
@@ -757,12 +757,12 @@ func parseSignedHeaderList(signedHeadersValue string) ([]string, s3err.ErrorCode
 	return signedHeaders, s3err.ErrNone
 }
 
-func (iam *IdentityAccessManagement) doesPolicySignatureV4Match(formValues http.Header) s3err.ErrorCode {
+func (iam *IdentityAccessManagement) doesPolicySignatureV4Match(formValues http.Header) (*Identity, s3err.ErrorCode) {
 
 	// Parse credential tag.
 	credHeader, err := parseCredentialHeader("Credential=" + formValues.Get("X-Amz-Credential"))
 	if err != s3err.ErrNone {
-		return err
+		return nil, err
 	}
 
 	identity, cred, found := iam.lookupByAccessKey(credHeader.accessKey)
@@ -775,19 +775,19 @@ func (iam *IdentityAccessManagement) doesPolicySignatureV4Match(formValues http.
 		glog.Warningf("InvalidAccessKeyId (POST policy): attempted key '%s' not found. Available keys: %d, Auth enabled: %v",
 			credHeader.accessKey, availableKeyCount, iam.isAuthEnabled)
 
-		return s3err.ErrInvalidAccessKeyID
+		return nil, s3err.ErrInvalidAccessKeyID
 	}
 
 	// Check service account expiration
 	if cred.isCredentialExpired() {
 		glog.V(2).Infof("Service account credential %s has expired (expiration: %d, now: %d)",
 			credHeader.accessKey, cred.Expiration, time.Now().Unix())
-		return s3err.ErrAccessDenied
+		return nil, s3err.ErrAccessDenied
 	}
 
 	bucket := formValues.Get("bucket")
 	if !identity.CanDo(s3_constants.ACTION_WRITE, bucket, "") {
-		return s3err.ErrAccessDenied
+		return nil, s3err.ErrAccessDenied
 	}
 
 	// Get signing key.
@@ -798,9 +798,9 @@ func (iam *IdentityAccessManagement) doesPolicySignatureV4Match(formValues http.
 
 	// Verify signature.
 	if !compareSignatureV4(newSignature, formValues.Get("X-Amz-Signature")) {
-		return s3err.ErrSignatureDoesNotMatch
+		return nil, s3err.ErrSignatureDoesNotMatch
 	}
-	return s3err.ErrNone
+	return identity, s3err.ErrNone
 }
 
 // sigV4PayloadHashHeader is x-amz-content-sha256. It participates in the

--- a/weed/s3api/s3api_object_handlers_postpolicy.go
+++ b/weed/s3api/s3api_object_handlers_postpolicy.go
@@ -79,10 +79,13 @@ func (s3a *S3ApiServer) PostPolicyBucketHandler(w http.ResponseWriter, r *http.R
 	}
 
 	// Verify policy signature.
-	errCode := s3a.iam.doesPolicySignatureMatch(formValues)
+	identity, errCode := s3a.iam.doesPolicySignatureMatch(formValues)
 	if errCode != s3err.ErrNone {
 		s3err.WriteErrorResponse(w, r, errCode)
 		return
+	}
+	if identity != nil {
+		r = r.WithContext(s3_constants.SetIdentityNameInContext(r.Context(), identity.Name))
 	}
 
 	policyBytes, err := base64.StdEncoding.DecodeString(formValues.Get("Policy"))
@@ -319,8 +322,8 @@ func getRedirectPostRawQuery(bucket, key, etag string) string {
 	return redirectValues.Encode()
 }
 
-// Check to see if Policy is signed correctly.
-func (iam *IdentityAccessManagement) doesPolicySignatureMatch(formValues http.Header) s3err.ErrorCode {
+// Check to see if Policy is signed correctly, returning the signing identity.
+func (iam *IdentityAccessManagement) doesPolicySignatureMatch(formValues http.Header) (*Identity, s3err.ErrorCode) {
 	// For SignV2 - Signature field will be valid
 	if _, ok := formValues["Signature"]; ok {
 		return iam.doesPolicySignatureV2Match(formValues)

--- a/weed/s3api/stats.go
+++ b/weed/s3api/stats.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/seaweedfs/seaweedfs/weed/util/version"
 
+	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
 	stats_collect "github.com/seaweedfs/seaweedfs/weed/stats"
@@ -31,10 +32,18 @@ func track(f http.HandlerFunc, action string) http.HandlerFunc {
 		r = s3_constants.EnsureIdentityHolder(r)
 		start := time.Now()
 		f(recorder, r)
+		elapsed := time.Since(start)
+		if glog.V(2) {
+			requester := s3_constants.GetIdentityNameFromContext(r)
+			if requester == "" {
+				requester = "-"
+			}
+			glog.Infof("%s %s %s %d %s", requester, r.Method, r.URL.Path, recorder.Status, elapsed)
+		}
 		if recorder.Status == http.StatusForbidden {
 			bucket = ""
 		}
-		stats_collect.S3RequestHistogram.WithLabelValues(action, bucket).Observe(time.Since(start).Seconds())
+		stats_collect.S3RequestHistogram.WithLabelValues(action, bucket).Observe(elapsed.Seconds())
 		stats_collect.S3RequestCounter.WithLabelValues(action, strconv.Itoa(recorder.Status), bucket).Inc()
 		stats_collect.RecordBucketActiveTime(bucket)
 		if !s3err.AuditAlreadyLogged(r) {

--- a/weed/s3api/stats.go
+++ b/weed/s3api/stats.go
@@ -38,7 +38,8 @@ func track(f http.HandlerFunc, action string) http.HandlerFunc {
 			if requester == "" {
 				requester = "-"
 			}
-			glog.Infof("%s %s %s %d %s", requester, r.Method, r.URL.Path, recorder.Status, elapsed)
+			// %q keeps requester- and key-supplied bytes (e.g. newlines) on one line
+			glog.Infof("%q %s %q %d %s", requester, r.Method, r.URL.Path, recorder.Status, elapsed)
 		}
 		if recorder.Status == http.StatusForbidden {
 			bucket = ""


### PR DESCRIPTION
Discussion https://github.com/seaweedfs/seaweedfs/discussions/10916 reports that S3 uploads leave no trace in the logs while bucket creation does. That asymmetry is real: bucket creation emits a low-verbosity mkdir line, but object PUTs only produce scattered handler debug lines at -v=3 and above, and there is no single per-request record at any level.

This adds one access line per S3 request in the track wrapper, at -v=2: requester, method, path, status, duration. It covers every routed request uniformly, including multipart part uploads and denied requests.

```
I0824 15:37:41 stats.go:41 tester PUT /authtest 200 2.627416ms
I0824 15:37:45 stats.go:41 tester PUT /authtest/hello.txt 200 211.945292ms
I0824 15:37:45 stats.go:41 - PUT /authtest/denied.txt 403 1.697625ms
```

The requester comes from the identity holder the wrapper already installs for audit logging, so it is populated even though authentication records the identity on an inner request copy. Anonymous requests log "-". The query string is deliberately not logged so presigned signatures stay out of the logs.

Verified against a local server with and without s3.config auth: plain PUT, 20MB multipart upload, list, and a bad-credential PUT all produce exactly one line each at -v=2 and none at the default verbosity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced S3 request diagnostics with method, path, requester, response status, and elapsed time.
  * Improved consistency when recording request timing information.
  * S3 POST policy uploads now preserve the authenticated requester identity for more accurate request attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->