### PR TITLE
filer, s3: reuse the volume server's guarded remote-storage client builder

### DIFF
--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -24,6 +24,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/pb/remote_pb"
 	"github.com/seaweedfs/seaweedfs/weed/remote_storage"
 	"github.com/seaweedfs/seaweedfs/weed/security"
+	weed_server "github.com/seaweedfs/seaweedfs/weed/server"
 	"github.com/seaweedfs/seaweedfs/weed/util"
 
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
@@ -3333,7 +3334,7 @@ func (s3a *S3ApiServer) openRemoteStream(ctx context.Context, bucket, object str
 		return nil, err
 	}
 
-	client, err := remote_storage.GetRemoteStorage(storageConf)
+	client, err := weed_server.BuildGuardedRemoteStorageClient(ctx, storageConf, false)
 	if err != nil {
 		return nil, err
 	}

--- a/weed/server/filer_server_handlers_read.go
+++ b/weed/server/filer_server_handlers_read.go
@@ -286,7 +286,7 @@ func (fs *FilerServer) streamFromRemote(ctx context.Context, dir, name string, o
 	if err != nil {
 		return nil, err
 	}
-	client, err := remote_storage.GetRemoteStorage(storageConf)
+	client, err := BuildGuardedRemoteStorageClient(ctx, storageConf, false)
 	if err != nil {
 		return nil, err
 	}

--- a/weed/server/volume_grpc_remote.go
+++ b/weed/server/volume_grpc_remote.go
@@ -350,6 +350,42 @@ func checkGcsCredentials(creds string) error {
 	return nil
 }
 
+// BuildGuardedRemoteStorageClient builds a remote storage client whose dial
+// path is validated against the SSRF deny-list and pinned against DNS
+// rebinding, unless allowUntrusted is set. It is the single builder for every
+// caller that dials a caller-influenced RemoteConf endpoint: the volume
+// FetchAndWriteNeedle write path and the filer and S3 gateway remote-mount read
+// paths, which otherwise reach the same s3manager sink unguarded.
+func BuildGuardedRemoteStorageClient(ctx context.Context, remoteConf *remote_pb.RemoteConf, allowUntrusted bool) (remote_storage.RemoteStorageClient, error) {
+	if !allowUntrusted {
+		if remoteConf.GetType() == "gcs" {
+			if credsErr := checkGcsCredentials(remoteConf.GetGcsGoogleApplicationCredentials()); credsErr != nil {
+				return nil, fmt.Errorf("reject remote credentials: %w", credsErr)
+			}
+		}
+		if endpoint, makeClient, ok := guardedRemoteClient(remoteConf); ok {
+			if validateErr := validateRemoteEndpoint(ctx, endpoint); validateErr != nil {
+				return nil, fmt.Errorf("reject remote endpoint: %w", validateErr)
+			}
+			// Build a one-shot client whose dial path re-validates the resolved
+			// IP every time. This pins the validated endpoint against DNS
+			// rebinding (a hostname that resolves to a public IP for
+			// validateRemoteEndpoint and then flips to 127.0.0.1 / 169.254.x.x
+			// when the SDK dials).
+			client, err := makeClient(newGuardedHTTPClient(endpoint))
+			if err != nil {
+				return nil, fmt.Errorf("get remote client: %w", err)
+			}
+			return client, nil
+		}
+	}
+	client, err := remote_storage.GetRemoteStorage(remoteConf)
+	if err != nil {
+		return nil, fmt.Errorf("get remote client: %w", err)
+	}
+	return client, nil
+}
+
 func (vs *VolumeServer) FetchAndWriteNeedle(ctx context.Context, req *volume_server_pb.FetchAndWriteNeedleRequest) (resp *volume_server_pb.FetchAndWriteNeedleResponse, err error) {
 	if err := vs.checkGrpcAdminAuth(ctx); err != nil {
 		return nil, err
@@ -366,29 +402,9 @@ func (vs *VolumeServer) FetchAndWriteNeedle(ctx context.Context, req *volume_ser
 
 	remoteConf := req.RemoteConf
 
-	if !vs.AllowUntrustedRemoteEndpoints && remoteConf.GetType() == "gcs" {
-		if credsErr := checkGcsCredentials(remoteConf.GetGcsGoogleApplicationCredentials()); credsErr != nil {
-			return nil, fmt.Errorf("reject remote credentials: %w", credsErr)
-		}
-	}
-
-	var client remote_storage.RemoteStorageClient
-	var getClientErr error
-	if endpoint, makeClient, ok := guardedRemoteClient(remoteConf); ok && !vs.AllowUntrustedRemoteEndpoints {
-		if validateErr := validateRemoteEndpoint(ctx, endpoint); validateErr != nil {
-			return nil, fmt.Errorf("reject remote endpoint: %w", validateErr)
-		}
-		// Build a one-shot client whose dial path re-validates the resolved
-		// IP every time. This pins the validated endpoint against DNS
-		// rebinding (a hostname that resolves to a public IP for
-		// validateRemoteEndpoint and then flips to 127.0.0.1 / 169.254.x.x
-		// when the SDK dials).
-		client, getClientErr = makeClient(newGuardedHTTPClient(endpoint))
-	} else {
-		client, getClientErr = remote_storage.GetRemoteStorage(remoteConf)
-	}
+	client, getClientErr := BuildGuardedRemoteStorageClient(ctx, remoteConf, vs.AllowUntrustedRemoteEndpoints)
 	if getClientErr != nil {
-		return nil, fmt.Errorf("get remote client: %w", getClientErr)
+		return nil, getClientErr
 	}
 
 	remoteStorageLocation := req.RemoteLocation

--- a/weed/server/volume_grpc_remote_test.go
+++ b/weed/server/volume_grpc_remote_test.go
@@ -638,3 +638,36 @@ func TestGuardedReplicaDialerRebind(t *testing.T) {
 		t.Fatalf("private peer must be allowed by the replica dialer, got %v", perr)
 	}
 }
+
+// TestBuildGuardedRemoteStorageClient confirms the shared builder refuses a
+// caller-influenced endpoint that resolves to a blocked address, and a gcs
+// credentials path, while allowUntrusted falls back to the plain builder.
+func TestBuildGuardedRemoteStorageClient(t *testing.T) {
+	loopbackS3 := &remote_pb.RemoteConf{
+		Name:        "poc",
+		Type:        "s3",
+		S3Endpoint:  "http://127.0.0.1:8000",
+		S3AccessKey: "k",
+		S3SecretKey: "s",
+		S3Region:    "us-east-1",
+	}
+	if _, err := BuildGuardedRemoteStorageClient(context.Background(), loopbackS3, false); err == nil {
+		t.Error("expected a loopback s3 endpoint to be rejected")
+	} else if !strings.Contains(err.Error(), "reject remote endpoint") {
+		t.Errorf("error = %v, want reject remote endpoint", err)
+	}
+	if _, err := BuildGuardedRemoteStorageClient(context.Background(), loopbackS3, true); err != nil {
+		t.Errorf("allowUntrusted should build the client: %v", err)
+	}
+
+	gcsPathCreds := &remote_pb.RemoteConf{
+		Name:                            "poc",
+		Type:                            "gcs",
+		GcsGoogleApplicationCredentials: "/etc/hostname",
+	}
+	if _, err := BuildGuardedRemoteStorageClient(context.Background(), gcsPathCreds, false); err == nil {
+		t.Error("expected a gcs credentials path to be rejected")
+	} else if !strings.Contains(err.Error(), "reject remote credentials") {
+		t.Errorf("error = %v, want reject remote credentials", err)
+	}
+}


### PR DESCRIPTION
### What

The volume server's `FetchAndWriteNeedle` builds its remote-storage client through a guarded path: it validates the caller-supplied endpoint, rejects credentials that would send the SDK reading elsewhere, and installs a dialer that re-checks the resolved address at connect time. The filer and S3 gateway have two more callers that dial the same caller-supplied `RemoteConf` endpoint when they serve a remote-mounted object straight from its origin, but they built the client with the bare `remote_storage.GetRemoteStorage`, so none of those checks applied there.

This routes both through the same builder.

- `weed/server/volume_grpc_remote.go` — extract the existing inline logic into `BuildGuardedRemoteStorageClient(ctx, conf, allowUntrusted)`. `FetchAndWriteNeedle` now calls it; no behavior change on that path.
- `weed/server/filer_server_handlers_read.go` — `streamFromRemote` (cold remote-only read passthrough) uses it.
- `weed/s3api/s3api_object_handlers.go` — `openRemoteStream` (remote-mount read fallback) uses it.

Both read paths are best-effort fallbacks, so a rejected endpoint surfaces as the existing retry/`503` path rather than a hard failure.

### Notes

- No new flags. The volume server keeps its `-volume.allowUntrustedRemoteEndpoints` opt-out; the filer/S3 read paths are guarded unconditionally.
- The Rust volume server is unaffected: it has no filer/S3 gateway, and its `fetch_and_write` guard is unchanged.

### Test

- Existing endpoint/replica/gcs guard tests stay green.
- Added `TestBuildGuardedRemoteStorageClient`: a loopback endpoint and a gcs credentials path are rejected; `allowUntrusted` falls back to the plain builder.

https://claude.ai/code/session_01AiH1FU3rmshSbFFTbJpaZN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection for remote storage connections by consistently validating endpoints and credentials before access.
  * Blocked unsafe remote endpoints, including loopback addresses, when untrusted connections are not allowed.
  * Preserved controlled access for explicitly trusted remote storage configurations.

* **Tests**
  * Added coverage verifying rejection of unsafe endpoints and credential paths, along with permitted trusted configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->