### PR TITLE
s3: share one retry allowance across a batch delete

### DIFF
--- a/weed/s3api/s3api_object_handlers_delete.go
+++ b/weed/s3api/s3api_object_handlers_delete.go
@@ -447,6 +447,10 @@ func (s3a *S3ApiServer) DeleteMultipleObjectsHandler(w http.ResponseWriter, r *h
 		identity, _ = id.(*Identity)
 	}
 
+	// The keys below each drive their own bounded filer retries, and the client
+	// picks how many keys there are, so the whole batch shares one allowance.
+	r = r.WithContext(withFilerRetryBudget(r.Context(), filerRetryRequestBudget))
+
 	err = s3a.WithFilerClient(false, func(client filer_pb.SeaweedFilerClient) error {
 		// delete file entries
 		for _, object := range deleteObjects.Objects {

--- a/weed/s3api/s3api_object_versioning.go
+++ b/weed/s3api/s3api_object_versioning.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/filer"
@@ -1375,13 +1376,63 @@ func (s3a *S3ApiServer) repointLatestBeforeDeletion(ctx context.Context, bucket,
 
 // retryAttempts and retryStep tune the bounded retries used when the
 // load-bearing filer ops in updateLatestVersionAfterDeletion fail with
-// transient errors. Doubled per attempt, capped at retryCap. Total
-// worst-case wall time ≈ 6.3s before propagating.
+// transient errors. Doubled per attempt, capped at retryCap, for a
+// worst case of ~3.1s of backoff per op before propagating.
 const (
 	updateLatestRetryAttempts = 6
 	updateLatestRetryStep     = 100 * time.Millisecond
 	updateLatestRetryCap      = 2 * time.Second
 )
+
+func retryFilerBackoff(attempt int) time.Duration {
+	backoff := updateLatestRetryStep << (attempt - 1)
+	if backoff <= 0 || backoff > updateLatestRetryCap {
+		return updateLatestRetryCap
+	}
+	return backoff
+}
+
+// filerRetryRequestBudget is the total backoff one request may spend across
+// every retryFilerOp it drives: the worst case of a single op, so a batch
+// whose length the client chooses waits about as long as one key would.
+var filerRetryRequestBudget = func() (total time.Duration) {
+	for attempt := 1; attempt < updateLatestRetryAttempts; attempt++ {
+		total += retryFilerBackoff(attempt)
+	}
+	return total
+}()
+
+type filerRetryBudgetKey struct{}
+
+type filerRetryBudget struct {
+	mu        sync.Mutex
+	remaining time.Duration
+}
+
+// withFilerRetryBudget hands every retryFilerOp reached through ctx one shared
+// allowance, so per-key backoff no longer multiplies by the number of keys.
+func withFilerRetryBudget(ctx context.Context, total time.Duration) context.Context {
+	return context.WithValue(ctx, filerRetryBudgetKey{}, &filerRetryBudget{remaining: total})
+}
+
+func filerRetryBudgetFrom(ctx context.Context) *filerRetryBudget {
+	budget, _ := ctx.Value(filerRetryBudgetKey{}).(*filerRetryBudget)
+	return budget
+}
+
+// take reserves up to d of what is left, reporting false once nothing is.
+func (b *filerRetryBudget) take(d time.Duration) (time.Duration, bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.remaining <= 0 {
+		return 0, false
+	}
+	if d > b.remaining {
+		d = b.remaining
+	}
+	b.remaining -= d
+	return d, true
+}
 
 // isRetryableFilerErr reports whether err is worth retrying through
 // retryFilerOp. Terminal conditions return false so the caller surfaces
@@ -1412,7 +1463,7 @@ func isRetryableFilerErr(err error) bool {
 
 func retryFilerOp(ctx context.Context, name string, fn func() error) error {
 	var lastErr error
-	backoff := updateLatestRetryStep
+	budget := filerRetryBudgetFrom(ctx)
 	for attempt := 1; attempt <= updateLatestRetryAttempts; attempt++ {
 		err := fn()
 		if err == nil {
@@ -1431,19 +1482,23 @@ func retryFilerOp(ctx context.Context, name string, fn func() error) error {
 		if attempt == updateLatestRetryAttempts {
 			break
 		}
+		backoff := retryFilerBackoff(attempt)
+		if budget != nil {
+			granted, ok := budget.take(backoff)
+			if !ok {
+				return fmt.Errorf("%s stopped after %d attempts, request retry allowance spent: %w", name, attempt, lastErr)
+			}
+			backoff = granted
+		}
 		// Context-aware backoff so a server shutdown / client
-		// disconnect cancels the worst-case ~6.3s retry budget
-		// immediately instead of blocking the goroutine.
+		// disconnect cancels the pending retries immediately
+		// instead of blocking the goroutine.
 		timer := time.NewTimer(backoff)
 		select {
 		case <-ctx.Done():
 			timer.Stop()
 			return ctx.Err()
 		case <-timer.C:
-		}
-		backoff *= 2
-		if backoff > updateLatestRetryCap {
-			backoff = updateLatestRetryCap
 		}
 	}
 	return fmt.Errorf("%s exhausted %d retries: %w", name, updateLatestRetryAttempts, lastErr)

--- a/weed/s3api/s3api_versioning_reconciler_test.go
+++ b/weed/s3api/s3api_versioning_reconciler_test.go
@@ -168,3 +168,78 @@ func TestRetryFilerOp_TerminalErrorsShortCircuit(t *testing.T) {
 		})
 	}
 }
+
+// TestFilerRetryBudget_ClampsToWhatIsLeft covers the allowance arithmetic:
+// a reservation larger than the remainder is trimmed, and once nothing is
+// left the caller is told to stop rather than handed a zero wait.
+func TestFilerRetryBudget_ClampsToWhatIsLeft(t *testing.T) {
+	b := &filerRetryBudget{remaining: 150 * time.Millisecond}
+
+	granted, ok := b.take(100 * time.Millisecond)
+	require.True(t, ok)
+	assert.Equal(t, 100*time.Millisecond, granted)
+
+	granted, ok = b.take(200 * time.Millisecond)
+	require.True(t, ok)
+	assert.Equal(t, 50*time.Millisecond, granted, "trimmed to the remainder")
+
+	_, ok = b.take(time.Millisecond)
+	assert.False(t, ok, "allowance spent")
+}
+
+// TestFilerRetryRequestBudget_MatchesOneOpWorstCase pins the request-wide
+// allowance to what a single retryFilerOp can sleep for, so a batch delete
+// adds the wait of one key rather than one per key.
+func TestFilerRetryRequestBudget_MatchesOneOpWorstCase(t *testing.T) {
+	var singleOp time.Duration
+	for attempt := 1; attempt < updateLatestRetryAttempts; attempt++ {
+		singleOp += retryFilerBackoff(attempt)
+	}
+	assert.Equal(t, singleOp, filerRetryRequestBudget)
+	assert.Equal(t, 3100*time.Millisecond, filerRetryRequestBudget)
+}
+
+// TestRetryFilerOp_SharedBudgetAcrossBatch is the batch-delete shape: many
+// keys, each driving its own retryFilerOp against a filer that always fails
+// retryably. Without a shared allowance every key pays the full per-op
+// backoff, so the wait scales with a key count the client picks. The
+// allowance here is deliberately small so the test never sleeps for the
+// production budget.
+func TestRetryFilerOp_SharedBudgetAcrossBatch(t *testing.T) {
+	const keys = 200
+	const allowance = 250 * time.Millisecond
+
+	ctx := withFilerRetryBudget(context.Background(), allowance)
+	calls := 0
+	start := time.Now()
+	for i := 0; i < keys; i++ {
+		err := retryFilerOp(ctx, "test", func() error {
+			calls++
+			return errors.New("transient")
+		})
+		require.Error(t, err)
+	}
+	elapsed := time.Since(start)
+
+	assert.LessOrEqual(t, calls, keys+updateLatestRetryAttempts, "only the keys that fit the allowance retry")
+	assert.Less(t, elapsed, 2*allowance, "the whole batch stays inside one allowance")
+}
+
+// TestRetryFilerOp_SpentBudgetStopsAfterFirstAttempt confirms a key that
+// arrives after the allowance is gone fails immediately, reporting why, and
+// still gets its one real attempt at the filer.
+func TestRetryFilerOp_SpentBudgetStopsAfterFirstAttempt(t *testing.T) {
+	ctx := withFilerRetryBudget(context.Background(), 0)
+	calls := 0
+	start := time.Now()
+	err := retryFilerOp(ctx, "test", func() error {
+		calls++
+		return errors.New("transient")
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, 1, calls, "the op still runs once")
+	assert.Less(t, time.Since(start), 50*time.Millisecond, "no backoff once the allowance is spent")
+	assert.Contains(t, err.Error(), "retry allowance spent")
+	assert.Contains(t, err.Error(), "transient", "underlying error preserved")
+}


### PR DESCRIPTION
`DeleteMultipleObjectsHandler` takes up to 1000 keys and walks them in one loop. On a versioned bucket each key with a version id that is currently the latest reaches `repointLatestBeforeDeletion`, whose list, getEntry and mkFile all run through `retryFilerOp`. That retry is bounded per call: 100 + 200 + 400 + 800 + 1600 ms, about 3.1s of backoff before it gives up. Per call is the wrong unit here, because the client chooses how many calls there are - a 1000 key batch against a filer that is briefly unhealthy can hold one request goroutine for the better part of an hour. Nothing else bounds it: the S3 server sets no write timeout, so `r.Context()` is only cancelled when the client disconnects.

The retry itself is fine, and shrinking it would trade away the resilience a single-key DELETE gets from it. So instead the batch now carries one allowance for the whole request.

`withFilerRetryBudget` puts a `filerRetryBudget` on the request context, sized to the worst case of a single op (derived from the existing constants, not a new number and not a flag). `retryFilerOp` reserves each backoff from that allowance when one is present, clamping the last wait to whatever is left; once it is spent, a key still gets its one real attempt at the filer and then fails immediately with `request retry allowance spent`, which lands in the multi-delete response as a per-key error the client can retry - the blob has not been removed at that point, so retrying is safe. A single-object DELETE attaches no allowance and behaves exactly as before.

Verified with `go build ./weed/...` and `go test ./weed/s3api/...`, both clean. The new tests assert on attempt counts and a deliberately small allowance rather than sleeping for the production budget: 200 keys against an always-failing op finish in 0.25s where the unbudgeted shape would need 200 x 3.1s.

Two adjacent loops have the same shape but are out of scope here, since neither takes a context and both would need signature changes to reach: `updateLatestVersionInDirectory` (8 attempts, up to 12.7s, plain `time.Sleep`, reached per key through `createDeleteMarker`) and `doGetLatestObjectVersion`. Worth a separate pass.

Fixes #10996

https://claude.ai/code/session_01BjDWtZsCoZY6x4pdDmGWxU


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when deleting multiple objects by applying a shared, bounded retry allowance.
  * Prevented batch operations from spending excessive time retrying temporary storage failures.
  * Preserved request cancellation and terminal-error handling while making retry behavior more consistent.

* **Tests**
  * Added coverage for retry limits, shared budgets, elapsed time, and behavior after the retry allowance is exhausted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->