### PR TITLE
master: cap the reported capacity at what the disks hold

### DIFF
--- a/weed/mount/weedfs_stats.go
+++ b/weed/mount/weedfs_stats.go
@@ -64,8 +64,8 @@ func (wfs *WFS) StatFs(cancel <-chan struct{}, in *fuse.InHeader, out *fuse.Stat
 			return nil
 		})
 		if err != nil {
+			// the last known sizes beat the empty filesystem a bare return reports
 			glog.V(0).Infof("filer Statistics: %v", err)
-			return fuse.OK
 		}
 	}
 

--- a/weed/server/master_grpc_server_statistics_test.go
+++ b/weed/server/master_grpc_server_statistics_test.go
@@ -123,11 +123,11 @@ func TestStatisticsReplicaCopyCount(t *testing.T) {
 	}
 }
 
-// reportDiskBytes has every node report the same filesystem capacity, the way
-// a volume server does in its heartbeat.
-func reportDiskBytes(ms *MasterServer, totalBytes, freeBytes uint64) {
+// reportDiskBytes has the first nodeCount nodes report the same filesystem
+// capacity, the way a volume server does in its heartbeat.
+func reportDiskBytes(ms *MasterServer, nodeCount int, totalBytes, freeBytes uint64) {
 	rack := ms.Topo.GetOrCreateDataCenter("dc1").GetOrCreateRack("rack1")
-	for _, node := range rack.Children() {
+	for _, node := range rack.Children()[:nodeCount] {
 		node.(*topology.DataNode).AdjustDiskUsageBytes(
 			map[string]uint64{"": totalBytes}, map[string]uint64{"": freeBytes})
 	}
@@ -153,13 +153,20 @@ func TestStatisticsPhysicalCapacity(t *testing.T) {
 		t.Fatalf("disks that report nothing: got %d, want %d", got, slotCapacity)
 	}
 
-	reportDiskBytes(ms, 8<<20, 1<<20)
+	// a volume server too old to report leaves the whole cluster on its slots,
+	// since the room it holds would otherwise go missing
+	reportDiskBytes(ms, 3, 8<<20, 1<<20)
+	if got := statistics().TotalSize; got != slotCapacity {
+		t.Errorf("one disk of four reporting nothing: got %d, want %d", got, slotCapacity)
+	}
+
+	reportDiskBytes(ms, 4, 8<<20, 1<<20)
 	resp := statistics()
 	if want := resp.UsedSize + (4 << 20); resp.TotalSize != want {
 		t.Errorf("four disks with 1MB free: got %d, want %d", resp.TotalSize, want)
 	}
 
-	reportDiskBytes(ms, 1<<30, 1<<30)
+	reportDiskBytes(ms, 4, 1<<30, 1<<30)
 	if got := statistics().TotalSize; got != slotCapacity {
 		t.Errorf("disks roomier than the slots: got %d, want %d", got, slotCapacity)
 	}

--- a/weed/server/master_grpc_server_statistics_test.go
+++ b/weed/server/master_grpc_server_statistics_test.go
@@ -122,3 +122,45 @@ func TestStatisticsReplicaCopyCount(t *testing.T) {
 		})
 	}
 }
+
+// reportDiskBytes has every node report the same filesystem capacity, the way
+// a volume server does in its heartbeat.
+func reportDiskBytes(ms *MasterServer, totalBytes, freeBytes uint64) {
+	rack := ms.Topo.GetOrCreateDataCenter("dc1").GetOrCreateRack("rack1")
+	for _, node := range rack.Children() {
+		node.(*topology.DataNode).AdjustDiskUsageBytes(
+			map[string]uint64{"": totalBytes}, map[string]uint64{"": freeBytes})
+	}
+}
+
+// TestStatisticsPhysicalCapacity covers a cluster configured with more volume
+// slots than its disks hold. Slots promise 40MB here; what the disks can still
+// take is what gets reported.
+func TestStatisticsPhysicalCapacity(t *testing.T) {
+	ms := newStatisticsMaster(t)
+
+	slotCapacity := uint64(40 * 1024 * 1024)
+	statistics := func() *master_pb.StatisticsResponse {
+		t.Helper()
+		resp, err := ms.Statistics(context.Background(), &master_pb.StatisticsRequest{})
+		if err != nil {
+			t.Fatalf("Statistics: %v", err)
+		}
+		return resp
+	}
+
+	if got := statistics().TotalSize; got != slotCapacity {
+		t.Fatalf("disks that report nothing: got %d, want %d", got, slotCapacity)
+	}
+
+	reportDiskBytes(ms, 8<<20, 1<<20)
+	resp := statistics()
+	if want := resp.UsedSize + (4 << 20); resp.TotalSize != want {
+		t.Errorf("four disks with 1MB free: got %d, want %d", resp.TotalSize, want)
+	}
+
+	reportDiskBytes(ms, 1<<30, 1<<30)
+	if got := statistics().TotalSize; got != slotCapacity {
+		t.Errorf("disks roomier than the slots: got %d, want %d", got, slotCapacity)
+	}
+}

--- a/weed/server/master_grpc_server_volume.go
+++ b/weed/server/master_grpc_server_volume.go
@@ -243,7 +243,7 @@ func (ms *MasterServer) Statistics(ctx context.Context, req *master_pb.Statistic
 	// more of them than its disks hold would report space it can never take.
 	// What the disks still have free, on top of what the cluster already wrote,
 	// is the real ceiling.
-	if freeBytes, reported := ms.Topo.GetDiskUsages().FreeBytes(); reported {
+	if freeBytes, reported := ms.Topo.FreeBytes(); reported {
 		totalSize = min(totalSize, clusterUsedSize+freeBytes)
 	}
 	// and the free space holds that many copies fewer of whatever the caller writes

--- a/weed/server/master_grpc_server_volume.go
+++ b/weed/server/master_grpc_server_volume.go
@@ -239,6 +239,13 @@ func (ms *MasterServer) Statistics(ctx context.Context, req *master_pb.Statistic
 	if req.Collection != "" {
 		clusterUsedSize = ms.Topo.CollectionVolumeStats("").UsedSize
 	}
+	// volume slots are provisioning, not capacity: a cluster configured with
+	// more of them than its disks hold would report space it can never take.
+	// What the disks still have free, on top of what the cluster already wrote,
+	// is the real ceiling.
+	if freeBytes, reported := ms.Topo.GetDiskUsages().FreeBytes(); reported {
+		totalSize = min(totalSize, clusterUsedSize+freeBytes)
+	}
 	// and the free space holds that many copies fewer of whatever the caller writes
 	var freeSize uint64
 	if totalSize > clusterUsedSize {

--- a/weed/topology/disk.go
+++ b/weed/topology/disk.go
@@ -129,6 +129,24 @@ func (d *DiskUsages) GetMaxVolumeCount() (maxVolumeCount int64) {
 	return
 }
 
+// FreeBytes sums the space the volume servers report as still free on their
+// filesystems. reported is false when none of them said anything -- a failed
+// statfs and a volume server older than the field look the same -- so callers
+// can fall back to counting volume slots.
+func (d *DiskUsages) FreeBytes() (freeBytes uint64, reported bool) {
+	d.RLock()
+	defer d.RUnlock()
+	for _, diskUsageCounts := range d.usages {
+		usage := diskUsageCounts.snapshot()
+		if usage.diskTotalBytes <= 0 {
+			continue
+		}
+		reported = true
+		freeBytes += uint64(max(0, usage.diskFreeBytes))
+	}
+	return
+}
+
 type DiskUsageCounts struct {
 	volumeCount       int64
 	remoteVolumeCount int64

--- a/weed/topology/disk.go
+++ b/weed/topology/disk.go
@@ -129,22 +129,24 @@ func (d *DiskUsages) GetMaxVolumeCount() (maxVolumeCount int64) {
 	return
 }
 
-// FreeBytes sums the space the volume servers report as still free on their
-// filesystems. reported is false when none of them said anything -- a failed
-// statfs and a volume server older than the field look the same -- so callers
-// can fall back to counting volume slots.
+// FreeBytes sums the space one volume server reports as still free on its
+// filesystems. reported is false as soon as a disk holding volume slots says
+// nothing -- a volume server older than the field looks that way -- since
+// leaving its space out would understate the room the server has.
 func (d *DiskUsages) FreeBytes() (freeBytes uint64, reported bool) {
 	d.RLock()
 	defer d.RUnlock()
 	for _, diskUsageCounts := range d.usages {
 		usage := diskUsageCounts.snapshot()
 		if usage.diskTotalBytes <= 0 {
+			if usage.maxVolumeCount > 0 {
+				return 0, false
+			}
 			continue
 		}
-		reported = true
 		freeBytes += uint64(max(0, usage.diskFreeBytes))
 	}
-	return
+	return freeBytes, true
 }
 
 type DiskUsageCounts struct {

--- a/weed/topology/topology.go
+++ b/weed/topology/topology.go
@@ -162,6 +162,25 @@ func (t *Topology) unregisterDataNodeAddress(addr pb.ServerAddress, dn *DataNode
 	}
 }
 
+// FreeBytes sums what every volume server reports as free on its filesystems.
+// reported is false unless all of them answered: the one that stayed quiet may
+// be the one holding the room, and a partial sum would read as a cluster with
+// none left.
+func (t *Topology) FreeBytes() (freeBytes uint64, reported bool) {
+	for _, dcNode := range t.Children() {
+		for _, rackNode := range dcNode.Children() {
+			for _, dataNode := range rackNode.Children() {
+				nodeFreeBytes, nodeReported := dataNode.GetDiskUsages().FreeBytes()
+				if !nodeReported {
+					return 0, false
+				}
+				freeBytes += nodeFreeBytes
+			}
+		}
+	}
+	return freeBytes, true
+}
+
 func (t *Topology) IsChildLocked() (bool, error) {
 	if t.IsLocked() {
 		return true, errors.New("topology is locked")


### PR DESCRIPTION
Fixes #10959.

## What was happening

`Statistics` answered with `max volume count * volume size limit`: how many
volumes the cluster is *allowed* to place, times how big each is allowed to get.
That is a provisioning number. It says nothing about how much space exists, and
writing or deleting data changes neither term, so it never moves.

`weed mount` feeds that number straight into `statfs`, so on Windows it lands in
Explorer's drive properties and in `dir`, where a capacity that is both wrong and
frozen is impossible to miss.

## Reproduction

A single volume server with 65536 slots, on a 460GB disk with 13GB free:

```
$ weed server -dir=/tmp/d -volume.max=65536 ...
$ # filer Statistics:
TotalSize=2111062325329920 (1966080.00 GiB)   # 1.9PB
UsedSize=0
```

1.9PB of capacity on a disk that holds 460GB. Writing 800MB moves `UsedSize` by
that much and leaves the reported free space visually unchanged, which is the
second half of the report.

## After

```
TotalSize=13714071552 (12.77 GiB)   # what df says is free
UsedSize=0
```

and after writing 800MB:

```
TotalSize=12881190336 (12.00 GiB)
```

The volume servers already send each filesystem's total and free bytes in every
heartbeat -- `command_volume_balance` and the EC balancer read them -- so the
master now bounds its answer by what the disks say is left: `min(slot capacity,
already written + free bytes)`. A disk roomier than its slot allowance keeps
reporting the slot limit, which is the real ceiling there. A volume server that
reports no disk bytes (older build, or a failed statfs) leaves the cluster on the
slot-only answer, so a mixed-version cluster degrades to today's behaviour rather
than to zero.

This is not Windows-specific -- `df` on a unix mount reported the same 1.9PB --
but Windows is where it is in the user's face.

## Second commit

A failed `Statistics` call returned from `StatFs` before filling in the answer,
so a mount whose filer or master was briefly unreachable reported an empty
filesystem instead of the sizes it already had. It now falls through to the last
known values.

## Tests

`TestStatisticsPhysicalCapacity` covers all three cases: nothing reported, disks
tighter than the slots, disks roomier than the slots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved statistics reporting when filesystem refreshes fail by retaining the latest cached values.
  - Prevented reported cluster capacity from exceeding physical disk capacity.
  - Improved capacity calculations when disk usage data is incomplete or exceeds configured limits.

- **Tests**
  - Added coverage for physical disk capacity and volume-slot capacity handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->