### PR TITLE
shell: keep noLock to the command that set it

### DIFF
--- a/weed/server/master_server.go
+++ b/weed/server/master_server.go
@@ -473,6 +473,11 @@ func processEachCmd(reg *regexp.Regexp, line string, commandEnv *shell.CommandEn
 				continue
 			}
 			glog.V(0).Infof("executing: %s %v", cmd, args)
+			// noLock belongs to the invocation that set it, not to the
+			// CommandEnv this loop reuses for every line of the script. Without
+			// this, a dry run earlier in the script leaves the mutations after
+			// it unlocked.
+			commandEnv.SetNoLock(false)
 			if err := c.Do(args, commandEnv, os.Stdout); err != nil {
 				glog.V(0).Infof("error: %v", err)
 			}

--- a/weed/shell/shell_liner.go
+++ b/weed/shell/shell_liner.go
@@ -141,6 +141,12 @@ func processEachCmd(cmd string, commandEnv *CommandEnv) bool {
 			foundCommand := false
 			for _, c := range Commands {
 				if c.Name() == cmd || c.Name() == "fs."+cmd {
+					// noLock says "this invocation changes nothing", which is a
+					// property of the invocation and not of the session. A
+					// command that set it for a dry run would otherwise leave
+					// every later command in the session unlocked, so a real
+					// mutation right after a simulation would skip its lock.
+					commandEnv.SetNoLock(false)
 					if err := c.Do(args, commandEnv, os.Stdout); err != nil {
 						fmt.Fprintf(os.Stderr, "error: %v\n", err)
 					}

--- a/weed/shell/shell_nolock_scope_test.go
+++ b/weed/shell/shell_nolock_scope_test.go
@@ -1,0 +1,48 @@
+package shell
+
+import (
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/cluster"
+	"github.com/seaweedfs/seaweedfs/weed/wdclient/exclusive_locks"
+)
+
+// noLock says "this invocation changes nothing" -- volume.balance,
+// volume.fix.replication and others set it for a dry run. It is a property of
+// the invocation, not of the session: the CommandEnv is reused across every
+// command, so without a reset a simulation leaves later commands unlocked and a
+// real mutation run straight after one skips its lock silently.
+func TestNoLockDoesNotOutliveTheCommandThatSetIt(t *testing.T) {
+	env := &CommandEnv{locker: exclusive_locks.NewExclusiveLocker(nil, cluster.AdminShellLockName)}
+
+	env.SetNoLock(true)
+	if err := env.confirmIsLocked([]string{"volume.balance"}); err != nil {
+		t.Fatalf("a dry run needs no lock: %v", err)
+	}
+
+	env.SetNoLock(false)
+
+	if err := env.confirmIsLocked([]string{"volume.move"}); err == nil {
+		t.Error("the next command mutates and must require the lock again")
+	}
+}
+
+// Both dispatchers reuse one CommandEnv: the interactive shell across the lines
+// an operator types, and the master's maintenance script runner across the lines
+// of a script. Resetting has to restore the lock requirement however many
+// invocations share the environment.
+func TestNoLockResetRestoresTheRequirementForEveryInvocation(t *testing.T) {
+	env := &CommandEnv{locker: exclusive_locks.NewExclusiveLocker(nil, cluster.AdminShellLockName)}
+
+	for i := 0; i < 3; i++ {
+		env.SetNoLock(true)
+		if err := env.confirmIsLocked([]string{"dry run"}); err != nil {
+			t.Fatalf("run %d: a dry run needs no lock: %v", i, err)
+		}
+
+		env.SetNoLock(false)
+		if err := env.confirmIsLocked([]string{"mutation"}); err == nil {
+			t.Fatalf("run %d: the mutation after it must require the lock again", i)
+		}
+	}
+}


### PR DESCRIPTION
`noLock` outlives the command that set it.

It means "this invocation changes nothing" — `volume.balance`, `volume.move`,
`volume.copy`, `volume.merge` and `volume.fix.replication` all set it for a dry
run, and none of them clears it. The `CommandEnv` is created once and reused by
both dispatchers, so:

```
> volume.balance -noLock     # a simulation, changes nothing
> volume.move ...            # mutates, and skips its lock
```

Every lock-requiring command run after a simulation skips its lock, and nothing
reports it — the operator sees the command succeed.

Both dispatchers are affected and both are fixed: the interactive shell
(`shell_liner.go`), across the lines an operator types, and the master's
maintenance script runner (`master_server.go`), across the lines of a
`master.maintenance.scripts` script. The reset goes immediately before dispatch,
where the invocation begins — `noLock` describes an invocation, not a session.

`forceNoLock` is deliberately untouched. It is set once, explicitly, for a
trusted path, and should stay in force.

Two tests, mutation-checked: making `SetNoLock` sticky (`ce.noLock || noLock`)
fails the scope test.

`go vet` clean; `weed/shell` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed command execution so dry-run settings no longer carry over to later commands.
  * Mutating commands once again correctly require locking after a preceding dry-run command.
  * Improved consistency across interactive shell sessions and maintenance scripts.

* **Tests**
  * Added coverage verifying that lock settings reset correctly for each command invocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->