### PR TITLE
master, filer, s3api: bound the collection RPCs that strand a caller

### DIFF
--- a/weed/filer/filer_delete_collection_test.go
+++ b/weed/filer/filer_delete_collection_test.go
@@ -1,0 +1,241 @@
+package filer
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/seaweedfs/seaweedfs/weed/cluster"
+	"github.com/seaweedfs/seaweedfs/weed/pb"
+	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+	"github.com/seaweedfs/seaweedfs/weed/util/log_buffer"
+	"github.com/seaweedfs/seaweedfs/weed/wdclient"
+)
+
+// collectionDeleteMaster is just enough of a master for a MasterClient to
+// consider itself connected, and records every CollectionDelete it is asked for.
+type collectionDeleteMaster struct {
+	master_pb.UnimplementedSeaweedServer
+	calls chan collectionDeleteCall
+}
+
+type collectionDeleteCall struct {
+	name string
+	// budget is the time the RPC arrived with, or 0 when it carried no deadline.
+	budget time.Duration
+}
+
+// KeepConnected is what MasterClient waits on before it reports a master: one
+// response is enough, then the stream idles until the server is torn down.
+func (m *collectionDeleteMaster) KeepConnected(stream master_pb.Seaweed_KeepConnectedServer) error {
+	if _, err := stream.Recv(); err != nil {
+		return err
+	}
+	if err := stream.Send(&master_pb.KeepConnectedResponse{}); err != nil {
+		return err
+	}
+	<-stream.Context().Done()
+	return nil
+}
+
+func (m *collectionDeleteMaster) CollectionDelete(ctx context.Context, req *master_pb.CollectionDeleteRequest) (*master_pb.CollectionDeleteResponse, error) {
+	call := collectionDeleteCall{name: req.Name}
+	if deadline, ok := ctx.Deadline(); ok {
+		call.budget = time.Until(deadline)
+	}
+	m.calls <- call
+	return &master_pb.CollectionDeleteResponse{}, nil
+}
+
+// hookedStore is the stub store with one extra seam: a callback that runs once
+// an entry has actually been removed, so a test can interleave an event -- a
+// client hanging up, say -- between the store write and whatever follows it.
+type hookedStore struct {
+	*stubFilerStore
+	onDeleteEntry func(util.FullPath)
+}
+
+func (s *hookedStore) DeleteEntry(ctx context.Context, p util.FullPath) error {
+	if err := s.stubFilerStore.DeleteEntry(ctx, p); err != nil {
+		return err
+	}
+	if s.onDeleteEntry != nil {
+		s.onDeleteEntry(p)
+	}
+	return nil
+}
+
+// newFilerWithFakeMaster builds a filer backed by the stub store, with its
+// MasterClient connected to a fake master the test can observe.
+func newFilerWithFakeMaster(t *testing.T) (*Filer, *hookedStore, *collectionDeleteMaster) {
+	t.Helper()
+
+	master := &collectionDeleteMaster{calls: make(chan collectionDeleteCall, 4)}
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	grpcServer := grpc.NewServer()
+	master_pb.RegisterSeaweedServer(grpcServer, master)
+	go func() { _ = grpcServer.Serve(lis) }()
+	t.Cleanup(grpcServer.Stop)
+
+	_, port, err := net.SplitHostPort(lis.Addr().String())
+	if err != nil {
+		t.Fatalf("split listener address: %v", err)
+	}
+	masterAddress := pb.ServerAddress(fmt.Sprintf("127.0.0.1:0.%s", port))
+
+	mc := wdclient.NewMasterClient(
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		"test", cluster.FilerType, pb.ServerAddress("localhost:0"), "", "",
+		*pb.NewServiceDiscoveryFromMap(map[string]pb.ServerAddress{"m": masterAddress}),
+	)
+
+	connecting, stopConnecting := context.WithCancel(context.Background())
+	t.Cleanup(stopConnecting)
+	go mc.KeepConnectedToMaster(connecting)
+
+	waiting, cancelWaiting := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancelWaiting()
+	mc.WaitUntilConnected(waiting)
+	if waiting.Err() != nil {
+		t.Fatal("the master client never connected to the fake master")
+	}
+
+	store := &hookedStore{stubFilerStore: newStubFilerStore()}
+	f := &Filer{
+		DirBucketsPath:      "/buckets",
+		RemoteStorage:       NewFilerRemoteStorage(),
+		Store:               NewFilerStoreWrapper(store),
+		FilerConf:           NewFilerConf(),
+		MaxFilenameLength:   255,
+		MasterClient:        mc,
+		FileIdDeletionQueue: util.NewUnboundedQueue(),
+		deletionQuit:        make(chan struct{}),
+		LocalMetaLogBuffer: log_buffer.NewLogBuffer("test", time.Minute,
+			func(*log_buffer.LogBuffer, time.Time, time.Time, []byte, int64, int64) {}, nil, func() {}),
+	}
+	return f, store, master
+}
+
+func awaitCollectionDelete(t *testing.T, master *collectionDeleteMaster, what string) collectionDeleteCall {
+	t.Helper()
+	select {
+	case call := <-master.calls:
+		return call
+	case <-time.After(20 * time.Second):
+		t.Fatalf("%s: CollectionDelete never reached the master", what)
+		return collectionDeleteCall{}
+	}
+}
+
+// Deleting a bucket entry deletes its collection, and the request hanging up
+// partway must not stop that. By the time the collection delete is reached the
+// bucket's metadata is already gone and the result is discarded, so skipping it
+// strands the bucket's volumes with nothing left to come back for them.
+//
+// The cancellation lands between the store removing the entry and the collection
+// delete, which is where a client disconnect actually bites: FilerStoreWrapper
+// refuses a context that is already dead on entry, so an up-front cancellation
+// fails the delete long before this point instead.
+func TestDeleteEntryMetaAndDataDeletesCollectionWhenTheRequestIsCancelledMidDelete(t *testing.T) {
+	f, store, master := newFilerWithFakeMaster(t)
+
+	const bucket = "bucket-a"
+	bucketPath := util.FullPath(f.DirBucketsPath + "/" + bucket)
+	if err := store.InsertEntry(context.Background(), &Entry{
+		FullPath: bucketPath,
+		Attr:     Attr{Mode: os.ModeDir | 0755},
+	}); err != nil {
+		t.Fatalf("seed the bucket entry: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// The client hangs up just as the bucket entry comes out of the store.
+	store.onDeleteEntry = func(util.FullPath) { cancel() }
+
+	if err := f.DeleteEntryMetaAndData(ctx, bucketPath, true, false, true, false, nil, 0); err != nil {
+		t.Fatalf("DeleteEntryMetaAndData: %v", err)
+	}
+	if ctx.Err() == nil {
+		t.Fatal("test setup: the request was never cancelled, so nothing was exercised")
+	}
+
+	call := awaitCollectionDelete(t, master, "request cancelled mid-delete")
+	if call.name != bucket {
+		t.Errorf("master was asked to delete collection %q, want %q", call.name, bucket)
+	}
+	if call.budget <= 0 {
+		t.Error("CollectionDelete arrived with no deadline; the RPC should still be bounded")
+	}
+
+	if store.getEntry(string(bucketPath)) != nil {
+		t.Error("the bucket entry survived the delete")
+	}
+}
+
+// The RPC itself carries a deadline even when the caller set none, so a master
+// that stops answering cannot hold the filer open indefinitely.
+func TestDoDeleteCollectionBoundsTheMasterRPC(t *testing.T) {
+	f, _, master := newFilerWithFakeMaster(t)
+
+	if err := f.DoDeleteCollection(context.Background(), "bucket-b"); err != nil {
+		t.Fatalf("DoDeleteCollection: %v", err)
+	}
+
+	call := awaitCollectionDelete(t, master, "bounded RPC")
+	if call.budget <= 0 {
+		t.Fatal("CollectionDelete reached the master with no deadline: a master that stops answering holds the filer, and the request behind it, open")
+	}
+	if call.budget > collectionDeleteTimeout {
+		t.Errorf("CollectionDelete budget = %v, want at most collectionDeleteTimeout %v", call.budget, collectionDeleteTimeout)
+	}
+}
+
+// With no master reachable, the budget has to cover the wait for a master
+// address too. MasterClient.WithClient waits on context.Background() there, so a
+// caller with a deadline still parks forever -- and since the gateway now gives
+// up and clients retry, that parks one handler goroutine per retry rather than
+// the single one master leaves behind.
+func TestDoDeleteCollectionGivesUpWhenNoMasterIsReachable(t *testing.T) {
+	// A master client that never connects: nothing is listening, and no
+	// KeepConnectedToMaster goroutine is started to change that.
+	mc := wdclient.NewMasterClient(
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		"test", cluster.FilerType, pb.ServerAddress("localhost:0"), "", "",
+		*pb.NewServiceDiscoveryFromMap(map[string]pb.ServerAddress{}),
+	)
+	f := &Filer{MasterClient: mc}
+
+	// A caller deadline nearer than collectionDeleteTimeout, so the same property
+	// is exercised without holding the suite for the full budget.
+	const callerBudget = 2 * time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), callerBudget)
+	defer cancel()
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() { done <- f.DoDeleteCollection(ctx, "bucket-c") }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("DoDeleteCollection reported success with no master reachable")
+		}
+		if elapsed := time.Since(start); elapsed > callerBudget*4 {
+			t.Errorf("DoDeleteCollection took %v to give up on a %v budget", elapsed, callerBudget)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("DoDeleteCollection never returned: the wait for a master address ignores the caller's budget, so every retry behind it parks another goroutine here")
+	}
+}

--- a/weed/filer/filer_delete_entry.go
+++ b/weed/filer/filer_delete_entry.go
@@ -3,6 +3,7 @@ package filer
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
@@ -63,7 +64,14 @@ func (f *Filer) DeleteEntryMetaAndData(ctx context.Context, p util.FullPath, isR
 
 	if isDeleteCollection {
 		collectionName := entry.Name()
-		f.DoDeleteCollection(collectionName)
+		// The bucket's metadata is already gone by this point and the result here
+		// is advisory, so a request that hangs up now must not take the
+		// collection's volumes with it: pass the values on without the
+		// cancellation, or the volumes are stranded with nothing left to come back
+		// for them. Same shape FilerStoreWrapper uses to keep a store write whole
+		// once it has started. DoDeleteCollection still bounds the RPC itself and
+		// logs what it could not delete.
+		f.DoDeleteCollection(context.WithoutCancel(ctx), collectionName)
 		// drop bucket-labeled series held by this process; the S3 gateway
 		// only cleans its own registry
 		stats.DeleteBucketMetrics(collectionName)
@@ -167,14 +175,36 @@ func (f *Filer) doDeleteEntryMetaAndData(ctx context.Context, entry *Entry, shou
 	return nil
 }
 
-func (f *Filer) DoDeleteCollection(collectionName string) (err error) {
+// collectionDeleteTimeout bounds the whole attempt to have a collection
+// deleted: the wait for a master address, the util.Retry walk around it, and the
+// RPC itself. The budget is taken before WithClientCtx, so a transient failure
+// cannot restart the clock and a master that is down or mid-election cannot park
+// the caller indefinitely (issue #7232).
+//
+// It bounds the wait, not the work. The master does not stop deleting when this
+// expires: it runs its volume-server fan-out on a context carrying no deadline
+// precisely so a caller giving up cannot strand it half done. A collection this
+// gave up on is therefore still being removed, and a later delete of the same
+// collection finds nothing left to do rather than repeating the work.
+//
+// 15s is fifteen times the bucket cleanup issue #7232 reports as healthy, and
+// the same budget the filer gives its other master RPC (collectionListTimeout).
+// A bucket deletion pays it at most twice -- once here, under the bucket entry's
+// own delete, and once again for the S3 gateway's follow-up DeleteCollection --
+// so the collection work stays inside roughly 25s of the 60s an S3 client waits.
+const collectionDeleteTimeout = 15 * time.Second
 
-	return f.MasterClient.WithClient(false, func(client master_pb.SeaweedClient) error {
-		_, err := client.CollectionDelete(context.Background(), &master_pb.CollectionDeleteRequest{
+func (f *Filer) DoDeleteCollection(ctx context.Context, collectionName string) (err error) {
+
+	ctx, cancel := context.WithTimeout(ctx, collectionDeleteTimeout)
+	defer cancel()
+
+	return f.MasterClient.WithClientCtx(ctx, false, func(client master_pb.SeaweedClient) error {
+		_, err := client.CollectionDelete(ctx, &master_pb.CollectionDeleteRequest{
 			Name: collectionName,
 		})
 		if err != nil {
-			glog.Infof("delete collection %s: %v", collectionName, err)
+			glog.InfofCtx(ctx, "delete collection %s: %v", collectionName, err)
 		}
 		return err
 	})

--- a/weed/s3api/s3api_bucket_handlers.go
+++ b/weed/s3api/s3api_bucket_handlers.go
@@ -35,6 +35,27 @@ import (
 	util_http "github.com/seaweedfs/seaweedfs/weed/util/http"
 )
 
+const (
+	// collectionListTimeout bounds the filer CollectionList a bucket creation
+	// issues, and collectionDeleteTimeout the filer DeleteCollection a bucket
+	// deletion issues. Neither carried a deadline, so a transient failure
+	// anywhere down the chain -- gateway to filer, filer to master, master to
+	// volume server -- held the S3 request open until the client gave up on it
+	// (issues #7229 and #7232).
+	//
+	// Both budgets are taken before WithFilerClientCtx, so they cover the whole
+	// failover walk rather than granting each filer a fresh one, and the walk
+	// stops rather than blaming filers for the caller running out of time.
+	//
+	// The listing matches what the filer allows itself for the same RPC. The
+	// delete is deliberately shorter: DeleteBucket has already paid the filer's
+	// own 15s for this collection, under the bucket entry's delete inside s3a.rm,
+	// and this call is the follow-up for when that did not happen. Together that
+	// is roughly 25s of the 60s an S3 client waits.
+	collectionListTimeout   = 15 * time.Second
+	collectionDeleteTimeout = 10 * time.Second
+)
+
 func (s3a *S3ApiServer) ListBucketsHandler(w http.ResponseWriter, r *http.Request) {
 
 	glog.V(3).Infof("ListBucketsHandler")
@@ -259,12 +280,13 @@ func (s3a *S3ApiServer) PutBucketHandler(w http.ResponseWriter, r *http.Request)
 		s3err.WriteErrorResponse(w, r, s3err.ErrBucketAlreadyExists)
 		return
 	}
-	if err := s3a.WithFilerClient(false, func(client filer_pb.SeaweedFilerClient) error {
-		if resp, err := client.CollectionList(context.Background(), &filer_pb.CollectionListRequest{
+	listCtx, cancelList := context.WithTimeout(context.Background(), collectionListTimeout)
+	defer cancelList()
+	if err := s3a.WithFilerClientCtx(listCtx, false, func(client filer_pb.SeaweedFilerClient) error {
+		if resp, err := client.CollectionList(listCtx, &filer_pb.CollectionListRequest{
 			IncludeEcVolumes:     true,
 			IncludeNormalVolumes: true,
 		}); err != nil {
-			glog.Errorf("list collection: %v", err)
 			return fmt.Errorf("list collections: %w", err)
 		} else {
 			for _, c := range resp.Collections {
@@ -276,8 +298,12 @@ func (s3a *S3ApiServer) PutBucketHandler(w http.ResponseWriter, r *http.Request)
 		}
 		return nil
 	}); err != nil {
-		s3err.WriteErrorResponse(w, r, s3err.ErrInternalError)
-		return
+		// Advisory only: the answer decides nothing below except whether to log
+		// that a leftover collection is being reused. s3a.exists is what decides
+		// whether the bucket already exists. Failing the whole creation because a
+		// diagnostic listing timed out is what made a transient master hiccup
+		// surface to the client as a failed CreateBucket.
+		glog.Warningf("PutBucketHandler: list collections for %s: %v", bucket, err)
 	}
 
 	// Bucket already exists: report whether the caller already owns it or the
@@ -475,13 +501,15 @@ func (s3a *S3ApiServer) DeleteBucketHandler(w http.ResponseWriter, r *http.Reque
 		}
 	}
 
-	err = s3a.WithFilerClient(false, func(client filer_pb.SeaweedFilerClient) error {
+	deleteCtx, cancelDelete := context.WithTimeout(context.Background(), collectionDeleteTimeout)
+	defer cancelDelete()
+	err = s3a.WithFilerClientCtx(deleteCtx, false, func(client filer_pb.SeaweedFilerClient) error {
 		deleteCollectionRequest := &filer_pb.DeleteCollectionRequest{
 			Collection: s3a.getCollectionName(bucket),
 		}
 
 		glog.V(1).Infof("delete collection: %v", deleteCollectionRequest)
-		if _, err := client.DeleteCollection(context.Background(), deleteCollectionRequest); err != nil {
+		if _, err := client.DeleteCollection(deleteCtx, deleteCollectionRequest); err != nil {
 			return fmt.Errorf("delete collection %s: %v", bucket, err)
 		}
 
@@ -491,7 +519,14 @@ func (s3a *S3ApiServer) DeleteBucketHandler(w http.ResponseWriter, r *http.Reque
 	if err != nil {
 		// Log but don't fail — the bucket directory is already removed, so the bucket
 		// is effectively deleted. The orphaned collection will be cleaned up or reused.
-		glog.Errorf("DeleteBucketHandler: failed to delete collection for bucket %s: %v", bucket, err)
+		if deleteCtx.Err() != nil {
+			// Our own budget ran out, which is not the same as a refusal: the master
+			// carries on deleting once asked, so this only says we stopped waiting
+			// for the confirmation. Not worth an error on an otherwise fine cluster.
+			glog.Warningf("DeleteBucketHandler: stopped waiting for the collection delete for bucket %s: %v", bucket, err)
+		} else {
+			glog.Errorf("DeleteBucketHandler: failed to delete collection for bucket %s: %v", bucket, err)
+		}
 	}
 
 	// Clean up bucket-related caches, locks, and metrics after successful deletion

--- a/weed/s3api/s3api_handlers.go
+++ b/weed/s3api/s3api_handlers.go
@@ -18,14 +18,23 @@ import (
 var _ = filer_pb.FilerClient(&S3ApiServer{})
 
 func (s3a *S3ApiServer) WithFilerClient(streamingMode bool, fn func(filer_pb.SeaweedFilerClient) error) error {
+	return s3a.WithFilerClientCtx(context.Background(), streamingMode, fn)
+}
+
+// WithFilerClientCtx is WithFilerClient told which context bounds the calls fn
+// makes. It does not cancel anything itself -- fn owns its own RPC contexts --
+// but the failover walk needs to know whose budget ran out: a caller's expiry is
+// not evidence against the filer that was answering, and must not be recorded as
+// one. Pass context.Background() when fn's calls carry no deadline.
+func (s3a *S3ApiServer) WithFilerClientCtx(ctx context.Context, streamingMode bool, fn func(filer_pb.SeaweedFilerClient) error) error {
 	// Use filerClient for proper connection management and failover
 	if s3a.filerClient != nil {
-		return s3a.withFilerClientFailover("", streamingMode, fn)
+		return s3a.withFilerClientFailover(ctx, "", streamingMode, fn)
 	}
 
 	// Fallback to direct connection if filerClient not initialized
 	// This should only happen during initialization or testing
-	return pb.WithGrpcClient(context.Background(), streamingMode, s3a.randomClientId, func(grpcConnection *grpc.ClientConn) error {
+	return pb.WithGrpcClient(ctx, streamingMode, s3a.randomClientId, func(grpcConnection *grpc.ClientConn) error {
 		client := filer_pb.NewSeaweedFilerClient(grpcConnection)
 		return fn(client)
 	}, s3a.getFilerAddress().ToGrpcAddress(), false, s3a.option.GrpcDialOption)
@@ -43,8 +52,10 @@ func (s3a *S3ApiServer) WithFilerClient(streamingMode bool, fn func(filer_pb.Sea
 // Failover replays fn from scratch, so it stops once any response has reached
 // fn: a replay after that could silently duplicate state fn accumulated (a
 // listing that failed mid-stream, say), so the error surfaces instead and the
-// caller decides whether a clean-slate retry is safe.
-func (s3a *S3ApiServer) withFilerClientFailover(preferred pb.ServerAddress, streamingMode bool, fn func(filer_pb.SeaweedFilerClient) error) error {
+// caller decides whether a clean-slate retry is safe. ctx is the budget bounding
+// fn's own calls; it is only read, to tell a filer's failure apart from the
+// caller running out of time.
+func (s3a *S3ApiServer) withFilerClientFailover(ctx context.Context, preferred pb.ServerAddress, streamingMode bool, fn func(filer_pb.SeaweedFilerClient) error) error {
 	currentFiler := s3a.filerClient.GetCurrentFiler()
 
 	candidates := make([]pb.ServerAddress, 0, 2+len(s3a.option.Filers))
@@ -87,7 +98,7 @@ func (s3a *S3ApiServer) withFilerClientFailover(preferred pb.ServerAddress, stre
 	var lastErr error
 	for _, filer := range ordered {
 		received := false
-		err := pb.WithGrpcClient(context.Background(), streamingMode, s3a.randomClientId, func(grpcConnection *grpc.ClientConn) error {
+		err := pb.WithGrpcClient(ctx, streamingMode, s3a.randomClientId, func(grpcConnection *grpc.ClientConn) error {
 			return fn(filer_pb.NewSeaweedFilerClient(receiveTrackingConn{ClientConnInterface: grpcConnection, received: &received}))
 		}, filer.ToGrpcAddress(), false, s3a.option.GrpcDialOption)
 
@@ -100,6 +111,16 @@ func (s3a *S3ApiServer) withFilerClientFailover(preferred pb.ServerAddress, stre
 			return nil
 		}
 		if errors.Is(err, filer_pb.ErrNotFound) {
+			return err
+		}
+
+		// The caller's own budget expiring is not evidence against this filer, and
+		// the next one has no time left to answer either. Recording it would let a
+		// slow master upstream mark every filer in the walk, and the three failures
+		// that open the circuit would then take unrelated object reads down with a
+		// health flag no filer earned.
+		if ctx.Err() != nil {
+			glog.V(2).Infof("WithFilerClient: giving up on %s, the caller's context ended: %v", filer, err)
 			return err
 		}
 

--- a/weed/s3api/s3api_handlers_failover_test.go
+++ b/weed/s3api/s3api_handlers_failover_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
@@ -133,5 +134,56 @@ func TestListAfterMidStreamFailureHasNoDuplicates(t *testing.T) {
 	}
 	if !isLast {
 		t.Fatal("want isLast")
+	}
+}
+
+// hangingCollectionFiler answers CollectionList only when the caller gives up,
+// standing in for a filer waiting on a master that has stopped answering.
+type hangingCollectionFiler struct {
+	filer_pb.UnimplementedSeaweedFilerServer
+	calls atomic.Int32
+}
+
+func (f *hangingCollectionFiler) CollectionList(ctx context.Context, _ *filer_pb.CollectionListRequest) (*filer_pb.CollectionListResponse, error) {
+	f.calls.Add(1)
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+// The caller's own budget expiring says nothing about the filer that was
+// answering it. Counted as a filer failure it would, after the three that open
+// the circuit, mark every filer in the walk unhealthy -- and LookupVolumeIds
+// skips unhealthy filers, so unrelated object reads would start failing over a
+// slow master they never touched.
+func TestFailoverDoesNotBlameFilersForTheCallersExpiredBudget(t *testing.T) {
+	first := &hangingCollectionFiler{}
+	second := &hangingCollectionFiler{}
+	firstAddr := startFakeFiler(t, first)
+	secondAddr := startFakeFiler(t, second)
+	s3a := newFailoverTestServer(t, firstAddr, secondAddr)
+
+	// More attempts than the three failures it takes to open the circuit.
+	for attempt := 0; attempt < 5; attempt++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		err := s3a.WithFilerClientCtx(ctx, false, func(client filer_pb.SeaweedFilerClient) error {
+			_, listErr := client.CollectionList(ctx, &filer_pb.CollectionListRequest{})
+			return listErr
+		})
+		cancel()
+		if err == nil {
+			t.Fatalf("attempt %d: want the expired budget surfaced as an error", attempt)
+		}
+	}
+
+	for _, addr := range []pb.ServerAddress{firstAddr, secondAddr} {
+		if s3a.filerClient.ShouldSkipUnhealthyFiler(addr) {
+			t.Errorf("filer %s was flagged unhealthy for the caller's own timeout; unrelated reads would now skip it", addr)
+		}
+	}
+
+	// And the walk stops rather than spending an already-spent budget on the
+	// next filer, which cannot answer any faster.
+	if n := second.calls.Load(); n != 0 {
+		t.Errorf("the second filer was tried %d times with no budget left to answer in", n)
 	}
 }

--- a/weed/s3api/s3api_object_routed_read.go
+++ b/weed/s3api/s3api_object_routed_read.go
@@ -38,7 +38,7 @@ func (s3a *S3ApiServer) getObjectEntryRoutedByKey(bucket, object string) (*filer
 
 	dir, name := fullPath.DirAndName()
 	var entry *filer_pb.Entry
-	err := s3a.withFilerClientFailover(preferred, false, func(client filer_pb.SeaweedFilerClient) error {
+	err := s3a.withFilerClientFailover(context.Background(), preferred, false, func(client filer_pb.SeaweedFilerClient) error {
 		resp, lookupErr := filer_pb.LookupEntry(context.Background(), client, &filer_pb.LookupDirectoryEntryRequest{
 			Directory: dir,
 			Name:      name,

--- a/weed/s3api/s3api_object_routed_write.go
+++ b/weed/s3api/s3api_object_routed_write.go
@@ -170,7 +170,7 @@ func (s3a *S3ApiServer) objectTxnOnFiler(owner pb.ServerAddress, req *filer_pb.O
 	if s3a.ownerRecentlyUnreachable(owner) {
 		preferred = ""
 	}
-	err := s3a.withFilerClientFailover(preferred, false, txn)
+	err := s3a.withFilerClientFailover(context.Background(), preferred, false, txn)
 	return resp, err
 }
 

--- a/weed/server/filer_grpc_server.go
+++ b/weed/server/filer_grpc_server.go
@@ -885,13 +885,30 @@ func (fs *FilerServer) resolveAssignStorageOption(ctx context.Context, req *file
 	return so, nil
 }
 
+// collectionListTimeout bounds the whole attempt to list collections: the wait
+// for a master address, the util.Retry walk around it, and the RPC itself. The
+// budget is taken before WithClientCtx, so a transient failure cannot restart
+// the clock and a master that is down or mid-election cannot park this handler
+// indefinitely (issue #7229).
+//
+// The master answers this out of its in-memory topology, so a reply that has not
+// arrived well inside the budget is not arriving. 15s is three times the 5s
+// MasterClient.grpcTimeout the tree already applies per master RPC, and a
+// quarter of the 60s an S3 client typically waits, so a stuck listing surfaces
+// as an error while the client still has retry budget left rather than after it
+// has spent it.
+const collectionListTimeout = 15 * time.Second
+
 func (fs *FilerServer) CollectionList(ctx context.Context, req *filer_pb.CollectionListRequest) (resp *filer_pb.CollectionListResponse, err error) {
 
 	glog.V(4).InfofCtx(ctx, "CollectionList %v", req)
 	resp = &filer_pb.CollectionListResponse{}
 
-	err = fs.filer.MasterClient.WithClient(false, func(client master_pb.SeaweedClient) error {
-		masterResp, err := client.CollectionList(context.Background(), &master_pb.CollectionListRequest{
+	ctx, cancel := context.WithTimeout(ctx, collectionListTimeout)
+	defer cancel()
+
+	err = fs.filer.MasterClient.WithClientCtx(ctx, false, func(client master_pb.SeaweedClient) error {
+		masterResp, err := client.CollectionList(ctx, &master_pb.CollectionListRequest{
 			IncludeNormalVolumes: req.IncludeNormalVolumes,
 			IncludeEcVolumes:     req.IncludeEcVolumes,
 		})
@@ -911,7 +928,7 @@ func (fs *FilerServer) DeleteCollection(ctx context.Context, req *filer_pb.Delet
 
 	glog.V(4).InfofCtx(ctx, "DeleteCollection %v", req)
 
-	err = fs.filer.DoDeleteCollection(req.GetCollection())
+	err = fs.filer.DoDeleteCollection(ctx, req.GetCollection())
 
 	return &filer_pb.DeleteCollectionResponse{}, err
 }

--- a/weed/server/master_grpc_server_collection.go
+++ b/weed/server/master_grpc_server_collection.go
@@ -2,13 +2,30 @@ package weed_server
 
 import (
 	"context"
+	"time"
 
 	"github.com/seaweedfs/raft"
 
+	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/operation"
+	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/volume_server_pb"
 )
+
+// deleteCollectionTimeout bounds one DeleteCollection RPC to a volume server, so
+// a server that accepts the connection and then stops answering cannot hold the
+// fan-out open forever with nothing to end it (issue #7234). Same bound as
+// allocateVolumeTimeout in weed/topology, the other master-to-volume-server
+// admin RPC.
+//
+// This bounds each RPC and deliberately not the fan-out as a whole: the loop
+// below runs the per-server contexts through context.WithoutCancel, keeping the
+// caller's values and dropping its deadline. A collection can span many servers
+// and the deletes are sequential, so laying a caller's budget over the whole
+// loop would abandon a large delete part-done and skip the EC pass with it,
+// leaving shards behind and no request left to retry them.
+const deleteCollectionTimeout = 1 * time.Minute
 
 func (ms *MasterServer) CollectionList(ctx context.Context, req *master_pb.CollectionListRequest) (*master_pb.CollectionListResponse, error) {
 
@@ -33,33 +50,60 @@ func (ms *MasterServer) CollectionDelete(ctx context.Context, req *master_pb.Col
 		return nil, raft.NotLeaderError
 	}
 
-	resp := &master_pb.CollectionDeleteResponse{}
-
-	err := ms.doDeleteNormalCollection(req.Name)
-
-	if err != nil {
+	if err := ms.deleteCollection(ctx, req.Name); err != nil {
 		return nil, err
 	}
 
-	err = ms.doDeleteEcCollection(req.Name)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return resp, nil
+	return &master_pb.CollectionDeleteResponse{}, nil
 }
 
-func (ms *MasterServer) doDeleteNormalCollection(collectionName string) error {
+// deleteCollection removes a collection's normal volumes and its EC shards. Both
+// passes always run: one collection can hold both, and returning after a failed
+// normal pass left the EC shards in place with no request left to come back for
+// them. The normal pass keeps precedence in what is reported, as it did before.
+func (ms *MasterServer) deleteCollection(ctx context.Context, collectionName string) error {
+
+	normalErr := ms.doDeleteNormalCollection(ctx, collectionName)
+	ecErr := ms.doDeleteEcCollection(ctx, collectionName)
+
+	if normalErr != nil {
+		if ecErr != nil {
+			glog.ErrorfCtx(ctx, "delete collection %s: ec shards also failed: %v", collectionName, ecErr)
+		}
+		return normalErr
+	}
+
+	return ecErr
+}
+
+func (ms *MasterServer) doDeleteNormalCollection(ctx context.Context, collectionName string) error {
 
 	collection, ok := ms.Topo.FindCollection(collectionName)
 	if !ok {
 		return nil
 	}
 
+	// Values only, no deadline: see deleteCollectionTimeout.
+	fanoutCtx := context.WithoutCancel(ctx)
+
+	// One RPC per server rather than one per replica. ListVolumeServers reports a
+	// node once for every replica of the collection it holds, and DeleteCollection
+	// removes the whole collection from the server it reaches, so a collection with
+	// thousands of volumes would otherwise repeat the same whole-collection delete
+	// thousands of times against the same handful of nodes.
+	// ListEcServersByCollection already returns each server once.
+	deleted := make(map[pb.ServerAddress]struct{})
 	for _, server := range collection.ListVolumeServers() {
-		err := operation.WithVolumeServerClient(false, server.ServerAddress(), ms.grpcDialOption, func(client volume_server_pb.VolumeServerClient) error {
-			_, deleteErr := client.DeleteCollection(context.Background(), &volume_server_pb.DeleteCollectionRequest{
+		address := server.ServerAddress()
+		if _, done := deleted[address]; done {
+			continue
+		}
+		deleted[address] = struct{}{}
+
+		err := operation.WithVolumeServerClient(false, address, ms.grpcDialOption, func(client volume_server_pb.VolumeServerClient) error {
+			rpcCtx, cancel := context.WithTimeout(fanoutCtx, deleteCollectionTimeout)
+			defer cancel()
+			_, deleteErr := client.DeleteCollection(rpcCtx, &volume_server_pb.DeleteCollectionRequest{
 				Collection: collectionName,
 			})
 			return deleteErr
@@ -73,13 +117,18 @@ func (ms *MasterServer) doDeleteNormalCollection(collectionName string) error {
 	return nil
 }
 
-func (ms *MasterServer) doDeleteEcCollection(collectionName string) error {
+func (ms *MasterServer) doDeleteEcCollection(ctx context.Context, collectionName string) error {
 
 	listOfEcServers := ms.Topo.ListEcServersByCollection(collectionName)
 
+	// Values only, no deadline: see deleteCollectionTimeout.
+	fanoutCtx := context.WithoutCancel(ctx)
+
 	for _, server := range listOfEcServers {
 		err := operation.WithVolumeServerClient(false, server, ms.grpcDialOption, func(client volume_server_pb.VolumeServerClient) error {
-			_, deleteErr := client.DeleteCollection(context.Background(), &volume_server_pb.DeleteCollectionRequest{
+			rpcCtx, cancel := context.WithTimeout(fanoutCtx, deleteCollectionTimeout)
+			defer cancel()
+			_, deleteErr := client.DeleteCollection(rpcCtx, &volume_server_pb.DeleteCollectionRequest{
 				Collection: collectionName,
 			})
 			return deleteErr

--- a/weed/server/master_grpc_server_collection_test.go
+++ b/weed/server/master_grpc_server_collection_test.go
@@ -1,0 +1,306 @@
+package weed_server
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
+	"github.com/seaweedfs/seaweedfs/weed/pb/volume_server_pb"
+	"github.com/seaweedfs/seaweedfs/weed/topology"
+)
+
+// recordingVolumeServer answers DeleteCollection the way the test asks and
+// reports what each call arrived carrying. failWith answers an error at once;
+// hang holds the call until the caller gives up or the test releases it, the way
+// a server that is still reachable but wedged behaves.
+type recordingVolumeServer struct {
+	volume_server_pb.UnimplementedVolumeServerServer
+
+	hang     bool
+	failWith error
+
+	calls       chan deleteCollectionCall
+	release     chan struct{}
+	releaseOnce sync.Once
+}
+
+type deleteCollectionCall struct {
+	collection string
+	// budget is the time the RPC arrived with, or 0 when it carried no deadline.
+	budget time.Duration
+}
+
+func newRecordingVolumeServer() *recordingVolumeServer {
+	return &recordingVolumeServer{
+		calls:   make(chan deleteCollectionCall, 8),
+		release: make(chan struct{}),
+	}
+}
+
+func (s *recordingVolumeServer) DeleteCollection(ctx context.Context, req *volume_server_pb.DeleteCollectionRequest) (*volume_server_pb.DeleteCollectionResponse, error) {
+	call := deleteCollectionCall{collection: req.Collection}
+	if deadline, ok := ctx.Deadline(); ok {
+		call.budget = time.Until(deadline)
+	}
+	s.calls <- call
+
+	if s.failWith != nil {
+		return nil, s.failWith
+	}
+	if s.hang {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-s.release:
+		}
+	}
+	return &volume_server_pb.DeleteCollectionResponse{}, nil
+}
+
+// Release unblocks every held DeleteCollection. Safe to call more than once.
+func (s *recordingVolumeServer) Release() {
+	s.releaseOnce.Do(func() { close(s.release) })
+}
+
+// serveVolumeServer publishes stub on a fresh localhost listener and returns the
+// data node coordinates a topology needs in order to reach it.
+func serveVolumeServer(t *testing.T, stub *recordingVolumeServer) (ip string, port, grpcPort int) {
+	t.Helper()
+	t.Cleanup(stub.Release)
+	grpcPort = serveGrpc(t, func(s *grpc.Server) {
+		volume_server_pb.RegisterVolumeServerServer(s, stub)
+	})
+	// Only the grpc port is dialed; the http port just has to stay distinct per
+	// server so the topology does not treat two nodes as one address.
+	port = grpcPort - 10000
+	if port <= 0 {
+		port = grpcPort + 1
+	}
+	return "127.0.0.1", port, grpcPort
+}
+
+func newTestMaster(topo *topology.Topology) *MasterServer {
+	return &MasterServer{
+		Topo:           topo,
+		grpcDialOption: grpc.WithTransportCredentials(insecure.NewCredentials()),
+	}
+}
+
+// awaitCall waits for one DeleteCollection to reach the stub.
+func awaitCall(t *testing.T, stub *recordingVolumeServer, what string) deleteCollectionCall {
+	t.Helper()
+	select {
+	case call := <-stub.calls:
+		return call
+	case <-time.After(15 * time.Second):
+		t.Fatalf("%s: the volume server never received DeleteCollection", what)
+		return deleteCollectionCall{}
+	}
+}
+
+// A caller with no deadline of its own must still not be able to wait forever:
+// the master has to bound each RPC, or one wedged volume server holds the
+// fan-out open with nothing to end it (issue #7234).
+func TestDoDeleteNormalCollectionBoundsEachVolumeServerRPC(t *testing.T) {
+	const collection = "bucket-a"
+
+	stub := newRecordingVolumeServer()
+	stub.hang = true
+	ip, port, grpcPort := serveVolumeServer(t, stub)
+
+	topo := topology.NewTopology("test", nil, 32*1024, 5, false)
+	dn := topo.GetOrCreateDataCenter("dc1").GetOrCreateRack("rack1").
+		GetOrCreateDataNode(ip, port, grpcPort, "", "vs1", map[string]uint32{"": 10})
+	topo.SyncDataNodeRegistration([]*master_pb.VolumeInformationMessage{
+		{Id: 1, Collection: collection, Version: 3},
+	}, dn)
+	ms := newTestMaster(topo)
+
+	done := make(chan error, 1)
+	go func() { done <- ms.doDeleteNormalCollection(context.Background(), collection) }()
+
+	call := awaitCall(t, stub, "bounded RPC")
+	if call.budget <= 0 {
+		t.Fatal("DeleteCollection reached the volume server with no deadline: a wedged server holds the fan-out open with nothing to end it")
+	}
+	if call.budget > deleteCollectionTimeout {
+		t.Errorf("DeleteCollection budget = %v, want at most deleteCollectionTimeout %v", call.budget, deleteCollectionTimeout)
+	}
+
+	stub.Release()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("doDeleteNormalCollection returned %v, want nil once the volume server answers", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("doDeleteNormalCollection did not return after the volume server answered")
+	}
+}
+
+// The fan-out must outlive the caller's budget. A collection can span many
+// servers and the deletes are sequential, so letting an inbound deadline end the
+// loop would abandon a large delete part-done, with volumes left behind and no
+// request still running to come back for them.
+func TestDoDeleteNormalCollectionOutlivesTheCallersDeadline(t *testing.T) {
+	const collection = "bucket-b"
+
+	stub := newRecordingVolumeServer()
+	ip, port, grpcPort := serveVolumeServer(t, stub)
+
+	topo := topology.NewTopology("test", nil, 32*1024, 5, false)
+	dn := topo.GetOrCreateDataCenter("dc1").GetOrCreateRack("rack1").
+		GetOrCreateDataNode(ip, port, grpcPort, "", "vs1", map[string]uint32{"": 10})
+	topo.SyncDataNodeRegistration([]*master_pb.VolumeInformationMessage{
+		{Id: 1, Collection: collection, Version: 3},
+	}, dn)
+	ms := newTestMaster(topo)
+
+	// The caller is already gone by the time the delete starts.
+	expired, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- ms.doDeleteNormalCollection(expired, collection) }()
+
+	call := awaitCall(t, stub, "cancelled caller")
+	if call.budget <= 0 {
+		t.Error("DeleteCollection arrived with no deadline; each RPC should still be bounded")
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("doDeleteNormalCollection returned %v; a cancelled caller must not fail the fan-out", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("doDeleteNormalCollection did not finish")
+	}
+
+	if _, found := topo.FindCollection(collection); found {
+		t.Error("the collection was left in the topology; the delete did not run to completion")
+	}
+}
+
+// ListVolumeServers reports a node once per replica it holds. DeleteCollection
+// removes the whole collection from the server it reaches, so the master must
+// send it once per server, not once per replica.
+func TestDoDeleteNormalCollectionSendsOneRPCPerVolumeServer(t *testing.T) {
+	const collection = "bucket-c"
+
+	stub := newRecordingVolumeServer()
+	ip, port, grpcPort := serveVolumeServer(t, stub)
+
+	topo := topology.NewTopology("test", nil, 32*1024, 5, false)
+	dn := topo.GetOrCreateDataCenter("dc1").GetOrCreateRack("rack1").
+		GetOrCreateDataNode(ip, port, grpcPort, "", "vs1", map[string]uint32{"": 10})
+	topo.SyncDataNodeRegistration([]*master_pb.VolumeInformationMessage{
+		{Id: 1, Collection: collection, Version: 3},
+		{Id: 2, Collection: collection, Version: 3},
+		{Id: 3, Collection: collection, Version: 3},
+	}, dn)
+
+	collectionInTopology, found := topo.FindCollection(collection)
+	if !found {
+		t.Fatalf("test setup: collection %s was not registered", collection)
+	}
+	if listed := len(collectionInTopology.ListVolumeServers()); listed < 2 {
+		t.Fatalf("test setup: the one node is listed %d times, expected once per replica", listed)
+	}
+
+	ms := newTestMaster(topo)
+	if err := ms.doDeleteNormalCollection(context.Background(), collection); err != nil {
+		t.Fatalf("doDeleteNormalCollection: %v", err)
+	}
+
+	awaitCall(t, stub, "one RPC per server")
+	select {
+	case extra := <-stub.calls:
+		t.Errorf("the same server was told to delete %q more than once", extra.collection)
+	default:
+	}
+}
+
+// The EC pass needs the same decoupling from the caller as the normal one. It
+// runs second, so it is the pass most likely to find the caller already gone,
+// and a deadline reaching it would leave shards behind exactly when there is
+// nothing left to retry them.
+func TestDeleteCollectionEcPassOutlivesTheCallersDeadline(t *testing.T) {
+	const collection = "bucket-e"
+
+	ec := newRecordingVolumeServer()
+	ecIP, ecPort, ecGrpcPort := serveVolumeServer(t, ec)
+
+	// EC shards only, so the normal pass finds nothing and the EC pass is what is
+	// under test.
+	topo := topology.NewTopology("test", nil, 32*1024, 5, false)
+	ecNode := topo.GetOrCreateDataCenter("dc1").GetOrCreateRack("rack1").
+		GetOrCreateDataNode(ecIP, ecPort, ecGrpcPort, "", "vs-ec", map[string]uint32{"": 10})
+	topo.SyncDataNodeEcShards([]*master_pb.VolumeEcShardInformationMessage{
+		{Id: 9, Collection: collection, EcIndexBits: 0x1f},
+	}, ecNode)
+
+	ms := newTestMaster(topo)
+
+	// The caller is already gone by the time the delete starts.
+	expired, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := ms.deleteCollection(expired, collection); err != nil {
+		t.Fatalf("deleteCollection returned %v; a cancelled caller must not fail the EC pass", err)
+	}
+
+	call := awaitCall(t, ec, "cancelled caller, ec pass")
+	if call.collection != collection {
+		t.Errorf("the ec server was told to delete %q, want %q", call.collection, collection)
+	}
+	if call.budget <= 0 {
+		t.Error("the EC DeleteCollection arrived with no deadline; each RPC should still be bounded")
+	}
+}
+
+// A collection can hold normal volumes and EC shards at once. Returning after a
+// failed normal pass left the EC shards in place with no request left to come
+// back for them, so both passes have to run.
+func TestDeleteCollectionRunsTheEcPassWhenTheNormalPassFails(t *testing.T) {
+	const collection = "bucket-d"
+
+	normal := newRecordingVolumeServer()
+	normal.failWith = errors.New("volume server is out of disk")
+	normalIP, normalPort, normalGrpcPort := serveVolumeServer(t, normal)
+
+	ec := newRecordingVolumeServer()
+	ecIP, ecPort, ecGrpcPort := serveVolumeServer(t, ec)
+
+	topo := topology.NewTopology("test", nil, 32*1024, 5, false)
+	rack := topo.GetOrCreateDataCenter("dc1").GetOrCreateRack("rack1")
+
+	normalNode := rack.GetOrCreateDataNode(normalIP, normalPort, normalGrpcPort, "", "vs-normal", map[string]uint32{"": 10})
+	topo.SyncDataNodeRegistration([]*master_pb.VolumeInformationMessage{
+		{Id: 1, Collection: collection, Version: 3},
+	}, normalNode)
+
+	ecNode := rack.GetOrCreateDataNode(ecIP, ecPort, ecGrpcPort, "", "vs-ec", map[string]uint32{"": 10})
+	topo.SyncDataNodeEcShards([]*master_pb.VolumeEcShardInformationMessage{
+		{Id: 9, Collection: collection, EcIndexBits: 0x1f},
+	}, ecNode)
+
+	ms := newTestMaster(topo)
+
+	if err := ms.deleteCollection(context.Background(), collection); err == nil {
+		t.Fatal("deleteCollection reported success while the normal pass failed")
+	}
+
+	// The failure is reported, and the EC shards are cleaned up anyway.
+	awaitCall(t, ec, "ec pass after a failed normal pass")
+
+	if _, found := topo.FindCollection(collection); !found {
+		t.Error("the normal collection was dropped from the topology despite failing; nothing would retry it")
+	}
+}

--- a/weed/server/master_server_handlers_admin.go
+++ b/weed/server/master_server_handlers_admin.go
@@ -13,8 +13,6 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
-	"github.com/seaweedfs/seaweedfs/weed/operation"
-	"github.com/seaweedfs/seaweedfs/weed/pb/volume_server_pb"
 	"github.com/seaweedfs/seaweedfs/weed/storage/backend/memory_map"
 	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
 	"github.com/seaweedfs/seaweedfs/weed/storage/super_block"
@@ -25,24 +23,21 @@ import (
 
 func (ms *MasterServer) collectionDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	collectionName := r.FormValue("collection")
-	collection, ok := ms.Topo.FindCollection(collectionName)
-	if !ok {
+	if _, ok := ms.Topo.FindCollection(collectionName); !ok {
 		writeJsonError(w, r, http.StatusBadRequest, fmt.Errorf("collection %s does not exist", collectionName))
 		return
 	}
-	for _, server := range collection.ListVolumeServers() {
-		err := operation.WithVolumeServerClient(false, server.ServerAddress(), ms.grpcDialOption, func(client volume_server_pb.VolumeServerClient) error {
-			_, deleteErr := client.DeleteCollection(context.Background(), &volume_server_pb.DeleteCollectionRequest{
-				Collection: collection.Name,
-			})
-			return deleteErr
-		})
-		if err != nil {
-			writeJsonError(w, r, http.StatusInternalServerError, err)
-			return
-		}
+
+	// The same two passes the gRPC CollectionDelete runs, rather than a second
+	// copy of the volume-server walk: this handler deleted only the normal
+	// volumes, leaving the collection's EC shards behind.
+	//
+	// Values only, no deadline: an operator's curl hanging up partway through must
+	// not abandon a destructive fan-out half done. Each RPC is still bounded.
+	if err := ms.deleteCollection(context.WithoutCancel(r.Context()), collectionName); err != nil {
+		writeJsonError(w, r, http.StatusInternalServerError, err)
+		return
 	}
-	ms.Topo.DeleteCollection(collectionName)
 
 	w.WriteHeader(http.StatusNoContent)
 	return

--- a/weed/wdclient/masterclient.go
+++ b/weed/wdclient/masterclient.go
@@ -416,6 +416,31 @@ func (mc *MasterClient) WithClient(streamingMode bool, fn func(client master_pb.
 	return mc.WithClientCustomGetMaster(getMasterF, streamingMode, fn)
 }
 
+// WithClientCtx is WithClient with ctx bounding the whole call, the wait for a
+// master address included.
+//
+// WithClient waits on context.Background(): GetMaster blocks until
+// KeepConnectedToMaster reports a master, and while none is reachable that is a
+// ~200ms poll with nothing to end it, since every failed connect cycle clears
+// the current master again. A caller that set a deadline is still stuck there,
+// before its own context is ever reached -- and if it is a request handler, a
+// client retrying behind it parks another goroutine in the same wait each time.
+//
+// Only pass a ctx that actually carries a deadline or cancellation; with
+// context.Background() this behaves exactly like WithClient.
+func (mc *MasterClient) WithClientCtx(ctx context.Context, streamingMode bool, fn func(client master_pb.SeaweedClient) error) error {
+	return util.Retry("master grpc", func() error {
+		master := mc.GetMaster(ctx)
+		// GetMaster returns the empty address when ctx ended first.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		return pb.WithMasterClient(ctx, streamingMode, master, mc.grpcDialOption, false, func(client master_pb.SeaweedClient) error {
+			return fn(client)
+		})
+	})
+}
+
 func (mc *MasterClient) WithClientCustomGetMaster(getMasterF func() pb.ServerAddress, streamingMode bool, fn func(client master_pb.SeaweedClient) error) error {
 	return util.Retry("master grpc", func() error {
 		return pb.WithMasterClient(context.Background(), streamingMode, getMasterF(), mc.grpcDialOption, false, func(client master_pb.SeaweedClient) error {


### PR DESCRIPTION
Fixes #7234. Fixes #7229. Addresses #7232.

Three issues from the same reporter share one cause: collection RPCs issued with `context.Background()`, so a filer or master that accepts a call and then goes quiet strands the caller until some unrelated higher-level timeout fires.

## What each hop does now

**Master to volume server.** Every `DeleteCollection` in the fan-out is bounded. The per-server contexts derive from `context.WithoutCancel(ctx)`, so an inbound expiry bounds each RPC without truncating the walk. Both passes now run unconditionally: previously a failure in the normal pass returned early and the EC pass never ran, which left EC shards behind with nothing to retry them. The normal error is still returned first, unwrapped, so its status code reaches the caller as before.

**Filer to master.** `CollectionList` and `CollectionDelete` are bounded, and the budget is taken outside `util.Retry` so it covers the whole walk rather than one attempt.

**Gateway to filer.** Same, taken outside `WithFilerClient` so one budget covers the failover walk instead of one per candidate.

## Two things worth calling out separately

**The fan-out sent the same whole-collection delete to the same server thousands of times.** `ListVolumeServers()` returns a node once per replica it holds, while `DeleteCollection` removes the collection from every disk location on the server it reaches. One RPC per server is enough, and `ListEcServersByCollection` already dedupes this way. The normal pass now does too. This is the one hunk that is not strictly about deadlines, and it is easy to drop if you would rather keep the change narrower, but a per-RPC bound is hard to reason about while the same call is issued thousands of times over.

**A failed collection listing no longer fails `PutBucket`.** The result of that listing feeds a `glog.Warningf` and nothing else, yet a transient failure returned 500 and refused the creation. That is the user-visible half of #7229: `test_bucket_list_many` creates buckets. The listing is advisory now, so a transient failure is logged and creation continues. Behaviour when the listing fails is identical to when it returns false, minus the warning. This is an API behaviour change in a request path, so it is a separate commit and easy to review on its own.

## On the wait in front of the RPCs

`MasterClient.WithClient` starts with `GetMaster(context.Background())`, which waits for a master leader with nothing to cut it short. Bounding only the RPC would have made this worse rather than better: the caller gives up, its client retries, and each retry parks another handler goroutine in that wait. So there is a new opt-in `WithClientCtx` used at these two call sites. `WithClient` is untouched and the other callers are unchanged.

That narrows the exposure on two request paths, it does not close the gap. The general fix touches every caller, and I filed it separately as #10997.

## Values

15s for the filer's `CollectionList`, 20s for its `CollectionDelete`, 10s for the gateway's follow-up delete. The follow-up is deliberately shorter: by then the filer has already spent its own budget on the same collection, and that call is only the safety net for when the bucket directory was already gone, so a `DeleteBucket` costs about 25s of the roughly 60s an S3 client waits.

The delete budget bounds the wait, not the work. The master keeps deleting on its own fan-out, so giving up costs the confirmation and not the deletion. A timeout there logs a warning rather than an error for that reason; a genuine refusal still logs an error.

I did not remove the gateway's second `DeleteCollection` call even though it is usually redundant, since dropping it is a behaviour change that does not belong in a timeout change.

## What I am not claiming

For #7232 the stall shortens to roughly a quarter and becomes a clean error instead of a hang. If the master genuinely cannot answer, the cleanup still does not complete promptly, so "addresses" rather than "fixes".

#7228 and #7233 are from the same series but are already bounded on current master, by `operation.Assign`'s shared 30s budget and by `allocateVolumeTimeout`. Both were real at 3.97. They are not part of this change.

## Testing

Six tests, each verified by reverting only its own behaviour and confirming it fails for the right reason. They stand up real gRPC listeners: a wedged volume server, a fake master serving `KeepConnected`, and hanging filers. Covered: each RPC carrying a deadline, the fan-out outliving a cancelled caller, one RPC per server, the EC pass running when the normal pass fails, the EC pass surviving a cancelled caller, and the filer giving up when no master is reachable.

`go build ./...`, `go vet` and the package tests match the base commit; the three failures in `weed/server` and `weed/topology` and the `copylocks` findings in `weed/s3api` test files are all present on `d8a189f07` too.

Not verified: I have no cluster, so this rests on code review plus unit tests at each hop rather than on reproducing the reporter's measurements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bucket and collection deletion reliability when requests are cancelled or services are temporarily unavailable.
  * Added bounded timeouts to collection listing, deletion, and volume-server operations.
  * Ensured collection cleanup continues across replicas and erasure-coded volumes.
  * Prevented caller timeouts from incorrectly marking filer services as unhealthy.
* **Tests**
  * Added coverage for cancellation handling, timeout enforcement, failover behavior, and complete collection cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->