### PR TITLE
get volume topology info without volume details

### DIFF
--- a/seaweed-volume/proto/master.proto
+++ b/seaweed-volume/proto/master.proto
@@ -418,8 +418,10 @@ message VolumeListRequest {
   // Empty and zero take everything. Wildcards are supported.
   string remote_storage_name = 4;
   bool local_volume_only = 5;
-  // Set to true when you only want the topology, not the volumes
-  bool without_volumes = 6;
+  // The topology, its disks and their counters alone, without the volumes
+  // and ec shards. Selecting volumes above contradicts this and is refused.
+  // A master that predates this field ignores it and answers in full.
+  bool topology_only = 6;
 }
 message VolumeListResponse {
   TopologyInfo topology_info = 1;

--- a/seaweed-volume/proto/master.proto
+++ b/seaweed-volume/proto/master.proto
@@ -418,6 +418,8 @@ message VolumeListRequest {
   // Empty and zero take everything. Wildcards are supported.
   string remote_storage_name = 4;
   bool local_volume_only = 5;
+  // Set to true when you only want the topology, not the volumes
+  bool without_volumes = 6;
 }
 message VolumeListResponse {
   TopologyInfo topology_info = 1;

--- a/weed/pb/master.proto
+++ b/weed/pb/master.proto
@@ -418,8 +418,10 @@ message VolumeListRequest {
   // Empty and zero take everything. Wildcards are supported.
   string remote_storage_name = 4;
   bool local_volume_only = 5;
-  // Set to true when you only want the topology, not the volumes
-  bool without_volumes = 6;
+  // The topology, its disks and their counters alone, without the volumes
+  // and ec shards. Selecting volumes above contradicts this and is refused.
+  // A master that predates this field ignores it and answers in full.
+  bool topology_only = 6;
 }
 message VolumeListResponse {
   TopologyInfo topology_info = 1;

--- a/weed/pb/master.proto
+++ b/weed/pb/master.proto
@@ -418,6 +418,8 @@ message VolumeListRequest {
   // Empty and zero take everything. Wildcards are supported.
   string remote_storage_name = 4;
   bool local_volume_only = 5;
+  // Set to true when you only want the topology, not the volumes
+  bool without_volumes = 6;
 }
 message VolumeListResponse {
   TopologyInfo topology_info = 1;

--- a/weed/pb/master_pb/master.pb.go
+++ b/weed/pb/master_pb/master.pb.go
@@ -2791,8 +2791,10 @@ type VolumeListRequest struct {
 	// Empty and zero take everything. Wildcards are supported.
 	RemoteStorageName string `protobuf:"bytes,4,opt,name=remote_storage_name,json=remoteStorageName,proto3" json:"remote_storage_name,omitempty"`
 	LocalVolumeOnly   bool   `protobuf:"varint,5,opt,name=local_volume_only,json=localVolumeOnly,proto3" json:"local_volume_only,omitempty"`
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// Set to true when you only want the topology, not the volumes
+	WithoutVolumes bool `protobuf:"varint,6,opt,name=without_volumes,json=withoutVolumes,proto3" json:"without_volumes,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *VolumeListRequest) Reset() {
@@ -2856,6 +2858,13 @@ func (x *VolumeListRequest) GetRemoteStorageName() string {
 func (x *VolumeListRequest) GetLocalVolumeOnly() bool {
 	if x != nil {
 		return x.LocalVolumeOnly
+	}
+	return false
+}
+
+func (x *VolumeListRequest) GetWithoutVolumes() bool {
+	if x != nil {
+		return x.WithoutVolumes
 	}
 	return false
 }
@@ -5232,7 +5241,7 @@ const file_master_proto_rawDesc = "" +
 	"\tdiskInfos\x18\x03 \x03(\v2&.master_pb.TopologyInfo.DiskInfosEntryR\tdiskInfos\x1aQ\n" +
 	"\x0eDiskInfosEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12)\n" +
-	"\x05value\x18\x02 \x01(\v2\x13.master_pb.DiskInfoR\x05value:\x028\x01\"\xe6\x01\n" +
+	"\x05value\x18\x02 \x01(\v2\x13.master_pb.DiskInfoR\x05value:\x028\x01\"\x8f\x02\n" +
 	"\x11VolumeListRequest\x12\x1e\n" +
 	"\n" +
 	"collection\x18\x01 \x01(\tR\n" +
@@ -5241,7 +5250,8 @@ const file_master_proto_rawDesc = "" +
 	"volume_ids\x18\x02 \x03(\rR\tvolumeIds\x126\n" +
 	"\x17default_collection_only\x18\x03 \x01(\bR\x15defaultCollectionOnly\x12.\n" +
 	"\x13remote_storage_name\x18\x04 \x01(\tR\x11remoteStorageName\x12*\n" +
-	"\x11local_volume_only\x18\x05 \x01(\bR\x0flocalVolumeOnly\"\x83\x01\n" +
+	"\x11local_volume_only\x18\x05 \x01(\bR\x0flocalVolumeOnly\x12'\n" +
+	"\x0fwithout_volumes\x18\x06 \x01(\bR\x0ewithoutVolumes\"\x83\x01\n" +
 	"\x12VolumeListResponse\x12<\n" +
 	"\rtopology_info\x18\x01 \x01(\v2\x17.master_pb.TopologyInfoR\ftopologyInfo\x12/\n" +
 	"\x14volume_size_limit_mb\x18\x02 \x01(\x04R\x11volumeSizeLimitMb\"\xda\x02\n" +

--- a/weed/pb/master_pb/master.pb.go
+++ b/weed/pb/master_pb/master.pb.go
@@ -2791,10 +2791,12 @@ type VolumeListRequest struct {
 	// Empty and zero take everything. Wildcards are supported.
 	RemoteStorageName string `protobuf:"bytes,4,opt,name=remote_storage_name,json=remoteStorageName,proto3" json:"remote_storage_name,omitempty"`
 	LocalVolumeOnly   bool   `protobuf:"varint,5,opt,name=local_volume_only,json=localVolumeOnly,proto3" json:"local_volume_only,omitempty"`
-	// Set to true when you only want the topology, not the volumes
-	WithoutVolumes bool `protobuf:"varint,6,opt,name=without_volumes,json=withoutVolumes,proto3" json:"without_volumes,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// The topology, its disks and their counters alone, without the volumes
+	// and ec shards. Selecting volumes above contradicts this and is refused.
+	// A master that predates this field ignores it and answers in full.
+	TopologyOnly  bool `protobuf:"varint,6,opt,name=topology_only,json=topologyOnly,proto3" json:"topology_only,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *VolumeListRequest) Reset() {
@@ -2862,9 +2864,9 @@ func (x *VolumeListRequest) GetLocalVolumeOnly() bool {
 	return false
 }
 
-func (x *VolumeListRequest) GetWithoutVolumes() bool {
+func (x *VolumeListRequest) GetTopologyOnly() bool {
 	if x != nil {
-		return x.WithoutVolumes
+		return x.TopologyOnly
 	}
 	return false
 }
@@ -5241,7 +5243,7 @@ const file_master_proto_rawDesc = "" +
 	"\tdiskInfos\x18\x03 \x03(\v2&.master_pb.TopologyInfo.DiskInfosEntryR\tdiskInfos\x1aQ\n" +
 	"\x0eDiskInfosEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12)\n" +
-	"\x05value\x18\x02 \x01(\v2\x13.master_pb.DiskInfoR\x05value:\x028\x01\"\x8f\x02\n" +
+	"\x05value\x18\x02 \x01(\v2\x13.master_pb.DiskInfoR\x05value:\x028\x01\"\x8b\x02\n" +
 	"\x11VolumeListRequest\x12\x1e\n" +
 	"\n" +
 	"collection\x18\x01 \x01(\tR\n" +
@@ -5250,8 +5252,8 @@ const file_master_proto_rawDesc = "" +
 	"volume_ids\x18\x02 \x03(\rR\tvolumeIds\x126\n" +
 	"\x17default_collection_only\x18\x03 \x01(\bR\x15defaultCollectionOnly\x12.\n" +
 	"\x13remote_storage_name\x18\x04 \x01(\tR\x11remoteStorageName\x12*\n" +
-	"\x11local_volume_only\x18\x05 \x01(\bR\x0flocalVolumeOnly\x12'\n" +
-	"\x0fwithout_volumes\x18\x06 \x01(\bR\x0ewithoutVolumes\"\x83\x01\n" +
+	"\x11local_volume_only\x18\x05 \x01(\bR\x0flocalVolumeOnly\x12#\n" +
+	"\rtopology_only\x18\x06 \x01(\bR\ftopologyOnly\"\x83\x01\n" +
 	"\x12VolumeListResponse\x12<\n" +
 	"\rtopology_info\x18\x01 \x01(\v2\x17.master_pb.TopologyInfoR\ftopologyInfo\x12/\n" +
 	"\x14volume_size_limit_mb\x18\x02 \x01(\x04R\x11volumeSizeLimitMb\"\xda\x02\n" +

--- a/weed/server/master_grpc_server_volume.go
+++ b/weed/server/master_grpc_server_volume.go
@@ -286,8 +286,13 @@ func (ms *MasterServer) VolumeList(ctx context.Context, req *master_pb.VolumeLis
 		return nil, raft.NotLeaderError
 	}
 
+	filter, err := topology.NewVolumeFilter(req)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
 	resp := &master_pb.VolumeListResponse{
-		TopologyInfo:      ms.Topo.ToTopologyInfo(topology.NewVolumeFilter(req)),
+		TopologyInfo:      ms.Topo.ToTopologyInfo(filter),
 		VolumeSizeLimitMb: uint64(ms.option.VolumeSizeLimitMB),
 	}
 
@@ -303,8 +308,13 @@ func (ms *MasterServer) VolumeListStream(req *master_pb.VolumeListRequest, strea
 		return raft.NotLeaderError
 	}
 
+	filter, err := topology.NewVolumeFilter(req)
+	if err != nil {
+		return status.Error(codes.InvalidArgument, err.Error())
+	}
+
 	listed := ms.Topo.ToTopologyInfo(topology.NoVolumes())
-	err := stream.Send(&master_pb.VolumeListStreamResponse{
+	err = stream.Send(&master_pb.VolumeListStreamResponse{
 		Header: &master_pb.VolumeListResponse{
 			TopologyInfo:      listed,
 			VolumeSizeLimitMb: uint64(ms.option.VolumeSizeLimitMB),
@@ -314,7 +324,7 @@ func (ms *MasterServer) VolumeListStream(req *master_pb.VolumeListRequest, strea
 		return err
 	}
 
-	return ms.Topo.StreamVolumes(listed, topology.NewVolumeFilter(req), 0, stream.Send)
+	return ms.Topo.StreamVolumes(listed, filter, 0, stream.Send)
 }
 
 func (ms *MasterServer) LookupEcVolume(ctx context.Context, req *master_pb.LookupEcVolumeRequest) (*master_pb.LookupEcVolumeResponse, error) {

--- a/weed/topology/volume_filter.go
+++ b/weed/topology/volume_filter.go
@@ -29,6 +29,12 @@ func NoVolumes() VolumeFilter {
 // than the wrong thing.
 func NewVolumeFilter(req *master_pb.VolumeListRequest) VolumeFilter {
 	var filter VolumeFilter
+
+	if req.WithoutVolumes {
+		filter.nothing = true
+		return filter
+	}
+
 	switch {
 	case req.Collection != "":
 		collection := req.Collection

--- a/weed/topology/volume_filter.go
+++ b/weed/topology/volume_filter.go
@@ -1,6 +1,8 @@
 package topology
 
 import (
+	"errors"
+
 	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
 	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
 	"github.com/seaweedfs/seaweedfs/weed/util/wildcard"
@@ -26,13 +28,19 @@ func NoVolumes() VolumeFilter {
 
 // NewVolumeFilter reads what a VolumeList request asked for, where empty and
 // zero mean everything so a caller that forgets to narrow gets too much rather
-// than the wrong thing.
-func NewVolumeFilter(req *master_pb.VolumeListRequest) VolumeFilter {
+// than the wrong thing. The exception is topology_only, which asks for no
+// volumes at all: pairing it with a selector is refused rather than resolved,
+// since either reading would silently drop half the request.
+func NewVolumeFilter(req *master_pb.VolumeListRequest) (VolumeFilter, error) {
 	var filter VolumeFilter
 
 	if req.TopologyOnly {
+		if req.Collection != "" || len(req.VolumeIds) > 0 || req.DefaultCollectionOnly ||
+			req.RemoteStorageName != "" || req.LocalVolumeOnly {
+			return filter, errors.New("topology_only asks for no volumes, so it cannot be combined with collection, volume_ids, default_collection_only, remote_storage_name or local_volume_only")
+		}
 		filter.nothing = true
-		return filter
+		return filter, nil
 	}
 
 	switch {
@@ -57,7 +65,7 @@ func NewVolumeFilter(req *master_pb.VolumeListRequest) VolumeFilter {
 			filter.VolumeIds[needle.VolumeId(volumeId)] = struct{}{}
 		}
 	}
-	return filter
+	return filter, nil
 }
 
 // SelectsEverything lets a caller size its result for the whole disk up front.

--- a/weed/topology/volume_filter.go
+++ b/weed/topology/volume_filter.go
@@ -30,7 +30,7 @@ func NoVolumes() VolumeFilter {
 func NewVolumeFilter(req *master_pb.VolumeListRequest) VolumeFilter {
 	var filter VolumeFilter
 
-	if req.WithoutVolumes {
+	if req.TopologyOnly {
 		filter.nothing = true
 		return filter
 	}

--- a/weed/topology/volume_filter_test.go
+++ b/weed/topology/volume_filter_test.go
@@ -243,7 +243,11 @@ func TestNewVolumeFilterReadsTheRequest(t *testing.T) {
 		{"both", &master_pb.VolumeListRequest{Collection: "c", DefaultCollectionOnly: true}, "c"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := collectionOf(NewVolumeFilter(tc.request)); got != tc.want {
+			filter, err := NewVolumeFilter(tc.request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := collectionOf(filter); got != tc.want {
 				t.Errorf("selected collection %q, want %q", got, tc.want)
 			}
 		})
@@ -275,7 +279,11 @@ func TestNewVolumeFilterReadsTheRemoteStorageRequest(t *testing.T) {
 		{"both", &master_pb.VolumeListRequest{RemoteStorageName: "s3.backup", LocalVolumeOnly: true}, "s3.backup"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := remoteStorageOf(NewVolumeFilter(tc.request)); got != tc.want {
+			filter, err := NewVolumeFilter(tc.request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := remoteStorageOf(filter); got != tc.want {
 				t.Errorf("selected remote storage %q, want %q", got, tc.want)
 			}
 		})
@@ -307,8 +315,59 @@ func TestNewVolumeFilterReadsTheVolumeIds(t *testing.T) {
 		{"a zero among the ids", &master_pb.VolumeListRequest{VolumeIds: []uint32{0}}, []uint32{0}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := idsOf(NewVolumeFilter(tc.request)); !equalIds(got, tc.want) {
+			filter, err := NewVolumeFilter(tc.request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := idsOf(filter); !equalIds(got, tc.want) {
 				t.Errorf("selected volume ids %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// topology_only leaves out the ec shards too, not just the volumes; the disks
+// and their counters stay.
+func TestNewVolumeFilterReadsTopologyOnly(t *testing.T) {
+	topo := filterTestTopology(t)
+	filter, err := NewVolumeFilter(&master_pb.VolumeListRequest{TopologyOnly: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	info := topo.ToTopologyInfo(filter)
+	volumes, ecVolumes := listed(info)
+	if len(volumes) != 0 || len(ecVolumes) != 0 {
+		t.Errorf("listed volumes %v and ec volumes %v, want neither", volumes, ecVolumes)
+	}
+
+	full := topo.ToTopologyInfo(VolumeFilter{})
+	fullDisk := full.DataCenterInfos[0].RackInfos[0].DataNodeInfos[0].DiskInfos[""]
+	disk := info.DataCenterInfos[0].RackInfos[0].DataNodeInfos[0].DiskInfos[""]
+	if disk == nil {
+		t.Fatal("the topology_only listing dropped the disk")
+	}
+	if disk.VolumeCount != fullDisk.VolumeCount || disk.MaxVolumeCount != fullDisk.MaxVolumeCount {
+		t.Errorf("disk counters %d/%d, want the full listing's %d/%d",
+			disk.VolumeCount, disk.MaxVolumeCount, fullDisk.VolumeCount, fullDisk.MaxVolumeCount)
+	}
+}
+
+// Selecting volumes in a request that asks for none is a caller bug, refused
+// rather than resolved either way in silence.
+func TestNewVolumeFilterRefusesTopologyOnlyWithSelectors(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		request *master_pb.VolumeListRequest
+	}{
+		{"a collection", &master_pb.VolumeListRequest{TopologyOnly: true, Collection: "c"}},
+		{"volume ids", &master_pb.VolumeListRequest{TopologyOnly: true, VolumeIds: []uint32{1}}},
+		{"the default collection", &master_pb.VolumeListRequest{TopologyOnly: true, DefaultCollectionOnly: true}},
+		{"a remote storage", &master_pb.VolumeListRequest{TopologyOnly: true, RemoteStorageName: "s3.backup"}},
+		{"the local volumes", &master_pb.VolumeListRequest{TopologyOnly: true, LocalVolumeOnly: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := NewVolumeFilter(tc.request); err == nil {
+				t.Error("expected the contradiction refused, got a filter")
 			}
 		})
 	}


### PR DESCRIPTION
# What problem are we solving?
fix https://github.com/seaweedfs/seaweedfs/issues/8882


# How are we solving the problem?
add a new field `topology_only` in `VolumeListRequest`

# How is the PR tested?



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to retrieve volume topology—including disks and counters—without individual volumes or erasure-coded shards.
  * Reduced response data when only topology information is needed.

* **Bug Fixes**
  * Requests combining topology-only mode with volume selectors are now rejected with a clear error instead of being partially applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
