### PR TITLE
DIAGNOSTIC (do not merge): is the version gate dropping the rename's source removal?

### DIFF
--- a/.github/workflows/mount-windows.yml
+++ b/.github/workflows/mount-windows.yml
@@ -127,6 +127,11 @@ jobs:
 
         Start-Mount 'seaweed-mount'
 
+        Invoke-Tests 'rename-loop' @('test','-v','-failfast','-count=400','-timeout','25m','./test/winfsp','-run','TestRenameOverExisting','-mountpoint=S:\')
+
+        Write-Host "diagnostic run: stopping after the rename loop"
+        exit 0
+
         Invoke-Tests 'exercise' @('test','-v','-timeout','20m','./test/winfsp','-mountpoint=S:\')
         Invoke-Tests 'persist-write' @('test','-v','-timeout','15m','./test/winfsp','-run','TestPersistence','-mountpoint=S:\','-phase=write','-filer=127.0.0.1:8888')
 
@@ -190,5 +195,5 @@ jobs:
       shell: pwsh
       run: |
         foreach ($f in 'C:\seaweed-mount.log','C:\seaweed-mount.err.log','C:\seaweed-remount.log','C:\seaweed-remount.err.log','C:\seaweed-remount2.log','C:\seaweed-remount2.err.log','C:\seaweed-dirmount.log','C:\seaweed-dirmount.err.log','C:\seaweed-mini.log','C:\seaweed-mini.err.log') {
-          if (Test-Path $f) { Write-Host "===== $f"; Get-Content $f -Tail 200 }
+          if (Test-Path $f) { Write-Host "===== $f"; Get-Content $f -Tail 3000 }
         }

--- a/weed/mount/meta_cache/meta_cache.go
+++ b/weed/mount/meta_cache/meta_cache.go
@@ -952,9 +952,13 @@ func (mc *MetaCache) applyMetadataResponseLocked(ctx context.Context, resp *file
 	// the version keeps the newer claim. Each half is gated independently.
 	if resp.TsNs != 0 {
 		if oldPath != "" && mc.entryVersionBlocksLocked(ctx, oldPath, resp.TsNs) {
+			recordTsNs, tombstone, unversioned := mc.entryVersionRecordLocked(ctx, oldPath)
+			glog.V(0).Infof("DIAG gate dropped removal of %s eventTs=%d record=%d floor=%d tombstone=%v unversioned=%v hasNew=%v",
+				oldPath, resp.TsNs, recordTsNs, mc.entryVersionFloorLocked(oldPath, recordTsNs), tombstone, unversioned, newEntry != nil)
 			oldPath = ""
 		}
 		if newEntry != nil && mc.entryVersionBlocksLocked(ctx, newEntry.FullPath, resp.TsNs) {
+			glog.V(0).Infof("DIAG gate dropped insert of %s eventTs=%d", newEntry.FullPath, resp.TsNs)
 			newEntry = nil
 		}
 	}


### PR DESCRIPTION
Not for merge. Chasing the second `TestRenameOverExisting` failure mode, where
the renamed-away source stays visible:

```
past the path cache err=<nil>; S:\winfsp-test-TestRenameOverExisting lists [dst src]
```

A deterministic meta_cache test shows the mechanism exists: in
`applyMetadataResponseLocked` the two halves of a rename event are gated
independently, so when the source's version record outranks the event's `TsNs`
the removal of the source is dropped while the insert of the destination still
lands — leaving exactly `[dst src]` with the correct destination content.

This run logs **only when that gate actually drops something**, so it adds no
output on the common path and does not perturb the timing the way `-v=4` did
(which made the loop pass 300/300 every time).

Carries #10965 so the destination-clobber failure does not mask this one.