### PR TITLE
s3tables: delete only the location the dropped table owns

### DIFF
--- a/weed/s3api/s3tables/handler_delete_decouple_test.go
+++ b/weed/s3api/s3tables/handler_delete_decouple_test.go
@@ -94,3 +94,29 @@ func TestDeleteTableColocatedRemovesData(t *testing.T) {
 	assert.Nil(t, fs.Get(GetNamespacePath(renameTestBucket, "ns"), "t"), "colocated table entry must be deleted")
 	assert.Nil(t, fs.Get(GetTablePath(renameTestBucket, "ns", "t"), "metadata"), "colocated table data must be deleted")
 }
+
+// A table whose MetadataLocation points at a sibling that is still a live
+// catalog entry must not be deleted: only the named table was authorized, so a
+// recursive purge of that location would destroy another tenant's table.
+func TestDeleteTableRefusesLiveSiblingDataPath(t *testing.T) {
+	fs, m := startRenameManager(t)
+
+	nsMeta, _ := json.Marshal(namespaceMetadata{Namespace: []string{"attackerns"}, OwnerAccountID: DefaultAccountID})
+	fs.Put(GetTableBucketPath(renameTestBucket), "attackerns", map[string][]byte{ExtendedKeyMetadata: nsMeta})
+
+	decoyMeta, _ := json.Marshal(tableMetadataInternal{
+		Name:             "decoy",
+		Namespace:        "attackerns",
+		Format:           "ICEBERG",
+		OwnerAccountID:   DefaultAccountID,
+		MetadataLocation: "s3://" + renameTestBucket + "/ns/t/metadata/v3.metadata.json",
+	})
+	fs.Put(GetNamespacePath(renameTestBucket, "attackerns"), "decoy", map[string][]byte{ExtendedKeyMetadata: decoyMeta})
+
+	require.Error(t, runDeleteTable(t, m, fs, "attackerns", "decoy"))
+
+	assert.NotNil(t, fs.Get(GetNamespacePath(renameTestBucket, "ns"), "t"),
+		"the targeted table's catalog entry must survive")
+	assert.NotNil(t, fs.Get(GetTablePath(renameTestBucket, "ns", "t"), "data"),
+		"the targeted table's data must survive")
+}

--- a/weed/s3api/s3tables/handler_table.go
+++ b/weed/s3api/s3tables/handler_table.go
@@ -1199,6 +1199,16 @@ func (h *S3TablesHandler) handleDeleteTable(w http.ResponseWriter, r *http.Reque
 			if strings.HasPrefix(tablePath+"/", dataPath+"/") {
 				return fmt.Errorf("refusing to delete table %s: data path %q is an ancestor of catalog path %q", tableName, dataPath, tablePath)
 			}
+			// The location is caller-supplied, so it may name a sibling that is
+			// still a live catalog entry. Only this table's authorization was
+			// checked; a decoupled location has had its catalog attributes
+			// stripped, so a surviving marker means the path belongs elsewhere.
+			switch _, markerErr := h.getExtendedAttribute(r.Context(), client, dataPath, ExtendedKeyMetadata); {
+			case markerErr == nil:
+				return fmt.Errorf("refusing to delete table %s: data path %q is another catalog entry", tableName, dataPath)
+			case !errors.Is(markerErr, ErrAttributeNotFound) && !errors.Is(markerErr, filer_pb.ErrNotFound):
+				return fmt.Errorf("refusing to delete table %s: cannot read data path %q: %w", tableName, dataPath, markerErr)
+			}
 			// Decoupled table (renamed, or created over a leftover): its data
 			// lives elsewhere. Purge the data, then clear the catalog marker
 			// without deleting the name path -- it may still hold another


### PR DESCRIPTION
`DeleteTable` derives its recursive purge target from the dropped table's stored `MetadataLocation`. That location comes from the caller on `CreateTable`/`RegisterTable`/`UpdateTable` and is never tied to the table it is stored on, so it can name a path the delete was never authorized for. The existing guards only reject a target outside the table bucket, or one that is an ancestor of the table's own catalog path -- a live table in a sibling namespace passes both, and the recursive delete then takes out its catalog entry and its data files.

A legitimately decoupled location is either a rename source or a leftover the name was reused over. Both have had their catalog attributes stripped, so a surviving metadata marker at the target means the path still belongs to another entry. Refuse those, next to the existing ancestor refusal.

Native `DeleteTable`, Iceberg `DropTable` and Lance `DropTable` all funnel through this path, so they are all covered.

Test covers a table whose metadata location points at a live table in another namespace: the drop is refused and the other table's entry and data survive. The existing decouple tests (rename source, reused name path, colocated) still pass unchanged.

https://claude.ai/code/session_019BhjadDrXArXg4oQPD9Df4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented deletion of a table when its data path belongs to another active catalog entry.
  - Preserved the associated catalog entry and data when such a conflicting path is detected.
  - Refused deletion when the data path cannot be safely verified.
  - Added coverage to verify that unsafe deletion attempts return an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->