### PR TITLE
s3: an abort answered mid-part no longer leaves the upload completable

### DIFF
--- a/weed/s3api/filer_multipart.go
+++ b/weed/s3api/filer_multipart.go
@@ -411,6 +411,11 @@ func (s3a *S3ApiServer) prepareMultipartCompletionState(r *http.Request, input *
 		}
 		return nil, nil, s3err.ErrInternalError
 	}
+	// only createMultipartUpload stamps the key; a directory a part write left behind is not an upload
+	if !isMultipartUploadEntry(pentry) {
+		stats.S3HandlerCounter.WithLabelValues(stats.ErrorCompletedNoSuchUpload).Inc()
+		return nil, nil, s3err.ErrNoSuchUpload
+	}
 
 	deleteEntries := make([]*filer_pb.Entry, 0)
 	partEntries := make(map[int][]*filer_pb.Entry, len(entries))

--- a/weed/s3api/s3api_multipart_upload_entry_test.go
+++ b/weed/s3api/s3api_multipart_upload_entry_test.go
@@ -1,0 +1,28 @@
+package s3api
+
+import (
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
+)
+
+func TestIsMultipartUploadEntry(t *testing.T) {
+	tests := []struct {
+		name  string
+		entry *filer_pb.Entry
+		want  bool
+	}{
+		{"aborted upload", nil, false},
+		{"directory re-created by a part write", &filer_pb.Entry{IsDirectory: true}, false},
+		{"key emptied", &filer_pb.Entry{IsDirectory: true, Extended: map[string][]byte{s3_constants.ExtMultipartObjectKey: {}}}, false},
+		{"open upload", &filer_pb.Entry{IsDirectory: true, Extended: map[string][]byte{s3_constants.ExtMultipartObjectKey: []byte("a.bin")}}, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isMultipartUploadEntry(tc.entry); got != tc.want {
+				t.Errorf("isMultipartUploadEntry() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/weed/s3api/s3api_object_handlers_copy.go
+++ b/weed/s3api/s3api_object_handlers_copy.go
@@ -1028,6 +1028,10 @@ func (s3a *S3ApiServer) CopyObjectPartHandler(w http.ResponseWriter, r *http.Req
 			s3err.WriteErrorResponse(w, r, errCode)
 			return
 		}
+		// the copy above re-creates a directory an abort removed mid-copy
+		if !s3a.checkUploadStillOpen(w, r, dstBucket, dstObject, uploadID) {
+			return
+		}
 		setEtag(w, "\""+strings.Trim(etag, "\"")+"\"")
 		// Mirror PutObjectPartHandler: write x-amz-server-side-encryption /
 		// x-amz-server-side-encryption-aws-kms-key-id headers on the response
@@ -1101,6 +1105,11 @@ func (s3a *S3ApiServer) CopyObjectPartHandler(w http.ResponseWriter, r *http.Req
 		entry.Extended = dstEntry.Extended
 	}); err != nil {
 		s3err.WriteErrorResponse(w, r, s3err.ErrInternalError)
+		return
+	}
+
+	// the copy above re-creates a directory an abort removed mid-copy
+	if !s3a.checkUploadStillOpen(w, r, dstBucket, dstObject, uploadID) {
 		return
 	}
 

--- a/weed/s3api/s3api_object_handlers_multipart.go
+++ b/weed/s3api/s3api_object_handlers_multipart.go
@@ -510,11 +510,14 @@ func (s3a *S3ApiServer) checkUploadStillOpen(w http.ResponseWriter, r *http.Requ
 	if isMultipartUploadEntry(entry) {
 		return true
 	}
-	s3a.abortMultipartUpload(&s3.AbortMultipartUploadInput{
+	// the upload is gone either way, so the client still hears NoSuchUpload
+	if _, code := s3a.abortMultipartUpload(&s3.AbortMultipartUploadInput{
 		Bucket:   aws.String(bucket),
 		Key:      objectKey(aws.String(object)),
 		UploadId: aws.String(uploadID),
-	})
+	}); code != s3err.ErrNone {
+		glog.Warningf("checkUploadStillOpen %s/%s: part left behind, cleanup failed", bucket, uploadID)
+	}
 	s3err.WriteErrorResponse(w, r, s3err.ErrNoSuchUpload)
 	return false
 }

--- a/weed/s3api/s3api_object_handlers_multipart.go
+++ b/weed/s3api/s3api_object_handlers_multipart.go
@@ -469,6 +469,11 @@ func (s3a *S3ApiServer) PutObjectPartHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	// the write above re-creates a directory an abort removed mid-body
+	if !s3a.checkUploadStillOpen(w, r, bucket, object, uploadID) {
+		return
+	}
+
 	glog.V(2).Infof("PutObjectPart: SUCCESS - bucket=%s, object=%s, partNumber=%d, etag=%s, sseType=%s",
 		bucket, object, partID, etag, sseMetadata.SSEType)
 
@@ -483,6 +488,35 @@ func (s3a *S3ApiServer) PutObjectPartHandler(w http.ResponseWriter, r *http.Requ
 
 func (s3a *S3ApiServer) genUploadsFolder(bucket string) string {
 	return fmt.Sprintf("%s/%s", s3a.bucketDir(bucket), s3_constants.MultipartUploadsFolder)
+}
+
+// isMultipartUploadEntry tells the .uploads/<id> directory createMultipartUpload
+// made from the one a part write re-created on its way to the filer: only the
+// former carries the destination object key.
+func isMultipartUploadEntry(entry *filer_pb.Entry) bool {
+	return entry != nil && len(entry.Extended[s3_constants.ExtMultipartObjectKey]) > 0
+}
+
+// checkUploadStillOpen re-checks the upload after a part landed, and removes the
+// part along with the directory it resurrected when an abort was answered while
+// the part was in flight. It reports whether the caller may answer success.
+func (s3a *S3ApiServer) checkUploadStillOpen(w http.ResponseWriter, r *http.Request, bucket, object, uploadID string) bool {
+	entry, err := s3a.getEntry(s3a.genUploadsFolder(bucket), uploadID)
+	if err != nil && !errors.Is(err, filer_pb.ErrNotFound) {
+		glog.Errorf("checkUploadStillOpen %s/%s: %v", bucket, uploadID, err)
+		s3err.WriteErrorResponse(w, r, s3err.ErrInternalError)
+		return false
+	}
+	if isMultipartUploadEntry(entry) {
+		return true
+	}
+	s3a.abortMultipartUpload(&s3.AbortMultipartUploadInput{
+		Bucket:   aws.String(bucket),
+		Key:      objectKey(aws.String(object)),
+		UploadId: aws.String(uploadID),
+	})
+	s3err.WriteErrorResponse(w, r, s3err.ErrNoSuchUpload)
+	return false
 }
 
 // getMultipartSSEAlgorithm returns the canonical SSE algorithm ("AES256" or


### PR DESCRIPTION
Fixes #11024.

`PutObjectPartHandler` checks that `.uploads/<id>` still exists before it reads
the part body. An abort answered during that read removes the directory, and the
part write that follows re-creates it on its way to the filer: the part lands
with a 200 and the upload `ListMultipartUploads` no longer lists still completes
into an object.

Reproduced with the reporter's script on `weed mini` at 624deaf3a:

```
A) part in flight across the abort
  AbortMultipartUpload       -> 204 No Content
  UploadPart body sent       -> 200 OK
  ListMultipartUploads       -> 200 OK, 0 listed
  CompleteMultipartUpload    -> 200 OK
  HEAD object                -> 200 OK
```

The re-created directory is the tell. `createMultipartUpload` stamps the
destination object key on `.uploads/<id>`; the filer's implicit parent creation
does not, which is also why the upload stopped listing:

```
fs.meta.cat /buckets/probe/.uploads/325ffddd..._bd04f45a...
  "isDirectory": true,
  "extended": {},
```

Three commits:

1. UploadPart re-checks the upload after the part lands and, when the directory
   is one its own write resurrected, drops it along with the part and answers
   `NoSuchUpload`.
2. UploadPartCopy has the same window — the check runs before the bytes are
   copied. Aborting mid-copy of a 40MB source made 8 of 16 attempts completable;
   both the re-encryption and the raw-copy path now re-check.
3. CompleteMultipartUpload refuses a `.uploads/<id>` carrying no upload record.
   Posting a part straight to the filer under an unused upload id used to
   assemble an object out of it; it now answers `NoSuchUpload`. This also covers
   directories a pre-fix gateway left behind.

After, A) matches the control case, and the copy race stops at 0 of 16:

```
A) part in flight across the abort
  AbortMultipartUpload       -> 204 No Content
  UploadPart body sent       -> 404 Not Found NoSuchUpload
  ListMultipartUploads       -> 200 OK, 0 listed
  CompleteMultipartUpload    -> 404 Not Found NoSuchUpload
  HEAD object                -> 404 Not Found
```

Multipart upload, UploadPartCopy and their round trips still work (40MB in 5
parts, byte-identical back); `go test ./weed/s3api/...` passes. The cost is one
extra `LookupDirectoryEntry` per part write, against a request that already
carried the part's bytes.

Not changed: the second `CompleteMultipartUpload` on an already-completed id
answering 200. That one is deliberate — the completion path recognizes the
object it wrote for this upload id and replays the same result, so a client
whose response was lost can retry.


https://claude.ai/code/session_01ByZ49KQdUtHhmjG6SpNczT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multipart upload validation for missing, invalid, or aborted uploads.
  * Prevented interrupted part uploads and copy operations from incorrectly reporting success.
  * Ensured orphaned upload directories return the appropriate “No Such Upload” error.
  * Improved cleanup handling when an upload is aborted during an in-progress copy.

* **Tests**
  * Added coverage for aborted, recreated, empty, and active multipart upload states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->