### PR TITLE
rust volume: stop racing the clock in torn_sdx_is_regenerated

### DIFF
--- a/seaweed-volume/src/storage/needle_map/sorted_file.rs
+++ b/seaweed-volume/src/storage/needle_map/sorted_file.rs
@@ -807,6 +807,13 @@ mod tests {
         sdx.set_len(good - 5).unwrap();
         drop(sdx);
         pooled_index_files().discard(&format!("{base}.sdx"));
+        // Truncation bumps the .sdx mtime, but "bumps" is only true at the
+        // filesystem's timestamp granularity: where both writes land in the
+        // same tick the torn file does not look fresher, and the precondition
+        // below then fails for a reason the test is not about. Age the .idx the
+        // way stale_sdx_is_regenerated does, so freshness is established rather
+        // than raced for.
+        filetime_backdate(&format!("{base}.idx"));
         assert!(
             std::fs::metadata(format!("{base}.sdx"))
                 .unwrap()


### PR DESCRIPTION
`torn_sdx_is_regenerated` truncates a good `.sdx` and asserts the result still looks fresher than its `.idx`, on the reasoning that truncation bumps the mtime. That holds only at the filesystem's timestamp granularity: where both writes land in the same tick the torn file does not look fresher, the precondition assert fires, and the run reports a failure that says nothing about the code under test.

It did exactly that on CI — the `Rust Unit Tests` job of an unrelated PR, whose merge build picks up this test from master: https://github.com/seaweedfs/seaweedfs/actions/runs/32951370365/job/98123266643

Backdate the `.idx` through the `filetime_backdate` helper the sibling `stale_sdx_is_regenerated` already uses, so the freshness the test depends on is established rather than raced for.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of torn index regeneration tests across filesystems with different timestamp precision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->