### PR TITLE
master: shed assigns retryably until volume servers register capacity

### DIFF
--- a/weed/server/master_grpc_server_assign.go
+++ b/weed/server/master_grpc_server_assign.go
@@ -117,7 +117,7 @@ func (ms *MasterServer) Assign(ctx context.Context, req *master_pb.AssignRequest
 		fid, count, dnList, shouldGrow, err := ms.Topo.PickForWrite(req.Count, option, vl, req.ExpectedDataSize)
 		if shouldGrow && !initiatedGrow && !ms.option.VolumeGrowthDisabled && vl.AddGrowRequestIfAbsent() {
 			initiatedGrow = true
-			if err != nil && ms.Topo.AvailableSpaceFor(option) <= 0 {
+			if err != nil && ms.Topo.AvailableSpaceFor(option) <= 0 && ms.Topo.CapacityFor(option) > 0 {
 				err = fmt.Errorf("%s and no free volumes left for %s", err.Error(), option.String())
 			}
 			ms.volumeGrowthRequestChan <- &topology.VolumeGrowRequest{
@@ -136,7 +136,14 @@ func (ms *MasterServer) Assign(ctx context.Context, req *master_pb.AssignRequest
 			}
 			if shouldGrow {
 				if ms.Topo.AvailableSpaceFor(option) <= 0 {
-					break // out of space: surface the real error, not a retryable shed
+					if ms.Topo.CapacityFor(option) > 0 {
+						break // out of space: surface the real error, not a retryable shed
+					}
+					// No capacity registered for this disk type yet, typically a
+					// just-started cluster whose volume servers have not
+					// heartbeated. Shed retryably so the first write rides out
+					// the startup window instead of failing outright.
+					return nil, status.Errorf(codes.ResourceExhausted, "no volume server capacity registered yet for %s", option.String())
 				}
 				// Only the initiator waits, and only while the growth it triggered
 				// is still pending: followers shed fast so a herd doesn't pin a

--- a/weed/server/master_grpc_server_assign_test.go
+++ b/weed/server/master_grpc_server_assign_test.go
@@ -175,9 +175,24 @@ func TestAssignAbortsOnCancel(t *testing.T) {
 // Out of space, Assign fails fast with the real error rather than masking it as
 // a retryable "growth in progress".
 func TestAssignFailsFastWhenOutOfSpace(t *testing.T) {
-	ms := newLeaderMaster() // no data nodes -> no free space
+	ms := newLeaderMaster()
+	// One slot, already taken by another collection's volume: capacity is
+	// registered but genuinely exhausted.
+	dn := ms.Topo.GetOrCreateDataCenter("dc1").GetOrCreateRack("rack1").
+		GetOrCreateDataNode("127.0.0.1", 8080, 18080, "127.0.0.1", "dn1", map[string]uint32{"": 1})
+	rp, err := super_block.NewReplicaPlacementFromString("000")
+	require.NoError(t, err)
+	v := storage.VolumeInfo{
+		Id:               needle.VolumeId(1),
+		Collection:       "other",
+		Version:          needle.GetCurrentVersion(),
+		ReplicaPlacement: rp,
+		Ttl:              needle.EMPTY_TTL,
+	}
+	dn.UpdateVolumes([]storage.VolumeInfo{v})
+	ms.Topo.RegisterVolumeLayout(v, dn)
 
-	req := &master_pb.AssignRequest{Count: 1, Replication: "000"}
+	req := &master_pb.AssignRequest{Count: 1, Replication: "000", Collection: "fresh"}
 
 	start := time.Now()
 	resp, err := ms.Assign(context.Background(), req)
@@ -187,7 +202,29 @@ func TestAssignFailsFastWhenOutOfSpace(t *testing.T) {
 	require.Nil(t, resp)
 	if st, ok := status.FromError(err); ok {
 		assert.NotEqual(t, codes.Unavailable, st.Code())
+		assert.NotEqual(t, codes.ResourceExhausted, st.Code())
 	}
 	assert.Contains(t, err.Error(), "no free volumes left")
+	assert.Less(t, elapsed, 2*time.Second)
+}
+
+// A topology with no registered capacity is a cluster whose volume servers have
+// not heartbeated yet, not one that is full: the first write to a fresh bucket
+// races the volume server registration at startup, so Assign must shed with a
+// retryable code instead of failing the write outright.
+func TestAssignShedsRetryablyBeforeCapacityRegisters(t *testing.T) {
+	ms := newLeaderMaster() // no data nodes: nothing has heartbeated yet
+
+	req := &master_pb.AssignRequest{Count: 1, Replication: "000"}
+
+	start := time.Now()
+	resp, err := ms.Assign(context.Background(), req)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.ResourceExhausted, st.Code())
 	assert.Less(t, elapsed, 2*time.Second)
 }

--- a/weed/topology/node.go
+++ b/weed/topology/node.go
@@ -313,6 +313,13 @@ func (n *NodeImpl) AvailableSpaceFor(option *VolumeGrowOption) int64 {
 	return freeVolumeSlotCount
 }
 
+// CapacityFor is the total registered volume slots for the option's disk type;
+// zero means no volume server has reported capacity for it yet.
+func (n *NodeImpl) CapacityFor(option *VolumeGrowOption) int64 {
+	t := n.getOrCreateDisk(option.DiskType)
+	return atomic.LoadInt64(&t.maxVolumeCount) + atomic.LoadInt64(&t.remoteVolumeCount)
+}
+
 // AvailableSpaceForReservation returns available space considering existing reservations
 func (n *NodeImpl) AvailableSpaceForReservation(option *VolumeGrowOption) int64 {
 	baseAvailable := n.AvailableSpaceFor(option)


### PR DESCRIPTION
Fixes #11031.

Reproduced with 8 `weed server -s3` instances starting concurrently on one host, each doing CreateBucket then a presigned PUT ~100ms later: the PUT intermittently answers 500 InternalError within 2-3ms and the follow-up GET 404s. Server side, every failure is

```
assign volume: rpc error: code = Unknown desc = failed to find writable volumes for collection:nucleus-... error: No writable volumes and no free volumes left for ...
```

The first write to a fresh bucket needs volume growth for the new collection, and at startup that assign can arrive before the volume server's first heartbeat has registered any capacity — under concurrent startup load the heartbeat is itself delayed for seconds (`SendHeartbeat find leader: <nil>` while raft elects). `AvailableSpaceFor` is then zero, and since 4.37 the assign loop breaks out immediately to surface the out-of-space error rather than shedding retryably. But "no capacity registered yet" is not "full", and the plain error is one no client retries, so the write fails outright. Before 4.37 the loop slept out the window in 200ms steps, which is why 3.97 answers the same sequence in ~210-280ms under load instead of failing. (The issue's bisection to 4.02 is load-noise; the fast-fail landed in 4.37.)

Now the master distinguishes the two states: it fails fast only when registered capacity is genuinely exhausted, and sheds `ResourceExhausted` while no volume server has reported capacity for the requested disk type, so the existing client retry budget in `operation.Assign` rides out the startup window.

Verified with the same harness: 4.44 fails 16/64 first-PUTs in one round; with this change three rounds of 64 pass with zero failures, and the new shed fired 12 times in spots where 4.44 answered 500.

https://claude.ai/code/session_018G9kWFgy8BaBAEkYV3YL9n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved volume assignment handling when storage capacity is exhausted.
  * Added retryable responses while volume-server capacity is still being registered, such as during cluster startup.
  * Preserved immediate, non-retryable errors for genuine out-of-space conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->