### PR TITLE
s3api: replay a delete the filer's transport dropped, and classify by status code

### DIFF
--- a/weed/s3api/filer_util.go
+++ b/weed/s3api/filer_util.go
@@ -132,14 +132,30 @@ func deleteObjectEntry(client filer_pb.SeaweedFilerClient, parentDirectoryPath, 
 // second attempt report a failure instead. Worth re-checking if this is ever
 // revisited.
 //
-// The replay is immediate. What clears a transient failure here is the gRPC
-// channel reconnecting underneath the call, not the passage of time, and any
-// wait short enough to sit in a request path is far too short to outlast a
-// filer that is genuinely down. Not sleeping also keeps the cost a property of
-// the delete rather than of the request: DeleteMultipleObjectsHandler deletes
-// up to deleteMultipleObjectsLimit keys and completeMultipartUpload removes one
-// entry per unused part, so a per-delete backoff would be paid once per key.
+// The replay carries no backoff of its own. What clears a transient failure
+// here is the gRPC channel reconnecting underneath the call, not the passage of
+// time, and a sleep would be paid once per key in handlers that delete up to
+// deleteMultipleObjectsLimit entries per request.
+//
+// That does not make the replay free. A pick that finds no ready subconn
+// returns balancer.ErrNoSubConnAvailable, and the picker then waits for the
+// balancer to publish a new one; WaitForReady(false) does not shorten that wait,
+// and its only escape is the context. So while a channel is CONNECTING an
+// attempt blocks rather than failing fast, and replaying would multiply that
+// stall by deleteRetryAttempts. deleteReplayTimeout bounds it instead.
 const deleteRetryAttempts = 3
+
+// deleteReplayTimeout bounds every replay of one delete taken together, so this
+// replay can add at most this much to a request however the channel behaves.
+//
+// The first attempt deliberately keeps the caller's own context: a recursive
+// delete of a large bucket is legitimately slow, and putting a deadline on it
+// here would fail deletes that succeed today. Only the attempts this change
+// adds are bounded, which is what keeps it from making anything worse than it
+// already is. Deriving from the caller's context rather than replacing it means
+// a real request context, once one is threaded in, still cancels the replay and
+// an earlier deadline of its own still wins.
+const deleteReplayTimeout = 2 * time.Second
 
 // isRetryableDeleteRPCError reports whether a failed DeleteEntry call is worth
 // replaying. It classifies by gRPC status code, never by message text.
@@ -159,6 +175,24 @@ const deleteRetryAttempts = 3
 // verbatim). Substring-matching that text would let an object named
 // "transport.log" make a permission denial look transient, and one named after
 // filer_pb.ErrNotFound make a genuine connection reset look authoritative.
+//
+// The set matches what pb.shouldInvalidateConnection treats as a broken
+// channel, less Aborted:
+//
+//   - Unavailable is the ordinary transport failure, and the reason this exists.
+//   - Internal is what grpc-go reports when a server ends a stream without
+//     trailers, which is how an L7 gRPC proxy truncating a reply arrives - the
+//     "error while returning the response" shape issue #7204 describes.
+//   - Aborted is excluded: it reports a concurrency conflict the filer decided
+//     on, not a channel that broke, so replaying it would just lose the race
+//     again.
+//   - ResourceExhausted is included for symmetry with the connection check but
+//     is unreachable today, as nothing filer-side sheds load with it. If a shed
+//     is ever added, an immediate zero-backoff replay is the wrong answer to
+//     backpressure and this line should become a delay instead.
+//
+// Context cancellation arrives as Canceled or DeadlineExceeded and is not
+// replayed: the caller is already gone.
 func isRetryableDeleteRPCError(err error) bool {
 	if err == nil {
 		return false
@@ -168,7 +202,7 @@ func isRetryableDeleteRPCError(err error) bool {
 		return false
 	}
 	switch s.Code() {
-	case codes.Unavailable, codes.ResourceExhausted:
+	case codes.Unavailable, codes.Internal, codes.ResourceExhausted:
 		return true
 	}
 	return false
@@ -185,32 +219,68 @@ func doDeleteEntry(ctx context.Context, client filer_pb.SeaweedFilerClient, pare
 
 	glog.V(1).Infof("delete entry %v/%v: %v", parentDirectoryPath, entryName, request)
 
-	// The loop always makes one attempt whatever deleteRetryAttempts is set to,
-	// so lastErr is never nil at the return below and no count can turn a
-	// delete that was never issued into a reported success.
-	var lastErr error
-	for attempt := 1; ; attempt++ {
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			// the caller is gone, so a further attempt has nobody to answer
-			lastErr = ctxErr
-			break
+	// Master logged every failed delete RPC at V(1); keep that, so a delete that
+	// ends in failure still says so here whatever the replay did.
+	fail := func(cause string) error {
+		glog.V(1).Infof("delete entry %s/%s: %s", parentDirectoryPath, entryName, cause)
+		return fmt.Errorf("delete entry %s/%s: %s", parentDirectoryPath, entryName, cause)
+	}
+
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return fail(ctxErr.Error())
+	}
+
+	// The first attempt is unconditional and runs on the caller's own context,
+	// so no attempt count can turn a delete that was never issued into a
+	// reported success, and a legitimately slow recursive delete keeps the
+	// budget it has today.
+	rpcErr, filerErr := deleteEntryAttempt(ctx, client, request)
+	if rpcErr == nil {
+		if filerErr == "" {
+			return nil
+		}
+		return fail(filerErr)
+	}
+	if !isRetryableDeleteRPCError(rpcErr) {
+		return fail(rpcErr.Error())
+	}
+
+	// Every replay shares this one bounded context, so the wait they add is
+	// capped whether or not the caller supplied a deadline of its own.
+	replayCtx, cancelReplays := context.WithTimeout(ctx, deleteReplayTimeout)
+	defer cancelReplays()
+
+	for attempt := 2; attempt <= deleteRetryAttempts; attempt++ {
+		glog.V(2).Infof("delete entry %s/%s attempt %d/%d hit a transient error, replaying: %v", parentDirectoryPath, entryName, attempt-1, deleteRetryAttempts, rpcErr)
+		if ctxErr := replayCtx.Err(); ctxErr != nil {
+			return fail(ctxErr.Error())
 		}
 
-		resp, err := client.DeleteEntry(ctx, request)
-		if err == nil {
-			if resp.Error == "" {
+		rpcErr, filerErr = deleteEntryAttempt(replayCtx, client, request)
+		if rpcErr == nil {
+			if filerErr == "" {
 				return nil
 			}
-			return fmt.Errorf("delete entry %s/%s: %v", parentDirectoryPath, entryName, resp.Error)
+			return fail(filerErr)
 		}
-
-		lastErr = err
-		if attempt >= deleteRetryAttempts || !isRetryableDeleteRPCError(err) {
+		if !isRetryableDeleteRPCError(rpcErr) {
 			break
 		}
-		glog.V(2).Infof("delete entry %s/%s attempt %d/%d hit a transient error, replaying: %v", parentDirectoryPath, entryName, attempt, deleteRetryAttempts, err)
 	}
-	return fmt.Errorf("delete entry %s/%s: %v", parentDirectoryPath, entryName, lastErr)
+	return fail(rpcErr.Error())
+}
+
+// deleteEntryAttempt makes one DeleteEntry call and keeps the two ways it can
+// fail apart. Only the RPC error is safe to classify; the filer's own message
+// is returned as a plain string so it cannot be mistaken for one, because
+// FilerServer.DeleteEntry reports its failures there with the deleted path
+// formatted in. See isRetryableDeleteRPCError.
+func deleteEntryAttempt(ctx context.Context, client filer_pb.SeaweedFilerClient, request *filer_pb.DeleteEntryRequest) (rpcErr error, filerErr string) {
+	resp, err := client.DeleteEntry(ctx, request)
+	if err != nil {
+		return err, ""
+	}
+	return nil, resp.Error
 }
 
 func demoteDirectoryMarkerToImplicitDirectory(client filer_pb.SeaweedFilerClient, parentDirectoryPath, entryName string) error {

--- a/weed/s3api/filer_util.go
+++ b/weed/s3api/filer_util.go
@@ -98,7 +98,7 @@ func (s3a *S3ApiServer) rm(parentDirectoryPath, entryName string, isDeleteData, 
 
 	return s3a.WithFilerClient(false, func(client filer_pb.SeaweedFilerClient) error {
 
-		return doDeleteEntry(client, parentDirectoryPath, entryName, isDeleteData, isRecursive)
+		return doDeleteEntry(context.Background(), client, parentDirectoryPath, entryName, isDeleteData, isRecursive)
 	})
 
 }
@@ -113,7 +113,7 @@ func (s3a *S3ApiServer) rmObject(parentDirectoryPath, entryName string, isDelete
 }
 
 func deleteObjectEntry(client filer_pb.SeaweedFilerClient, parentDirectoryPath, entryName string, isDeleteData, isRecursive bool) error {
-	err := doDeleteEntry(client, parentDirectoryPath, entryName, isDeleteData, isRecursive)
+	err := doDeleteEntry(context.Background(), client, parentDirectoryPath, entryName, isDeleteData, isRecursive)
 	if err == nil {
 		return nil
 	}
@@ -124,7 +124,57 @@ func deleteObjectEntry(client filer_pb.SeaweedFilerClient, parentDirectoryPath, 
 	return demoteDirectoryMarkerToImplicitDirectory(client, parentDirectoryPath, entryName)
 }
 
-func doDeleteEntry(client filer_pb.SeaweedFilerClient, parentDirectoryPath string, entryName string, isDeleteData bool, isRecursive bool) error {
+// A delete is idempotent at the filer, so replaying one whose reply was lost in
+// transit cannot turn into a spurious failure: FilerServer.DeleteEntry leaves
+// resp.Error empty when the entry is already gone. That rests on it comparing
+// the sentinel by identity (err != filer_pb.ErrNotFound) rather than with
+// errors.Is, so a future wrap of that error on the filer side would make the
+// second attempt report a failure instead. Worth re-checking if this is ever
+// revisited.
+//
+// The replay is immediate. What clears a transient failure here is the gRPC
+// channel reconnecting underneath the call, not the passage of time, and any
+// wait short enough to sit in a request path is far too short to outlast a
+// filer that is genuinely down. Not sleeping also keeps the cost a property of
+// the delete rather than of the request: DeleteMultipleObjectsHandler deletes
+// up to deleteMultipleObjectsLimit keys and completeMultipartUpload removes one
+// entry per unused part, so a per-delete backoff would be paid once per key.
+const deleteRetryAttempts = 3
+
+// isRetryableDeleteRPCError reports whether a failed DeleteEntry call is worth
+// replaying. It classifies by gRPC status code, never by message text.
+//
+// Every failure it can see carries a code no client input can influence.
+// FilerServer.DeleteEntry answers (resp, nil) in every case, its own failures
+// included, so a non-nil error out of the call was produced by the gRPC stack
+// itself. Context cancellation arrives as Canceled or DeadlineExceeded and is
+// not replayed: the caller is already gone.
+//
+// The filer's own failures arrive in resp.Error instead and are never replayed.
+// They are its considered answer about the tree, and they are free text with
+// the deleted path formatted into them - and, for a recursive delete, the paths
+// of the children it stopped on (weed/filer/filer_delete_entry.go builds
+// "delete file %s: %v", "list folder %s: %v" and MsgFailDelNonEmptyFolder that
+// way, and weed/server/filer_grpc_server.go copies the result into resp.Error
+// verbatim). Substring-matching that text would let an object named
+// "transport.log" make a permission denial look transient, and one named after
+// filer_pb.ErrNotFound make a genuine connection reset look authoritative.
+func isRetryableDeleteRPCError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s, ok := status.FromError(err)
+	if !ok {
+		return false
+	}
+	switch s.Code() {
+	case codes.Unavailable, codes.ResourceExhausted:
+		return true
+	}
+	return false
+}
+
+func doDeleteEntry(ctx context.Context, client filer_pb.SeaweedFilerClient, parentDirectoryPath string, entryName string, isDeleteData bool, isRecursive bool) error {
 	request := &filer_pb.DeleteEntryRequest{
 		Directory:            parentDirectoryPath,
 		Name:                 entryName,
@@ -134,15 +184,33 @@ func doDeleteEntry(client filer_pb.SeaweedFilerClient, parentDirectoryPath strin
 	}
 
 	glog.V(1).Infof("delete entry %v/%v: %v", parentDirectoryPath, entryName, request)
-	if resp, err := client.DeleteEntry(context.Background(), request); err != nil {
-		glog.V(1).Infof("delete entry %v: %v", request, err)
-		return fmt.Errorf("delete entry %s/%s: %v", parentDirectoryPath, entryName, err)
-	} else {
-		if resp.Error != "" {
+
+	// The loop always makes one attempt whatever deleteRetryAttempts is set to,
+	// so lastErr is never nil at the return below and no count can turn a
+	// delete that was never issued into a reported success.
+	var lastErr error
+	for attempt := 1; ; attempt++ {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			// the caller is gone, so a further attempt has nobody to answer
+			lastErr = ctxErr
+			break
+		}
+
+		resp, err := client.DeleteEntry(ctx, request)
+		if err == nil {
+			if resp.Error == "" {
+				return nil
+			}
 			return fmt.Errorf("delete entry %s/%s: %v", parentDirectoryPath, entryName, resp.Error)
 		}
+
+		lastErr = err
+		if attempt >= deleteRetryAttempts || !isRetryableDeleteRPCError(err) {
+			break
+		}
+		glog.V(2).Infof("delete entry %s/%s attempt %d/%d hit a transient error, replaying: %v", parentDirectoryPath, entryName, attempt, deleteRetryAttempts, err)
 	}
-	return nil
+	return fmt.Errorf("delete entry %s/%s: %v", parentDirectoryPath, entryName, lastErr)
 }
 
 func demoteDirectoryMarkerToImplicitDirectory(client filer_pb.SeaweedFilerClient, parentDirectoryPath, entryName string) error {

--- a/weed/s3api/filer_util_delete_retry_test.go
+++ b/weed/s3api/filer_util_delete_retry_test.go
@@ -59,6 +59,41 @@ func (c *alwaysTransientClient) DeleteEntry(_ context.Context, _ *filer_pb.Delet
 	return nil, status.Error(codes.Unavailable, "transport is closing")
 }
 
+// ctxCapturingClient records each attempt's context deadline, and always fails
+// so that every allowed attempt is made.
+type ctxCapturingClient struct {
+	filer_pb.SeaweedFilerClient
+
+	deadlines   []time.Time
+	hadDeadline []bool
+}
+
+func (c *ctxCapturingClient) DeleteEntry(ctx context.Context, _ *filer_pb.DeleteEntryRequest, _ ...grpc.CallOption) (*filer_pb.DeleteEntryResponse, error) {
+	deadline, ok := ctx.Deadline()
+	c.hadDeadline = append(c.hadDeadline, ok)
+	c.deadlines = append(c.deadlines, deadline)
+	return nil, status.Error(codes.Unavailable, "transport is closing")
+}
+
+// blockingClient stands in for a pick that finds no ready subconn: the call does
+// not fail fast, it waits for the context, which is the case deleteReplayTimeout
+// exists to bound.
+type blockingClient struct {
+	filer_pb.SeaweedFilerClient
+
+	attempts int
+}
+
+func (c *blockingClient) DeleteEntry(ctx context.Context, _ *filer_pb.DeleteEntryRequest, _ ...grpc.CallOption) (*filer_pb.DeleteEntryResponse, error) {
+	c.attempts++
+	if c.attempts == 1 {
+		// fail fast once so the loop reaches a replay
+		return nil, status.Error(codes.Unavailable, "transport is closing")
+	}
+	<-ctx.Done()
+	return nil, status.FromContextError(ctx.Err()).Err()
+}
+
 // transientKeys each embed a substring from util's transient-error list, and
 // notFoundKey is named after the not-found sentinel. A client can create any of
 // them, so none may influence whether a delete is replayed.
@@ -183,6 +218,61 @@ func TestDoDeleteEntryReplaysWithoutSleeping(t *testing.T) {
 	assert.Less(t, elapsed, 5*time.Second, "the replay must not sleep, so a batch cannot multiply a backoff")
 }
 
+// The first attempt keeps the caller's own context, so a recursive delete of a
+// large bucket is not suddenly given a deadline it never had. Every replay
+// shares one bounded context, because a pick with no ready subconn waits for
+// the context rather than failing fast, and three unbounded waits would be
+// three times the stall of the one attempt master made.
+func TestDoDeleteEntryBoundsOnlyItsReplays(t *testing.T) {
+	client := &ctxCapturingClient{}
+
+	err := doDeleteEntry(context.Background(), client, "/buckets/b", "k", true, false)
+
+	require.Error(t, err)
+	require.Len(t, client.hadDeadline, deleteRetryAttempts)
+	assert.False(t, client.hadDeadline[0], "the first attempt must keep the caller's context untouched")
+	for i := 1; i < deleteRetryAttempts; i++ {
+		assert.True(t, client.hadDeadline[i], "replay %d must be bounded", i)
+	}
+	// one budget shared by every replay, not one per replay
+	assert.Equal(t, client.deadlines[1], client.deadlines[2], "the replays must share a single bound")
+}
+
+// A deadline the caller brought still wins: the replay context derives from it,
+// so it cannot extend the caller's own budget.
+func TestDoDeleteEntryReplayKeepsACallerDeadline(t *testing.T) {
+	client := &ctxCapturingClient{}
+	callerDeadline := time.Now().Add(20 * time.Millisecond)
+	ctx, cancel := context.WithDeadline(context.Background(), callerDeadline)
+	defer cancel()
+
+	_ = doDeleteEntry(ctx, client, "/buckets/b", "k", true, false)
+
+	require.NotEmpty(t, client.hadDeadline)
+	for i, had := range client.hadDeadline {
+		assert.True(t, had, "attempt %d must carry the caller's deadline", i)
+		assert.False(t, client.deadlines[i].After(callerDeadline),
+			"attempt %d must not outlive the caller's own deadline", i)
+	}
+}
+
+// The bound is what makes the replay escape a pick that never returns. Driven
+// with a caller deadline far below deleteReplayTimeout so the test does not
+// wait out the real bound.
+func TestDoDeleteEntryReplayUnblocksOnTheContext(t *testing.T) {
+	client := &blockingClient{}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := doDeleteEntry(ctx, client, "/buckets/b", "k", true, false)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Less(t, elapsed, deleteReplayTimeout, "a blocked replay must end on the context, not run to its own bound")
+	assert.LessOrEqual(t, client.attempts, deleteRetryAttempts)
+}
+
 // A caller that has gone away stops the replay: the loop checks the context
 // before every attempt, so a cancelled request cannot be held open by retries.
 func TestDoDeleteEntryStopsWhenTheCallerIsGone(t *testing.T) {
@@ -234,6 +324,8 @@ func TestDoDeleteEntryPropagatesNonTransientError(t *testing.T) {
 		"permission denied": status.Error(codes.PermissionDenied, "not allowed"),
 		"invalid argument":  status.Error(codes.InvalidArgument, "bad name"),
 		"not found":         status.Error(codes.NotFound, filer_pb.ErrNotFound.Error()),
+		// a conflict the filer decided on, not a channel that broke
+		"aborted": status.Error(codes.Aborted, "conflicting update"),
 	} {
 		t.Run(name, func(t *testing.T) {
 			client := &deleteRetryClient{callErrs: []error{deleteErr, nil}}
@@ -264,6 +356,11 @@ func TestIsRetryableDeleteRPCError(t *testing.T) {
 	assert.False(t, isRetryableDeleteRPCError(nil))
 	assert.True(t, isRetryableDeleteRPCError(status.Error(codes.Unavailable, "transport is closing")))
 	assert.True(t, isRetryableDeleteRPCError(status.Error(codes.ResourceExhausted, "too many requests")))
+	// a server ending the stream without trailers, which is how a truncated
+	// reply through an L7 gRPC proxy arrives
+	assert.True(t, isRetryableDeleteRPCError(status.Error(codes.Internal, "server closed the stream without sending trailers")))
+	// a conflict the filer decided on: replaying would only lose the race again
+	assert.False(t, isRetryableDeleteRPCError(status.Error(codes.Aborted, "conflicting update")))
 	assert.False(t, isRetryableDeleteRPCError(status.Error(codes.NotFound, filer_pb.ErrNotFound.Error())))
 	assert.False(t, isRetryableDeleteRPCError(status.Error(codes.PermissionDenied, "not allowed")))
 	assert.False(t, isRetryableDeleteRPCError(status.Error(codes.Canceled, "context canceled")))

--- a/weed/s3api/filer_util_delete_retry_test.go
+++ b/weed/s3api/filer_util_delete_retry_test.go
@@ -1,0 +1,275 @@
+package s3api
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/filer"
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	grpc "google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// deleteRetryClient is a filer whose DeleteEntry fails in a scripted way for
+// the first attempts and then behaves. The two scripts are the two ways a
+// delete can fail, and they are not interchangeable: callErrs fails the RPC
+// itself, which is what a transport blip looks like and what issues #7204 and
+// #7224 report, while respErrs returns a successful RPC carrying the filer's
+// own message in resp.Error, which is how FilerServer.DeleteEntry reports every
+// failure of its own.
+type deleteRetryClient struct {
+	filer_pb.SeaweedFilerClient
+
+	callErrs []error
+	respErrs []string
+
+	attempts int
+	requests []*filer_pb.DeleteEntryRequest
+}
+
+func (c *deleteRetryClient) DeleteEntry(_ context.Context, req *filer_pb.DeleteEntryRequest, _ ...grpc.CallOption) (*filer_pb.DeleteEntryResponse, error) {
+	attempt := c.attempts
+	c.attempts++
+	c.requests = append(c.requests, req)
+
+	if attempt < len(c.callErrs) && c.callErrs[attempt] != nil {
+		return nil, c.callErrs[attempt]
+	}
+	if attempt < len(c.respErrs) && c.respErrs[attempt] != "" {
+		return &filer_pb.DeleteEntryResponse{Error: c.respErrs[attempt]}, nil
+	}
+	return &filer_pb.DeleteEntryResponse{}, nil
+}
+
+// alwaysTransientClient fails every DeleteEntry the same way, standing in for a
+// filer whose channel is in TRANSIENT_FAILURE.
+type alwaysTransientClient struct {
+	filer_pb.SeaweedFilerClient
+
+	attempts int
+}
+
+func (c *alwaysTransientClient) DeleteEntry(_ context.Context, _ *filer_pb.DeleteEntryRequest, _ ...grpc.CallOption) (*filer_pb.DeleteEntryResponse, error) {
+	c.attempts++
+	return nil, status.Error(codes.Unavailable, "transport is closing")
+}
+
+// transientKeys each embed a substring from util's transient-error list, and
+// notFoundKey is named after the not-found sentinel. A client can create any of
+// them, so none may influence whether a delete is replayed.
+var (
+	transientKeys = []string{"transport.log", "unavailable.txt", "slowdown.csv", "internalerror.bin", "throttling.json"}
+	notFoundKey   = filer_pb.ErrNotFound.Error()
+)
+
+// Issue #7204: the bucket delete. A transport blip on the DeleteEntry call used
+// to reach DeleteBucketHandler, which answered 500; boto3 then resent the
+// DELETE, found the bucket already gone and surfaced NoSuchBucket. The replay
+// keeps a blip inside the gateway, so the client sees the 204 it expects.
+func TestDoDeleteEntryRecoversFromTransientCall(t *testing.T) {
+	client := &deleteRetryClient{
+		callErrs: []error{
+			status.Error(codes.Unavailable, "transport is closing"),
+			status.Error(codes.Unavailable, "transport is closing"),
+			nil,
+		},
+	}
+
+	err := doDeleteEntry(context.Background(), client, "/buckets", "test-bucket", false, true)
+
+	require.NoError(t, err)
+	assert.Equal(t, deleteRetryAttempts, client.attempts, "should have used every allowed attempt")
+	// the replay must ask for exactly the same delete, recursion flags included
+	for _, req := range client.requests {
+		assert.Equal(t, "/buckets", req.Directory)
+		assert.Equal(t, "test-bucket", req.Name)
+		assert.True(t, req.IsRecursive)
+		assert.True(t, req.IgnoreRecursiveError)
+	}
+}
+
+// Issue #7224: the multi-object delete, driven through the wrapper
+// DeleteMultipleObjectsHandler uses. The per-key failure used to be reported as
+// an InternalError entry inside a 200, which no S3 SDK retries, so the object
+// silently stayed.
+func TestDeleteUnversionedObjectRecoversFromTransientCall(t *testing.T) {
+	client := &deleteRetryClient{
+		callErrs: []error{status.Error(codes.ResourceExhausted, "too many requests"), nil},
+	}
+	s3a := &S3ApiServer{option: &S3ApiServerOption{BucketsPath: "/buckets"}}
+
+	err := s3a.deleteUnversionedObjectWithClient(client, "mybucket", "a/b/c.txt", false)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, client.attempts)
+	require.Len(t, client.requests, 2)
+	assert.Equal(t, "/buckets/mybucket/a/b", client.requests[1].Directory)
+	assert.Equal(t, "c.txt", client.requests[1].Name)
+}
+
+// A failure the filer reports itself is its considered answer about the tree,
+// and it is never replayed. The fixture is the shape production actually
+// produces: weed/filer/filer_delete_entry.go formats the deleted path into the
+// message, and weed/server/filer_grpc_server.go copies it into resp.Error
+// verbatim, so the object's own key sits inside the text being judged.
+func TestFilerReportedFailureIsNotReplayed(t *testing.T) {
+	for _, key := range transientKeys {
+		t.Run(key, func(t *testing.T) {
+			client := &deleteRetryClient{
+				respErrs: []string{"delete file /buckets/b/logs/" + key + ": permission denied"},
+			}
+
+			err := doDeleteEntry(context.Background(), client, "/buckets/b/logs", key, true, false)
+
+			require.Error(t, err)
+			assert.Equal(t, 1, client.attempts, "the key name must not make a denial look transient")
+		})
+	}
+}
+
+// The same holds for a recursive delete, where the filer names the child it
+// stopped on. That child is a client-chosen key too, so stripping only the
+// deleted entry's own path would not have been enough.
+func TestFilerReportedRecursiveFailureIsNotReplayed(t *testing.T) {
+	client := &deleteRetryClient{
+		respErrs: []string{"delete directory /buckets/b: list folder /buckets/b/transport.log: permission denied"},
+	}
+
+	err := doDeleteEntry(context.Background(), client, "/buckets", "b", false, true)
+
+	require.Error(t, err)
+	assert.Equal(t, 1, client.attempts, "a child key must not make a denial look transient")
+}
+
+// The reverse spoof: an object named after the not-found sentinel must not make
+// a genuine transport blip look authoritative and suppress the replay. On the
+// RPC path this holds because the name is not in the status; it is pinned here
+// so a future move back to text matching cannot reintroduce it. The resp.Error
+// half of the same spoof is closed by not classifying that text at all.
+func TestObjectNamedLikeNotFoundStillReplays(t *testing.T) {
+	client := &deleteRetryClient{
+		callErrs: []error{status.Error(codes.Unavailable, "connection reset by peer"), nil},
+	}
+
+	err := doDeleteEntry(context.Background(), client, "/buckets/b", notFoundKey, true, false)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, client.attempts, "the key name must not suppress a replay")
+}
+
+// The replay is immediate, so its cost is a property of the delete and not of
+// the request. Both batching handlers delete far more than one entry per
+// request, so any per-delete sleep would be paid once per key: the 100ms/200ms
+// backoff this replaced would turn the loop below into 30 seconds. The ceiling
+// is deliberately far above the real figure (single-digit milliseconds) so a
+// loaded runner cannot flake it while a reintroduced backoff still cannot pass.
+func TestDoDeleteEntryReplaysWithoutSleeping(t *testing.T) {
+	const keys = 100
+
+	client := &alwaysTransientClient{}
+
+	start := time.Now()
+	for i := 0; i < keys; i++ {
+		require.Error(t, doDeleteEntry(context.Background(), client, "/buckets/b", fmt.Sprintf("k%d", i), true, false))
+	}
+	elapsed := time.Since(start)
+
+	assert.Equal(t, deleteRetryAttempts*keys, client.attempts, "every key must still get its attempts")
+	assert.Less(t, elapsed, 5*time.Second, "the replay must not sleep, so a batch cannot multiply a backoff")
+}
+
+// A caller that has gone away stops the replay: the loop checks the context
+// before every attempt, so a cancelled request cannot be held open by retries.
+func TestDoDeleteEntryStopsWhenTheCallerIsGone(t *testing.T) {
+	client := &alwaysTransientClient{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := doDeleteEntry(ctx, client, "/buckets/b", "k", true, false)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), context.Canceled.Error())
+	assert.Zero(t, client.attempts, "a cancelled caller must not reach the filer at all")
+}
+
+// A cancellation that arrives as a gRPC status mid-flight is not replayed
+// either: the caller is gone, so a further attempt has nobody to answer.
+func TestDoDeleteEntryDoesNotReplayCancellation(t *testing.T) {
+	for name, cancelErr := range map[string]error{
+		"canceled":          status.Error(codes.Canceled, "context canceled"),
+		"deadline exceeded": status.Error(codes.DeadlineExceeded, "context deadline exceeded"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			client := &deleteRetryClient{callErrs: []error{cancelErr, nil}}
+
+			err := doDeleteEntry(context.Background(), client, "/buckets/b", "k", true, false)
+
+			require.Error(t, err)
+			assert.Equal(t, 1, client.attempts)
+		})
+	}
+}
+
+// The replay is bounded: a filer whose channel stays down still fails the
+// delete, and the error reaches the caller rather than being spun on.
+func TestDoDeleteEntryGivesUpAfterBoundedAttempts(t *testing.T) {
+	client := &alwaysTransientClient{}
+
+	err := doDeleteEntry(context.Background(), client, "/buckets/b", "k", true, false)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Unavailable")
+	assert.Equal(t, deleteRetryAttempts, client.attempts)
+}
+
+// A code that is not a transport condition is a real failure and must propagate
+// on the first attempt.
+func TestDoDeleteEntryPropagatesNonTransientError(t *testing.T) {
+	for name, deleteErr := range map[string]error{
+		"permission denied": status.Error(codes.PermissionDenied, "not allowed"),
+		"invalid argument":  status.Error(codes.InvalidArgument, "bad name"),
+		"not found":         status.Error(codes.NotFound, filer_pb.ErrNotFound.Error()),
+	} {
+		t.Run(name, func(t *testing.T) {
+			client := &deleteRetryClient{callErrs: []error{deleteErr, nil}}
+
+			err := doDeleteEntry(context.Background(), client, "/buckets/b", "k", true, false)
+
+			require.Error(t, err)
+			assert.Equal(t, 1, client.attempts, "only a transport condition is replayed")
+		})
+	}
+}
+
+// The wrapping the caller sees is unchanged, because deleteObjectEntry decides
+// whether to demote a directory marker by matching on this text.
+func TestDoDeleteEntryKeepsItsErrorWrapping(t *testing.T) {
+	client := &deleteRetryClient{
+		respErrs: []string{filer.MsgFailDelNonEmptyFolder + ": /buckets/test/photos"},
+	}
+
+	err := doDeleteEntry(context.Background(), client, "/buckets/test", "photos", true, false)
+
+	require.Error(t, err)
+	assert.Equal(t, "delete entry /buckets/test/photos: "+filer.MsgFailDelNonEmptyFolder+": /buckets/test/photos", err.Error())
+	assert.Equal(t, 1, client.attempts, "a non-empty folder is an answer about the tree, not a hiccup")
+}
+
+func TestIsRetryableDeleteRPCError(t *testing.T) {
+	assert.False(t, isRetryableDeleteRPCError(nil))
+	assert.True(t, isRetryableDeleteRPCError(status.Error(codes.Unavailable, "transport is closing")))
+	assert.True(t, isRetryableDeleteRPCError(status.Error(codes.ResourceExhausted, "too many requests")))
+	assert.False(t, isRetryableDeleteRPCError(status.Error(codes.NotFound, filer_pb.ErrNotFound.Error())))
+	assert.False(t, isRetryableDeleteRPCError(status.Error(codes.PermissionDenied, "not allowed")))
+	assert.False(t, isRetryableDeleteRPCError(status.Error(codes.Canceled, "context canceled")))
+	assert.False(t, isRetryableDeleteRPCError(status.Error(codes.DeadlineExceeded, "context deadline exceeded")))
+	assert.False(t, isRetryableDeleteRPCError(context.Canceled))
+	// the text is never consulted, so a message that reads transient is not one
+	assert.False(t, isRetryableDeleteRPCError(fmt.Errorf("connection reset by peer")))
+	assert.False(t, isRetryableDeleteRPCError(status.Error(codes.PermissionDenied, "transport is closing")))
+}


### PR DESCRIPTION
References #7204 and #7224.

Both issues bottom out in the same place: `doDeleteEntry` in `weed/s3api/filer_util.go` issues `DeleteEntry` once and turns any failure into an error the client sees. For #7204 that becomes a 500, boto3 resends the DELETE, and the second one finds the bucket already gone and answers `NoSuchBucket`. For #7224 it becomes a per-key `InternalError` inside a 200 response, which no SDK retries, so the object silently survives.

`doDeleteEntry` is the only `DeleteEntry` call in `weed/s3api` proper, so a replay there covers every delete path in both handlers without touching any of the 23 `rm`/`rmObject` call sites.

## What this actually recovers, and what it does not

It recovers a transport blip: a filer restart, a GOAWAY, a single reset stream, anything where the channel is reconnecting underneath the call and a fresh attempt lands on a working transport.

It does not help when a filer is genuinely down. Once the channel is in TRANSIENT_FAILURE every attempt returns `Unavailable` immediately and the handler still emits the 500 or the in-200 `InternalError`. **If you test this with `docker stop filer` you will see no change at all.** In a multi-object delete the loop holds one filer client for the whole batch and `receiveTrackingConn` blocks failover once any reply has arrived, so a filer dying mid-batch means the remaining keys each replay and none of them recover.

That is why this says "references" and not "fixes". The complete answers are different changes: not mapping a transient filer failure to 500, and using a retryable per-key code. Both are behaviour changes I did not want to bundle here.

## The replay is immediate, and bounded anyway

No backoff. What clears a transient failure here is the channel reconnecting, not the passage of time, and a sleep would be paid once per key in handlers that delete up to 1000 entries per request.

Immediate is still not free, though. When a pick finds no ready subconn the picker waits for the balancer to publish one, and `WaitForReady(false)` does not shorten that wait; only the context does. So replaying multiplies that stall by the attempt count. There is a single bounded context shared by the replays to cap it.

The first attempt deliberately keeps the caller's own context. A recursive delete of a large bucket is legitimately slow, and putting a deadline on it here would fail deletes that succeed today. Only the attempts this change adds are bounded, so it cannot make anything slower than it already is.

## Classification is by status code only

The previous shape of this classified by message text through `util.IsTransientError`, which substring-matches. That is spoofable here, because the filer formats the object path into the error before the gateway sees it: `weed/filer/filer_delete_entry.go` wraps with `delete file %s: %v` and `weed/server/filer_grpc_server.go` copies that verbatim into `resp.Error`. A `PermissionDenied` on a key named `logs/transport.log` would have been replayed, and an object named after the not-found sentinel would have suppressed a legitimate replay. Stripping a prefix does not fix it either, since a recursive delete names the child entry it stopped on, which is another client-chosen key.

So this classifies by gRPC status code and never reads message text. `FilerServer.DeleteEntry` has exactly one return statement, `return resp, nil`, and reports failure through `resp.Error`, so everything the classifier sees came from the gRPC stack and carries no client-controlled text by construction.

The consequence is a deliberate narrowing worth seeing plainly: a `resp.Error` whose text happens to read transient is no longer replayed at all. Against current master nothing that works today stops working, since master never replayed anything.

The retryable set is `Unavailable`, `Internal` and `ResourceExhausted`, matching what `pb.shouldInvalidateConnection` treats as a broken channel, less `Aborted`. `Aborted` reports a conflict the filer decided on rather than a channel that broke. `ResourceExhausted` is unreachable today and is there for symmetry; if a filer-side load shed is ever added, an immediate replay would be the wrong answer to backpressure.

## Same class of bug, still open nearby

Two places still match against a message with the object path formatted in, both identical on current master so neither is a regression, but a reader should not take the claim above as broader than it is: `deleteObjectEntry`'s `MsgFailDelNonEmptyFolder` check, and `pb.shouldInvalidateConnection`'s substring fallback. `isRetryableListError` has the same shape and came in with #10886 and #10890, which is my own earlier contribution. I filed the general problem as #10994.

## Testing

Verified by reverting each property separately: removing the replay fails 5 tests, restoring free-text classification fails the classifier tests, removing the context check fails 1, and removing the replay bound fails 1. Several of the other tests pin invariants rather than demonstrating a change, and pass under both the old and new shape; they are there to stop a future edit from reintroducing the spoof.

Not verified: no cluster here, so this rests on unit tests and code reading rather than on reproducing the reporters' setups.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved S3 deletion reliability by automatically retrying transient service failures.
  * Stops retrying when the request is cancelled or the retry time limit is reached.
  * Preserves immediate handling for permanent failures and filer-reported errors.
  * Ensures delete operations use consistent request context and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->