### PR TITLE
VERIFY ONLY (do not merge): 400x rename loop for the source-removal gate fix

### DIFF
--- a/.github/workflows/mount-windows.yml
+++ b/.github/workflows/mount-windows.yml
@@ -127,6 +127,8 @@ jobs:
 
         Start-Mount 'seaweed-mount'
 
+        Invoke-Tests 'rename-loop' @('test','-v','-failfast','-count=400','-timeout','25m','./test/winfsp','-run','TestRenameOverExisting','-mountpoint=S:\')
+
         Invoke-Tests 'exercise' @('test','-v','-timeout','20m','./test/winfsp','-mountpoint=S:\')
         Invoke-Tests 'persist-write' @('test','-v','-timeout','15m','./test/winfsp','-run','TestPersistence','-mountpoint=S:\','-phase=write','-filer=127.0.0.1:8888')
 

--- a/test/winfsp/semantics_test.go
+++ b/test/winfsp/semantics_test.go
@@ -180,9 +180,29 @@ func TestRenameOverExisting(t *testing.T) {
 		// they indict different layers; a second look says whether it persists.
 		time.Sleep(200 * time.Millisecond)
 		fi2, err2 := os.Stat(src)
-		t.Fatalf("stat of the renamed-away source did not return not-exist: stat=%v err=%v; 200ms later stat=%v err=%v",
-			describeFileInfo(fi), err, describeFileInfo(fi2), err2)
+		// A listing reads no per-path cache and the mount's own forgets
+		// within a second, so a name that survives both is back on the filer.
+		listed := dirNames(t, dir)
+		time.Sleep(2 * time.Second)
+		_, errLater := os.Stat(src)
+		t.Fatalf("stat of the renamed-away source did not return not-exist: stat=%v err=%v; 200ms later stat=%v err=%v; past the path cache err=%v; %s lists %v",
+			describeFileInfo(fi), err, describeFileInfo(fi2), err2, errLater, dir, listed)
 	}
+}
+
+// dirNames lists a directory for a failure message, reporting the error in
+// place of the names rather than failing a test that is already failing.
+func dirNames(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return []string{"readdir: " + err.Error()}
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	return names
 }
 
 func TestRenameAcrossDirectories(t *testing.T) {

--- a/weed/mount/filehandle.go
+++ b/weed/mount/filehandle.go
@@ -40,7 +40,11 @@ type FileHandle struct {
 	savedName         string // last known file name if inode-to-path state is forgotten
 
 	isDeleted bool
-	isRenamed bool // set by Rename before waiting for async flush; skips old-path metadata flush
+	// deleteEpoch counts the times isDeleted was raised, all of them under the
+	// handle's flush lock. A caller that raised it and then found it had
+	// nothing to delete after all can tell its own mark from a later one.
+	deleteEpoch uint64
+	isRenamed   bool // set by Rename before waiting for async flush; skips old-path metadata flush
 
 	// entryVersionTsNs is the filer log position the handle's entry reflects.
 	// State at or below it must not replace the entry — that rolls it back.

--- a/weed/mount/meta_cache/meta_cache.go
+++ b/weed/mount/meta_cache/meta_cache.go
@@ -497,13 +497,19 @@ func (mc *MetaCache) entryVersionRecordLocked(ctx context.Context, fp util.FullP
 	return int64(util.BytesToUint64(value[:8])), tombstone, unversioned
 }
 
-// entryVersionBlocksLocked reports whether a write at tsNs is already
+// entryVersionBlocksLocked reports whether a change at tsNs is already
 // reflected at fp. The path's version is its own record or, lacking one, the
 // listing floors — which cover names a listing saw present and absent alike.
 // A tombstone fences with no entry present, and a later floor outranks it; a
 // plain record only counts while its entry exists: records linger after a
 // bulk folder wipe and must not fence a recreate.
-func (mc *MetaCache) entryVersionBlocksLocked(ctx context.Context, fp util.FullPath, tsNs int64) bool {
+//
+// removal asks a different question from a write. An entry still present at
+// exactly tsNs has the write at that version reflected but not its removal --
+// a rename stamps the source and takes the name away at the same version --
+// so only a strictly newer record fences one out. A tombstone is the removal
+// already reflected, and fences at tsNs like any other write.
+func (mc *MetaCache) entryVersionBlocksLocked(ctx context.Context, fp util.FullPath, tsNs int64, removal bool) bool {
 	recordTsNs, tombstone, unversioned := mc.entryVersionRecordLocked(ctx, fp)
 	if unversioned {
 		// Local content no log position describes: fence nothing, so any
@@ -513,7 +519,11 @@ func (mc *MetaCache) entryVersionBlocksLocked(ctx context.Context, fp util.FullP
 	if !tombstone && !mc.entryExistsLocked(ctx, fp) {
 		recordTsNs = 0
 	}
-	return mc.entryVersionFloorLocked(fp, recordTsNs) >= tsNs
+	floorTsNs := mc.entryVersionFloorLocked(fp, recordTsNs)
+	if removal && !tombstone {
+		return floorTsNs > tsNs
+	}
+	return floorTsNs >= tsNs
 }
 
 // entryExistsLocked reports whether fp has a live entry, applying the same TTL
@@ -951,10 +961,10 @@ func (mc *MetaCache) applyMetadataResponseLocked(ctx context.Context, resp *file
 	// already reflected in it, and applying it would roll the entry back while
 	// the version keeps the newer claim. Each half is gated independently.
 	if resp.TsNs != 0 {
-		if oldPath != "" && mc.entryVersionBlocksLocked(ctx, oldPath, resp.TsNs) {
+		if oldPath != "" && mc.entryVersionBlocksLocked(ctx, oldPath, resp.TsNs, true) {
 			oldPath = ""
 		}
-		if newEntry != nil && mc.entryVersionBlocksLocked(ctx, newEntry.FullPath, resp.TsNs) {
+		if newEntry != nil && mc.entryVersionBlocksLocked(ctx, newEntry.FullPath, resp.TsNs, false) {
 			newEntry = nil
 		}
 	}

--- a/weed/mount/meta_cache/meta_cache_apply_test.go
+++ b/weed/mount/meta_cache/meta_cache_apply_test.go
@@ -868,7 +868,7 @@ func TestExpiredEntryIsJudgedByDirectoryFloor(t *testing.T) {
 	// is the accurate answer, and an event above the floor must apply.
 	mc.setEntryVersionLocked(context.Background(), util.FullPath("/dir/file"), 5000)
 	mc.dirVersionFloors[util.FullPath("/dir")] = 3000
-	blocks := mc.entryVersionBlocksLocked(context.Background(), util.FullPath("/dir/file"), 4000)
+	blocks := mc.entryVersionBlocksLocked(context.Background(), util.FullPath("/dir/file"), 4000, false)
 	mc.Unlock()
 
 	if blocks {

--- a/weed/mount/meta_cache/meta_cache_rename_gate_test.go
+++ b/weed/mount/meta_cache/meta_cache_rename_gate_test.go
@@ -1,0 +1,95 @@
+package meta_cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+)
+
+// A rename stamps its source and takes the name away at the same log position,
+// so the removal arrives at exactly the version the source already records.
+// Read as a write that is already reflected, it was dropped and the source
+// stayed visible next to the destination.
+func TestRenameRemovesSourceAtItsOwnVersion(t *testing.T) {
+	const version = 1787761708173717200
+
+	mc, _, _, _ := newTestMetaCache(t, map[util.FullPath]bool{"/": true, "/dir": true})
+	defer mc.Shutdown()
+	ctx := context.Background()
+
+	write := func(name string, tsNs int64) *filer_pb.SubscribeMetadataResponse {
+		return &filer_pb.SubscribeMetadataResponse{
+			Directory: "/dir",
+			EventNotification: &filer_pb.EventNotification{
+				NewEntry: &filer_pb.Entry{
+					Name:       name,
+					Attributes: &filer_pb.FuseAttributes{Crtime: 1, Mtime: 1, FileMode: 0100644, FileSize: 3},
+				},
+			},
+			TsNs: tsNs,
+		}
+	}
+	for _, event := range []*filer_pb.SubscribeMetadataResponse{write("src", version), write("dst", version-1000)} {
+		if err := mc.ApplyMetadataResponseOwned(ctx, event, LocalMetadataResponseApplyOptions); err != nil {
+			t.Fatalf("seed %s: %v", event.EventNotification.NewEntry.Name, err)
+		}
+	}
+
+	rename := &filer_pb.SubscribeMetadataResponse{
+		Directory: "/dir",
+		EventNotification: &filer_pb.EventNotification{
+			OldEntry: &filer_pb.Entry{Name: "src"},
+			NewEntry: &filer_pb.Entry{
+				Name:       "dst",
+				Attributes: &filer_pb.FuseAttributes{Crtime: 1, Mtime: 1, FileMode: 0100644, FileSize: 3},
+			},
+			NewParentPath: "/dir",
+		},
+		TsNs: version,
+	}
+	if err := mc.ApplyMetadataResponseOwned(ctx, rename, LocalMetadataResponseApplyOptions); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	if entry, _, err := mc.FindEntry(ctx, "/dir/src"); err == nil && entry != nil {
+		t.Error("the renamed-away source is still cached")
+	}
+	if entry, _, err := mc.FindEntry(ctx, "/dir/dst"); err != nil || entry == nil {
+		t.Errorf("the rename destination is missing: %v", err)
+	}
+}
+
+// A removal older than the entry's record is still stale and must not apply:
+// the record describes a write the removal never saw.
+func TestRemovalOlderThanTheRecordStillFences(t *testing.T) {
+	mc, _, _, _ := newTestMetaCache(t, map[util.FullPath]bool{"/": true, "/dir": true})
+	defer mc.Shutdown()
+	ctx := context.Background()
+
+	if err := mc.ApplyMetadataResponseOwned(ctx, &filer_pb.SubscribeMetadataResponse{
+		Directory: "/dir",
+		EventNotification: &filer_pb.EventNotification{
+			NewEntry: &filer_pb.Entry{
+				Name:       "file",
+				Attributes: &filer_pb.FuseAttributes{Crtime: 1, Mtime: 1, FileMode: 0100644, FileSize: 3},
+			},
+		},
+		TsNs: 2000,
+	}, LocalMetadataResponseApplyOptions); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := mc.ApplyMetadataResponseOwned(ctx, &filer_pb.SubscribeMetadataResponse{
+		Directory:         "/dir",
+		EventNotification: &filer_pb.EventNotification{OldEntry: &filer_pb.Entry{Name: "file"}},
+		TsNs:              1000,
+	}, LocalMetadataResponseApplyOptions); err != nil {
+		t.Fatalf("stale removal: %v", err)
+	}
+
+	if entry, _, err := mc.FindEntry(ctx, "/dir/file"); err != nil || entry == nil {
+		t.Errorf("a removal older than the entry's record deleted it: %v", err)
+	}
+}

--- a/weed/mount/meta_cache/meta_cache_sections.go
+++ b/weed/mount/meta_cache/meta_cache_sections.go
@@ -362,7 +362,7 @@ func (mc *MetaCache) applySectionRefreshNow(ctx context.Context, dirPath util.Fu
 			mc.setEntryVersionLocked(ctx, entry.FullPath, 0)
 			continue
 		}
-		if mc.entryVersionBlocksLocked(ctx, entry.FullPath, snapshotTsNs) {
+		if mc.entryVersionBlocksLocked(ctx, entry.FullPath, snapshotTsNs, false) {
 			continue
 		}
 		// An unversioned marker would bypass the section floor, so it cannot
@@ -404,7 +404,7 @@ func (mc *MetaCache) applySectionRefreshNow(ctx context.Context, dirPath util.Fu
 			if mc.pinnedChildFn != nil && mc.pinnedChildFn(entry) {
 				continue
 			}
-			if mc.entryVersionBlocksLocked(ctx, entry.FullPath, snapshotTsNs) {
+			if mc.entryVersionBlocksLocked(ctx, entry.FullPath, snapshotTsNs, false) {
 				continue
 			}
 			if err := mc.localStore.DeleteEntry(ctx, entry.FullPath); err != nil {

--- a/weed/mount/weedfs.go
+++ b/weed/mount/weedfs.go
@@ -823,7 +823,7 @@ func (wfs *WFS) onEntryInvalidation(invalidation meta_cache.EntryInvalidation) {
 	// the old content back over what took the name. Marked from here, holding
 	// no other handle's lock.
 	if replacedInode != 0 {
-		wfs.markHandleDeleted(replacedInode)
+		wfs.markHandleDeleted(replacedInode, true)
 	}
 }
 

--- a/weed/mount/weedfs.go
+++ b/weed/mount/weedfs.go
@@ -823,7 +823,7 @@ func (wfs *WFS) onEntryInvalidation(invalidation meta_cache.EntryInvalidation) {
 	// the old content back over what took the name. Marked from here, holding
 	// no other handle's lock.
 	if replacedInode != 0 {
-		wfs.markHandleDeleted(replacedInode, true)
+		wfs.markHandleDeleted(replacedInode)
 	}
 }
 
@@ -938,6 +938,7 @@ func (wfs *WFS) invalidateOpenFileHandle(invalidation meta_cache.EntryInvalidati
 		// dirty pages stay, so the open fd still reads its buffered writes.
 		if invalidation.Deleted {
 			fh.isDeleted = true
+			fh.deleteEpoch++
 		}
 		if !fh.dirtyMetadata {
 			fh.dirtyPages.Destroy()

--- a/weed/mount/weedfs_file_mkrm.go
+++ b/weed/mount/weedfs_file_mkrm.go
@@ -245,11 +245,11 @@ func (wfs *WFS) Unlink(cancel <-chan struct{}, header *fuse.InHeader, name strin
 	// finishes first; even if it recreated the entry, the filer delete below
 	// will remove it again.
 	if inode, found := wfs.inodeToPath.GetInode(entryFullPath); found {
-		wfs.markHandleDeleted(inode, true)
+		wfs.markHandleDeleted(inode)
 		wfs.waitForPendingAsyncFlush(inode)
 	} else if entry != nil && entry.Attributes != nil && entry.Attributes.Inode != 0 {
 		inodeFromEntry := entry.Attributes.Inode
-		wfs.markHandleDeleted(inodeFromEntry, true)
+		wfs.markHandleDeleted(inodeFromEntry)
 		wfs.waitForPendingAsyncFlush(inodeFromEntry)
 	}
 
@@ -436,18 +436,39 @@ func (wfs *WFS) createRegularFile(dirFullPath util.FullPath, name string, mode u
 }
 
 // markHandleDeleted flags the inode's open handle so its flushes stop writing
-// the entry back, and clears the flag again when a caller that raised it did
-// not go through with the delete. Taken and released under the handle's flush
-// lock: a flush already holding it finishes before the caller's delete runs,
-// and any later flush sees the flag; setting the flag bare raced the flush's
-// own check and resurrected the entry right after the delete.
-func (wfs *WFS) markHandleDeleted(inode uint64, deleted bool) {
+// the entry back, and reports which mark this was. Taken and released under
+// the handle's flush lock: a flush already holding it finishes before the
+// caller's delete runs, and any later flush sees the flag; setting the flag
+// bare raced the flush's own check and resurrected the entry right after the
+// delete.
+func (wfs *WFS) markHandleDeleted(inode uint64) uint64 {
+	fh, found := wfs.fhMap.FindFileHandle(inode)
+	if !found {
+		return 0
+	}
+	fhActiveLock := wfs.fhLockTable.AcquireLock("markHandleDeleted", fh.fh, util.ExclusiveLock)
+	fh.isDeleted = true
+	fh.deleteEpoch++
+	epoch := fh.deleteEpoch
+	wfs.fhLockTable.ReleaseLock(fh.fh, fhActiveLock)
+	return epoch
+}
+
+// clearHandleDeleted lifts a mark whose delete did not go through. Only the
+// mark epoch names: an unlink that raised the flag after it owns the entry's
+// fate and keeps it.
+func (wfs *WFS) clearHandleDeleted(inode uint64, epoch uint64) {
+	if epoch == 0 {
+		return
+	}
 	fh, found := wfs.fhMap.FindFileHandle(inode)
 	if !found {
 		return
 	}
-	fhActiveLock := wfs.fhLockTable.AcquireLock("markHandleDeleted", fh.fh, util.ExclusiveLock)
-	fh.isDeleted = deleted
+	fhActiveLock := wfs.fhLockTable.AcquireLock("clearHandleDeleted", fh.fh, util.ExclusiveLock)
+	if fh.deleteEpoch == epoch {
+		fh.isDeleted = false
+	}
 	wfs.fhLockTable.ReleaseLock(fh.fh, fhActiveLock)
 }
 

--- a/weed/mount/weedfs_file_mkrm.go
+++ b/weed/mount/weedfs_file_mkrm.go
@@ -245,11 +245,11 @@ func (wfs *WFS) Unlink(cancel <-chan struct{}, header *fuse.InHeader, name strin
 	// finishes first; even if it recreated the entry, the filer delete below
 	// will remove it again.
 	if inode, found := wfs.inodeToPath.GetInode(entryFullPath); found {
-		wfs.markHandleDeleted(inode)
+		wfs.markHandleDeleted(inode, true)
 		wfs.waitForPendingAsyncFlush(inode)
 	} else if entry != nil && entry.Attributes != nil && entry.Attributes.Inode != 0 {
 		inodeFromEntry := entry.Attributes.Inode
-		wfs.markHandleDeleted(inodeFromEntry)
+		wfs.markHandleDeleted(inodeFromEntry, true)
 		wfs.waitForPendingAsyncFlush(inodeFromEntry)
 	}
 
@@ -436,17 +436,18 @@ func (wfs *WFS) createRegularFile(dirFullPath util.FullPath, name string, mode u
 }
 
 // markHandleDeleted flags the inode's open handle so its flushes stop writing
-// the entry back. Taken and released under the handle's flush lock: a flush
-// already holding it finishes before the caller's delete runs, and any later
-// flush sees the flag; setting the flag bare raced the flush's own check and
-// resurrected the entry right after the delete.
-func (wfs *WFS) markHandleDeleted(inode uint64) {
+// the entry back, and clears the flag again when a caller that raised it did
+// not go through with the delete. Taken and released under the handle's flush
+// lock: a flush already holding it finishes before the caller's delete runs,
+// and any later flush sees the flag; setting the flag bare raced the flush's
+// own check and resurrected the entry right after the delete.
+func (wfs *WFS) markHandleDeleted(inode uint64, deleted bool) {
 	fh, found := wfs.fhMap.FindFileHandle(inode)
 	if !found {
 		return
 	}
-	fhActiveLock := wfs.fhLockTable.AcquireLock("Unlink", fh.fh, util.ExclusiveLock)
-	fh.isDeleted = true
+	fhActiveLock := wfs.fhLockTable.AcquireLock("markHandleDeleted", fh.fh, util.ExclusiveLock)
+	fh.isDeleted = deleted
 	wfs.fhLockTable.ReleaseLock(fh.fh, fhActiveLock)
 }
 

--- a/weed/mount/weedfs_rename.go
+++ b/weed/mount/weedfs_rename.go
@@ -214,17 +214,22 @@ func (wfs *WFS) Rename(cancel <-chan struct{}, in *fuse.RenameIn, oldName string
 		}
 	}
 
-	// POSIX: enforce sticky bit on the destination directory when replacing an existing entry.
+	var newEntry *filer_pb.Entry
 	if in.Flags != RenameNoReplace {
-		if newEntry, _, newStatus := wfs.maybeLoadEntry(newPath); newStatus == fuse.OK && newEntry != nil {
-			if newDirEntry, _, dirCode := wfs.maybeLoadEntry(newDir); dirCode == fuse.OK && newDirEntry != nil && newDirEntry.Attributes != nil {
-				targetUid := uint32(0)
-				if newEntry.Attributes != nil {
-					targetUid = newEntry.Attributes.Uid
-				}
-				if code := checkStickyBit(newDirEntry.Attributes.FileMode, newDirEntry.Attributes.Uid, targetUid, in.Uid); code != fuse.OK {
-					return code
-				}
+		if loaded, _, newStatus := wfs.maybeLoadEntry(newPath); newStatus == fuse.OK {
+			newEntry = loaded
+		}
+	}
+
+	// POSIX: enforce sticky bit on the destination directory when replacing an existing entry.
+	if newEntry != nil {
+		if newDirEntry, _, dirCode := wfs.maybeLoadEntry(newDir); dirCode == fuse.OK && newDirEntry != nil && newDirEntry.Attributes != nil {
+			targetUid := uint32(0)
+			if newEntry.Attributes != nil {
+				targetUid = newEntry.Attributes.Uid
+			}
+			if code := checkStickyBit(newDirEntry.Attributes.FileMode, newDirEntry.Attributes.Uid, targetUid, in.Uid); code != fuse.OK {
+				return code
 			}
 		}
 	}
@@ -272,9 +277,22 @@ func (wfs *WFS) Rename(cancel <-chan struct{}, in *fuse.RenameIn, oldName string
 	// after the application's CloseHandle returned, so the flush can land on
 	// top of what the rename just put there.
 	if in.Flags == RenameEmptyFlag {
-		if targetInode, found := wfs.inodeToPath.GetInode(newPath); found && targetInode != sourceInode {
-			wfs.markHandleDeleted(targetInode)
+		targetInode, targetMapped := wfs.inodeToPath.GetInode(newPath)
+		if !targetMapped && newEntry != nil && newEntry.Attributes != nil {
+			// Forget dropped the mapping, but the entry's stored inode still
+			// names the handle, the way the source side falls back.
+			targetInode = newEntry.Attributes.Inode
+		}
+		if targetInode != 0 && targetInode != sourceInode {
+			wfs.markHandleDeleted(targetInode, true)
 			wfs.waitForPendingAsyncFlush(targetInode)
+			// A rename that does not happen leaves the destination where it
+			// was, so its handle has to go back to writing that name.
+			defer func() {
+				if code != fuse.OK {
+					wfs.markHandleDeleted(targetInode, false)
+				}
+			}()
 		}
 	}
 

--- a/weed/mount/weedfs_rename.go
+++ b/weed/mount/weedfs_rename.go
@@ -284,13 +284,13 @@ func (wfs *WFS) Rename(cancel <-chan struct{}, in *fuse.RenameIn, oldName string
 			targetInode = newEntry.Attributes.Inode
 		}
 		if targetInode != 0 && targetInode != sourceInode {
-			wfs.markHandleDeleted(targetInode, true)
+			epoch := wfs.markHandleDeleted(targetInode)
 			wfs.waitForPendingAsyncFlush(targetInode)
 			// A rename that does not happen leaves the destination where it
 			// was, so its handle has to go back to writing that name.
 			defer func() {
 				if code != fuse.OK {
-					wfs.markHandleDeleted(targetInode, false)
+					wfs.clearHandleDeleted(targetInode, epoch)
 				}
 			}()
 		}

--- a/weed/mount/weedfs_rename.go
+++ b/weed/mount/weedfs_rename.go
@@ -284,8 +284,12 @@ func (wfs *WFS) Rename(cancel <-chan struct{}, in *fuse.RenameIn, oldName string
 			targetInode = newEntry.Attributes.Inode
 		}
 		if targetInode != 0 && targetInode != sourceInode {
-			epoch := wfs.markHandleDeleted(targetInode)
+			// Drained before the mark, not after: a flush already queued
+			// belongs to the destination as it stands, and one that runs
+			// marked is skipped and takes its handle with it, past the reach
+			// of the restore below.
 			wfs.waitForPendingAsyncFlush(targetInode)
+			epoch := wfs.markHandleDeleted(targetInode)
 			// A rename that does not happen leaves the destination where it
 			// was, so its handle has to go back to writing that name.
 			defer func() {

--- a/weed/mount/weedfs_rename.go
+++ b/weed/mount/weedfs_rename.go
@@ -240,10 +240,11 @@ func (wfs *WFS) Rename(cancel <-chan struct{}, in *fuse.RenameIn, oldName string
 	//   1. deferFilerCreate=true — file handle still open, dirtyMetadata set.
 	//   2. writebackCache — close() triggered async flush, handle released.
 	// The filer rename will fail with ENOENT unless we flush/wait first.
-	if inode, found := wfs.inodeToPath.GetInode(oldPath); found {
+	sourceInode, sourceMapped := wfs.inodeToPath.GetInode(oldPath)
+	if sourceMapped {
 		// Case 1: handle still open with deferred metadata — flush synchronously
 		// BEFORE any async flush interference.
-		if fh, ok := wfs.fhMap.FindFileHandle(inode); ok && fh.dirtyMetadata {
+		if fh, ok := wfs.fhMap.FindFileHandle(sourceInode); ok && fh.dirtyMetadata {
 			glog.V(4).Infof("dir Rename %s: flushing deferred metadata before rename", oldPath)
 			// Prerequisite for the rename, so it must complete: non-cancellable context.
 			if flushStatus := wfs.doFlush(context.Background(), fh, oldEntry.Attributes.Uid, oldEntry.Attributes.Gid, false); flushStatus != fuse.OK {
@@ -255,14 +256,26 @@ func (wfs *WFS) Rename(cancel <-chan struct{}, in *fuse.RenameIn, oldName string
 		// Mark ALL handles for this inode as renamed so the async flush
 		// skips old-path metadata creation (which would re-insert the
 		// renamed entry into the meta cache after rename events clean it up).
-		wfs.fhMap.MarkInodeRenamed(inode)
-		wfs.waitForPendingAsyncFlush(inode)
+		wfs.fhMap.MarkInodeRenamed(sourceInode)
+		wfs.waitForPendingAsyncFlush(sourceInode)
 	} else if oldEntry != nil && oldEntry.Attributes != nil && oldEntry.Attributes.Inode != 0 {
 		// GetInode failed (Forget already removed the mapping), but the
 		// entry's stored inode can still identify pending async flushes.
-		inode = oldEntry.Attributes.Inode
-		wfs.fhMap.MarkInodeRenamed(inode)
-		wfs.waitForPendingAsyncFlush(inode)
+		sourceInode = oldEntry.Attributes.Inode
+		wfs.fhMap.MarkInodeRenamed(sourceInode)
+		wfs.waitForPendingAsyncFlush(sourceInode)
+	}
+
+	// Replacing the destination deletes what it held, so a handle still open
+	// on that entry has to stop writing the name back, exactly as an unlink
+	// makes it. Windows is where this bites: the close carrying the flush runs
+	// after the application's CloseHandle returned, so the flush can land on
+	// top of what the rename just put there.
+	if in.Flags == RenameEmptyFlag {
+		if targetInode, found := wfs.inodeToPath.GetInode(newPath); found && targetInode != sourceInode {
+			wfs.markHandleDeleted(targetInode)
+			wfs.waitForPendingAsyncFlush(targetInode)
+		}
 	}
 
 	// Acquire DLM locks on both old and new paths to prevent another mount


### PR DESCRIPTION
Verification run for the fix in #10965's branch. 400 iterations of TestRenameOverExisting plus the full suite. Will be closed once the result is known.