### PR TITLE
s3: deny anonymous access when the identity config loads no identities

### DIFF
--- a/weed/s3api/auth_config_default_deny_test.go
+++ b/weed/s3api/auth_config_default_deny_test.go
@@ -40,3 +40,12 @@ func TestNoConfigKeepsAnonymousAllowed(t *testing.T) {
 
 	assert.False(t, iam.isEnabled(), "auth must stay off when no config file and no identities are configured")
 }
+
+// The proto parser drops what it does not recognise, so a typo has to be named
+// at startup or the resulting lockout has no visible cause.
+func TestUnknownS3ConfigKeys(t *testing.T) {
+	assert.Equal(t, []string{"identites"}, unknownS3ConfigKeys([]byte(`{"identites":[],"accounts":[]}`)))
+	assert.Empty(t, unknownS3ConfigKeys([]byte(`{"identities":[],"service_accounts":[],"serviceAccounts":[],"policies":[],"groups":[]}`)))
+	assert.Empty(t, unknownS3ConfigKeys([]byte(`{"kms":{},"sts":{},"policy":{},"providers":[],"roles":[]}`)), "sections owned by other subsystems are not typos")
+	assert.Empty(t, unknownS3ConfigKeys([]byte(`not json`)))
+}

--- a/weed/s3api/auth_config_default_deny_test.go
+++ b/weed/s3api/auth_config_default_deny_test.go
@@ -1,0 +1,42 @@
+package s3api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
+	"github.com/stretchr/testify/assert"
+)
+
+// A config file the proto parser reads as empty - a mistyped "identites", an
+// unpopulated secret mount - used to leave the gateway serving every
+// anonymous request, including ListBuckets and bucket creation.
+func TestConfigWithoutIdentitiesDeniesAnonymous(t *testing.T) {
+	resetMemoryStore()
+
+	path := writeTempIamConfig(t, `{"identites":[{"name":"admin","credentials":[{"accessKey":"adminkey","secretKey":"adminsecret"}],"actions":["Admin"]}]}`)
+	iam := NewIdentityAccessManagementWithStore(&S3ApiServerOption{Config: path}, nil, "memory")
+
+	assert.True(t, iam.isEnabled(), "naming a config file asks for authentication, even if it yields no identity")
+
+	handlerCalled := false
+	handler := iam.Auth(func(w http.ResponseWriter, r *http.Request) {
+		handlerCalled = true
+	}, s3_constants.ACTION_LIST)
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil))
+
+	assert.False(t, handlerCalled, "ListBuckets must not run for an anonymous caller")
+	assert.Equal(t, http.StatusForbidden, recorder.Code)
+}
+
+// `weed mini` and `docker run seaweedfs` name no config file and stay open.
+func TestNoConfigKeepsAnonymousAllowed(t *testing.T) {
+	resetMemoryStore()
+
+	iam := NewIdentityAccessManagementWithStore(&S3ApiServerOption{}, nil, "memory")
+
+	assert.False(t, iam.isEnabled(), "auth must stay off when no config file and no identities are configured")
+}

--- a/weed/s3api/auth_config_default_deny_test.go
+++ b/weed/s3api/auth_config_default_deny_test.go
@@ -14,8 +14,9 @@ import (
 // request, including ListBuckets and bucket creation.
 func TestConfigWithoutIdentitiesDeniesAnonymous(t *testing.T) {
 	for name, config := range map[string]string{
-		"empty":            `{"identities":[]}`,
-		"unrecognised key": `{"identity":[{"name":"admin","credentials":[{"accessKey":"adminkey","secretKey":"adminsecret"}],"actions":["Admin"]}]}`,
+		"no identities key": `{}`,
+		"empty":             `{"identities":[]}`,
+		"unrecognised key":  `{"identity":[{"name":"admin","credentials":[{"accessKey":"adminkey","secretKey":"adminsecret"}],"actions":["Admin"]}]}`,
 	} {
 		t.Run(name, func(t *testing.T) {
 			resetMemoryStore()

--- a/weed/s3api/auth_config_default_deny_test.go
+++ b/weed/s3api/auth_config_default_deny_test.go
@@ -9,28 +9,35 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// A config file the proto parser reads as empty - a singular "identity", an
-// unpopulated secret mount - used to leave the gateway serving every
-// anonymous request, including ListBuckets and bucket creation.
+// A config file the proto parser reads as empty - an unpopulated secret mount,
+// a singular "identity" - used to leave the gateway serving every anonymous
+// request, including ListBuckets and bucket creation.
 func TestConfigWithoutIdentitiesDeniesAnonymous(t *testing.T) {
-	resetMemoryStore()
-	clearEnvironmentVariableCredentials(t)
+	for name, config := range map[string]string{
+		"empty":            `{"identities":[]}`,
+		"unrecognised key": `{"identity":[{"name":"admin","credentials":[{"accessKey":"adminkey","secretKey":"adminsecret"}],"actions":["Admin"]}]}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			resetMemoryStore()
+			clearEnvironmentVariableCredentials(t)
 
-	path := writeTempIamConfig(t, `{"identity":[{"name":"admin","credentials":[{"accessKey":"adminkey","secretKey":"adminsecret"}],"actions":["Admin"]}]}`)
-	iam := NewIdentityAccessManagementWithStore(&S3ApiServerOption{Config: path}, nil, "memory")
+			path := writeTempIamConfig(t, config)
+			iam := NewIdentityAccessManagementWithStore(&S3ApiServerOption{Config: path}, nil, "memory")
 
-	assert.True(t, iam.isEnabled(), "naming a config file asks for authentication, even if it yields no identity")
+			assert.True(t, iam.isEnabled(), "naming a config file asks for authentication, even if it yields no identity")
 
-	handlerCalled := false
-	handler := iam.Auth(func(w http.ResponseWriter, r *http.Request) {
-		handlerCalled = true
-	}, s3_constants.ACTION_LIST)
+			handlerCalled := false
+			handler := iam.Auth(func(w http.ResponseWriter, r *http.Request) {
+				handlerCalled = true
+			}, s3_constants.ACTION_LIST)
 
-	recorder := httptest.NewRecorder()
-	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil))
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/", nil))
 
-	assert.False(t, handlerCalled, "ListBuckets must not run for an anonymous caller")
-	assert.Equal(t, http.StatusForbidden, recorder.Code)
+			assert.False(t, handlerCalled, "ListBuckets must not run for an anonymous caller")
+			assert.Equal(t, http.StatusForbidden, recorder.Code)
+		})
+	}
 }
 
 // `weed mini` and `docker run seaweedfs` name no config file and stay open.

--- a/weed/s3api/auth_config_default_deny_test.go
+++ b/weed/s3api/auth_config_default_deny_test.go
@@ -14,6 +14,7 @@ import (
 // anonymous request, including ListBuckets and bucket creation.
 func TestConfigWithoutIdentitiesDeniesAnonymous(t *testing.T) {
 	resetMemoryStore()
+	clearEnvironmentVariableCredentials(t)
 
 	path := writeTempIamConfig(t, `{"identites":[{"name":"admin","credentials":[{"accessKey":"adminkey","secretKey":"adminsecret"}],"actions":["Admin"]}]}`)
 	iam := NewIdentityAccessManagementWithStore(&S3ApiServerOption{Config: path}, nil, "memory")
@@ -35,10 +36,18 @@ func TestConfigWithoutIdentitiesDeniesAnonymous(t *testing.T) {
 // `weed mini` and `docker run seaweedfs` name no config file and stay open.
 func TestNoConfigKeepsAnonymousAllowed(t *testing.T) {
 	resetMemoryStore()
+	clearEnvironmentVariableCredentials(t)
 
 	iam := NewIdentityAccessManagementWithStore(&S3ApiServerOption{}, nil, "memory")
 
 	assert.False(t, iam.isEnabled(), "auth must stay off when no config file and no identities are configured")
+}
+
+// AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY register an admin identity of
+// their own, which would decide isAuthEnabled before the config file does.
+func clearEnvironmentVariableCredentials(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
 }
 
 // The proto parser drops what it does not recognise, so a typo has to be named

--- a/weed/s3api/auth_config_default_deny_test.go
+++ b/weed/s3api/auth_config_default_deny_test.go
@@ -9,14 +9,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// A config file the proto parser reads as empty - a mistyped "identites", an
+// A config file the proto parser reads as empty - a singular "identity", an
 // unpopulated secret mount - used to leave the gateway serving every
 // anonymous request, including ListBuckets and bucket creation.
 func TestConfigWithoutIdentitiesDeniesAnonymous(t *testing.T) {
 	resetMemoryStore()
 	clearEnvironmentVariableCredentials(t)
 
-	path := writeTempIamConfig(t, `{"identites":[{"name":"admin","credentials":[{"accessKey":"adminkey","secretKey":"adminsecret"}],"actions":["Admin"]}]}`)
+	path := writeTempIamConfig(t, `{"identity":[{"name":"admin","credentials":[{"accessKey":"adminkey","secretKey":"adminsecret"}],"actions":["Admin"]}]}`)
 	iam := NewIdentityAccessManagementWithStore(&S3ApiServerOption{Config: path}, nil, "memory")
 
 	assert.True(t, iam.isEnabled(), "naming a config file asks for authentication, even if it yields no identity")
@@ -53,7 +53,7 @@ func clearEnvironmentVariableCredentials(t *testing.T) {
 // The proto parser drops what it does not recognise, so a typo has to be named
 // at startup or the resulting lockout has no visible cause.
 func TestUnknownS3ConfigKeys(t *testing.T) {
-	assert.Equal(t, []string{"identites"}, unknownS3ConfigKeys([]byte(`{"identites":[],"accounts":[]}`)))
+	assert.Equal(t, []string{"identity"}, unknownS3ConfigKeys([]byte(`{"identity":[],"accounts":[]}`)))
 	assert.Empty(t, unknownS3ConfigKeys([]byte(`{"identities":[],"service_accounts":[],"serviceAccounts":[],"policies":[],"groups":[]}`)))
 	assert.Empty(t, unknownS3ConfigKeys([]byte(`{"kms":{},"sts":{},"policy":{},"providers":[],"roles":[]}`)), "sections owned by other subsystems are not typos")
 	assert.Empty(t, unknownS3ConfigKeys([]byte(`not json`)))

--- a/weed/s3api/auth_credentials.go
+++ b/weed/s3api/auth_credentials.go
@@ -404,7 +404,7 @@ func NewIdentityAccessManagementWithStore(option *S3ApiServerOption, filerClient
 	identityCount := len(iam.identities)
 	// Pointing the gateway at a config file is the operator asking for
 	// authentication. A file that yields no identity - an empty secret mount, a
-	// mistyped key the proto parser drops - must deny everyone rather than serve
+	// key the proto parser does not recognise - must deny everyone rather than serve
 	// the cluster to anonymous callers.
 	iam.isAuthEnabled = identityCount > 0 || startConfigFile != ""
 	iam.m.Unlock()
@@ -660,8 +660,8 @@ func (iam *IdentityAccessManagement) loadS3ApiConfigurationFromFile(fileName str
 var nonIdentityS3ConfigKeys = []string{"kms", "sts", "policy", "providers", "roles"}
 
 // unknownS3ConfigKeys returns the top-level keys the proto parser discards. A
-// mistyped "identites" otherwise loads as an empty config, which denies every
-// request with nothing pointing at the typo.
+// singular "identity" otherwise loads as an empty config, which denies every
+// request with nothing pointing at the mistake.
 func unknownS3ConfigKeys(content []byte) []string {
 	var root map[string]json.RawMessage
 	if err := json.Unmarshal(content, &root); err != nil {

--- a/weed/s3api/auth_credentials.go
+++ b/weed/s3api/auth_credentials.go
@@ -400,24 +400,23 @@ func NewIdentityAccessManagementWithStore(option *S3ApiServerOption, filerClient
 	// For "weed mini" without any S3 config, default to allowing all access (isAuthEnabled = false)
 	// If any credentials are configured (via file, filer, or env vars), enable authentication
 	iam.m.Lock()
-	iam.isAuthEnabled = len(iam.identities) > 0
+	identityCount := len(iam.identities)
+	// Pointing the gateway at a config file is the operator asking for
+	// authentication. A file that yields no identity - an empty secret mount, a
+	// mistyped key the proto parser drops - must deny everyone rather than serve
+	// the cluster to anonymous callers.
+	iam.isAuthEnabled = identityCount > 0 || startConfigFile != ""
 	iam.m.Unlock()
-	if iam.isAuthEnabled {
-		hasAnyIdentity.Store(true)
-	}
 
-	if iam.isAuthEnabled {
-		// Credentials were configured - enable authentication
-		glog.V(1).Infof("S3 authentication enabled (%d identities configured)", len(iam.identities))
-	} else {
-		// No credentials configured
-		if startConfigFile != "" {
-			// Config file was specified but contained no identities - this is unusual, log a warning
-			glog.Warningf("S3 config file %s specified but no identities loaded - authentication disabled", startConfigFile)
-		} else {
-			// No config file and no identities - this is the normal allow-all case
-			glog.V(1).Infof("S3 authentication disabled - no credentials configured (allowing all access)")
-		}
+	switch {
+	case identityCount > 0:
+		hasAnyIdentity.Store(true)
+		glog.V(1).Infof("S3 authentication enabled (%d identities configured)", identityCount)
+	case startConfigFile != "":
+		glog.Warningf("S3 config file %s loaded no identities - every request is denied until one is configured", startConfigFile)
+	default:
+		// No config file and no identities - this is the normal allow-all case
+		glog.V(1).Infof("S3 authentication disabled - no credentials configured (allowing all access)")
 	}
 
 	return iam
@@ -1297,6 +1296,7 @@ func (iam *IdentityAccessManagement) UpsertIdentity(ident *iam_pb.Identity) erro
 //
 // Driven solely by isAuthEnabled, which is set when:
 //   - any locally managed identities/credentials are loaded (file/filer/env), or
+//   - the operator names a config file, whether or not it yields an identity, or
 //   - the operator passes -s3.iam.config, which triggers EnableAuthEnforcement
 //     at startup time even before any identities sync in.
 //

--- a/weed/s3api/auth_credentials.go
+++ b/weed/s3api/auth_credentials.go
@@ -28,6 +28,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
 	"github.com/seaweedfs/seaweedfs/weed/util/wildcard"
 	"github.com/seaweedfs/seaweedfs/weed/wdclient"
+	"google.golang.org/protobuf/reflect/protoreflect"
 
 	// Import KMS providers to register them
 	_ "github.com/seaweedfs/seaweedfs/weed/kms/aws"
@@ -628,6 +629,10 @@ func (iam *IdentityAccessManagement) loadS3ApiConfigurationFromFile(fileName str
 		return fmt.Errorf("fail to read %s : %v", fileName, readErr)
 	}
 
+	if unknown := unknownS3ConfigKeys(content); len(unknown) > 0 {
+		glog.Warningf("S3 config %s: ignoring unknown top-level keys %v", fileName, unknown)
+	}
+
 	// Initialize KMS if configuration contains KMS settings
 	if err := iam.initializeKMSFromConfig(content); err != nil {
 		glog.Warningf("KMS initialization failed: %v", err)
@@ -647,6 +652,31 @@ func (iam *IdentityAccessManagement) loadS3ApiConfigurationFromFile(fileName str
 	iam.markStaticIdentities(config)
 	iam.updateCredentialManagerStaticIdentities()
 	return nil
+}
+
+// nonIdentityS3ConfigKeys are the top-level sections of a config file that
+// belong to another subsystem rather than to S3ApiConfiguration: the KMS block,
+// and the advanced IAM blocks of a -s3.iam.config file.
+var nonIdentityS3ConfigKeys = []string{"kms", "sts", "policy", "providers", "roles"}
+
+// unknownS3ConfigKeys returns the top-level keys the proto parser discards. A
+// mistyped "identites" otherwise loads as an empty config, which denies every
+// request with nothing pointing at the typo.
+func unknownS3ConfigKeys(content []byte) []string {
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(content, &root); err != nil {
+		return nil
+	}
+	fields := (&iam_pb.S3ApiConfiguration{}).ProtoReflect().Descriptor().Fields()
+	var unknown []string
+	for key := range root {
+		if slices.Contains(nonIdentityS3ConfigKeys, key) || fields.ByName(protoreflect.Name(key)) != nil || fields.ByJSONName(key) != nil {
+			continue
+		}
+		unknown = append(unknown, key)
+	}
+	slices.Sort(unknown)
+	return unknown
 }
 
 func (iam *IdentityAccessManagement) LoadS3ApiConfigurationFromBytes(content []byte) error {


### PR DESCRIPTION
Fixes #10952

## What happens today

An S3 gateway started with `-s3.config` serves **every anonymous request** whenever that file loads no identity:

```
$ cat s3.json
{ "identity": [ { "name": "admin", "credentials": [...], "actions": ["Admin"] } ] }
                ^ singular; the field is "identities"

$ weed server -s3 -s3.config=s3.json
W ... S3 config file s3.json specified but no identities loaded - authentication disabled

$ curl -s -w '%{http_code}' http://127.0.0.1:8333/
<ListAllMyBucketsResult ...><Owner><ID></ID></Owner><Buckets></Buckets></ListAllMyBucketsResult>200

$ curl -s -X PUT -w '%{http_code}' http://127.0.0.1:8333/anonbucket
200
```

The identity config is parsed with `DiscardUnknown: true`, so an unrecognised top-level key, an unpopulated secret mount, or an advanced-IAM-shaped file passed to `-s3.config` all parse "successfully" into zero identities. `isAuthEnabled` was then `len(identities) > 0`, i.e. false, and the gateway fell back to allow-all: not just the `200` on `ListBuckets` from the report, but anonymous bucket creation and object writes too.

## Changes

**1. Deny by default when a supplied config loads no identities.** Naming a config file is the operator asking for authentication, so the fallback is now deny-everyone rather than allow-everyone. The startup log says so:

```
W ... S3 config file s3.json loaded no identities - every request is denied until one is configured
```

**2. Name the discarded top-level keys.** Without this the lockout above has no visible cause; now startup prints `ignoring unknown top-level keys [identity]`. Sections owned by other subsystems (`kms`, and the `sts`/`policy`/`providers`/`roles` blocks of an `-s3.iam.config` file) are not flagged.

Unchanged: with no config file and no identities — `weed mini`, `docker run seaweedfs` — anonymous access stays open, which is what makes the image work out of the box (#9557).

## On the other items in the issue

- *"Default-deny anonymous when auth is enabled and no `anonymous` identity exists"* already holds on master. With one admin identity and no `anonymous` entry, anonymous `GET /`, `PUT /bucket`, `POST /` (S3Tables), and virtual-host `GET /` all return `403`. The reported `200` comes from the zero-identity path above, not from a missing `anonymous` entry.
- *"`defaultEffect: Deny` is unusable with `-s3.config` (#7720)"* no longer holds either. The two flags combine today: `-s3.config` supplies the static identities and `-s3.iam.config` supplies STS/roles/`defaultEffect`. Verified by running both together — signed admin requests succeed, anonymous gets `403`.

No new CLI flag: the secure behavior is the behavior.

## Testing

- `TestConfigWithoutIdentitiesDeniesAnonymous` — a config with an unrecognised key enables auth and `403`s anonymous `ListBuckets` through the real `Auth` middleware.
- `TestNoConfigKeepsAnonymousAllowed` — the no-config allow-all path is preserved.
- `TestUnknownS3ConfigKeys` — unrecognised keys are named, other subsystems' sections are not.
- Manual end-to-end against `weed server -s3`: unrecognised-key config now `403`s anonymous `GET /`, `PUT` bucket and `PUT` object; a valid config still lets a SigV4 admin create buckets, upload and list while anonymous gets `403`; no config still serves anonymous.
- `go test ./weed/s3api/...` green.

No Rust counterpart: the S3 gateway exists only in Go.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * S3 authentication is enforced whenever an authentication configuration file is provided, even if it contains no identities.
  * Startup messages clarify whether authentication is configured, empty, or disabled.
  * Configuration validation reports unrecognized S3 settings while accepting supported KMS and IAM sections.

* **Bug Fixes**
  * Anonymous access remains available when no authentication configuration is provided.
  * Improved configuration-key validation helps identify authentication setup errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->