### PR TITLE
fix: Move cluster.LiveLock.generation to first field fix 32bit alignment

### DIFF
--- a/weed/cluster/lock_client.go
+++ b/weed/cluster/lock_client.go
@@ -117,6 +117,7 @@ func (lc *LockClient) PriorOwnerForKey(key string) pb.ServerAddress {
 }
 
 type LiveLock struct {
+	generation          int64 // fencing token from the lock server; MUST stay first so the 64-bit atomic ops stay 8-byte aligned on 32-bit ARM
 	key                 string
 	renewToken          string
 	expireAtNs          int64
@@ -129,8 +130,7 @@ type LiveLock struct {
 	lc                  *LockClient
 	owner               string
 	lockTTL             time.Duration
-	consecutiveFailures int   // Track connection failures to trigger fallback
-	generation          int64 // fencing token from the lock server
+	consecutiveFailures int // Track connection failures to trigger fallback
 }
 
 // NewShortLivedLock creates a lock with a 5-second duration

--- a/weed/cluster/lock_client_test.go
+++ b/weed/cluster/lock_client_test.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -148,5 +149,19 @@ func TestLockClientPriorOwnerForKeyExpires(t *testing.T) {
 		if got := lc.PriorOwnerForKey(fmt.Sprintf("key-%d", i)); got != "" {
 			t.Fatalf("prior owner should expire after the cooling window, got %q", got)
 		}
+	}
+}
+
+// LiveLock.generation is a fencing token written and read with 64-bit atomic
+// operations. On 32-bit platforms (GOARCH=386 and GOARCH=arm) a 64-bit atomic
+// op requires an 8-byte-aligned address, which Go only guarantees for the
+// first field of an allocated struct. generation must therefore stay first:
+// a misaligned field makes StoreInt64 panic with "unaligned 64-bit atomic
+// operation" the moment this test runs on a 32-bit target.
+func TestLiveLockGenerationIsAligned(t *testing.T) {
+	var lock LiveLock
+	atomic.StoreInt64(&lock.generation, 42)
+	if got := lock.Generation(); got != 42 {
+		t.Fatalf("generation = %d, want 42", got)
 	}
 }


### PR DESCRIPTION
# What problem are we solving?
On 32-bit systems the generation fields becomes unaligned. Not an issue on 64bit.

Discovered on 32bit raspbian, validated by manual patch (in addition to test).


# How are we solving the problem?
Move the `generation` field which becomes unaligned to be in the first position, making it aligned.

# How is the PR tested?
In addition to the unit test, I've confirmed that the patch works on 32bit rpie by applying it
manually, see [here](https://github.com/baalimago/kinoview/commit/37dd9eceac996d2d66295b4d79dfdb8d7396e981#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddc)


# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lock reliability on 32-bit platforms by ensuring generation values are correctly aligned for atomic operations.

* **Tests**
  * Added coverage to verify generation updates work safely on supported 32-bit architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->