### PR TITLE
s3: distinguish a failed bucket lookup from a missing bucket on HEAD

### DIFF
--- a/weed/s3api/s3api_bucket_handlers.go
+++ b/weed/s3api/s3api_bucket_handlers.go
@@ -561,8 +561,13 @@ func (s3a *S3ApiServer) HeadBucketHandler(w http.ResponseWriter, r *http.Request
 	bucket, _ := s3_constants.GetBucketAndObject(r)
 	glog.V(3).Infof("HeadBucketHandler %s", bucket)
 
-	if entry, err := s3a.getBucketEntry(bucket); entry == nil || errors.Is(err, filer_pb.ErrNotFound) {
-		s3err.WriteErrorResponse(w, r, s3err.ErrNoSuchBucket)
+	if _, err := s3a.getBucketEntry(bucket); err != nil {
+		if errors.Is(err, filer_pb.ErrNotFound) {
+			s3err.WriteErrorResponse(w, r, s3err.ErrNoSuchBucket)
+			return
+		}
+		glog.Errorf("HeadBucketHandler: failed to get bucket entry for %s: %v", bucket, err)
+		s3err.WriteErrorResponse(w, r, s3err.ErrInternalError)
 		return
 	}
 

--- a/weed/s3api/s3api_head_bucket_test.go
+++ b/weed/s3api/s3api_head_bucket_test.go
@@ -1,0 +1,88 @@
+package s3api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/seaweedfs/seaweedfs/weed/pb"
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/wdclient"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+)
+
+type fakeLookupFiler struct {
+	filer_pb.UnimplementedSeaweedFilerServer
+	entry     *filer_pb.Entry
+	lookupErr error
+}
+
+func (f *fakeLookupFiler) LookupDirectoryEntry(ctx context.Context, req *filer_pb.LookupDirectoryEntryRequest) (*filer_pb.LookupDirectoryEntryResponse, error) {
+	if f.lookupErr != nil {
+		return nil, f.lookupErr
+	}
+	return &filer_pb.LookupDirectoryEntryResponse{Entry: f.entry}, nil
+}
+
+func newHeadBucketTestServer(t *testing.T, impl filer_pb.SeaweedFilerServer) *S3ApiServer {
+	t.Helper()
+	filers := []pb.ServerAddress{startFakeFiler(t, impl)}
+	dialOption := grpc.WithTransportCredentials(insecure.NewCredentials())
+	return &S3ApiServer{
+		option:      &S3ApiServerOption{Filers: filers, GrpcDialOption: dialOption, BucketsPath: "/buckets"},
+		filerClient: wdclient.NewFilerClient(filers, dialOption, ""),
+	}
+}
+
+// A lookup that fails for a reason other than "not found" must not be reported
+// as a missing bucket: a 404 is a definite answer and stops the client retrying.
+func TestHeadBucketSeparatesLookupFailureFromMissingBucket(t *testing.T) {
+	const bucket = "head-bucket"
+	cases := []struct {
+		name     string
+		filer    *fakeLookupFiler
+		wantCode int
+		wantBody string
+	}{
+		{
+			name:     "transient lookup failure",
+			filer:    &fakeLookupFiler{lookupErr: status.Error(codes.Internal, "filer store unavailable")},
+			wantCode: http.StatusInternalServerError,
+			wantBody: "<Code>InternalError</Code>",
+		},
+		{
+			name:     "missing bucket",
+			filer:    &fakeLookupFiler{},
+			wantCode: http.StatusNotFound,
+			wantBody: "<Code>NoSuchBucket</Code>",
+		},
+		{
+			name:     "existing bucket",
+			filer:    &fakeLookupFiler{entry: &filer_pb.Entry{Name: bucket, IsDirectory: true}},
+			wantCode: http.StatusOK,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s3a := newHeadBucketTestServer(t, tc.filer)
+			req := httptest.NewRequest(http.MethodHead, "/"+bucket, nil)
+			req = mux.SetURLVars(req, map[string]string{"bucket": bucket})
+			rr := httptest.NewRecorder()
+
+			s3a.HeadBucketHandler(rr, req)
+
+			if rr.Code != tc.wantCode {
+				t.Fatalf("status = %d, want %d: %s", rr.Code, tc.wantCode, rr.Body.String())
+			}
+			if tc.wantBody != "" && !strings.Contains(rr.Body.String(), tc.wantBody) {
+				t.Fatalf("body = %s, want %s", rr.Body.String(), tc.wantBody)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`HeadBucketHandler` collapsed every lookup outcome into one arm: `entry == nil || errors.Is(err, filer_pb.ErrNotFound)`. Any error leaves `entry` nil, so a transient filer failure during a HEAD was answered with 404 NoSuchBucket. That is misleading on its own and also stops clients from retrying, since a 404 is a definite answer. Same shape #7220 reported for DeleteBucket, which `checkBucket` has since fixed by going through `getBucketConfig`.

The handler now splits the two cases the way `GetBucketPolicyHandler` and `getBucketConfig` already do: `ErrNotFound` stays 404 NoSuchBucket, anything else is logged and answered 500 InternalError. It keeps the direct `getBucketEntry` read rather than routing through `getBucketConfig`, so a HEAD stays an authoritative filer lookup instead of becoming a cache-first existence answer that could report a stale 200 or 404 while a cross-gateway metadata event is in flight.

Verified with a new table test driving the handler against a fake filer: a lookup failing with a non-NotFound gRPC error yields 500 InternalError, a genuine miss still yields 404 NoSuchBucket, and an existing bucket still yields 200. The test fails on the pre-fix handler with `status = 404, want 500`. `go build ./weed/...` and `go test ./weed/s3api/...` pass.

Fixes #10998

https://claude.ai/code/session_01BjDWtZsCoZY6x4pdDmGWxU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bucket status checks to distinguish temporary lookup failures from missing buckets.
  * Returns appropriate responses for existing buckets, unavailable services, and nonexistent buckets.

* **Tests**
  * Added coverage for successful bucket checks, missing buckets, and internal lookup errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->