### PR TITLE
helm: trim the Lance chart comments

### DIFF
--- a/k8s/charts/seaweedfs/templates/s3/s3-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/s3/s3-deployment.yaml
@@ -149,6 +149,7 @@ spec:
               {{- if .Values.s3.icebergPort }}
               -port.iceberg={{ .Values.s3.icebergPort }} \
               {{- end }}
+              {{- /* rendered even when 0: an if would drop the flag and weed would serve its default */}}
               -port.lance={{ .Values.s3.lancePort | default 0 }} \
               {{- range .Values.s3.extraArgs }}
               {{ . }} \

--- a/k8s/charts/seaweedfs/templates/worker/worker-deployment.yaml
+++ b/k8s/charts/seaweedfs/templates/worker/worker-deployment.yaml
@@ -232,14 +232,14 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            # The URL reaches the shell below; a value with metacharacters must
-            # arrive as data, not syntax.
+            {{- /* the URL crosses a shell line; metacharacters must arrive as data, not syntax */}}
             - name: LANCE_NAMESPACE_URL
               value: {{ include "seaweedfs.worker.lanceNamespaceUrl" . | quote }}
           command:
             - "/bin/sh"
             - "-ec"
             - |
+              {{- /* the armv7/386 placeholder is empty; exec of it becomes the shell and exits 0 */}}
               if [ ! -s /usr/bin/weed-worker ]; then
                 echo "the Rust worker is not available on this platform ($(uname -m)); it ships for amd64 and arm64" >&2
                 exit 1

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -1006,9 +1006,8 @@ s3:
   # Iceberg catalog REST port (Apache Iceberg REST Catalog API)
   # Set to a port number to enable, or 0/null to disable
   icebergPort: null
-  # Lance Namespace REST port (Lance Namespace API), on by default like
-  # standalone `weed s3`. Set to 0 to disable; that also drops the worker's
-  # Lance maintenance container.
+  # Lance Namespace port; weed serves 9101 by default, 0 disables it
+  # (and, unless worker.namespaceUrl points elsewhere, the worker's Lance container)
   lancePort: 9101
   loggingOverrideLevel: null
   # enable user & permission to s3 (need to inject to all services)
@@ -1474,18 +1473,10 @@ worker:
   metricsPort: 9327
   metricsIp: ""  # If empty, defaults to 0.0.0.0
 
-  # The Lance maintenance worker (/usr/bin/weed-worker, Rust) runs as a
-  # second container beside `weed worker` whenever its namespace is
-  # reachable: namespaceUrl set, or s3 enabled with a nonzero s3.lancePort.
-  # It runs alongside rather than instead, because the job families are
-  # disjoint: the Go worker serves vacuum, balance, EC and
-  # iceberg_maintenance; only the Rust worker serves lance_compact,
-  # lance_optimize_indices and lance_cleanup_versions. The binary ships for
-  # amd64 and arm64; on an armv7/386-only cluster set s3.lancePort: 0, or
-  # the container exits at startup naming the platform.
+  # The lance_* jobs run in their own container, /usr/bin/weed-worker.
+  # amd64/arm64 only; pin mixed clusters with worker.affinity/nodeSelector.
 
-  # Lance namespace URL override. When empty, derived from this release's
-  # S3 service and s3.lancePort.
+  # Lance namespace URL override; empty derives it from s3.lancePort.
   namespaceUrl: ""
 
   # Metrics port for the Lance worker container; the Go worker keeps metricsPort


### PR DESCRIPTION
Comment cleanup over the Lance chart wiring from #10936, which merged while I was still trimming. Comments only, zero rendering change: I diffed the full rendered manifest set before and after across defaults, lancePort=0, a namespaceUrl-only worker, and the security combo - byte-identical except that the env-var note no longer leaks two comment lines into the rendered worker manifest, since it is now a template comment like the rest.

The values paragraphs compress to the density of the surrounding file, and the two spots that invite a wrong simplification each keep a one-line why: -port.lance is rendered even at 0 because a truthiness if would drop the flag and weed would quietly serve its default, and the platform guard exists because the armv7/386 placeholder is empty, so exec of it becomes the shell and exits 0.

https://claude.ai/code/session_01Rkp1Mw5E89Jp6dzJFYiMrm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified Helm chart documentation for the S3 Lance Namespace port and worker Lance settings.
  - Added deployment template comments explaining port handling and platform-specific worker behavior.
  - Configuration defaults and runtime behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->