### PR TITLE
mount: name the disk after the mounted path

### DIFF
--- a/weed/command/mount.go
+++ b/weed/command/mount.go
@@ -199,6 +199,10 @@ var cmdMount = &Command{
   at the desktop; the network path form is reachable from every session, and
   each user can map their own drive letter to it.
 
+  Where the platform labels the disk, in Finder and in Explorer, the mounted
+  path names it: -filer.path="/Image Disk" shows up as "Image Disk". Mounting
+  the whole tree labels it with the filer address instead.
+
   RDMA Acceleration:
   For ultra-fast reads, enable RDMA acceleration with an RDMA sidecar:
     weed mount -filer=localhost:8888 -dir=/mnt/seaweedfs \

--- a/weed/command/mount_common.go
+++ b/weed/command/mount_common.go
@@ -283,3 +283,14 @@ func resolveCacheDirs(option *MountOptions) (string, string) {
 	}
 	return cacheDirForRead, cacheDirForWrite
 }
+
+// volumeName labels the mount where the platform shows one, in Finder and in
+// Explorer. The mounted path names the disk; the filer address, which every
+// mount from one filer shares, is only the whole-tree fallback.
+func volumeName(filer, filerMountRootPath string) string {
+	name := path.Base(filerMountRootPath)
+	if name == "/" || name == "." {
+		name = filer
+	}
+	return strings.ReplaceAll(name, ",", "+")
+}

--- a/weed/command/mount_common_test.go
+++ b/weed/command/mount_common_test.go
@@ -1,0 +1,58 @@
+//go:build linux || darwin || freebsd || windows
+
+package command
+
+import "testing"
+
+func Test_volumeName(t *testing.T) {
+	tests := []struct {
+		name               string
+		filer              string
+		filerMountRootPath string
+		expected           string
+	}{
+		{
+			name:               "whole tree falls back to the filer",
+			filer:              "127.0.0.1:8888",
+			filerMountRootPath: "/",
+			expected:           "127.0.0.1:8888",
+		},
+		{
+			name:               "empty path falls back to the filer",
+			filer:              "127.0.0.1:8888",
+			filerMountRootPath: "",
+			expected:           "127.0.0.1:8888",
+		},
+		{
+			name:               "several filers stay parseable as one option",
+			filer:              "127.0.0.1:8888,127.0.0.1:8889",
+			filerMountRootPath: "/",
+			expected:           "127.0.0.1:8888+127.0.0.1:8889",
+		},
+		{
+			name:               "mounted directory names the disk",
+			filer:              "127.0.0.1:8888",
+			filerMountRootPath: "/buckets/images",
+			expected:           "images",
+		},
+		{
+			name:               "trailing slash is not a name",
+			filer:              "127.0.0.1:8888",
+			filerMountRootPath: "/buckets/videos/",
+			expected:           "videos",
+		},
+		{
+			name:               "spaces are kept, commas are not",
+			filer:              "127.0.0.1:8888",
+			filerMountRootPath: "/Image, Disk",
+			expected:           "Image+ Disk",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := volumeName(tt.filer, tt.filerMountRootPath); got != tt.expected {
+				t.Errorf("volumeName(%q, %q) = %q, want %q", tt.filer, tt.filerMountRootPath, got, tt.expected)
+			}
+		})
+	}
+}

--- a/weed/command/mount_std.go
+++ b/weed/command/mount_std.go
@@ -180,7 +180,7 @@ func RunMount(option *MountOptions, umask os.FileMode) bool {
 			fuseMountOptions.Options = append(fuseMountOptions.Options, "novncache")
 		}
 		fuseMountOptions.Options = append(fuseMountOptions.Options, "slow_statfs")
-		fuseMountOptions.Options = append(fuseMountOptions.Options, "volname="+serverFriendlyName)
+		fuseMountOptions.Options = append(fuseMountOptions.Options, "volname="+volumeName(*option.filer, filerMountRootPath))
 		fuseMountOptions.Options = append(fuseMountOptions.Options, fmt.Sprintf("iosize=%d", ioSizeMB*1024*1024))
 	}
 

--- a/weed/command/mount_std.go
+++ b/weed/command/mount_std.go
@@ -134,7 +134,6 @@ func RunMount(option *MountOptions, umask os.FileMode) bool {
 	// mount fuse
 	fuseMountOptions := &fuse.MountOptions{
 		AllowOther:               *option.allowOthers,
-		Options:                  option.extraOptions,
 		MaxBackground:            maxBackground,
 		CongestionThreshold:      congestionThreshold,
 		MaxWrite:                 1024 * 1024 * 2,
@@ -183,6 +182,9 @@ func RunMount(option *MountOptions, umask os.FileMode) bool {
 		fuseMountOptions.Options = append(fuseMountOptions.Options, "volname="+volumeName(*option.filer, filerMountRootPath))
 		fuseMountOptions.Options = append(fuseMountOptions.Options, fmt.Sprintf("iosize=%d", ioSizeMB*1024*1024))
 	}
+	// Last, so an option given on the command line wins over the default
+	// this mount picked for it.
+	fuseMountOptions.Options = append(fuseMountOptions.Options, option.extraOptions...)
 
 	if option.writebackCache != nil {
 		fuseMountOptions.EnableWriteback = *option.writebackCache

--- a/weed/command/mount_windows.go
+++ b/weed/command/mount_windows.go
@@ -104,7 +104,7 @@ func RunMount(option *MountOptions, umask os.FileMode) bool {
 	}
 
 	host := winfsp.New(seaweedFileSystem, winfsp.Options{
-		VolumeName:   strings.ReplaceAll(*option.filer, ",", "+"),
+		VolumeName:   volumeName(*option.filer, *option.filerMountRootPath),
 		Uid:          ownedByMounter,
 		Gid:          ownedByMounter,
 		CacheTimeout: windowsCacheTimeout,


### PR DESCRIPTION
Closes #10957.

Every mount was labelled with the filer address, so a user with several mounts from one filer saw the same "127.0.0.1" disk in Finder or Explorer for all of them, with nothing to tell an image disk from a video disk.

The mounted path is what already distinguishes those mounts, and `df` has always shown it — `FsName` is `filer:filer.path`. The volume label now uses it too: `-filer.path="/Image Disk"` gives a disk named `Image Disk`, and only a whole-tree mount keeps the filer address. Labels are short by convention and WinFsp caps them at 32 characters, so the label is the path's last segment rather than the whole thing.

Second commit: `-o` options were placed *before* the ones the mount derives for itself, so `weed fuse -o volname=...` (and `iosize`, `daemon_timeout`, ...) lost to the derived value. They are appended last now, which is what the Windows adapter already documents for its own passthrough.

No new flags — the name comes from what is mounted.

Not exercised against a live mount: this machine has no loadable macFUSE kext and no Windows host. The label derivation is covered by `Test_volumeName`, and `weed/command` builds for linux, darwin and windows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mount labels on Windows and macOS now reflect the mounted filer path, making mounted volumes easier to identify.
  * Mounting an entire filer tree continues to use the filer address as the volume label.
  * Custom mount options now take precedence over platform defaults.

* **Documentation**
  * Added guidance explaining how platform-specific mount labels are determined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->