### PR TITLE
shell: remove the directories emptied by volume.fsck's filer entry purge

### DIFF
--- a/weed/shell/command_volume_fsck.go
+++ b/weed/shell/command_volume_fsck.go
@@ -728,18 +728,16 @@ func (c *commandVolumeFsck) purgeEmptyDirectories() {
 	sort.Slice(dirs, func(i, j int) bool { return len(dirs[i]) > len(dirs[j]) })
 
 	for _, dir := range dirs {
-		isKeyObject, lookupErr := c.isDirectoryKeyObject(dir)
-		if lookupErr != nil {
+		entry, _, _, lookupErr := filer_pb.GetEntry(context.Background(), c.env, dir)
+		if lookupErr != nil && !errors.Is(lookupErr, filer_pb.ErrNotFound) {
 			fmt.Fprintf(c.writer, "lookup directory %s: %v\n", dir, lookupErr)
 			continue
 		}
 		// a directory key object is an S3 object of its own
-		if isKeyObject {
+		if entry == nil || entry.IsDirectoryKeyObject() {
 			continue
 		}
-		parent, name := dir.DirAndName()
-		// a non-recursive delete lets the filer reject a directory that is not empty
-		if err := filer_pb.Remove(context.Background(), c.env, parent, name, false, false, false, false, nil); err != nil {
+		if err := c.deleteEmptyDirectory(dir, entry.Attributes.GetMtime()); err != nil {
 			if !strings.Contains(err.Error(), filer.MsgFailDelNonEmptyFolder) {
 				fmt.Fprintf(c.writer, "delete empty directory %s: %v\n", dir, err)
 			}
@@ -747,6 +745,27 @@ func (c *commandVolumeFsck) purgeEmptyDirectories() {
 		}
 		fmt.Fprintf(c.writer, "deleted empty directory %s\n", dir)
 	}
+}
+
+// deleteEmptyDirectory deletes dir unless it changed since it was looked up at mtime,
+// so a directory promoted to an S3 object meanwhile survives. The delete is not
+// recursive, leaving the filer to reject a directory that is not empty.
+func (c *commandVolumeFsck) deleteEmptyDirectory(dir util.FullPath, mtime int64) error {
+	parent, name := dir.DirAndName()
+	return c.env.WithFilerClient(false, func(client filer_pb.SeaweedFilerClient) error {
+		resp, err := client.DeleteEntry(context.Background(), &filer_pb.DeleteEntryRequest{
+			Directory:          parent,
+			Name:               name,
+			IfNotModifiedAfter: mtime,
+		})
+		if err != nil {
+			return err
+		}
+		if resp.Error != "" {
+			return errors.New(resp.Error)
+		}
+		return nil
+	})
 }
 
 func (c *commandVolumeFsck) canPurgeDirectory(dir util.FullPath) bool {
@@ -757,14 +776,6 @@ func (c *commandVolumeFsck) canPurgeDirectory(dir util.FullPath) bool {
 	// deleting a bucket drops its whole collection
 	parent, _ := dir.DirAndName()
 	return string(dir) != c.bucketsPath && parent != c.bucketsPath
-}
-
-func (c *commandVolumeFsck) isDirectoryKeyObject(dir util.FullPath) (bool, error) {
-	entry, _, _, err := filer_pb.GetEntry(context.Background(), c.env, dir)
-	if err != nil && !errors.Is(err, filer_pb.ErrNotFound) {
-		return false, err
-	}
-	return entry != nil && entry.IsDirectoryKeyObject(), nil
 }
 
 func (c *commandVolumeFsck) oneVolumeFileIdsSubtractFilerFileIds(dataNodeId string, volumeId uint32, vinfo *VInfo, modifyFrom, cutoffFrom uint64) (inUseCount uint64, orphanFileIds []string, orphanDataSize uint64, err error) {

--- a/weed/shell/command_volume_fsck.go
+++ b/weed/shell/command_volume_fsck.go
@@ -741,8 +741,9 @@ func (c *commandVolumeFsck) purgeEmptyDirectories() {
 		if entry == nil || entry.IsDirectoryKeyObject() {
 			continue
 		}
+		// a zero mtime turns the delete's condition off, leaving nothing to hold it to
 		mtime := entry.Attributes.GetMtime()
-		if mtime > time.Now().Add(-directoryQuietPeriod).Unix() {
+		if mtime <= 0 || mtime > time.Now().Add(-directoryQuietPeriod).Unix() {
 			continue
 		}
 		if err := c.deleteEmptyDirectory(dir, mtime); err != nil {

--- a/weed/shell/command_volume_fsck.go
+++ b/weed/shell/command_volume_fsck.go
@@ -44,6 +44,10 @@ func init() {
 const (
 	readbufferSize                 = 16
 	jwtFilerTokenExpirationSeconds = 300
+	// mtime is only second resolution, so a directory touched this recently is
+	// left for the next run rather than compared against a timestamp a
+	// concurrent write could share
+	directoryQuietPeriod = 5 * time.Second
 )
 
 type commandVolumeFsck struct {
@@ -737,7 +741,11 @@ func (c *commandVolumeFsck) purgeEmptyDirectories() {
 		if entry == nil || entry.IsDirectoryKeyObject() {
 			continue
 		}
-		if err := c.deleteEmptyDirectory(dir, entry.Attributes.GetMtime()); err != nil {
+		mtime := entry.Attributes.GetMtime()
+		if mtime > time.Now().Add(-directoryQuietPeriod).Unix() {
+			continue
+		}
+		if err := c.deleteEmptyDirectory(dir, mtime); err != nil {
 			if !strings.Contains(err.Error(), filer.MsgFailDelNonEmptyFolder) {
 				fmt.Fprintf(c.writer, "delete empty directory %s: %v\n", dir, err)
 			}

--- a/weed/shell/command_volume_fsck.go
+++ b/weed/shell/command_volume_fsck.go
@@ -743,7 +743,7 @@ func (c *commandVolumeFsck) purgeEmptyDirectories() {
 		}
 		// a zero mtime turns the delete's condition off, leaving nothing to hold it to
 		mtime := entry.Attributes.GetMtime()
-		if mtime <= 0 || mtime > time.Now().Add(-directoryQuietPeriod).Unix() {
+		if mtime <= 0 || mtime >= time.Now().Add(-directoryQuietPeriod).Unix() {
 			continue
 		}
 		if err := c.deleteEmptyDirectory(dir, mtime); err != nil {

--- a/weed/shell/command_volume_fsck.go
+++ b/weed/shell/command_volume_fsck.go
@@ -61,6 +61,8 @@ type commandVolumeFsck struct {
 	verifyNeedle              *bool
 	filerSigningKey           string
 	unresolvedManifestEntries atomic.Int64
+	purgedDirsLock            sync.Mutex
+	purgedDirs                map[util.FullPath]struct{}
 }
 
 func (c *commandVolumeFsck) Name() string {
@@ -122,6 +124,7 @@ func (c *commandVolumeFsck) Do(args []string, commandEnv *CommandEnv, writer io.
 	// unresolved-manifest counter so a previous failed run can't permanently
 	// suppress -reallyDeleteFromVolume in this session.
 	c.unresolvedManifestEntries.Store(0)
+	c.purgedDirs = make(map[util.FullPath]struct{})
 
 	if err = commandEnv.confirmIsLocked(args); err != nil {
 		return
@@ -248,6 +251,7 @@ func (c *commandVolumeFsck) Do(args []string, commandEnv *CommandEnv, writer io.
 				return fmt.Errorf("findFilerChunksMissingInVolumeServers: %w", err)
 			}
 		}
+		c.purgeEmptyDirectories()
 	} else {
 		// collect all filer file ids
 		if err = c.collectFilerFileIdAndPaths(dataNodeVolumeIdToVInfo, false, 0, 0); err != nil {
@@ -694,6 +698,73 @@ func (c *commandVolumeFsck) httpDelete(path util.FullPath) {
 		fmt.Fprintln(c.writer, "delete response Status : ", resp.Status)
 		fmt.Fprintln(c.writer, "delete response Headers : ", resp.Header)
 	}
+
+	if resp.StatusCode < http.StatusBadRequest {
+		dir, _ := path.DirAndName()
+		c.purgedDirsLock.Lock()
+		c.purgedDirs[util.FullPath(dir)] = struct{}{}
+		c.purgedDirsLock.Unlock()
+	}
+}
+
+// purgeEmptyDirectories removes the directories emptied by the purged entries, walking up while each parent is empty too.
+func (c *commandVolumeFsck) purgeEmptyDirectories() {
+	candidates := make(map[util.FullPath]struct{})
+	c.purgedDirsLock.Lock()
+	for dir := range c.purgedDirs {
+		for d := dir; c.canPurgeDirectory(d); {
+			candidates[d] = struct{}{}
+			parent, _ := d.DirAndName()
+			d = util.FullPath(parent)
+		}
+	}
+	c.purgedDirsLock.Unlock()
+
+	dirs := make([]util.FullPath, 0, len(candidates))
+	for dir := range candidates {
+		dirs = append(dirs, dir)
+	}
+	// deepest first, so a directory is only tried once its children are gone
+	sort.Slice(dirs, func(i, j int) bool { return len(dirs[i]) > len(dirs[j]) })
+
+	for _, dir := range dirs {
+		isKeyObject, lookupErr := c.isDirectoryKeyObject(dir)
+		if lookupErr != nil {
+			fmt.Fprintf(c.writer, "lookup directory %s: %v\n", dir, lookupErr)
+			continue
+		}
+		// a directory key object is an S3 object of its own
+		if isKeyObject {
+			continue
+		}
+		parent, name := dir.DirAndName()
+		// a non-recursive delete lets the filer reject a directory that is not empty
+		if err := filer_pb.Remove(context.Background(), c.env, parent, name, false, false, false, false, nil); err != nil {
+			if !strings.Contains(err.Error(), filer.MsgFailDelNonEmptyFolder) {
+				fmt.Fprintf(c.writer, "delete empty directory %s: %v\n", dir, err)
+			}
+			continue
+		}
+		fmt.Fprintf(c.writer, "deleted empty directory %s\n", dir)
+	}
+}
+
+func (c *commandVolumeFsck) canPurgeDirectory(dir util.FullPath) bool {
+	root := c.getCollectFilerFilePath()
+	if string(dir) == root || !strings.HasPrefix(string(dir), strings.TrimSuffix(root, "/")+"/") {
+		return false
+	}
+	// deleting a bucket drops its whole collection
+	parent, _ := dir.DirAndName()
+	return string(dir) != c.bucketsPath && parent != c.bucketsPath
+}
+
+func (c *commandVolumeFsck) isDirectoryKeyObject(dir util.FullPath) (bool, error) {
+	entry, _, _, err := filer_pb.GetEntry(context.Background(), c.env, dir)
+	if err != nil && !errors.Is(err, filer_pb.ErrNotFound) {
+		return false, err
+	}
+	return entry != nil && entry.IsDirectoryKeyObject(), nil
 }
 
 func (c *commandVolumeFsck) oneVolumeFileIdsSubtractFilerFileIds(dataNodeId string, volumeId uint32, vinfo *VInfo, modifyFrom, cutoffFrom uint64) (inUseCount uint64, orphanFileIds []string, orphanDataSize uint64, err error) {

--- a/weed/shell/command_volume_fsck_test.go
+++ b/weed/shell/command_volume_fsck_test.go
@@ -134,7 +134,8 @@ func startStubFiler(t *testing.T, stub *stubFilerServer) *CommandEnv {
 }
 
 func TestVolumeFsckPurgeEmptyDirectories(t *testing.T) {
-	directory := &filer_pb.Entry{IsDirectory: true}
+	settled := &filer_pb.FuseAttributes{Mtime: time.Now().Add(-time.Hour).Unix()}
+	directory := &filer_pb.Entry{IsDirectory: true, Attributes: settled}
 	stub := &stubFilerServer{entries: map[string]*filer_pb.Entry{
 		"/orphan":                 directory,
 		"/orphan/dir":             directory,
@@ -144,7 +145,10 @@ func TestVolumeFsckPurgeEmptyDirectories(t *testing.T) {
 		"/keep/file.txt":          {},
 		"/buckets":                directory,
 		"/buckets/bucket1":        directory,
-		"/buckets/bucket1/folder": {IsDirectory: true, Attributes: &filer_pb.FuseAttributes{Mime: "application/octet-stream"}},
+		"/buckets/bucket1/folder": {IsDirectory: true, Attributes: &filer_pb.FuseAttributes{Mime: "application/octet-stream", Mtime: settled.Mtime}},
+		// no mtime to condition a delete on, so it stays
+		"/nomtime":     {IsDirectory: true},
+		"/nomtime/dir": {IsDirectory: true},
 	}}
 
 	verbose := false
@@ -158,6 +162,7 @@ func TestVolumeFsckPurgeEmptyDirectories(t *testing.T) {
 			"/orphan/dir/wide":        {},
 			"/keep":                   {},
 			"/buckets/bucket1/folder": {},
+			"/nomtime/dir":            {},
 		},
 		env: startStubFiler(t, stub),
 	}

--- a/weed/shell/command_volume_fsck_test.go
+++ b/weed/shell/command_volume_fsck_test.go
@@ -73,22 +73,36 @@ func TestVolumeFsckHttpDeleteRecordsParentDirectory(t *testing.T) {
 	}
 }
 
-// stubFilerServer keeps a flat set of full paths and enforces the same
-// non-recursive delete rule as the filer: a directory with children is kept.
+// stubFilerServer keeps a flat set of full paths and enforces the same delete
+// rules as the filer: a directory with children is kept, and so is one modified
+// after the caller looked it up. A path in writtenAfterLookup is modified by a
+// client right after fsck reads it.
 type stubFilerServer struct {
 	filer_pb.UnimplementedSeaweedFilerServer
-	entries map[string]*filer_pb.Entry
-	deleted []string
+	entries            map[string]*filer_pb.Entry
+	writtenAfterLookup map[string]bool
+	deleted            []string
 }
 
 func (s *stubFilerServer) LookupDirectoryEntry(ctx context.Context, req *filer_pb.LookupDirectoryEntryRequest) (*filer_pb.LookupDirectoryEntryResponse, error) {
-	return &filer_pb.LookupDirectoryEntryResponse{Entry: s.entries[string(util.NewFullPath(req.Directory, req.Name))]}, nil
+	fullPath := string(util.NewFullPath(req.Directory, req.Name))
+	entry := s.entries[fullPath]
+	if entry != nil && s.writtenAfterLookup[fullPath] {
+		seen := &filer_pb.Entry{IsDirectory: entry.IsDirectory, Attributes: &filer_pb.FuseAttributes{Mtime: entry.Attributes.GetMtime()}}
+		entry.Attributes.Mtime++
+		return &filer_pb.LookupDirectoryEntryResponse{Entry: seen}, nil
+	}
+	return &filer_pb.LookupDirectoryEntryResponse{Entry: entry}, nil
 }
 
 func (s *stubFilerServer) DeleteEntry(ctx context.Context, req *filer_pb.DeleteEntryRequest) (*filer_pb.DeleteEntryResponse, error) {
 	fullPath := string(util.NewFullPath(req.Directory, req.Name))
-	if _, found := s.entries[fullPath]; !found {
+	entry, found := s.entries[fullPath]
+	if !found {
 		return &filer_pb.DeleteEntryResponse{Error: filer_pb.ErrNotFound.Error()}, nil
+	}
+	if req.IfNotModifiedAfter > 0 && entry.Attributes.GetMtime() > req.IfNotModifiedAfter {
+		return &filer_pb.DeleteEntryResponse{}, nil
 	}
 	for path := range s.entries {
 		if strings.HasPrefix(path, fullPath+"/") {
@@ -98,6 +112,24 @@ func (s *stubFilerServer) DeleteEntry(ctx context.Context, req *filer_pb.DeleteE
 	delete(s.entries, fullPath)
 	s.deleted = append(s.deleted, fullPath)
 	return &filer_pb.DeleteEntryResponse{}, nil
+}
+
+// startStubFiler serves stub on a random localhost port and returns the shell
+// environment whose filer client reaches it.
+func startStubFiler(t *testing.T, stub *stubFilerServer) *CommandEnv {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := grpc.NewServer()
+	filer_pb.RegisterSeaweedFilerServer(srv, stub)
+	go srv.Serve(lis)
+	t.Cleanup(srv.Stop)
+	return &CommandEnv{option: &ShellOptions{
+		FilerAddress:   pb.ServerAddress(fmt.Sprintf("127.0.0.1:1.%d", lis.Addr().(*net.TCPAddr).Port)),
+		GrpcDialOption: grpc.WithTransportCredentials(insecure.NewCredentials()),
+	}}
 }
 
 func TestVolumeFsckPurgeEmptyDirectories(t *testing.T) {
@@ -114,15 +146,6 @@ func TestVolumeFsckPurgeEmptyDirectories(t *testing.T) {
 		"/buckets/bucket1/folder": {IsDirectory: true, Attributes: &filer_pb.FuseAttributes{Mime: "application/octet-stream"}},
 	}}
 
-	lis, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
-	srv := grpc.NewServer()
-	filer_pb.RegisterSeaweedFilerServer(srv, stub)
-	go srv.Serve(lis)
-	t.Cleanup(srv.Stop)
-
 	verbose := false
 	c := &commandVolumeFsck{
 		verbose:         &verbose,
@@ -135,10 +158,7 @@ func TestVolumeFsckPurgeEmptyDirectories(t *testing.T) {
 			"/keep":                   {},
 			"/buckets/bucket1/folder": {},
 		},
-		env: &CommandEnv{option: &ShellOptions{
-			FilerAddress:   pb.ServerAddress(fmt.Sprintf("127.0.0.1:1.%d", lis.Addr().(*net.TCPAddr).Port)),
-			GrpcDialOption: grpc.WithTransportCredentials(insecure.NewCredentials()),
-		}},
+		env: startStubFiler(t, stub),
 	}
 
 	c.purgeEmptyDirectories()
@@ -149,5 +169,31 @@ func TestVolumeFsckPurgeEmptyDirectories(t *testing.T) {
 	sort.Strings(stub.deleted)
 	if strings.Join(stub.deleted, ",") != strings.Join(expected, ",") {
 		t.Errorf("deleted %v, expected %v", stub.deleted, expected)
+	}
+}
+
+func TestVolumeFsckPurgeEmptyDirectoriesKeepsChangedDirectory(t *testing.T) {
+	stub := &stubFilerServer{
+		entries: map[string]*filer_pb.Entry{
+			"/race":     {IsDirectory: true, Attributes: &filer_pb.FuseAttributes{Mtime: 100}},
+			"/race/dir": {IsDirectory: true, Attributes: &filer_pb.FuseAttributes{Mtime: 100}},
+		},
+		writtenAfterLookup: map[string]bool{"/race/dir": true},
+	}
+
+	verbose := false
+	c := &commandVolumeFsck{
+		verbose:         &verbose,
+		writer:          io.Discard,
+		bucketsPath:     "/buckets",
+		scopedFilerPath: "/",
+		purgedDirs:      map[util.FullPath]struct{}{"/race/dir": {}},
+		env:             startStubFiler(t, stub),
+	}
+
+	c.purgeEmptyDirectories()
+
+	if len(stub.deleted) > 0 {
+		t.Errorf("deleted %v, expected a directory written to after the lookup to be kept", stub.deleted)
 	}
 }

--- a/weed/shell/command_volume_fsck_test.go
+++ b/weed/shell/command_volume_fsck_test.go
@@ -1,0 +1,153 @@
+package shell
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/filer"
+	"github.com/seaweedfs/seaweedfs/weed/pb"
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func TestVolumeFsckCanPurgeDirectory(t *testing.T) {
+	testCases := []struct {
+		scopedFilerPath string
+		dir             util.FullPath
+		expected        bool
+	}{
+		{"/", "/orphan/dir/deep", true},
+		{"/", "/orphan", true},
+		{"/", "/", false},
+		{"/", "/buckets", false},
+		{"/", "/buckets/bucket1", false},
+		{"/", "/buckets/bucket1/dir", true},
+		{"/buckets/bucket1", "/buckets/bucket1", false},
+		{"/buckets/bucket1", "/buckets/bucket1/dir", true},
+		{"/buckets/bucket1", "/buckets/bucket11/dir", false},
+		{"/buckets/bucket1", "/orphan/dir", false},
+	}
+	for _, tc := range testCases {
+		c := &commandVolumeFsck{bucketsPath: "/buckets", scopedFilerPath: tc.scopedFilerPath}
+		if actual := c.canPurgeDirectory(tc.dir); actual != tc.expected {
+			t.Errorf("scope %s: canPurgeDirectory(%s) = %v, expected %v", tc.scopedFilerPath, tc.dir, actual, tc.expected)
+		}
+	}
+}
+
+func TestVolumeFsckHttpDeleteRecordsParentDirectory(t *testing.T) {
+	filer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/locked/") {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer filer.Close()
+
+	verbose := false
+	c := &commandVolumeFsck{
+		verbose:    &verbose,
+		writer:     io.Discard,
+		purgedDirs: make(map[util.FullPath]struct{}),
+		env:        &CommandEnv{option: &ShellOptions{FilerAddress: pb.ServerAddress(strings.TrimPrefix(filer.URL, "http://"))}},
+	}
+
+	c.httpDelete("/orphan/dir/deep/file.txt")
+	c.httpDelete("/locked/dir/file.txt")
+
+	if _, found := c.purgedDirs["/orphan/dir/deep"]; !found {
+		t.Errorf("expected /orphan/dir/deep to be recorded, got %v", c.purgedDirs)
+	}
+	if _, found := c.purgedDirs["/locked/dir"]; found {
+		t.Errorf("expected a rejected delete not to be recorded, got %v", c.purgedDirs)
+	}
+}
+
+// stubFilerServer keeps a flat set of full paths and enforces the same
+// non-recursive delete rule as the filer: a directory with children is kept.
+type stubFilerServer struct {
+	filer_pb.UnimplementedSeaweedFilerServer
+	entries map[string]*filer_pb.Entry
+	deleted []string
+}
+
+func (s *stubFilerServer) LookupDirectoryEntry(ctx context.Context, req *filer_pb.LookupDirectoryEntryRequest) (*filer_pb.LookupDirectoryEntryResponse, error) {
+	return &filer_pb.LookupDirectoryEntryResponse{Entry: s.entries[string(util.NewFullPath(req.Directory, req.Name))]}, nil
+}
+
+func (s *stubFilerServer) DeleteEntry(ctx context.Context, req *filer_pb.DeleteEntryRequest) (*filer_pb.DeleteEntryResponse, error) {
+	fullPath := string(util.NewFullPath(req.Directory, req.Name))
+	if _, found := s.entries[fullPath]; !found {
+		return &filer_pb.DeleteEntryResponse{Error: filer_pb.ErrNotFound.Error()}, nil
+	}
+	for path := range s.entries {
+		if strings.HasPrefix(path, fullPath+"/") {
+			return &filer_pb.DeleteEntryResponse{Error: filer.MsgFailDelNonEmptyFolder + ": " + fullPath}, nil
+		}
+	}
+	delete(s.entries, fullPath)
+	s.deleted = append(s.deleted, fullPath)
+	return &filer_pb.DeleteEntryResponse{}, nil
+}
+
+func TestVolumeFsckPurgeEmptyDirectories(t *testing.T) {
+	directory := &filer_pb.Entry{IsDirectory: true}
+	stub := &stubFilerServer{entries: map[string]*filer_pb.Entry{
+		"/orphan":                 directory,
+		"/orphan/dir":             directory,
+		"/orphan/dir/deep":        directory,
+		"/orphan/dir/wide":        directory,
+		"/keep":                   directory,
+		"/keep/file.txt":          {},
+		"/buckets":                directory,
+		"/buckets/bucket1":        directory,
+		"/buckets/bucket1/folder": {IsDirectory: true, Attributes: &filer_pb.FuseAttributes{Mime: "application/octet-stream"}},
+	}}
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := grpc.NewServer()
+	filer_pb.RegisterSeaweedFilerServer(srv, stub)
+	go srv.Serve(lis)
+	t.Cleanup(srv.Stop)
+
+	verbose := false
+	c := &commandVolumeFsck{
+		verbose:         &verbose,
+		writer:          io.Discard,
+		bucketsPath:     "/buckets",
+		scopedFilerPath: "/",
+		purgedDirs: map[util.FullPath]struct{}{
+			"/orphan/dir/deep":        {},
+			"/orphan/dir/wide":        {},
+			"/keep":                   {},
+			"/buckets/bucket1/folder": {},
+		},
+		env: &CommandEnv{option: &ShellOptions{
+			FilerAddress:   pb.ServerAddress(fmt.Sprintf("127.0.0.1:1.%d", lis.Addr().(*net.TCPAddr).Port)),
+			GrpcDialOption: grpc.WithTransportCredentials(insecure.NewCredentials()),
+		}},
+	}
+
+	c.purgeEmptyDirectories()
+
+	// the two emptied leaves, then the parent they shared, then its own parent
+	expected := []string{"/orphan/dir/deep", "/orphan/dir/wide", "/orphan/dir", "/orphan"}
+	sort.Strings(expected)
+	sort.Strings(stub.deleted)
+	if strings.Join(stub.deleted, ",") != strings.Join(expected, ",") {
+		t.Errorf("deleted %v, expected %v", stub.deleted, expected)
+	}
+}

--- a/weed/shell/command_volume_fsck_test.go
+++ b/weed/shell/command_volume_fsck_test.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/pb"
@@ -169,6 +170,29 @@ func TestVolumeFsckPurgeEmptyDirectories(t *testing.T) {
 	sort.Strings(stub.deleted)
 	if strings.Join(stub.deleted, ",") != strings.Join(expected, ",") {
 		t.Errorf("deleted %v, expected %v", stub.deleted, expected)
+	}
+}
+
+func TestVolumeFsckPurgeEmptyDirectoriesKeepsFreshDirectory(t *testing.T) {
+	stub := &stubFilerServer{entries: map[string]*filer_pb.Entry{
+		"/fresh":     {IsDirectory: true, Attributes: &filer_pb.FuseAttributes{Mtime: time.Now().Unix()}},
+		"/fresh/dir": {IsDirectory: true, Attributes: &filer_pb.FuseAttributes{Mtime: time.Now().Unix()}},
+	}}
+
+	verbose := false
+	c := &commandVolumeFsck{
+		verbose:         &verbose,
+		writer:          io.Discard,
+		bucketsPath:     "/buckets",
+		scopedFilerPath: "/",
+		purgedDirs:      map[util.FullPath]struct{}{"/fresh/dir": {}},
+		env:             startStubFiler(t, stub),
+	}
+
+	c.purgeEmptyDirectories()
+
+	if len(stub.deleted) > 0 {
+		t.Errorf("deleted %v, expected a directory modified within the quiet period to be kept", stub.deleted)
 	}
 }
 


### PR DESCRIPTION
Fixes #10979.

`volume.fsck -findMissingChunksInFiler -reallyDeleteFilerEntries` deleted the orphan filer entries but left their parent directories behind, so a namespace slowly accumulated empty directories that had to be cleaned up by hand. The filer's own `EmptyFolderCleaner` does not cover this: it only runs inside buckets that opt in.

fsck now remembers the parent of every entry it purges and, once the purge is done, walks up from each one deleting the directories that are now empty:

- the delete is non-recursive, so the filer itself rejects a directory that still has children — no separate emptiness check to race with a concurrent write
- candidates are collected with all their ancestors and processed deepest first, so a directory emptied by two purged siblings is removed too
- a bucket directory is never deleted (that would drop its whole collection), the walk stops at the scanned root, and a directory that is an S3 object of its own is left alone

Reproduced on a local cluster: uploaded `/orphan/dir/deep/file.txt`, deleted its needle on the volume server, then ran the fsck above. Before, the entry was purged and `/orphan/dir/deep` stayed behind; now it is removed while `/orphan/dir` survives because a live file remains in it. Same for `/sib/a` + `/sib/b` and their shared parent, and for `/buckets/bucket1/dir` while `/buckets/bucket1` is kept.

https://claude.ai/code/session_01BncsNo2RVANCDtdbw96Kfc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `volume.fsck` cleanup by removing directories that become empty after missing chunks are purged.
  * Preserves protected root, bucket, and scoped paths.
  * Avoids deleting directories that still contain content or were recently modified.
  * Safely prevents removal when directories change during cleanup.

* **Tests**
  * Added coverage for cleanup scope rules, successful deletion tracking, nested empty-directory cleanup, quiet-period handling, and concurrent directory changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->