### PR TITLE
DIAGNOSTIC (do not merge): reproduce the flaky winfsp rename source

### DIFF
--- a/.github/workflows/mount-windows.yml
+++ b/.github/workflows/mount-windows.yml
@@ -77,7 +77,7 @@ jobs:
 
         function Start-Mount($log) {
           Start-Process -FilePath .\weed.exe `
-            -ArgumentList '-logtostderr','-v=4','mount','-filer=127.0.0.1:8888','-dir=S:' `
+            -ArgumentList '-logtostderr','mount','-filer=127.0.0.1:8888','-dir=S:' `
             -RedirectStandardOutput "C:\$log.log" -RedirectStandardError "C:\$log.err.log"
           $deadline = (Get-Date).AddMinutes(2)
           while ((Get-Date) -lt $deadline) {

--- a/.github/workflows/mount-windows.yml
+++ b/.github/workflows/mount-windows.yml
@@ -77,7 +77,7 @@ jobs:
 
         function Start-Mount($log) {
           Start-Process -FilePath .\weed.exe `
-            -ArgumentList '-logtostderr','mount','-filer=127.0.0.1:8888','-dir=S:' `
+            -ArgumentList '-logtostderr','-v=4','mount','-filer=127.0.0.1:8888','-dir=S:' `
             -RedirectStandardOutput "C:\$log.log" -RedirectStandardError "C:\$log.err.log"
           $deadline = (Get-Date).AddMinutes(2)
           while ((Get-Date) -lt $deadline) {
@@ -128,6 +128,9 @@ jobs:
         Start-Mount 'seaweed-mount'
 
         Invoke-Tests 'rename-loop' @('test','-v','-failfast','-count=300','-timeout','25m','./test/winfsp','-run','TestRenameOverExisting','-mountpoint=S:\')
+
+        Write-Host "diagnostic run: stopping after the rename loop"
+        exit 0
 
         Invoke-Tests 'exercise' @('test','-v','-timeout','20m','./test/winfsp','-mountpoint=S:\')
         Invoke-Tests 'persist-write' @('test','-v','-timeout','15m','./test/winfsp','-run','TestPersistence','-mountpoint=S:\','-phase=write','-filer=127.0.0.1:8888')

--- a/.github/workflows/mount-windows.yml
+++ b/.github/workflows/mount-windows.yml
@@ -77,7 +77,7 @@ jobs:
 
         function Start-Mount($log) {
           Start-Process -FilePath .\weed.exe `
-            -ArgumentList '-logtostderr','mount','-filer=127.0.0.1:8888','-dir=S:' `
+            -ArgumentList '-logtostderr','-v=4','mount','-filer=127.0.0.1:8888','-dir=S:' `
             -RedirectStandardOutput "C:\$log.log" -RedirectStandardError "C:\$log.err.log"
           $deadline = (Get-Date).AddMinutes(2)
           while ((Get-Date) -lt $deadline) {
@@ -126,6 +126,8 @@ jobs:
         Write-Host "filer is up on http 8888 and grpc 18888"
 
         Start-Mount 'seaweed-mount'
+
+        Invoke-Tests 'rename-loop' @('test','-v','-failfast','-count=300','-timeout','25m','./test/winfsp','-run','TestRenameOverExisting','-mountpoint=S:\')
 
         Invoke-Tests 'exercise' @('test','-v','-timeout','20m','./test/winfsp','-mountpoint=S:\')
         Invoke-Tests 'persist-write' @('test','-v','-timeout','15m','./test/winfsp','-run','TestPersistence','-mountpoint=S:\','-phase=write','-filer=127.0.0.1:8888')
@@ -190,5 +192,5 @@ jobs:
       shell: pwsh
       run: |
         foreach ($f in 'C:\seaweed-mount.log','C:\seaweed-mount.err.log','C:\seaweed-remount.log','C:\seaweed-remount.err.log','C:\seaweed-remount2.log','C:\seaweed-remount2.err.log','C:\seaweed-dirmount.log','C:\seaweed-dirmount.err.log','C:\seaweed-mini.log','C:\seaweed-mini.err.log') {
-          if (Test-Path $f) { Write-Host "===== $f"; Get-Content $f -Tail 200 }
+          if (Test-Path $f) { Write-Host "===== $f"; Get-Content $f -Tail 4000 }
         }

--- a/test/winfsp/semantics_test.go
+++ b/test/winfsp/semantics_test.go
@@ -180,9 +180,31 @@ func TestRenameOverExisting(t *testing.T) {
 		// they indict different layers; a second look says whether it persists.
 		time.Sleep(200 * time.Millisecond)
 		fi2, err2 := os.Stat(src)
-		t.Fatalf("stat of the renamed-away source did not return not-exist: stat=%v err=%v; 200ms later stat=%v err=%v",
-			describeFileInfo(fi), err, describeFileInfo(fi2), err2)
+		// Which layer answered narrows the search. A listing goes through
+		// readdir, which reads no per-path cache, and the mount's own path
+		// cache forgets within a second; a name that survives both came back
+		// from the filer.
+		listed := dirNames(t, dir)
+		time.Sleep(2 * time.Second)
+		_, errLater := os.Stat(src)
+		t.Fatalf("stat of the renamed-away source did not return not-exist: stat=%v err=%v; 200ms later stat=%v err=%v; past the path cache err=%v; %s lists %v",
+			describeFileInfo(fi), err, describeFileInfo(fi2), err2, errLater, dir, listed)
 	}
+}
+
+// dirNames lists a directory for a failure message, reporting the error in
+// place of the names rather than failing a test that is already failing.
+func dirNames(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return []string{"readdir: " + err.Error()}
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	return names
 }
 
 func TestRenameAcrossDirectories(t *testing.T) {

--- a/test/winfsp/semantics_test.go
+++ b/test/winfsp/semantics_test.go
@@ -180,10 +180,8 @@ func TestRenameOverExisting(t *testing.T) {
 		// they indict different layers; a second look says whether it persists.
 		time.Sleep(200 * time.Millisecond)
 		fi2, err2 := os.Stat(src)
-		// Which layer answered narrows the search. A listing goes through
-		// readdir, which reads no per-path cache, and the mount's own path
-		// cache forgets within a second; a name that survives both came back
-		// from the filer.
+		// A listing reads no per-path cache and the mount's own forgets
+		// within a second, so a name that survives both is back on the filer.
 		listed := dirNames(t, dir)
 		time.Sleep(2 * time.Second)
 		_, errLater := os.Stat(src)

--- a/weed/mount/meta_cache/meta_cache.go
+++ b/weed/mount/meta_cache/meta_cache.go
@@ -201,7 +201,7 @@ func (mc *MetaCache) atomicUpdateEntryFromFilerLocked(ctx context.Context, oldPa
 	vacatingOldPath := oldPath != "" && !(newEntry != nil && oldPath == newEntry.FullPath)
 	if entry != nil && vacatingOldPath {
 		ctx = context.WithValue(ctx, "OP", "MV")
-		glog.V(3).Infof("DeleteEntry %s", oldPath)
+		glog.V(0).Infof("DIAG DeleteEntry %s", oldPath)
 		if err := mc.localStore.DeleteEntry(ctx, oldPath); err != nil {
 			return err
 		}
@@ -223,7 +223,7 @@ func (mc *MetaCache) atomicUpdateEntryFromFilerLocked(ctx context.Context, oldPa
 	if newEntry != nil {
 		newDir, _ := newEntry.DirAndName()
 		if allowUncachedInsert || mc.isCachedFn(util.FullPath(newDir)) {
-			glog.V(3).Infof("InsertEntry %s/%s", newDir, newEntry.Name())
+			glog.V(0).Infof("DIAG InsertEntry %s/%s", newDir, newEntry.Name())
 			if err := mc.localStore.InsertEntry(ctx, newEntry); err != nil {
 				return err
 			}

--- a/weed/mount/weedfs_file_sync.go
+++ b/weed/mount/weedfs_file_sync.go
@@ -218,6 +218,17 @@ func (wfs *WFS) flushMetadataToFiler(ctx context.Context, fh *FileHandle, dir, n
 		return nil
 	}
 
+	// The name is only ours to write while it still belongs to this inode. A
+	// rename that replaced it handed it to another entry, and writing here
+	// would overwrite that entry with this handle's stale one. Windows makes
+	// this easy to hit: the close carrying the flush runs after the
+	// application's CloseHandle has already returned, so a handle on the
+	// replaced destination flushes once the rename has landed.
+	if inode, found := wfs.inodeToPath.GetInode(util.FullPath(dir).Child(name)); found && inode != fh.inode {
+		glog.V(3).Infof("flushMetadataToFiler %s/%s fh %d: the name now holds inode %d, skipping", dir, name, fh.fh, inode)
+		return nil
+	}
+
 	entry := fh.GetEntry()
 	entry.Name = name // this flush may be just after a rename operation
 

--- a/weed/mount/weedfs_file_sync.go
+++ b/weed/mount/weedfs_file_sync.go
@@ -218,17 +218,6 @@ func (wfs *WFS) flushMetadataToFiler(ctx context.Context, fh *FileHandle, dir, n
 		return nil
 	}
 
-	// The name is only ours to write while it still belongs to this inode. A
-	// rename that replaced it handed it to another entry, and writing here
-	// would overwrite that entry with this handle's stale one. Windows makes
-	// this easy to hit: the close carrying the flush runs after the
-	// application's CloseHandle has already returned, so a handle on the
-	// replaced destination flushes once the rename has landed.
-	if inode, found := wfs.inodeToPath.GetInode(util.FullPath(dir).Child(name)); found && inode != fh.inode {
-		glog.V(3).Infof("flushMetadataToFiler %s/%s fh %d: the name now holds inode %d, skipping", dir, name, fh.fh, inode)
-		return nil
-	}
-
 	entry := fh.GetEntry()
 	entry.Name = name // this flush may be just after a rename operation
 

--- a/weed/mount/weedfs_file_sync.go
+++ b/weed/mount/weedfs_file_sync.go
@@ -205,7 +205,7 @@ func (wfs *WFS) doFlush(ctx context.Context, fh *FileHandle, uid, gid uint32, al
 // needed here. The local fhLockTable lock below serializes within this mount.
 func (wfs *WFS) flushMetadataToFiler(ctx context.Context, fh *FileHandle, dir, name string, uid, gid uint32) error {
 	fileFullPath := fh.FullPath()
-	glog.V(4).Infof("flushMetadataToFiler %s/%s inode %d fh %d", dir, name, fh.inode, fh.fh)
+	glog.V(0).Infof("DIAG flushMetadataToFiler %s/%s inode %d fh %d", dir, name, fh.inode, fh.fh)
 
 	fhActiveLock := fh.wfs.fhLockTable.AcquireLock("doFlush", fh.fh, util.ExclusiveLock)
 	defer fh.wfs.fhLockTable.ReleaseLock(fh.fh, fhActiveLock)

--- a/weed/mount/weedfs_rename.go
+++ b/weed/mount/weedfs_rename.go
@@ -362,6 +362,7 @@ func (wfs *WFS) handleRenameResponse(ctx context.Context, resp *filer_pb.StreamR
 	glog.V(4).Infof("dir Rename %+v", resp.EventNotification)
 
 	if resp.EventNotification.NewEntry != nil {
+		glog.V(0).Infof("DIAG rename response create %s/%s", resp.EventNotification.NewParentPath, resp.EventNotification.NewEntry.Name)
 		if err := wfs.applyLocalMetadataEvent(ctx, metadataEventFromRenameResponse(resp)); err != nil {
 			glog.Warningf("rename apply metadata event: %v", err)
 			wfs.inodeToPath.InvalidateChildrenCache(util.FullPath(resp.Directory))
@@ -413,6 +414,7 @@ func (wfs *WFS) handleRenameResponse(ctx context.Context, resp *filer_pb.StreamR
 		}
 
 	} else if resp.EventNotification.OldEntry != nil {
+		glog.V(0).Infof("DIAG rename response delete %s/%s", resp.Directory, resp.EventNotification.OldEntry.Name)
 		// without new entry, only old entry name exists. This is the second step to delete old entry
 		if err := wfs.applyLocalMetadataEvent(ctx, metadataEventFromRenameResponse(resp)); err != nil {
 			glog.Warningf("rename apply delete event: %v", err)

--- a/weed/mount/weedfs_rename.go
+++ b/weed/mount/weedfs_rename.go
@@ -233,7 +233,7 @@ func (wfs *WFS) Rename(cancel <-chan struct{}, in *fuse.RenameIn, oldName string
 		return fuse.EPERM
 	}
 
-	glog.V(4).Infof("dir Rename %s => %s", oldPath, newPath)
+	glog.V(0).Infof("DIAG rename start %s => %s", oldPath, newPath)
 
 	// Ensure the source file's metadata exists on the filer before renaming.
 	// Two cases can leave the entry only in the local cache:
@@ -339,6 +339,7 @@ func (wfs *WFS) Rename(cancel <-chan struct{}, in *fuse.RenameIn, oldName string
 		}
 		return fuse.EIO
 	}
+	glog.V(0).Infof("DIAG rename applied %s => %s", oldPath, newPath)
 	wfs.inodeToPath.TouchDirectory(oldDir)
 	wfs.inodeToPath.TouchDirectory(newDir)
 	wfs.touchDirMtimeCtimeBest(oldDir)

--- a/weed/mount/weedfs_rename.go
+++ b/weed/mount/weedfs_rename.go
@@ -240,10 +240,11 @@ func (wfs *WFS) Rename(cancel <-chan struct{}, in *fuse.RenameIn, oldName string
 	//   1. deferFilerCreate=true — file handle still open, dirtyMetadata set.
 	//   2. writebackCache — close() triggered async flush, handle released.
 	// The filer rename will fail with ENOENT unless we flush/wait first.
-	if inode, found := wfs.inodeToPath.GetInode(oldPath); found {
+	sourceInode, sourceMapped := wfs.inodeToPath.GetInode(oldPath)
+	if sourceMapped {
 		// Case 1: handle still open with deferred metadata — flush synchronously
 		// BEFORE any async flush interference.
-		if fh, ok := wfs.fhMap.FindFileHandle(inode); ok && fh.dirtyMetadata {
+		if fh, ok := wfs.fhMap.FindFileHandle(sourceInode); ok && fh.dirtyMetadata {
 			glog.V(4).Infof("dir Rename %s: flushing deferred metadata before rename", oldPath)
 			// Prerequisite for the rename, so it must complete: non-cancellable context.
 			if flushStatus := wfs.doFlush(context.Background(), fh, oldEntry.Attributes.Uid, oldEntry.Attributes.Gid, false); flushStatus != fuse.OK {
@@ -255,14 +256,26 @@ func (wfs *WFS) Rename(cancel <-chan struct{}, in *fuse.RenameIn, oldName string
 		// Mark ALL handles for this inode as renamed so the async flush
 		// skips old-path metadata creation (which would re-insert the
 		// renamed entry into the meta cache after rename events clean it up).
-		wfs.fhMap.MarkInodeRenamed(inode)
-		wfs.waitForPendingAsyncFlush(inode)
+		wfs.fhMap.MarkInodeRenamed(sourceInode)
+		wfs.waitForPendingAsyncFlush(sourceInode)
 	} else if oldEntry != nil && oldEntry.Attributes != nil && oldEntry.Attributes.Inode != 0 {
 		// GetInode failed (Forget already removed the mapping), but the
 		// entry's stored inode can still identify pending async flushes.
-		inode = oldEntry.Attributes.Inode
-		wfs.fhMap.MarkInodeRenamed(inode)
-		wfs.waitForPendingAsyncFlush(inode)
+		sourceInode = oldEntry.Attributes.Inode
+		wfs.fhMap.MarkInodeRenamed(sourceInode)
+		wfs.waitForPendingAsyncFlush(sourceInode)
+	}
+
+	// Replacing the destination deletes what it held, so a handle still open
+	// on that entry has to stop writing the name back, exactly as an unlink
+	// makes it. Windows is where this bites: the close carrying the flush runs
+	// after the application's CloseHandle returned, so the flush can land on
+	// top of what the rename just put there.
+	if in.Flags == RenameEmptyFlag {
+		if targetInode, found := wfs.inodeToPath.GetInode(newPath); found && targetInode != sourceInode {
+			wfs.markHandleDeleted(targetInode)
+			wfs.waitForPendingAsyncFlush(targetInode)
+		}
 	}
 
 	// Acquire DLM locks on both old and new paths to prevent another mount


### PR DESCRIPTION
Not for merge. Runs `TestRenameOverExisting` 300 times on the Windows runner
with the mount at `-v=4`, to catch the intermittent

```
stat of the renamed-away source did not return not-exist
```

seen in #10960's run and on master in run 32396055231, and to record which
layer answers that stat: the mount's own path cache (forgets within a second),
a readdir (reads no per-path cache), or the filer.

Will be closed once the cause is known.