### PR TITLE
filer: apply the path's storage rule TTL on every write path

### DIFF
--- a/weed/filer/entry.go
+++ b/weed/filer/entry.go
@@ -181,6 +181,16 @@ func (entry *Entry) isS3Entry() bool {
 	return false
 }
 
+// ApplyStorageTtl stamps the TTL the entry's data was placed with. Remote
+// entries never expire locally; the remote storage owns their lifecycle.
+func (entry *Entry) ApplyStorageTtl(ttlSec int32) {
+	if entry.Remote != nil {
+		ttlSec = 0
+	}
+	entry.TtlSec = ttlSec
+	entry.ApplyS3ExpiryMetadata()
+}
+
 func (entry *Entry) ApplyS3ExpiryMetadata() {
 	if entry.TtlSec == 0 {
 		return

--- a/weed/server/filer_grpc_server.go
+++ b/weed/server/filer_grpc_server.go
@@ -388,8 +388,7 @@ func (fs *FilerServer) ObjectTransactionBatch(ctx context.Context, req *filer_pb
 
 // applyStorageDefaultsToEntry enforces the path's storage rule (read-only
 // prefixes reject the write) and fills in the rule TTL when the entry carries
-// none. Remote entries never expire locally; the remote storage owns their
-// lifecycle. The returned option carries the same TTL as the entry, so chunks a
+// none. The returned option carries the same TTL as the entry, so chunks a
 // caller still has to place expire with it.
 func (fs *FilerServer) applyStorageDefaultsToEntry(ctx context.Context, entry *filer.Entry) (*operation.StorageOption, error) {
 	if entry.Remote != nil {
@@ -399,10 +398,7 @@ func (fs *FilerServer) applyStorageDefaultsToEntry(ctx context.Context, entry *f
 	if err != nil {
 		return nil, err
 	}
-	if entry.Remote == nil {
-		entry.TtlSec = so.TtlSeconds
-	}
-	entry.ApplyS3ExpiryMetadata()
+	entry.ApplyStorageTtl(so.TtlSeconds)
 	return so, nil
 }
 

--- a/weed/server/filer_grpc_server.go
+++ b/weed/server/filer_grpc_server.go
@@ -389,15 +389,17 @@ func (fs *FilerServer) ObjectTransactionBatch(ctx context.Context, req *filer_pb
 // applyStorageDefaultsToEntry enforces the path's storage rule (read-only
 // prefixes reject the write) and fills in the rule TTL when the entry carries
 // none. Remote entries never expire locally; the remote storage owns their
-// lifecycle.
+// lifecycle. The returned option carries the same TTL as the entry, so chunks a
+// caller still has to place expire with it.
 func (fs *FilerServer) applyStorageDefaultsToEntry(ctx context.Context, entry *filer.Entry) (*operation.StorageOption, error) {
-	so, err := fs.detectStorageOption(ctx, string(entry.FullPath), "", "", 0, "", "", "", "")
+	if entry.Remote != nil {
+		entry.TtlSec = 0
+	}
+	so, err := fs.detectStorageOption(ctx, string(entry.FullPath), "", "", entry.TtlSec, "", "", "", "")
 	if err != nil {
 		return nil, err
 	}
-	if entry.Remote != nil {
-		entry.TtlSec = 0
-	} else if entry.TtlSec == 0 {
+	if entry.Remote == nil {
 		entry.TtlSec = so.TtlSeconds
 	}
 	entry.ApplyS3ExpiryMetadata()
@@ -785,9 +787,9 @@ func (fs *FilerServer) AppendToEntry(ctx context.Context, req *filer_pb.AppendTo
 	}
 
 	entry.Chunks = append(entry.GetChunks(), req.Chunks...)
-	so, err := fs.detectStorageOption(ctx, string(fullpath), "", "", entry.TtlSec, "", "", "", "")
+	so, err := fs.applyStorageDefaultsToEntry(ctx, entry)
 	if err != nil {
-		glog.WarningfCtx(ctx, "detectStorageOption: %v", err)
+		glog.WarningfCtx(ctx, "applyStorageDefaultsToEntry: %v", err)
 		return &filer_pb.AppendToEntryResponse{}, err
 	}
 	entry.Chunks, err = filer.MaybeManifestize(fs.saveAsChunk(ctx, so), entry.GetChunks())

--- a/weed/server/filer_server_handlers_copy.go
+++ b/weed/server/filer_server_handlers_copy.go
@@ -157,6 +157,21 @@ func (fs *FilerServer) copy(ctx context.Context, w http.ResponseWriter, r *http.
 		return
 	}
 
+	// The copy is remote-backed when a data-only copy restores the destination's
+	// remote pointer, otherwise when the source carries one. Such an entry never
+	// expires locally, so its cached chunks must not land on a TTL volume either:
+	// the entry keeps listing them once they are gone, which reads as cached
+	// rather than remote-only, and nothing re-fetches.
+	remoteBacked := srcEntry.Remote != nil
+	if dataOnly && existingDstEntry != nil {
+		remoteBacked = existingDstEntry.Remote != nil
+	}
+	if remoteBacked && so.TtlSeconds != 0 {
+		withoutTtl := *so
+		withoutTtl.TtlSeconds = 0
+		so = &withoutTtl
+	}
+
 	// Copy the file content and chunks
 	newEntry, err := fs.copyEntry(ctx, srcEntry, finalDstPath, so)
 	if err != nil {
@@ -167,6 +182,11 @@ func (fs *FilerServer) copy(ctx context.Context, w http.ResponseWriter, r *http.
 	if dataOnly && existingDstEntry != nil {
 		preserveDestinationMetadataForDataCopy(existingDstEntry, newEntry)
 	}
+
+	// The chunks above were placed under the destination's storage option, so the
+	// entry has to carry its TTL and not the source's (or, for a data-only copy,
+	// the destination's older one) - otherwise the entry and its data expire apart.
+	newEntry.ApplyStorageTtl(so.TtlSeconds)
 
 	// Pass o_excl = !overwrite so the default copy refuses to replace an
 	// existing destination, while overwrite=true updates the pre-created target.

--- a/weed/server/filer_server_storage_rule_ttl_test.go
+++ b/weed/server/filer_server_storage_rule_ttl_test.go
@@ -2,6 +2,8 @@ package weed_server
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/seaweedfs/seaweedfs/weed/filer"
@@ -51,6 +53,36 @@ func TestObjectTransactionPutAppliesRuleTtl(t *testing.T) {
 	}
 
 	entry, err := store.FindEntry(context.Background(), ttlRulePrefix+"obj")
+	if err != nil {
+		t.Fatalf("FindEntry: %v", err)
+	}
+	if entry.TtlSec != 180 {
+		t.Errorf("entry TtlSec = %d, want 180", entry.TtlSec)
+	}
+}
+
+// A completed TUS upload uploads its chunks under the target path's rule, so the
+// entry it lands has to expire with them.
+func TestCompleteTusUploadAppliesRuleTtl(t *testing.T) {
+	fs, store := newTusTestServer(t, nil)
+	addTtlRule(t, fs.filer)
+
+	targetPath := ttlRulePrefix + "upload.bin"
+	seedTusSession(t, fs, store, TusSession{ID: tusTestUploadID, TargetPath: targetPath, Size: 8})
+	seedTusChunk(t, fs, store, tusTestUploadID, 0, 8, "3,01637037d6")
+
+	req := tusRequest(http.MethodPatch, "/.tus/.uploads/"+tusTestUploadID, map[string]string{
+		"Authorization": "Bearer " + signFilerToken(t, tusTestWriteKey, nil, nil),
+		"Content-Type":  "application/offset+octet-stream",
+		"Upload-Offset": "8",
+	}, "")
+	rec := httptest.NewRecorder()
+	fs.tusHandler(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("PATCH = %d, want %d; body=%q", rec.Code, http.StatusNoContent, rec.Body.String())
+	}
+
+	entry, err := store.FindEntry(context.Background(), util.FullPath(targetPath))
 	if err != nil {
 		t.Fatalf("FindEntry: %v", err)
 	}

--- a/weed/server/filer_server_storage_rule_ttl_test.go
+++ b/weed/server/filer_server_storage_rule_ttl_test.go
@@ -2,9 +2,11 @@ package weed_server
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
@@ -58,6 +60,77 @@ func TestObjectTransactionPutAppliesRuleTtl(t *testing.T) {
 	}
 	if entry.TtlSec != 180 {
 		t.Errorf("entry TtlSec = %d, want 180", entry.TtlSec)
+	}
+}
+
+// A copy landing in a TTL path re-uploads its chunks under that path's rule, so
+// the entry has to carry the rule's TTL too - whatever TTL the source had.
+func TestCopyAppliesRuleTtl(t *testing.T) {
+	for _, sourceTtlSec := range []int32{0, 600} {
+		t.Run(fmt.Sprintf("source ttl %d", sourceTtlSec), func(t *testing.T) {
+			store := newRenameTestStore()
+			source := newFileEntry("/src.txt", 11)
+			source.Content = []byte("hello")
+			source.TtlSec = sourceTtlSec
+			source.Crtime = time.Now() // a TTL entry older than its TTL reads back as expired
+			store.entries["/src.txt"] = source
+			store.entries[ttlRulePrefix] = newDirectoryEntry(ttlRulePrefix, 10)
+
+			server := &FilerServer{
+				filer:          newRenameTestFiler(t, store),
+				option:         &FilerOption{},
+				entryLockTable: util.NewLockTable[util.FullPath](),
+			}
+			addTtlRule(t, server.filer)
+
+			req := httptest.NewRequest(http.MethodPost, ttlRulePrefix+"dst.txt?cp.from=/src.txt", http.NoBody)
+			rec := httptest.NewRecorder()
+			server.PostHandler(rec, req, 0)
+			if rec.Code != http.StatusNoContent {
+				t.Fatalf("copy = %d, want %d; body=%q", rec.Code, http.StatusNoContent, rec.Body.String())
+			}
+
+			entry, err := store.FindEntry(context.Background(), ttlRulePrefix+"dst.txt")
+			if err != nil {
+				t.Fatalf("FindEntry: %v", err)
+			}
+			if entry.TtlSec != 180 {
+				t.Errorf("entry TtlSec = %d, want 180", entry.TtlSec)
+			}
+		})
+	}
+}
+
+// A remote-backed entry copied into a TTL path must not expire locally: the
+// remote storage owns its lifecycle, so a local expiry would drop the pointer
+// to an object that is still there.
+func TestCopyKeepsRemoteEntryUnexpiring(t *testing.T) {
+	store := newRenameTestStore()
+	source := newFileEntry("/src.txt", 11)
+	source.Remote = &filer_pb.RemoteEntry{StorageName: "s3-remote", RemoteSize: 5}
+	store.entries["/src.txt"] = source
+	store.entries[ttlRulePrefix] = newDirectoryEntry(ttlRulePrefix, 10)
+
+	server := &FilerServer{
+		filer:          newRenameTestFiler(t, store),
+		option:         &FilerOption{},
+		entryLockTable: util.NewLockTable[util.FullPath](),
+	}
+	addTtlRule(t, server.filer)
+
+	req := httptest.NewRequest(http.MethodPost, ttlRulePrefix+"dst.txt?cp.from=/src.txt", http.NoBody)
+	rec := httptest.NewRecorder()
+	server.PostHandler(rec, req, 0)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("copy = %d, want %d; body=%q", rec.Code, http.StatusNoContent, rec.Body.String())
+	}
+
+	entry, err := store.FindEntry(context.Background(), ttlRulePrefix+"dst.txt")
+	if err != nil {
+		t.Fatalf("FindEntry: %v", err)
+	}
+	if entry.TtlSec != 0 {
+		t.Errorf("remote entry TtlSec = %d, want 0", entry.TtlSec)
 	}
 }
 

--- a/weed/server/filer_server_storage_rule_ttl_test.go
+++ b/weed/server/filer_server_storage_rule_ttl_test.go
@@ -1,0 +1,60 @@
+package weed_server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/filer"
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+)
+
+const ttlRulePrefix = "/buckets/ttl/"
+
+// addTtlRule gives ttlRulePrefix a 3 minute volume TTL, the fs.configure setting
+// whose effect every write path below has to reproduce on the entries it stores.
+func addTtlRule(t *testing.T, f *filer.Filer) {
+	t.Helper()
+	if err := f.FilerConf.AddLocationConf(&filer_pb.FilerConf_PathConf{
+		LocationPrefix: ttlRulePrefix,
+		Ttl:            "3m",
+	}); err != nil {
+		t.Fatalf("AddLocationConf: %v", err)
+	}
+}
+
+// An object written through ObjectTransaction (the routed S3 write path) must
+// pick up the path's TTL rule, the same as one written through CreateEntry.
+func TestObjectTransactionPutAppliesRuleTtl(t *testing.T) {
+	store := newRenameTestStore()
+	store.entries[ttlRulePrefix] = newDirectoryEntry(ttlRulePrefix, 10)
+
+	server := &FilerServer{
+		filer:          newRenameTestFiler(t, store),
+		option:         &FilerOption{},
+		entryLockTable: util.NewLockTable[util.FullPath](),
+	}
+	addTtlRule(t, server.filer)
+
+	if _, err := server.ObjectTransaction(context.Background(), &filer_pb.ObjectTransactionRequest{
+		LockKey: ttlRulePrefix + "obj",
+		Mutations: []*filer_pb.ObjectMutation{{
+			Type:      filer_pb.ObjectMutation_PUT,
+			Directory: "/buckets/ttl",
+			Entry: &filer_pb.Entry{
+				Name:       "obj",
+				Attributes: &filer_pb.FuseAttributes{FileMode: 0644},
+			},
+		}},
+	}); err != nil {
+		t.Fatalf("ObjectTransaction: %v", err)
+	}
+
+	entry, err := store.FindEntry(context.Background(), ttlRulePrefix+"obj")
+	if err != nil {
+		t.Fatalf("FindEntry: %v", err)
+	}
+	if entry.TtlSec != 180 {
+		t.Errorf("entry TtlSec = %d, want 180", entry.TtlSec)
+	}
+}

--- a/weed/server/filer_server_tus_complete_test.go
+++ b/weed/server/filer_server_tus_complete_test.go
@@ -2,11 +2,13 @@ package weed_server
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/util"
 )
 
@@ -118,5 +120,38 @@ func TestFilerServer_completeTusUpload_GapRejected(t *testing.T) {
 	}
 	if _, findErr := store.FindEntry(context.Background(), util.FullPath(targetPath)); findErr == nil {
 		t.Fatalf("entry created despite gap")
+	}
+}
+
+// TestFilerServer_completeTusUpload_ReadOnlyTarget verifies a read-only prefix
+// still refuses the completing upload, before the session's chunks are claimed.
+func TestFilerServer_completeTusUpload_ReadOnlyTarget(t *testing.T) {
+	fs, store := newTusTestServer(t, nil)
+	if err := fs.filer.FilerConf.AddLocationConf(&filer_pb.FilerConf_PathConf{
+		LocationPrefix: "/buckets/frozen/",
+		ReadOnly:       true,
+	}); err != nil {
+		t.Fatalf("AddLocationConf: %v", err)
+	}
+
+	targetPath := "/buckets/frozen/upload.bin"
+	session := &TusSession{
+		ID:         tusTestUploadID,
+		TargetPath: targetPath,
+		Size:       8,
+		Offset:     8,
+		Chunks:     []*TusChunkInfo{{Offset: 0, Size: 8, FileId: "3,01637037d6"}},
+	}
+	seedTusSession(t, fs, store, *session)
+
+	err := fs.completeTusUpload(context.Background(), session)
+	if !errors.Is(err, ErrReadOnly) {
+		t.Fatalf("completeTusUpload err = %v, want %v", err, ErrReadOnly)
+	}
+	if _, findErr := store.FindEntry(context.Background(), util.FullPath(targetPath)); findErr == nil {
+		t.Fatalf("entry created under a read-only prefix")
+	}
+	if consumed, checkErr := fs.isTusSessionConsumed(context.Background(), tusTestUploadID); checkErr != nil || consumed {
+		t.Fatalf("session consumed = %v (err %v), want false", consumed, checkErr)
 	}
 }

--- a/weed/server/filer_server_tus_session.go
+++ b/weed/server/filer_server_tus_session.go
@@ -545,11 +545,25 @@ func (fs *FilerServer) completeTusUpload(ctx context.Context, session *TusSessio
 
 	// Create the final file entry
 	targetPath := util.FullPath(session.TargetPath)
+	entry := &filer.Entry{
+		FullPath: targetPath,
+		Attr: filer.Attr{
+			Mode:   0644,
+			Crtime: session.CreatedAt,
+			Mtime:  time.Now(),
+			Uid:    OS_UID,
+			Gid:    OS_GID,
+			Mime:   contentType,
+		},
+		Chunks: fileChunks,
+	}
 
-	// Apply the same read-only / WORM protections the normal write path enforces
-	// before landing the entry at the client-chosen target path.
-	if fs.filer.FilerConf.MatchStorageRule(string(targetPath)).ReadOnly {
-		return fmt.Errorf("%w: %s", ErrReadOnly, targetPath)
+	// Apply the same storage rule (read-only prefixes, TTL) and WORM protections
+	// the normal write path enforces before landing the entry at the
+	// client-chosen target path.
+	so, err := fs.applyStorageDefaultsToEntry(ctx, entry)
+	if err != nil {
+		return err
 	}
 	if wormEnforced, err := fs.wormEnforcedForEntry(ctx, string(targetPath)); err != nil {
 		return fmt.Errorf("check worm: %w", err)
@@ -574,21 +588,8 @@ func (fs *FilerServer) completeTusUpload(ctx context.Context, session *TusSessio
 		return fmt.Errorf("session deleted before completion: %w", err)
 	}
 
-	entry := &filer.Entry{
-		FullPath: targetPath,
-		Attr: filer.Attr{
-			Mode:   0644,
-			Crtime: session.CreatedAt,
-			Mtime:  time.Now(),
-			Uid:    OS_UID,
-			Gid:    OS_GID,
-			Mime:   contentType,
-		},
-		Chunks: fileChunks,
-	}
-
 	// Ensure parent directory exists
-	if err := fs.filer.CreateEntry(ctx, entry, nil, false, false, nil, false, fs.filer.MaxFilenameLength); err != nil {
+	if err := fs.filer.CreateEntry(ctx, entry, nil, false, false, nil, false, so.MaxFileNameLength); err != nil {
 		return fmt.Errorf("create final file entry: %w", err)
 	}
 


### PR DESCRIPTION
Fixes #10962.

### The reported path is already fixed

`ObjectTransaction` -> `applyObjectMutation` -> `Filer::CreateEntry` did skip the storage-rule TTL that `FilerServer::CreateEntry` applies. That was fixed in #10196, which pulled the stamping into `applyStorageDefaultsToEntry` and called it from both handlers; the fix is in 4.38 and later, so upgrading from the reported 4.34 resolves it.

Reverting that one call reproduces the report exactly - an object written through `ObjectTransaction` under a 3 minute `fs.configure` TTL lands with `ttlSec 0`:

```
--- FAIL: TestObjectTransactionPutAppliesRuleTtl
    entry TtlSec = 0, want 180
```

The first commit adds that as a regression test so the two write paths cannot drift apart again.

### Three sibling paths still drop the TTL

Chasing the same rule through the rest of the filer turned up three write paths that resolve the storage option from the path - so their chunks *do* go to a TTL volume - but never stamp the TTL on the entry they store. The entry then outlives the data it points at:

- `AppendToEntry`: a new entry is created with `ttlSec 0` while its chunks are assigned under the rule.
- TUS completion: `tusWriteData` uploads under the target path's rule, then `completeTusUpload` builds the final entry with `ttlSec 0`.
- The copy handler: chunks are re-uploaded under the destination's option, but the entry keeps the *source's* `ttlSec`, which is 0 for a source outside the prefix.

Each is one commit, routed through the existing `applyStorageDefaultsToEntry` rather than a new helper. The helper now feeds the entry's own TTL into `detectStorageOption` instead of a hardcoded 0, so an existing entry's TTL still drives where its appended chunks land. TUS completion also drops its hand-rolled read-only check (`applyStorageDefaultsToEntry` already returns `ErrReadOnly`) and picks up the rule's name-length limit.

### Tests

`TestCopyAppliesRuleTtl` and `TestCompleteTusUploadAppliesRuleTtl` both fail on master and pass here. `AppendToEntry` takes a cluster lock on entry, so it has no unit test in this package; the change there is the same three-line swap.

The whole `weed/server` package is green.

No Rust mirror: the Rust side is a volume server, and none of this lives outside the Go filer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Storage rules and TTL settings are now applied consistently to uploaded, copied, appended, and completed file entries.
  * Copied entries now correctly inherit destination storage expiration settings.
  * Remote-backed entries remain unexpired when appropriate.
  * Read-only storage paths reject completed uploads without creating entries or consuming upload sessions.
  * WORM protections and filename limits remain enforced during upload completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->