### PR TITLE
Let filer.sync move past a chunk the source cluster no longer has

### DIFF
--- a/weed/replication/sink/filersink/fetch_write.go
+++ b/weed/replication/sink/filersink/fetch_write.go
@@ -47,23 +47,22 @@ func isSourceChunkMissing(err error) bool {
 	return errors.Is(err, source.ErrVolumeNotFound) || errors.Is(err, util_http.ErrNotFound)
 }
 
-// missingSourceChunkGate tracks how long the source has been unable to produce a
-// chunk across retries, so a lookup race or a restarting volume server is waited
-// out while a vacuumed one is written off instead of retried forever.
+// missingSourceChunkGate decides when to stop retrying a chunk the source cannot
+// produce, so a lookup race or a restarting volume server is waited out while a
+// vacuumed one is written off instead of retried forever. The wait is kept per
+// volume on the sink: a volume that is gone took every file it held with it, and
+// waiting it out once per file would stall the sync for as long as it holds files.
 type missingSourceChunkGate struct {
-	missingSince time.Time
-	gaveUp       bool
+	sink     *FilerSink
+	volumeId string
+	gaveUp   bool
 }
 
 func (g *missingSourceChunkGate) isPermanent(err error) bool {
 	if !isSourceChunkMissing(err) {
-		g.missingSince = time.Time{}
 		return false
 	}
-	if g.missingSince.IsZero() {
-		g.missingSince = time.Now()
-	}
-	if time.Since(g.missingSince) < missingSourceChunkGrace {
+	if time.Since(g.sink.sourceVolumeMissingSince(g.volumeId)) < missingSourceChunkGrace {
 		return false
 	}
 	g.gaveUp = true
@@ -194,7 +193,7 @@ func (fs *FilerSink) replicateOneManifestChunk(ctx context.Context, sourceChunk 
 	// supersession or, when that cannot be checked, after a few attempts.
 	var resolvedChunks []*filer_pb.FileChunk
 	resolveName := fmt.Sprintf("resolve manifest %s", sourceChunk.GetFileIdString())
-	missingGate := &missingSourceChunkGate{}
+	missingGate := fs.newMissingSourceChunkGate(sourceChunk.GetFileIdString())
 	err := util.RetryUntil(resolveName, func() error {
 		rc, e := filer.ResolveOneChunkManifest(ctx, fs.filerSource.LookupFileId, sourceChunk)
 		if e != nil {
@@ -374,7 +373,7 @@ func (fs *FilerSink) fetchAndWrite(sourceChunk *filer_pb.FileChunk, path string,
 
 	transientBackoff := time.Duration(0)
 	_, canCheckSupersession := fs.targetPathToSourcePath(path)
-	missingGate := &missingSourceChunkGate{}
+	missingGate := fs.newMissingSourceChunkGate(sourceChunk.GetFileIdString())
 	var partialData []byte
 	var savedFilename string
 	var savedHeader http.Header
@@ -418,8 +417,7 @@ func (fs *FilerSink) fetchAndWrite(sourceChunk *filer_pb.FileChunk, path string,
 		if err := validateReplicatedReadSize(sourceChunk, len(fullData)); err != nil {
 			return err
 		}
-		servedFileId := sourceChunk.GetFileIdString()
-		fs.lastServedFileId.Store(&servedFileId)
+		fs.sourceServed(sourceChunk.GetFileIdString())
 
 		transferStatus.mu.Lock()
 		transferStatus.BytesReceived = int64(len(fullData))
@@ -555,6 +553,24 @@ func validateReplicatedReadSize(sourceChunk *filer_pb.FileChunk, readSize int) e
 			readSize, sourceChunk.Size)
 	}
 	return nil
+}
+
+func (fs *FilerSink) newMissingSourceChunkGate(fileId string) *missingSourceChunkGate {
+	return &missingSourceChunkGate{sink: fs, volumeId: filer.VolumeId(fileId)}
+}
+
+// sourceVolumeMissingSince returns when the sink first found volumeId
+// unlocatable, recording now on the first sighting.
+func (fs *FilerSink) sourceVolumeMissingSince(volumeId string) time.Time {
+	since, _ := fs.missingVolumes.LoadOrStore(volumeId, time.Now())
+	return since.(time.Time)
+}
+
+// sourceServed records a chunk the source did serve: the probe
+// sourceStillServesChunks re-checks, and proof its volume is locatable again.
+func (fs *FilerSink) sourceServed(fileId string) {
+	fs.lastServedFileId.Store(&fileId)
+	fs.missingVolumes.Delete(filer.VolumeId(fileId))
 }
 
 // sourceStillServesChunks reports whether the source cluster can still locate the

--- a/weed/replication/sink/filersink/fetch_write.go
+++ b/weed/replication/sink/filersink/fetch_write.go
@@ -573,12 +573,13 @@ func (fs *FilerSink) sourceServed(fileId string) {
 	fs.missingVolumes.Delete(filer.VolumeId(fileId))
 }
 
-// sourceStillServesChunks reports whether the source cluster can still locate the
+// sourceStillServesChunks reports whether the source cluster can still produce the
 // last chunk it served. A volume with no locations reads the same whether it was
 // vacuumed away or every replica is down, so before an entry is written off the
-// sink re-checks a file id the source did serve: if that one has become
-// unresolvable too the source is in an outage, and skipping would drop live files
-// wholesale.
+// sink re-reads a file id the source did serve: if that one cannot be produced
+// either the source is in an outage, and skipping would drop live files wholesale.
+// It is a read and not a lookup because a lookup only proves the master still has
+// the topology, not that a volume server answers.
 func (fs *FilerSink) sourceStillServesChunks() bool {
 	if fs.filerSource == nil {
 		return false
@@ -587,10 +588,12 @@ func (fs *FilerSink) sourceStillServesChunks() bool {
 	if probe == nil {
 		return false
 	}
-	if _, err := fs.filerSource.LookupFileId(context.Background(), *probe); err != nil {
-		glog.V(0).Infof("source cannot locate %s either, so it is not only the one chunk: %v", *probe, err)
+	_, _, resp, err := fs.filerSource.ReadPart(*probe, 0)
+	if err != nil {
+		glog.V(0).Infof("source cannot serve %s either, so it is not only the one chunk: %v", *probe, err)
 		return false
 	}
+	util_http.CloseResponse(resp)
 	return true
 }
 

--- a/weed/replication/sink/filersink/fetch_write.go
+++ b/weed/replication/sink/filersink/fetch_write.go
@@ -417,6 +417,8 @@ func (fs *FilerSink) fetchAndWrite(sourceChunk *filer_pb.FileChunk, path string,
 		if err := validateReplicatedReadSize(sourceChunk, len(fullData)); err != nil {
 			return err
 		}
+		servedFileId := sourceChunk.GetFileIdString()
+		fs.lastServedFileId.Store(&servedFileId)
 
 		transferStatus.mu.Lock()
 		transferStatus.BytesReceived = int64(len(fullData))
@@ -547,6 +549,27 @@ func validateReplicatedReadSize(sourceChunk *filer_pb.FileChunk, readSize int) e
 			readSize, sourceChunk.Size)
 	}
 	return nil
+}
+
+// sourceStillServesChunks reports whether the source cluster can still locate the
+// last chunk it served. A volume with no locations reads the same whether it was
+// vacuumed away or every replica is down, so before an entry is written off the
+// sink re-checks a file id the source did serve: if that one has become
+// unresolvable too the source is in an outage, and skipping would drop live files
+// wholesale.
+func (fs *FilerSink) sourceStillServesChunks() bool {
+	if fs.filerSource == nil {
+		return false
+	}
+	probe := fs.lastServedFileId.Load()
+	if probe == nil {
+		return false
+	}
+	if _, err := fs.filerSource.LookupFileId(context.Background(), *probe); err != nil {
+		glog.V(0).Infof("source cannot locate %s either, so it is not only the one chunk: %v", *probe, err)
+		return false
+	}
+	return true
 }
 
 // hasSourceNewerVersion reports whether the source's current entry for targetPath

--- a/weed/replication/sink/filersink/fetch_write.go
+++ b/weed/replication/sink/filersink/fetch_write.go
@@ -29,6 +29,56 @@ import (
 	util_http "github.com/seaweedfs/seaweedfs/weed/util/http"
 )
 
+// missingSourceChunkGrace is how long a chunk the source cannot produce keeps
+// being retried before it counts as gone for good. Long enough to outlast a
+// volume server restart or a master failover, after which every volume that
+// still exists is registered again.
+var missingSourceChunkGrace = 30 * time.Minute
+
+// errSourceChunkMissing is a permanent replication failure: the source cluster
+// no longer holds the chunk's data, so no later attempt can fetch it.
+var errSourceChunkMissing = errors.New("source chunk missing")
+
+// isSourceChunkMissing reports whether the source answered that it does not have
+// the chunk — no location for its volume, or a 404 from the volume server that
+// does. Both shapes also cover a volume that is merely offline, which is why the
+// gate below waits them out instead of trusting a single answer.
+func isSourceChunkMissing(err error) bool {
+	return errors.Is(err, source.ErrVolumeNotFound) || errors.Is(err, util_http.ErrNotFound)
+}
+
+// missingSourceChunkGate tracks how long the source has been unable to produce a
+// chunk across retries, so a lookup race or a restarting volume server is waited
+// out while a vacuumed one is written off instead of retried forever.
+type missingSourceChunkGate struct {
+	missingSince time.Time
+	gaveUp       bool
+}
+
+func (g *missingSourceChunkGate) isPermanent(err error) bool {
+	if !isSourceChunkMissing(err) {
+		g.missingSince = time.Time{}
+		return false
+	}
+	if g.missingSince.IsZero() {
+		g.missingSince = time.Now()
+	}
+	if time.Since(g.missingSince) < missingSourceChunkGrace {
+		return false
+	}
+	g.gaveUp = true
+	return true
+}
+
+// wrap marks err permanent once the gate gave up, so the sink can tell a source
+// that lost the data from one that is only unreachable right now.
+func (g *missingSourceChunkGate) wrap(err error) error {
+	if err == nil || !g.gaveUp {
+		return err
+	}
+	return fmt.Errorf("%w: %w", errSourceChunkMissing, err)
+}
+
 func (fs *FilerSink) replicateChunks(ctx context.Context, sourceChunks []*filer_pb.FileChunk, path string, sourceMtimeNs int64) (replicatedChunks []*filer_pb.FileChunk, err error) {
 	if len(sourceChunks) == 0 {
 		return
@@ -144,6 +194,7 @@ func (fs *FilerSink) replicateOneManifestChunk(ctx context.Context, sourceChunk 
 	// supersession or, when that cannot be checked, after a few attempts.
 	var resolvedChunks []*filer_pb.FileChunk
 	resolveName := fmt.Sprintf("resolve manifest %s", sourceChunk.GetFileIdString())
+	missingGate := &missingSourceChunkGate{}
 	err := util.RetryUntil(resolveName, func() error {
 		rc, e := filer.ResolveOneChunkManifest(ctx, fs.filerSource.LookupFileId, sourceChunk)
 		if e != nil {
@@ -151,9 +202,9 @@ func (fs *FilerSink) replicateOneManifestChunk(ctx context.Context, sourceChunk 
 		}
 		resolvedChunks = rc
 		return nil
-	}, fs.manifestResolveRetryGate(path, sourceMtimeNs, sourceChunk.GetFileIdString()))
+	}, fs.manifestResolveRetryGate(path, sourceMtimeNs, sourceChunk.GetFileIdString(), missingGate))
 	if err != nil {
-		return nil, fmt.Errorf("resolve manifest %s: %w", sourceChunk.GetFileIdString(), err)
+		return nil, fmt.Errorf("resolve manifest %s: %w", sourceChunk.GetFileIdString(), missingGate.wrap(err))
 	}
 
 	replicatedResolvedChunks, err := fs.replicateChunks(ctx, resolvedChunks, path, sourceMtimeNs)
@@ -196,18 +247,24 @@ const maxUnverifiableResolveAttempts = 3
 
 // manifestResolveRetryGate decides whether a failing manifest resolve keeps
 // retrying: stop when the source superseded the replayed version (the caller
-// skips it as lossless), stop immediately on non-transient errors (e.g. corrupt
-// manifest data) so the configured metadata error policy applies, and stop
-// after a few attempts when supersession cannot be checked at all (incremental
+// skips it as lossless), stop once the source has been unable to produce the
+// manifest for the whole grace period, stop immediately on non-transient errors
+// (e.g. corrupt manifest data) so the configured metadata error policy applies,
+// and stop after a few attempts when supersession cannot be checked at all (incremental
 // dated target keys don't map back to a source path) — propagating lets
 // filer.backup decide with the event's real source key instead of spinning
 // here forever.
-func (fs *FilerSink) manifestResolveRetryGate(path string, sourceMtimeNs int64, chunkName string) func(error) bool {
+func (fs *FilerSink) manifestResolveRetryGate(path string, sourceMtimeNs int64, chunkName string, missingGate *missingSourceChunkGate) func(error) bool {
 	_, canCheckSupersession := fs.targetPathToSourcePath(path)
 	attempts := 0
 	return func(resolveErr error) (shouldContinue bool) {
 		if fs.hasSourceNewerVersion(path, sourceMtimeNs) {
 			glog.V(1).Infof("skip retrying stale source manifest %s for %s: %v", chunkName, path, resolveErr)
+			return false
+		}
+		if missingGate.isPermanent(resolveErr) {
+			glog.Errorf("source has not had manifest %s for %s in %v, giving up on it: %v",
+				chunkName, path, missingSourceChunkGrace, resolveErr)
 			return false
 		}
 		if !isTransientResolveError(resolveErr) {
@@ -316,6 +373,7 @@ func (fs *FilerSink) fetchAndWrite(sourceChunk *filer_pb.FileChunk, path string,
 	defer fs.activeTransfers.Delete(sourceChunk.GetFileIdString())
 
 	transientBackoff := time.Duration(0)
+	missingGate := &missingSourceChunkGate{}
 	var partialData []byte
 	var savedFilename string
 	var savedHeader http.Header
@@ -417,6 +475,11 @@ func (fs *FilerSink) fetchAndWrite(sourceChunk *filer_pb.FileChunk, path string,
 		transferStatus.mu.Lock()
 		transferStatus.LastErr = retryErr.Error()
 		transferStatus.mu.Unlock()
+		if missingGate.isPermanent(retryErr) {
+			glog.Errorf("source has not had %s for %s in %v, giving up on it: %v",
+				sourceChunk.GetFileIdString(), path, missingSourceChunkGrace, retryErr)
+			return false
+		}
 		if isRetryableNetworkError(retryErr) {
 			transientBackoff = nextTransientBackoff(transientBackoff)
 			transferStatus.mu.Lock()
@@ -435,7 +498,7 @@ func (fs *FilerSink) fetchAndWrite(sourceChunk *filer_pb.FileChunk, path string,
 		return true
 	})
 	if err != nil {
-		return "", err
+		return "", missingGate.wrap(err)
 	}
 
 	return fileId, nil

--- a/weed/replication/sink/filersink/fetch_write.go
+++ b/weed/replication/sink/filersink/fetch_write.go
@@ -373,6 +373,7 @@ func (fs *FilerSink) fetchAndWrite(sourceChunk *filer_pb.FileChunk, path string,
 	defer fs.activeTransfers.Delete(sourceChunk.GetFileIdString())
 
 	transientBackoff := time.Duration(0)
+	_, canCheckSupersession := fs.targetPathToSourcePath(path)
 	missingGate := &missingSourceChunkGate{}
 	var partialData []byte
 	var savedFilename string
@@ -477,6 +478,11 @@ func (fs *FilerSink) fetchAndWrite(sourceChunk *filer_pb.FileChunk, path string,
 		transferStatus.mu.Lock()
 		transferStatus.LastErr = retryErr.Error()
 		transferStatus.mu.Unlock()
+		if isSourceChunkMissing(retryErr) && !canCheckSupersession {
+			glog.V(0).Infof("source does not have %s for %s, supersession unverifiable, propagating: %v",
+				sourceChunk.GetFileIdString(), path, retryErr)
+			return false
+		}
 		if missingGate.isPermanent(retryErr) {
 			glog.Errorf("source has not had %s for %s in %v, giving up on it: %v",
 				sourceChunk.GetFileIdString(), path, missingSourceChunkGrace, retryErr)

--- a/weed/replication/sink/filersink/fetch_write_test.go
+++ b/weed/replication/sink/filersink/fetch_write_test.go
@@ -1,9 +1,11 @@
 package filersink
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -11,6 +13,9 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/seaweedfs/seaweedfs/weed/operation"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
@@ -390,7 +395,7 @@ func TestSourceSupersedesEpochMtime(t *testing.T) {
 // attempts and propagate instead of spinning forever.
 func TestManifestResolveRetryGateUnverifiableSupersessionBounded(t *testing.T) {
 	fs := &FilerSink{isIncremental: true, dir: "/backup"}
-	gate := fs.manifestResolveRetryGate("/backup/2026-07-10/buckets/x/f.pt", 123, "3,01abc")
+	gate := fs.manifestResolveRetryGate("/backup/2026-07-10/buckets/x/f.pt", 123, "3,01abc", &missingSourceChunkGate{})
 	resolveErr := errors.New("LookupFileId volume id 3: not found")
 	for i := 1; i < maxUnverifiableResolveAttempts; i++ {
 		if !gate(resolveErr) {
@@ -408,7 +413,7 @@ func TestManifestResolveRetryGateUnverifiableSupersessionBounded(t *testing.T) {
 // retrying until the source is superseded.
 func TestManifestResolveRetryGateNonTransientPropagates(t *testing.T) {
 	fs := &FilerSink{dir: "/backup"}
-	gate := fs.manifestResolveRetryGate("/backup/buckets/x/f.pt", 123, "3,01abc")
+	gate := fs.manifestResolveRetryGate("/backup/buckets/x/f.pt", 123, "3,01abc", &missingSourceChunkGate{})
 	permanentErrs := []error{
 		errors.New("fail to unmarshal manifest 3,01abc: proto: cannot parse invalid wire-format data"),
 		errors.New("invalid fileId abc"),
@@ -423,5 +428,116 @@ func TestManifestResolveRetryGateNonTransientPropagates(t *testing.T) {
 	}
 	if isTransientResolveError(nil) {
 		t.Error("isTransientResolveError(nil) must be false")
+	}
+}
+
+// vacuumedSourceServer answers as a healthy source filer whose master no longer
+// has the chunk's volume: the entry is still there, unchanged, but the volume has
+// no locations. That is what a replayed event looks like once vacuum has removed
+// the volume its chunks lived in.
+type vacuumedSourceServer struct {
+	filer_pb.UnimplementedSeaweedFilerServer
+	mtime int64
+}
+
+func (s *vacuumedSourceServer) LookupVolume(ctx context.Context, req *filer_pb.LookupVolumeRequest) (*filer_pb.LookupVolumeResponse, error) {
+	return &filer_pb.LookupVolumeResponse{LocationsMap: map[string]*filer_pb.Locations{}}, nil
+}
+
+func (s *vacuumedSourceServer) LookupDirectoryEntry(ctx context.Context, req *filer_pb.LookupDirectoryEntryRequest) (*filer_pb.LookupDirectoryEntryResponse, error) {
+	return &filer_pb.LookupDirectoryEntryResponse{Entry: &filer_pb.Entry{
+		Name:       req.Name,
+		Attributes: &filer_pb.FuseAttributes{Mtime: s.mtime},
+	}}, nil
+}
+
+// A chunk the source cluster cannot produce must stop being retried once the
+// grace period is up. Before, the retry loop ran forever: the sync job never
+// completed, so it held its slot and pinned the offset watermark at the event
+// ahead of it, and filer.sync never checkpointed again.
+func TestFetchAndWriteStopsOnMissingSourceChunk(t *testing.T) {
+	prevRetryWaitTime, prevGrace := util.RetryWaitTime, missingSourceChunkGrace
+	util.RetryWaitTime = 100 * time.Millisecond
+	missingSourceChunkGrace = 500 * time.Millisecond
+	t.Cleanup(func() {
+		util.RetryWaitTime, missingSourceChunkGrace = prevRetryWaitTime, prevGrace
+	})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	server := grpc.NewServer()
+	filer_pb.RegisterSeaweedFilerServer(server, &vacuumedSourceServer{mtime: 5})
+	go server.Serve(listener)
+	t.Cleanup(server.Stop)
+
+	address := listener.Addr().String()
+	filerSrc := &source.FilerSource{}
+	if err := filerSrc.DoInitialize(address, address, "/src", false); err != nil {
+		t.Fatalf("filerSource.DoInitialize: %v", err)
+	}
+	filerSrc.SetGrpcDialOption(grpc.WithTransportCredentials(insecure.NewCredentials()))
+
+	fs := &FilerSink{
+		filerSource: filerSrc,
+		address:     address,
+		dir:         "/dst",
+		executor:    util.NewLimitedConcurrentExecutor(1),
+	}
+	fs.SetUploader(operation.NewUploaderWithHttpClient(http.DefaultClient))
+
+	done := make(chan error, 1)
+	go func() {
+		_, fetchErr := fs.fetchAndWrite(&filer_pb.FileChunk{FileId: "5617,01abc", Size: 10}, "/dst/x.bin", 5*int64(time.Second))
+		done <- fetchErr
+	}()
+
+	select {
+	case fetchErr := <-done:
+		if !errors.Is(fetchErr, errSourceChunkMissing) {
+			t.Fatalf("expected errSourceChunkMissing, got %v", fetchErr)
+		}
+		if !errors.Is(fetchErr, source.ErrVolumeNotFound) {
+			t.Fatalf("expected the underlying lookup failure to survive, got %v", fetchErr)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("fetchAndWrite is still retrying a chunk the source cannot produce")
+	}
+}
+
+// The gate waits out the shapes a restarting volume server produces, and only
+// gives up once the source has been saying "gone" for the whole grace period.
+func TestMissingSourceChunkGate(t *testing.T) {
+	volumeGone := fmt.Errorf("read part 5617,01abc: %w", source.ErrVolumeNotFound)
+	needleGone := fmt.Errorf("read part 5617,01abc: 404 Not Found: %w", util_http.ErrNotFound)
+
+	gate := &missingSourceChunkGate{}
+	for _, err := range []error{volumeGone, needleGone} {
+		if gate.isPermanent(err) {
+			t.Fatalf("must keep retrying inside the grace period: %v", err)
+		}
+	}
+	if got := gate.wrap(volumeGone); errors.Is(got, errSourceChunkMissing) {
+		t.Fatalf("must not mark permanent while still retrying: %v", got)
+	}
+
+	// an unrelated failure means the source never got to answer: start over
+	gate.isPermanent(errors.New("connection reset by peer"))
+	if !gate.missingSince.IsZero() {
+		t.Fatal("a non-missing error must restart the grace period")
+	}
+
+	gate.isPermanent(volumeGone)
+	gate.missingSince = time.Now().Add(-2 * missingSourceChunkGrace)
+	if !gate.isPermanent(volumeGone) {
+		t.Fatal("must give up once the source has been missing the chunk for the whole grace period")
+	}
+	wrapped := gate.wrap(volumeGone)
+	if !errors.Is(wrapped, errSourceChunkMissing) || !errors.Is(wrapped, source.ErrVolumeNotFound) {
+		t.Fatalf("wrapped error lost a sentinel: %v", wrapped)
+	}
+	if gate.wrap(nil) != nil {
+		t.Fatal("a successful retry must not be turned into an error")
 	}
 }

--- a/weed/replication/sink/filersink/fetch_write_test.go
+++ b/weed/replication/sink/filersink/fetch_write_test.go
@@ -434,11 +434,12 @@ func TestManifestResolveRetryGateNonTransientPropagates(t *testing.T) {
 
 // sourceFilerServer answers as a source filer that still holds the entry,
 // unchanged, while its master locates the chunk's volume only for the volume ids
-// in resolvable. With none listed it is a cluster that has vacuumed the volume
-// away — or lost every replica of it.
+// in resolvable, which it serves from volumeUrl. With none listed it is a cluster
+// that has vacuumed the volume away — or lost every replica of it.
 type sourceFilerServer struct {
 	filer_pb.UnimplementedSeaweedFilerServer
 	mtime      int64
+	volumeUrl  string
 	resolvable []string
 }
 
@@ -447,7 +448,7 @@ func (s *sourceFilerServer) LookupVolume(ctx context.Context, req *filer_pb.Look
 	for _, vid := range req.VolumeIds {
 		if slices.Contains(s.resolvable, vid) {
 			locationsMap[vid] = &filer_pb.Locations{
-				Locations: []*filer_pb.Location{{Url: "127.0.0.1:1"}},
+				Locations: []*filer_pb.Location{{Url: s.volumeUrl}},
 			}
 		}
 	}
@@ -461,14 +462,25 @@ func (s *sourceFilerServer) LookupDirectoryEntry(ctx context.Context, req *filer
 	}}, nil
 }
 
-func startSourceFiler(t *testing.T, mtime int64, resolvable ...string) *source.FilerSource {
+// liveVolume serves a chunk read the way a healthy volume server would, so the
+// sink's probe finds the source still producing data.
+func liveVolume(t *testing.T) string {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("chunk bytes"))
+	}))
+	t.Cleanup(server.Close)
+	return strings.TrimPrefix(server.URL, "http://")
+}
+
+func startSourceFiler(t *testing.T, mtime int64, volumeUrl string, resolvable ...string) *source.FilerSource {
 	t.Helper()
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
 	server := grpc.NewServer()
-	filer_pb.RegisterSeaweedFilerServer(server, &sourceFilerServer{mtime: mtime, resolvable: resolvable})
+	filer_pb.RegisterSeaweedFilerServer(server, &sourceFilerServer{mtime: mtime, volumeUrl: volumeUrl, resolvable: resolvable})
 	go server.Serve(listener)
 	t.Cleanup(server.Stop)
 
@@ -493,7 +505,7 @@ func TestFetchAndWriteStopsOnMissingSourceChunk(t *testing.T) {
 		util.RetryWaitTime, missingSourceChunkGrace = prevRetryWaitTime, prevGrace
 	})
 
-	filerSrc := startSourceFiler(t, 5)
+	filerSrc := startSourceFiler(t, 5, "")
 
 	fs := &FilerSink{
 		filerSource: filerSrc,
@@ -580,7 +592,7 @@ func TestOnReplicateChunkErrorMissingSourceChunk(t *testing.T) {
 	missing := fmt.Errorf("copy 5617,02def: %w: %w", errSourceChunkMissing, source.ErrVolumeNotFound)
 
 	t.Run("source still serving", func(t *testing.T) {
-		fs := &FilerSink{filerSource: startSourceFiler(t, 5, "5616"), dir: "/dst"}
+		fs := &FilerSink{filerSource: startSourceFiler(t, 5, liveVolume(t), "5616"), dir: "/dst"}
 		served := probe
 		fs.lastServedFileId.Store(&served)
 
@@ -590,7 +602,7 @@ func TestOnReplicateChunkErrorMissingSourceChunk(t *testing.T) {
 	})
 
 	t.Run("source locating nothing", func(t *testing.T) {
-		fs := &FilerSink{filerSource: startSourceFiler(t, 5), dir: "/dst"}
+		fs := &FilerSink{filerSource: startSourceFiler(t, 5, ""), dir: "/dst"}
 		served := probe
 		fs.lastServedFileId.Store(&served)
 
@@ -599,8 +611,25 @@ func TestOnReplicateChunkErrorMissingSourceChunk(t *testing.T) {
 		}
 	})
 
+	t.Run("probe locates but cannot be read", func(t *testing.T) {
+		gone := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "Not Found", http.StatusNotFound)
+		}))
+		defer gone.Close()
+		fs := &FilerSink{
+			filerSource: startSourceFiler(t, 5, strings.TrimPrefix(gone.URL, "http://"), "5616"),
+			dir:         "/dst",
+		}
+		served := probe
+		fs.lastServedFileId.Store(&served)
+
+		if err := fs.onReplicateChunkError("/dst/x.bin", liveEntry, missing); !errors.Is(err, errSourceChunkMissing) {
+			t.Fatalf("a volume the master lists but no server answers must not license a skip, got %v", err)
+		}
+	})
+
 	t.Run("nothing served yet", func(t *testing.T) {
-		fs := &FilerSink{filerSource: startSourceFiler(t, 5, "5616"), dir: "/dst"}
+		fs := &FilerSink{filerSource: startSourceFiler(t, 5, liveVolume(t), "5616"), dir: "/dst"}
 
 		if err := fs.onReplicateChunkError("/dst/x.bin", liveEntry, missing); !errors.Is(err, errSourceChunkMissing) {
 			t.Fatalf("expected the error to be held with no probe to check, got %v", err)
@@ -618,7 +647,7 @@ func TestFetchAndWriteMissingSourceChunkUnverifiableSupersession(t *testing.T) {
 	t.Cleanup(func() { util.RetryWaitTime = prevRetryWaitTime })
 
 	fs := &FilerSink{
-		filerSource:   startSourceFiler(t, 5),
+		filerSource:   startSourceFiler(t, 5, ""),
 		dir:           "/backup",
 		isIncremental: true,
 		executor:      util.NewLimitedConcurrentExecutor(1),

--- a/weed/replication/sink/filersink/fetch_write_test.go
+++ b/weed/replication/sink/filersink/fetch_write_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -431,24 +432,53 @@ func TestManifestResolveRetryGateNonTransientPropagates(t *testing.T) {
 	}
 }
 
-// vacuumedSourceServer answers as a healthy source filer whose master no longer
-// has the chunk's volume: the entry is still there, unchanged, but the volume has
-// no locations. That is what a replayed event looks like once vacuum has removed
-// the volume its chunks lived in.
-type vacuumedSourceServer struct {
+// sourceFilerServer answers as a source filer that still holds the entry,
+// unchanged, while its master locates the chunk's volume only for the volume ids
+// in resolvable. With none listed it is a cluster that has vacuumed the volume
+// away — or lost every replica of it.
+type sourceFilerServer struct {
 	filer_pb.UnimplementedSeaweedFilerServer
-	mtime int64
+	mtime      int64
+	resolvable []string
 }
 
-func (s *vacuumedSourceServer) LookupVolume(ctx context.Context, req *filer_pb.LookupVolumeRequest) (*filer_pb.LookupVolumeResponse, error) {
-	return &filer_pb.LookupVolumeResponse{LocationsMap: map[string]*filer_pb.Locations{}}, nil
+func (s *sourceFilerServer) LookupVolume(ctx context.Context, req *filer_pb.LookupVolumeRequest) (*filer_pb.LookupVolumeResponse, error) {
+	locationsMap := make(map[string]*filer_pb.Locations)
+	for _, vid := range req.VolumeIds {
+		if slices.Contains(s.resolvable, vid) {
+			locationsMap[vid] = &filer_pb.Locations{
+				Locations: []*filer_pb.Location{{Url: "127.0.0.1:1"}},
+			}
+		}
+	}
+	return &filer_pb.LookupVolumeResponse{LocationsMap: locationsMap}, nil
 }
 
-func (s *vacuumedSourceServer) LookupDirectoryEntry(ctx context.Context, req *filer_pb.LookupDirectoryEntryRequest) (*filer_pb.LookupDirectoryEntryResponse, error) {
+func (s *sourceFilerServer) LookupDirectoryEntry(ctx context.Context, req *filer_pb.LookupDirectoryEntryRequest) (*filer_pb.LookupDirectoryEntryResponse, error) {
 	return &filer_pb.LookupDirectoryEntryResponse{Entry: &filer_pb.Entry{
 		Name:       req.Name,
 		Attributes: &filer_pb.FuseAttributes{Mtime: s.mtime},
 	}}, nil
+}
+
+func startSourceFiler(t *testing.T, mtime int64, resolvable ...string) *source.FilerSource {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	server := grpc.NewServer()
+	filer_pb.RegisterSeaweedFilerServer(server, &sourceFilerServer{mtime: mtime, resolvable: resolvable})
+	go server.Serve(listener)
+	t.Cleanup(server.Stop)
+
+	address := listener.Addr().String()
+	filerSrc := &source.FilerSource{}
+	if err := filerSrc.DoInitialize(address, address, "/src", false); err != nil {
+		t.Fatalf("filerSource.DoInitialize: %v", err)
+	}
+	filerSrc.SetGrpcDialOption(grpc.WithTransportCredentials(insecure.NewCredentials()))
+	return filerSrc
 }
 
 // A chunk the source cluster cannot produce must stop being retried once the
@@ -463,25 +493,10 @@ func TestFetchAndWriteStopsOnMissingSourceChunk(t *testing.T) {
 		util.RetryWaitTime, missingSourceChunkGrace = prevRetryWaitTime, prevGrace
 	})
 
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
-	server := grpc.NewServer()
-	filer_pb.RegisterSeaweedFilerServer(server, &vacuumedSourceServer{mtime: 5})
-	go server.Serve(listener)
-	t.Cleanup(server.Stop)
-
-	address := listener.Addr().String()
-	filerSrc := &source.FilerSource{}
-	if err := filerSrc.DoInitialize(address, address, "/src", false); err != nil {
-		t.Fatalf("filerSource.DoInitialize: %v", err)
-	}
-	filerSrc.SetGrpcDialOption(grpc.WithTransportCredentials(insecure.NewCredentials()))
+	filerSrc := startSourceFiler(t, 5)
 
 	fs := &FilerSink{
 		filerSource: filerSrc,
-		address:     address,
 		dir:         "/dst",
 		executor:    util.NewLimitedConcurrentExecutor(1),
 	}
@@ -540,4 +555,43 @@ func TestMissingSourceChunkGate(t *testing.T) {
 	if gate.wrap(nil) != nil {
 		t.Fatal("a successful retry must not be turned into an error")
 	}
+}
+
+// Once the source has lost a chunk for good, holding the sync offset for its
+// entry only stops every later event from ever being checkpointed: the bytes are
+// not coming back. Skip it loudly instead — but only while the source is
+// demonstrably still serving other chunks, since a cluster that cannot locate
+// anything is having an outage and skipping would drop live files wholesale.
+func TestOnReplicateChunkErrorMissingSourceChunk(t *testing.T) {
+	const probe = "5616,01abc"
+	liveEntry := &filer_pb.Entry{Attributes: &filer_pb.FuseAttributes{Mtime: 5}}
+	missing := fmt.Errorf("copy 5617,02def: %w: %w", errSourceChunkMissing, source.ErrVolumeNotFound)
+
+	t.Run("source still serving", func(t *testing.T) {
+		fs := &FilerSink{filerSource: startSourceFiler(t, 5, "5616"), dir: "/dst"}
+		served := probe
+		fs.lastServedFileId.Store(&served)
+
+		if err := fs.onReplicateChunkError("/dst/x.bin", liveEntry, missing); err != nil {
+			t.Fatalf("expected the entry to be skipped, got %v", err)
+		}
+	})
+
+	t.Run("source locating nothing", func(t *testing.T) {
+		fs := &FilerSink{filerSource: startSourceFiler(t, 5), dir: "/dst"}
+		served := probe
+		fs.lastServedFileId.Store(&served)
+
+		if err := fs.onReplicateChunkError("/dst/x.bin", liveEntry, missing); !errors.Is(err, errSourceChunkMissing) {
+			t.Fatalf("expected the error to be held for a retry, got %v", err)
+		}
+	})
+
+	t.Run("nothing served yet", func(t *testing.T) {
+		fs := &FilerSink{filerSource: startSourceFiler(t, 5, "5616"), dir: "/dst"}
+
+		if err := fs.onReplicateChunkError("/dst/x.bin", liveEntry, missing); !errors.Is(err, errSourceChunkMissing) {
+			t.Fatalf("expected the error to be held with no probe to check, got %v", err)
+		}
+	})
 }

--- a/weed/replication/sink/filersink/fetch_write_test.go
+++ b/weed/replication/sink/filersink/fetch_write_test.go
@@ -595,3 +595,40 @@ func TestOnReplicateChunkErrorMissingSourceChunk(t *testing.T) {
 		}
 	})
 }
+
+// An incremental sink's dated target keys cannot be mapped back to a source path,
+// so nothing here can tell a vacuumed chunk from a superseded one. Waiting out the
+// grace period would stall every such entry for half an hour; propagate instead
+// and let filer.backup decide with the event's real source key.
+func TestFetchAndWriteMissingSourceChunkUnverifiableSupersession(t *testing.T) {
+	prevRetryWaitTime := util.RetryWaitTime
+	util.RetryWaitTime = 100 * time.Millisecond
+	t.Cleanup(func() { util.RetryWaitTime = prevRetryWaitTime })
+
+	fs := &FilerSink{
+		filerSource:   startSourceFiler(t, 5),
+		dir:           "/backup",
+		isIncremental: true,
+		executor:      util.NewLimitedConcurrentExecutor(1),
+	}
+	fs.SetUploader(operation.NewUploaderWithHttpClient(http.DefaultClient))
+
+	done := make(chan error, 1)
+	go func() {
+		_, fetchErr := fs.fetchAndWrite(&filer_pb.FileChunk{FileId: "5617,01abc", Size: 10},
+			"/backup/2026-07-10/x.bin", 5*int64(time.Second))
+		done <- fetchErr
+	}()
+
+	select {
+	case fetchErr := <-done:
+		if !errors.Is(fetchErr, source.ErrVolumeNotFound) {
+			t.Fatalf("expected the lookup failure to propagate, got %v", fetchErr)
+		}
+		if errors.Is(fetchErr, errSourceChunkMissing) {
+			t.Fatalf("must not write the chunk off without checking supersession: %v", fetchErr)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("fetchAndWrite waited out the grace period with supersession unverifiable")
+	}
+}

--- a/weed/replication/sink/filersink/fetch_write_test.go
+++ b/weed/replication/sink/filersink/fetch_write_test.go
@@ -396,7 +396,7 @@ func TestSourceSupersedesEpochMtime(t *testing.T) {
 // attempts and propagate instead of spinning forever.
 func TestManifestResolveRetryGateUnverifiableSupersessionBounded(t *testing.T) {
 	fs := &FilerSink{isIncremental: true, dir: "/backup"}
-	gate := fs.manifestResolveRetryGate("/backup/2026-07-10/buckets/x/f.pt", 123, "3,01abc", &missingSourceChunkGate{})
+	gate := fs.manifestResolveRetryGate("/backup/2026-07-10/buckets/x/f.pt", 123, "3,01abc", fs.newMissingSourceChunkGate("3,01abc"))
 	resolveErr := errors.New("LookupFileId volume id 3: not found")
 	for i := 1; i < maxUnverifiableResolveAttempts; i++ {
 		if !gate(resolveErr) {
@@ -414,7 +414,7 @@ func TestManifestResolveRetryGateUnverifiableSupersessionBounded(t *testing.T) {
 // retrying until the source is superseded.
 func TestManifestResolveRetryGateNonTransientPropagates(t *testing.T) {
 	fs := &FilerSink{dir: "/backup"}
-	gate := fs.manifestResolveRetryGate("/backup/buckets/x/f.pt", 123, "3,01abc", &missingSourceChunkGate{})
+	gate := fs.manifestResolveRetryGate("/backup/buckets/x/f.pt", 123, "3,01abc", fs.newMissingSourceChunkGate("3,01abc"))
 	permanentErrs := []error{
 		errors.New("fail to unmarshal manifest 3,01abc: proto: cannot parse invalid wire-format data"),
 		errors.New("invalid fileId abc"),
@@ -523,11 +523,15 @@ func TestFetchAndWriteStopsOnMissingSourceChunk(t *testing.T) {
 
 // The gate waits out the shapes a restarting volume server produces, and only
 // gives up once the source has been saying "gone" for the whole grace period.
+// The wait belongs to the volume: a vacuumed one takes every file it held with
+// it, and waiting it out per file would stall the sync for as long as it holds
+// files.
 func TestMissingSourceChunkGate(t *testing.T) {
 	volumeGone := fmt.Errorf("read part 5617,01abc: %w", source.ErrVolumeNotFound)
 	needleGone := fmt.Errorf("read part 5617,01abc: 404 Not Found: %w", util_http.ErrNotFound)
 
-	gate := &missingSourceChunkGate{}
+	fs := &FilerSink{}
+	gate := fs.newMissingSourceChunkGate("5617,01abc")
 	for _, err := range []error{volumeGone, needleGone} {
 		if gate.isPermanent(err) {
 			t.Fatalf("must keep retrying inside the grace period: %v", err)
@@ -537,23 +541,31 @@ func TestMissingSourceChunkGate(t *testing.T) {
 		t.Fatalf("must not mark permanent while still retrying: %v", got)
 	}
 
-	// an unrelated failure means the source never got to answer: start over
-	gate.isPermanent(errors.New("connection reset by peer"))
-	if !gate.missingSince.IsZero() {
-		t.Fatal("a non-missing error must restart the grace period")
+	// an unrelated failure is not the source answering "gone": it must not start a wait
+	other := fs.newMissingSourceChunkGate("5618,01abc")
+	other.isPermanent(errors.New("connection reset by peer"))
+	if _, found := fs.missingVolumes.Load("5618"); found {
+		t.Fatal("a non-missing error must not start the volume's wait")
 	}
 
-	gate.isPermanent(volumeGone)
-	gate.missingSince = time.Now().Add(-2 * missingSourceChunkGrace)
-	if !gate.isPermanent(volumeGone) {
-		t.Fatal("must give up once the source has been missing the chunk for the whole grace period")
+	// a second file in the same volume inherits that wait instead of restarting it
+	fs.missingVolumes.Store("5617", time.Now().Add(-2*missingSourceChunkGrace))
+	second := fs.newMissingSourceChunkGate("5617,02def")
+	if !second.isPermanent(volumeGone) {
+		t.Fatal("a later file must inherit the wait its volume already served")
 	}
-	wrapped := gate.wrap(volumeGone)
+	wrapped := second.wrap(volumeGone)
 	if !errors.Is(wrapped, errSourceChunkMissing) || !errors.Is(wrapped, source.ErrVolumeNotFound) {
 		t.Fatalf("wrapped error lost a sentinel: %v", wrapped)
 	}
-	if gate.wrap(nil) != nil {
+	if second.wrap(nil) != nil {
 		t.Fatal("a successful retry must not be turned into an error")
+	}
+
+	// the volume answering again clears the wait it had served
+	fs.sourceServed("5617,09fff")
+	if _, found := fs.missingVolumes.Load("5617"); found {
+		t.Fatal("a served chunk must clear its volume's wait")
 	}
 }
 

--- a/weed/replication/sink/filersink/filer_sink.go
+++ b/weed/replication/sink/filersink/filer_sink.go
@@ -464,7 +464,7 @@ func (fs *FilerSink) onReplicateChunkError(key string, entry *filer_pb.Entry, er
 		return nil
 	}
 	if errors.Is(err, errSourceChunkMissing) && fs.sourceStillServesChunks() {
-		glog.Errorf("skip %s: the source cluster no longer has its data: %v", key, err)
+		glog.Errorf("skip %s: the source cluster cannot produce its data, so it stays unreplicated: %v", key, err)
 		return nil
 	}
 	return fmt.Errorf("replicate entry chunks %s: %w", key, err)

--- a/weed/replication/sink/filersink/filer_sink.go
+++ b/weed/replication/sink/filersink/filer_sink.go
@@ -65,6 +65,7 @@ type FilerSink struct {
 	// lastServedFileId is the most recent chunk the source did serve, the probe
 	// sourceStillServesChunks re-checks before writing an entry off.
 	lastServedFileId atomic.Pointer[string]
+	missingVolumes   sync.Map // source volume id -> time.Time first found unlocatable
 }
 
 func init() {

--- a/weed/replication/sink/filersink/filer_sink.go
+++ b/weed/replication/sink/filersink/filer_sink.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/seaweedfs/seaweedfs/weed/operation"
 	"github.com/seaweedfs/seaweedfs/weed/pb"
@@ -61,6 +62,9 @@ type FilerSink struct {
 	signature         int32
 	activeTransfers   sync.Map // chunkFileId -> *ChunkTransferStatus
 	uploader          *operation.Uploader
+	// lastServedFileId is the most recent chunk the source did serve, the probe
+	// sourceStillServesChunks re-checks before writing an entry off.
+	lastServedFileId atomic.Pointer[string]
 }
 
 func init() {
@@ -447,13 +451,19 @@ func (fs *FilerSink) onCorruptChunk(key string, entry *filer_pb.Entry, err error
 }
 
 // onReplicateChunkError handles a non-size-mismatch replicateChunks failure.
-// Skip (return nil) only when the live source has moved past this version —
-// deleted or strictly-newer mtime — so a later event carries the current
-// content and the skip is lossless. Otherwise propagate so the offset stays
-// put and the event is retried; returning nil would silently drop the file.
+// Skip (return nil) when the live source has moved past this version — deleted
+// or strictly-newer mtime — so a later event carries the current content and the
+// skip is lossless, or when the source has lost the chunk for good: it can never
+// serve those bytes to anyone, and holding the offset for it only stops every
+// later event from ever being checkpointed. Otherwise propagate so the offset
+// stays put and the event is retried; returning nil would silently drop the file.
 func (fs *FilerSink) onReplicateChunkError(key string, entry *filer_pb.Entry, err error) error {
 	if fs.hasSourceNewerVersion(key, getEntryMtimeNs(entry)) {
 		glog.Warningf("skip stale entry %s, source superseded during replicate: %v", key, err)
+		return nil
+	}
+	if errors.Is(err, errSourceChunkMissing) && fs.sourceStillServesChunks() {
+		glog.Errorf("skip %s: the source cluster no longer has its data: %v", key, err)
 		return nil
 	}
 	return fmt.Errorf("replicate entry chunks %s: %w", key, err)

--- a/weed/replication/source/filer_source.go
+++ b/weed/replication/source/filer_source.go
@@ -2,6 +2,7 @@ package source
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -17,6 +18,12 @@ import (
 	util_http "github.com/seaweedfs/seaweedfs/weed/util/http"
 	util_http_client "github.com/seaweedfs/seaweedfs/weed/util/http/client"
 )
+
+// ErrVolumeNotFound reports that the source cluster has no location for a
+// chunk's volume: vacuumed away, deleted, or every replica offline. Callers
+// need it apart from a lookup that simply failed, which a later attempt can
+// still get past.
+var ErrVolumeNotFound = errors.New("volume not found")
 
 type FilerSource struct {
 	grpcAddress    string
@@ -88,8 +95,8 @@ func (fs *FilerSource) LookupFileId(ctx context.Context, part string) (fileUrls 
 	locations := vid2Locations[vid]
 
 	if locations == nil || len(locations.Locations) == 0 {
-		glog.V(1).InfofCtx(ctx, "LookupFileId locate volume id %s: %v", vid, err)
-		return nil, fmt.Errorf("LookupFileId locate volume id %s: %v", vid, err)
+		glog.V(1).InfofCtx(ctx, "LookupFileId locate volume id %s: %v", vid, ErrVolumeNotFound)
+		return nil, fmt.Errorf("LookupFileId locate volume id %s: %w", vid, ErrVolumeNotFound)
 	}
 
 	if !fs.proxyByFiler {

--- a/weed/replication/source/filer_source.go
+++ b/weed/replication/source/filer_source.go
@@ -125,12 +125,16 @@ func (fs *FilerSource) ReadPart(fileId string, offset int64) (filename string, h
 	}
 
 	if fs.proxyByFiler {
-		filename, header, resp, err = downloadFn("http://"+fs.address+"/?proxyChunkId="+fileId, "", offset)
+		fileUrl := "http://" + fs.address + "/?proxyChunkId=" + fileId
+		filename, header, resp, err = downloadFn(fileUrl, "", offset)
+		if err == nil {
+			err = readPartStatusError(fileUrl, resp)
+		}
 		if err != nil {
 			glog.V(0).Infof("read part %s via filer proxy %s offset %d: %v", fileId, fs.address, offset, err)
-		} else {
-			glog.V(4).Infof("read part %s via filer proxy %s offset %d content-length:%s", fileId, fs.address, offset, header.Get("Content-Length"))
+			return "", nil, nil, err
 		}
+		glog.V(4).Infof("read part %s via filer proxy %s offset %d content-length:%s", fileId, fs.address, offset, header.Get("Content-Length"))
 		return
 	}
 
@@ -141,15 +145,34 @@ func (fs *FilerSource) ReadPart(fileId string, offset int64) (filename string, h
 
 	for _, fileUrl := range fileUrls {
 		filename, header, resp, err = downloadFn(fileUrl, "", offset)
-		if err != nil {
-			glog.V(0).Infof("fail to read part %s from %s offset %d: %v", fileId, fileUrl, offset, err)
-		} else {
-			glog.V(4).Infof("read part %s from %s offset %d content-length:%s", fileId, fileUrl, offset, header.Get("Content-Length"))
-			break
+		if err == nil {
+			err = readPartStatusError(fileUrl, resp)
 		}
+		if err != nil {
+			resp = nil
+			glog.V(0).Infof("fail to read part %s from %s offset %d: %v", fileId, fileUrl, offset, err)
+			continue
+		}
+		glog.V(4).Infof("read part %s from %s offset %d content-length:%s", fileId, fileUrl, offset, header.Get("Content-Length"))
+		break
 	}
 
 	return filename, header, resp, err
+}
+
+// readPartStatusError turns a failure status into an error and closes the
+// response. Otherwise the caller copies the error page as chunk content and
+// reports it as a short read; a needle vacuum has removed answers 404, which
+// is the source having lost the data rather than corruption.
+func readPartStatusError(fileUrl string, resp *http.Response) error {
+	if resp == nil || resp.StatusCode < http.StatusBadRequest {
+		return nil
+	}
+	defer util_http.CloseResponse(resp)
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("%s: %s: %w", fileUrl, resp.Status, util_http.ErrNotFound)
+	}
+	return fmt.Errorf("%s: %s", fileUrl, resp.Status)
 }
 
 var _ = filer_pb.FilerClient(&FilerSource{})

--- a/weed/replication/source/filer_source_test.go
+++ b/weed/replication/source/filer_source_test.go
@@ -3,14 +3,22 @@ package source
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"sync/atomic"
 	"testing"
 
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	util_http "github.com/seaweedfs/seaweedfs/weed/util/http"
 )
 
@@ -280,5 +288,108 @@ func TestDownloadFile_GzipPartialReadThenResume(t *testing.T) {
 	fullData := append(partialData, remainingData...)
 	if !bytes.Equal(fullData, testData) {
 		t.Fatalf("combined data mismatch: got %d bytes, want %d", len(fullData), len(testData))
+	}
+}
+
+// lookupFilerServer answers volume lookups with a fixed set of locations, so a
+// test can hand ReadPart several replicas, or none at all.
+type lookupFilerServer struct {
+	filer_pb.UnimplementedSeaweedFilerServer
+	locations []string
+}
+
+func (s *lookupFilerServer) LookupVolume(ctx context.Context, req *filer_pb.LookupVolumeRequest) (*filer_pb.LookupVolumeResponse, error) {
+	locationsMap := make(map[string]*filer_pb.Locations)
+	for _, vid := range req.VolumeIds {
+		if len(s.locations) == 0 {
+			continue
+		}
+		locations := &filer_pb.Locations{}
+		for _, url := range s.locations {
+			locations.Locations = append(locations.Locations, &filer_pb.Location{Url: url})
+		}
+		locationsMap[vid] = locations
+	}
+	return &filer_pb.LookupVolumeResponse{LocationsMap: locationsMap}, nil
+}
+
+func startLookupFiler(t *testing.T, locations ...string) *FilerSource {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	server := grpc.NewServer()
+	filer_pb.RegisterSeaweedFilerServer(server, &lookupFilerServer{locations: locations})
+	go server.Serve(listener)
+	t.Cleanup(server.Stop)
+
+	address := listener.Addr().String()
+	filerSource := &FilerSource{}
+	if err := filerSource.DoInitialize(address, address, "/", false); err != nil {
+		t.Fatalf("DoInitialize: %v", err)
+	}
+	filerSource.SetGrpcDialOption(grpc.WithTransportCredentials(insecure.NewCredentials()))
+	return filerSource
+}
+
+// A volume the source cluster no longer has must be reported as ErrVolumeNotFound,
+// not as an untyped message the caller can only string-match.
+func TestLookupFileIdVolumeNotFound(t *testing.T) {
+	filerSource := startLookupFiler(t)
+
+	_, err := filerSource.LookupFileId(context.Background(), "5617,01abc")
+	if !errors.Is(err, ErrVolumeNotFound) {
+		t.Fatalf("expected ErrVolumeNotFound, got %v", err)
+	}
+}
+
+// A replica answering 404 is a failed read, not an empty file: ReadPart must move
+// on to the next replica instead of handing the error page back as content.
+func TestReadPartSkipsNotFoundReplica(t *testing.T) {
+	const body = "chunk bytes"
+
+	gone := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Not Found", http.StatusNotFound)
+	}))
+	defer gone.Close()
+	live := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(body))
+	}))
+	defer live.Close()
+
+	filerSource := startLookupFiler(t,
+		strings.TrimPrefix(gone.URL, "http://"), strings.TrimPrefix(live.URL, "http://"))
+
+	_, _, resp, err := filerSource.ReadPart("5617,01abc", 0)
+	if err != nil {
+		t.Fatalf("ReadPart: %v", err)
+	}
+	defer util_http.CloseResponse(resp)
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if string(data) != body {
+		t.Fatalf("got %q, want %q", data, body)
+	}
+}
+
+// Every replica gone: the caller must see a not-found error it can act on, and no
+// response left open behind it.
+func TestReadPartAllReplicasNotFound(t *testing.T) {
+	gone := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Not Found", http.StatusNotFound)
+	}))
+	defer gone.Close()
+
+	filerSource := startLookupFiler(t, strings.TrimPrefix(gone.URL, "http://"))
+
+	_, _, resp, err := filerSource.ReadPart("5617,01abc", 0)
+	if !errors.Is(err, util_http.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+	if resp != nil {
+		t.Fatal("expected no response alongside the error")
 	}
 }


### PR DESCRIPTION
Fixes #11010.

`filer.sync` stops checkpointing, permanently, once it replays an event whose chunks live in a volume the source has since vacuumed away. The process stays up and looks healthy while its offset never moves again.

### What happens

Two shapes reach the sink, and both are in the reporter's log:

- **The volume is gone.** `LookupFileId` finds no locations, and `fetchAndWrite`'s `RetryUntil` gate treats that as neither a size mismatch, nor supersession, nor a network error — so it returns `shouldContinue = true` and retries every ~6s forever. The sync job never finishes, so it holds its slot and pins the offset watermark at the event ahead of it. That is the wedge.
- **The needle is gone but the volume is still there.** The volume server answers 404, and `ReadPart` never looked at the response status — so the error page came back as a successful read and its bytes were counted as file content. The entry was then reported as a chunk size mismatch: a corruption claim about data the source had simply lost. A 404 from one replica also ended the search instead of trying the next.

Reproduced against a fake source filer that still holds the entry, unchanged, while its master locates nothing: `fetchAndWrite` was still retrying after five seconds with no way out.

### The fix

- `LookupFileId` returns a typed `ErrVolumeNotFound` instead of formatting a nil error into its message, which was all a caller had to match on.
- `ReadPart` fails on a failure status, closing the response; 404 becomes a not-found error and the next replica gets a turn.
- A chunk the source cannot produce is waited out for a grace period long enough to cover a volume server restart or a master failover, then given up on and marked permanent, instead of being retried forever.
- An entry whose data the source has lost for good is skipped with an error naming it, so replication carries on and the offset advances. Nothing brings those bytes back, and holding the offset for them only stops every later event from ever being checkpointed.

### The wait is per volume, not per chunk

A vacuumed volume took every file it held with it. Timing the grace period per chunk would serialize those waits behind the bounded chunk executor, so one gone volume holding many files would stall the sync for far longer than the grace period — the wedge again, only slower. The wait is tracked per source volume on the sink: the first chunk to find it unlocatable starts the clock, every later chunk inherits it and gives up as soon as it has run out, and a chunk the source does serve clears it. So a gone volume costs one grace period in total, however many files it held.

An incremental sink's dated target keys can't be mapped back to a source path, so supersession can't be checked there at all. Those propagate immediately rather than waiting, and `filer.backup` decides with the event's real source key — the same reasoning `manifestResolveRetryGate` already applies.

### Why the skip is conditional

A volume with no locations reads the same whether it was vacuumed away or every replica is down, and during a cluster-wide outage that answer comes back for *every* chunk — skipping then would drop live files wholesale. So the sink first re-checks a file id the source did serve: if that one has become unresolvable too, the error is held for a retry as before.

Supersession still wins ahead of all of this, so a stale replay whose file was overwritten or deleted is skipped immediately, as it is today.

### Not changed

The reporter pointed at `repl_util/replication_util.go`. That path serves the local/gcs/azure/b2 sinks; `filer.sync` reads through `filersink`'s own `fetchAndWrite`, which is where the loop that never ends lives.

### Tests

- `TestFetchAndWriteStopsOnMissingSourceChunk` — the reproduction, now returning `errSourceChunkMissing` instead of spinning.
- `TestMissingSourceChunkGate` — the grace period, that an unrelated failure doesn't start it, that a second file in the same volume inherits the wait rather than restarting it, and that a served chunk clears it.
- `TestFetchAndWriteMissingSourceChunkUnverifiableSupersession` — no wait when supersession can't be checked.
- `TestOnReplicateChunkErrorMissingSourceChunk` — skip while the source still serves other chunks; hold when it can locate nothing, and when nothing has been served yet to check against.
- `TestReadPartSkipsNotFoundReplica`, `TestReadPartAllReplicasNotFound`, `TestLookupFileIdVolumeNotFound`.

https://claude.ai/code/session_01SRPEP4jRu29FbLSN6bjLaK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved replication handling for temporarily unavailable source chunks with a per-volume grace period.
  - Stopped retries for chunks confirmed to be permanently unavailable, allowing replication to continue.
  - Improved recovery when source servers restart or experience outages.
  - Correctly handled missing volumes and HTTP 404 responses without treating error pages as chunk data.
  - Added fallback behavior when individual replicas are unavailable.
  - Improved error reporting for source chunks that cannot be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->