### PR TITLE
webdav: describe a listed entry the way clients expect

### DIFF
--- a/weed/server/webdav_server.go
+++ b/weed/server/webdav_server.go
@@ -382,11 +382,7 @@ func (fs *WebDavFileSystem) stat(ctx context.Context, fullFilePath string) (os.F
 	fullpath := util.FullPath(fullFilePath)
 
 	if listedFi := listedEntriesFrom(ctx).get(string(fullpath)); listedFi != nil {
-		// the caller's spelling of the path, trailing slash and all, is what a
-		// lookup would have reported back
-		fi := *listedFi
-		fi.name = string(fullpath)
-		return &fi, nil
+		return listedFi, nil
 	}
 
 	entry, _, _, err := filer_pb.GetEntry(ctx, fs, fullpath)
@@ -404,16 +400,19 @@ func (fs *WebDavFileSystem) stat(ctx context.Context, fullFilePath string) (os.F
 }
 
 func toFileInfo(fullpath util.FullPath, entry *filer_pb.Entry) *FileInfo {
+	// Name is what WebDAV publishes as DAV:displayname; clients that build a
+	// child URL from it reach nothing when it carries the whole path.
+	fp := util.FullPath(listedEntryKey(string(fullpath)))
 	fi := &FileInfo{
 		size:         int64(filer.FileSize(entry)),
-		name:         string(fullpath),
+		name:         fp.Name(),
 		mode:         os.FileMode(entry.Attributes.FileMode),
 		modifiedTime: time.Unix(entry.Attributes.Mtime, 0),
 		etag:         filer.ETag(entry),
 		isDirectory:  entry.IsDirectory,
 	}
 
-	if fi.name == "/" {
+	if fp == "/" {
 		fi.modifiedTime = time.Now()
 		fi.isDirectory = true
 	}
@@ -594,24 +593,14 @@ func (f *WebDavFile) Readdir(count int) (ret []os.FileInfo, err error) {
 	listed := listedEntriesFrom(ctx)
 
 	err = filer_pb.ReadDirAllEntries(ctx, f.fs, util.FullPath(dir), "", func(entry *filer_pb.Entry, isLast bool) error {
-		fi := FileInfo{
-			size:         int64(filer.FileSize(entry)),
-			name:         entry.Name,
-			mode:         os.FileMode(entry.Attributes.FileMode),
-			modifiedTime: time.Unix(entry.Attributes.Mtime, 0),
-			isDirectory:  entry.IsDirectory,
-		}
-
-		if !strings.HasSuffix(fi.name, "/") && fi.IsDir() {
-			fi.name += "/"
-		}
+		childPath := util.NewFullPath(dir, entry.Name)
+		fi := toFileInfo(childPath, entry)
 
 		glog.V(4).Infof("entry: %v", fi.name)
 
-		childPath := util.NewFullPath(dir, entry.Name)
-		listed.put(string(childPath), toFileInfo(childPath, entry))
+		listed.put(string(childPath), fi)
 
-		ret = append(ret, &fi)
+		ret = append(ret, fi)
 		return nil
 	})
 	if err != nil {

--- a/weed/server/webdav_server.go
+++ b/weed/server/webdav_server.go
@@ -115,6 +115,11 @@ func (fi *FileInfo) ETag(ctx context.Context) (string, error) {
 	if fi.err != nil {
 		return "", fi.err
 	}
+	if fi.etag == "" {
+		// nothing hashed this entry; let webdav derive one rather than
+		// publish an empty DAV:getetag, which is not a valid entity-tag
+		return "", webdav.ErrNotImplemented
+	}
 	return fi.etag, nil
 }
 

--- a/weed/server/webdav_server_test.go
+++ b/weed/server/webdav_server_test.go
@@ -1,0 +1,36 @@
+package weed_server
+
+import (
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+)
+
+func TestToFileInfoName(t *testing.T) {
+	tests := []struct {
+		fullpath string
+		want     string
+	}{
+		{"/photo.jpg", "photo.jpg"},
+		{"/Images/photo.jpg", "photo.jpg"},
+		{"/Images/2026/photo.jpg", "photo.jpg"},
+		{"/Images", "Images"},
+		{"/Images/", "Images"},
+		{"/", ""},
+	}
+	for _, tt := range tests {
+		entry := &filer_pb.Entry{Name: "photo.jpg", Attributes: &filer_pb.FuseAttributes{}}
+		fi := toFileInfo(util.FullPath(tt.fullpath), entry)
+		if fi.Name() != tt.want {
+			t.Errorf("toFileInfo(%q).Name() = %q, want %q (DAV:displayname must not carry the path)", tt.fullpath, fi.Name(), tt.want)
+		}
+	}
+}
+
+func TestToFileInfoRootIsDirectory(t *testing.T) {
+	entry := &filer_pb.Entry{Attributes: &filer_pb.FuseAttributes{}}
+	if !toFileInfo("/", entry).IsDir() {
+		t.Error("root is not a directory")
+	}
+}

--- a/weed/server/webdav_server_test.go
+++ b/weed/server/webdav_server_test.go
@@ -1,7 +1,11 @@
 package weed_server
 
 import (
+	"context"
+	"os"
 	"testing"
+
+	"golang.org/x/net/webdav"
 
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/util"
@@ -32,5 +36,21 @@ func TestToFileInfoRootIsDirectory(t *testing.T) {
 	entry := &filer_pb.Entry{Attributes: &filer_pb.FuseAttributes{}}
 	if !toFileInfo("/", entry).IsDir() {
 		t.Error("root is not a directory")
+	}
+}
+
+func TestFileInfoETag(t *testing.T) {
+	ctx := context.Background()
+
+	if _, err := (&FileInfo{}).ETag(ctx); err != webdav.ErrNotImplemented {
+		t.Errorf("empty etag returned %v, want ErrNotImplemented so webdav derives one", err)
+	}
+	if etag, err := (&FileInfo{etag: "abc"}).ETag(ctx); err != nil || etag != "abc" {
+		t.Errorf("ETag() = %q, %v, want \"abc\", nil", etag, err)
+	}
+
+	failed := &FileInfo{err: os.ErrInvalid}
+	if _, err := failed.ETag(ctx); err != os.ErrInvalid {
+		t.Errorf("ETag() = %v, want the stat error", err)
 	}
 }

--- a/weed/server/wrapped_webdav_fs.go
+++ b/weed/server/wrapped_webdav_fs.go
@@ -2,7 +2,6 @@ package weed_server
 
 import (
 	"context"
-	"io/fs"
 	"os"
 	"path"
 
@@ -22,10 +21,8 @@ func (w wrappedFs) confine(name string) string {
 	return w.subFolder + path.Clean("/"+name)
 }
 
-// NewWrappedFs returns a webdav.FileSystem identical to fs, except it
-// provides access to a sub-folder of fs that is denominated by subFolder.
-// It transparently handles renaming paths and filenames so that the outer part of the wrapped filesystem
-// does not leak out.
+// NewWrappedFs returns a webdav.FileSystem identical to fs, except that it
+// serves only the subFolder sub-tree of fs.
 func NewWrappedFs(fs webdav.FileSystem, subFolder string) webdav.FileSystem {
 	return wrappedFs{
 		subFolder:  subFolder,
@@ -40,8 +37,7 @@ func (w wrappedFs) Mkdir(ctx context.Context, name string, perm os.FileMode) err
 
 func (w wrappedFs) OpenFile(ctx context.Context, name string, flag int, perm os.FileMode) (webdav.File, error) {
 	name = w.confine(name)
-	file, err := w.FileSystem.OpenFile(ctx, name, flag, perm)
-	return wrappedFile{File: file}, err
+	return w.FileSystem.OpenFile(ctx, name, flag, perm)
 }
 
 func (w wrappedFs) RemoveAll(ctx context.Context, name string) error {
@@ -57,35 +53,5 @@ func (w wrappedFs) Rename(ctx context.Context, oldName, newName string) error {
 
 func (w wrappedFs) Stat(ctx context.Context, name string) (os.FileInfo, error) {
 	name = w.confine(name)
-	info, err := w.FileSystem.Stat(ctx, name)
-	return wrappedFileInfo{FileInfo: info}, err
-}
-
-type wrappedFile struct {
-	webdav.File
-}
-
-func (w wrappedFile) Readdir(count int) ([]fs.FileInfo, error) {
-	infos, err := w.File.Readdir(count)
-	for i, info := range infos {
-		infos[i] = wrappedFileInfo{FileInfo: info}
-	}
-	return infos, err
-}
-
-func (w wrappedFile) Stat() (fs.FileInfo, error) {
-	info, err := w.File.Stat()
-	return wrappedFileInfo{FileInfo: info}, err
-}
-
-type wrappedFileInfo struct {
-	fs.FileInfo
-}
-
-func (w wrappedFileInfo) ETag(ctx context.Context) (string, error) {
-	etag, _ := w.FileInfo.(webdav.ETager).ETag(ctx)
-	if len(etag) == 0 {
-		return etag, webdav.ErrNotImplemented
-	}
-	return etag, nil
+	return w.FileSystem.Stat(ctx, name)
 }

--- a/weed/server/wrapped_webdav_fs.go
+++ b/weed/server/wrapped_webdav_fs.go
@@ -5,7 +5,6 @@ import (
 	"io/fs"
 	"os"
 	"path"
-	"strings"
 
 	"golang.org/x/net/webdav"
 )
@@ -42,12 +41,7 @@ func (w wrappedFs) Mkdir(ctx context.Context, name string, perm os.FileMode) err
 func (w wrappedFs) OpenFile(ctx context.Context, name string, flag int, perm os.FileMode) (webdav.File, error) {
 	name = w.confine(name)
 	file, err := w.FileSystem.OpenFile(ctx, name, flag, perm)
-	file = wrappedFile{
-		File:      file,
-		subFolder: &w.subFolder,
-	}
-
-	return file, err
+	return wrappedFile{File: file}, err
 }
 
 func (w wrappedFs) RemoveAll(ctx context.Context, name string) error {
@@ -64,46 +58,28 @@ func (w wrappedFs) Rename(ctx context.Context, oldName, newName string) error {
 func (w wrappedFs) Stat(ctx context.Context, name string) (os.FileInfo, error) {
 	name = w.confine(name)
 	info, err := w.FileSystem.Stat(ctx, name)
-	info = wrappedFileInfo{
-		subFolder: &w.subFolder,
-		FileInfo:  info,
-	}
-	return info, err
+	return wrappedFileInfo{FileInfo: info}, err
 }
 
 type wrappedFile struct {
 	webdav.File
-	subFolder *string
 }
 
 func (w wrappedFile) Readdir(count int) ([]fs.FileInfo, error) {
 	infos, err := w.File.Readdir(count)
 	for i, info := range infos {
-		infos[i] = wrappedFileInfo{
-			subFolder: w.subFolder,
-			FileInfo:  info,
-		}
+		infos[i] = wrappedFileInfo{FileInfo: info}
 	}
 	return infos, err
 }
 
 func (w wrappedFile) Stat() (fs.FileInfo, error) {
 	info, err := w.File.Stat()
-	info = wrappedFileInfo{
-		subFolder: w.subFolder,
-		FileInfo:  info,
-	}
-	return info, err
+	return wrappedFileInfo{FileInfo: info}, err
 }
 
 type wrappedFileInfo struct {
-	subFolder *string
 	fs.FileInfo
-}
-
-func (w wrappedFileInfo) Name() string {
-	name := w.FileInfo.Name()
-	return strings.TrimPrefix(name, *w.subFolder)
 }
 
 func (w wrappedFileInfo) ETag(ctx context.Context) (string, error) {


### PR DESCRIPTION
Fixes #10980.

A folder on a WebDAV-mapped Windows drive lists nothing, while the same files at the root of the drive show up fine.

Two properties in the PROPFIND answer are wrong, and both only bite below the root.

**`DAV:displayname` carried the whole path.** `WebDavFileSystem.stat` built its `os.FileInfo` with `name` set to the full path, and x/net/webdav publishes `FileInfo.Name()` as `DAV:displayname`. So a listing of `/Images/` answered:

```xml
<D:href>/Images/a.jpg</D:href>
<D:displayname>/Images/a.jpg</D:displayname>
```

A client that takes `displayname` for the child's name — the Windows redirector does, and the interop advice against replicating the last path segment there is [long-standing](https://lists.w3.org/Archives/Public/w3c-dist-auth/2003JulSep/0123.html) — then goes looking for `/Images/Images/a.jpg`. At the root the two spellings differ only by a leading slash, which is why the root keeps working and every sub-folder looks empty.

`toFileInfo` now names the entry, so `stat` and `Readdir` describe a child the same way and `Readdir` can just call it. The sub-folder wrapper existed mostly to trim the outer path back off a name and goes away with it.

**`DAV:getetag` was empty.** Nothing in this gateway's upload path asks for a content MD5, so `filer.ETag` returns `""` and every file answered `<D:getetag></D:getetag>` — not a valid entity-tag. `FileInfo.ETag` now reports it unimplemented, the way the sub-folder wrapper already did for its own entries, and webdav derives one from modification time and size.

Before / after, same tree:

```
href=/Images/a.jpg   displayname=/Images/a.jpg   etag=
href=/Images/a.jpg   displayname=a.jpg           etag="18cfbe7bcbdeb0004e20"
```

Verified against a live filer over the exact sequence Explorer uses to copy a file in (MKCOL, LOCK, PUT, PROPPATCH, UNLOCK, PROPFIND), plus nested folders, GET, MOVE and DELETE.

One thing this cannot fix, for anyone who lands here from the same symptom: the redirector also refuses to enumerate a folder whose properties exceed `FileAttributesLimitInBytes` under `HKLM\SYSTEM\CurrentControlSet\Services\WebClient\Parameters`, 1 MB by default. A PROPFIND response runs about 580 bytes per entry, so a folder past roughly 1700 files goes blank on the client side with nothing to see in the server log. Raising that value and restarting WebClient is the only lever.

https://claude.ai/code/session_01XCeuCWpF9xo9CfyHvCQE9c


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved WebDAV file and directory names, including root and nested paths.
  - Corrected directory listings to include accurate metadata and trailing slashes.
  - Fixed ETag handling so missing values are generated appropriately instead of appearing empty.
  - Improved propagation of file-stat errors.
- **Tests**
  - Added coverage for path names, root directory detection, ETags, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->