### PR TITLE
master: scope the startup capacity shed to a truly empty topology

### DIFF
--- a/weed/server/master_grpc_server_assign.go
+++ b/weed/server/master_grpc_server_assign.go
@@ -117,8 +117,12 @@ func (ms *MasterServer) Assign(ctx context.Context, req *master_pb.AssignRequest
 		fid, count, dnList, shouldGrow, err := ms.Topo.PickForWrite(req.Count, option, vl, req.ExpectedDataSize)
 		if shouldGrow && !initiatedGrow && !ms.option.VolumeGrowthDisabled && vl.AddGrowRequestIfAbsent() {
 			initiatedGrow = true
-			if err != nil && ms.Topo.AvailableSpaceFor(option) <= 0 && ms.Topo.CapacityFor(option) > 0 {
-				err = fmt.Errorf("%s and no free volumes left for %s", err.Error(), option.String())
+			if err != nil && ms.Topo.AvailableSpaceFor(option) <= 0 {
+				if ms.Topo.CapacityFor(option) > 0 {
+					err = fmt.Errorf("%s and no free volumes left for %s", err.Error(), option.String())
+				} else if ms.Topo.CapacityForAnyDisk() > 0 {
+					err = fmt.Errorf("%s and no volume server carries disk type %q for %s", err.Error(), option.DiskType.ReadableString(), option.String())
+				}
 			}
 			ms.volumeGrowthRequestChan <- &topology.VolumeGrowRequest{
 				Option: option,
@@ -136,13 +140,17 @@ func (ms *MasterServer) Assign(ctx context.Context, req *master_pb.AssignRequest
 			}
 			if shouldGrow {
 				if ms.Topo.AvailableSpaceFor(option) <= 0 {
-					if ms.Topo.CapacityFor(option) > 0 {
-						break // out of space: surface the real error, not a retryable shed
+					// Fail fast whenever any capacity is registered: full for
+					// this medium, or a medium no volume server serves — a
+					// state a heartbeat won't change, so a retryable shed
+					// would loop until the client's deadline. Shed retryably
+					// only while nothing at all has registered, a just-started
+					// cluster whose volume servers have not heartbeated, so
+					// the first write rides out the startup window instead of
+					// failing outright.
+					if ms.Topo.CapacityForAnyDisk() > 0 {
+						break // surface the real error, not a retryable shed
 					}
-					// No capacity registered for this disk type yet, typically a
-					// just-started cluster whose volume servers have not
-					// heartbeated. Shed retryably so the first write rides out
-					// the startup window instead of failing outright.
 					return nil, status.Errorf(codes.ResourceExhausted, "no volume server capacity registered yet for %s", option.String())
 				}
 				// Only the initiator waits, and only while the growth it triggered

--- a/weed/server/master_grpc_server_assign.go
+++ b/weed/server/master_grpc_server_assign.go
@@ -117,12 +117,8 @@ func (ms *MasterServer) Assign(ctx context.Context, req *master_pb.AssignRequest
 		fid, count, dnList, shouldGrow, err := ms.Topo.PickForWrite(req.Count, option, vl, req.ExpectedDataSize)
 		if shouldGrow && !initiatedGrow && !ms.option.VolumeGrowthDisabled && vl.AddGrowRequestIfAbsent() {
 			initiatedGrow = true
-			if err != nil && ms.Topo.AvailableSpaceFor(option) <= 0 {
-				if ms.Topo.CapacityFor(option) > 0 {
-					err = fmt.Errorf("%s and no free volumes left for %s", err.Error(), option.String())
-				} else if ms.Topo.CapacityForAnyDisk() > 0 {
-					err = fmt.Errorf("%s and no volume server carries disk type %q for %s", err.Error(), option.DiskType.ReadableString(), option.String())
-				}
+			if err != nil && ms.Topo.AvailableSpaceFor(option) <= 0 && ms.Topo.CapacityFor(option) > 0 {
+				err = fmt.Errorf("%s and no free volumes left for %s", err.Error(), option.String())
 			}
 			ms.volumeGrowthRequestChan <- &topology.VolumeGrowRequest{
 				Option: option,
@@ -149,6 +145,13 @@ func (ms *MasterServer) Assign(ctx context.Context, req *master_pb.AssignRequest
 					// the first write rides out the startup window instead of
 					// failing outright.
 					if ms.Topo.CapacityForAnyDisk() > 0 {
+						if ms.Topo.CapacityFor(option) <= 0 {
+							// Wrapped here, not beside the "no free volumes left"
+							// wrap above, so followers and growth-disabled
+							// masters name the unserved medium too — the
+							// initiator block is skipped for both.
+							lastErr = fmt.Errorf("%s and no volume server carries disk type %q for %s", err.Error(), option.DiskType.ReadableString(), option.String())
+						}
 						break // surface the real error, not a retryable shed
 					}
 					return nil, status.Errorf(codes.ResourceExhausted, "no volume server capacity registered yet for %s", option.String())

--- a/weed/server/master_grpc_server_assign_test.go
+++ b/weed/server/master_grpc_server_assign_test.go
@@ -232,26 +232,44 @@ func TestAssignShedsRetryablyBeforeCapacityRegisters(t *testing.T) {
 // A cluster serving only other media is not one still starting up: capacity for
 // the requested disk type will never register, so the startup shed would loop
 // until the client's deadline. Assign must fail fast with the real error and
-// name the unserved medium.
+// name the unserved medium — for the growth initiator, for a follower whose
+// growth is already in flight, and when growth is disabled outright.
 func TestAssignFailsFastWhenDiskTypeUnserved(t *testing.T) {
-	ms := newLeaderMaster()
-	// ssd capacity registered, but the request asks for the default (hdd).
-	ms.Topo.GetOrCreateDataCenter("dc1").GetOrCreateRack("rack1").
-		GetOrCreateDataNode("127.0.0.1", 8080, 18080, "127.0.0.1", "dn1", map[string]uint32{"ssd": 1})
-
-	req := &master_pb.AssignRequest{Count: 1, Replication: "000", Collection: "fresh"}
-
-	start := time.Now()
-	resp, err := ms.Assign(context.Background(), req)
-	elapsed := time.Since(start)
-
-	require.Error(t, err)
-	require.Nil(t, resp)
-	if st, ok := status.FromError(err); ok {
-		assert.NotEqual(t, codes.Unavailable, st.Code())
-		assert.NotEqual(t, codes.ResourceExhausted, st.Code())
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, ms *MasterServer, req *master_pb.AssignRequest)
+	}{
+		{"initiator", func(t *testing.T, ms *MasterServer, req *master_pb.AssignRequest) {}},
+		{"follower joins growth in flight", func(t *testing.T, ms *MasterServer, req *master_pb.AssignRequest) {
+			markGrowthInFlight(t, ms.Topo, req)
+		}},
+		{"growth disabled", func(t *testing.T, ms *MasterServer, req *master_pb.AssignRequest) {
+			ms.option.VolumeGrowthDisabled = true
+		}},
 	}
-	assert.Contains(t, err.Error(), topology.NoWritableVolumes)
-	assert.Contains(t, err.Error(), `no volume server carries disk type "hdd"`)
-	assert.Less(t, elapsed, 2*time.Second)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ms := newLeaderMaster()
+			// ssd capacity registered, but the request asks for the default (hdd).
+			ms.Topo.GetOrCreateDataCenter("dc1").GetOrCreateRack("rack1").
+				GetOrCreateDataNode("127.0.0.1", 8080, 18080, "127.0.0.1", "dn1", map[string]uint32{"ssd": 1})
+
+			req := &master_pb.AssignRequest{Count: 1, Replication: "000", Collection: "fresh"}
+			tc.setup(t, ms, req)
+
+			start := time.Now()
+			resp, err := ms.Assign(context.Background(), req)
+			elapsed := time.Since(start)
+
+			require.Error(t, err)
+			require.Nil(t, resp)
+			if st, ok := status.FromError(err); ok {
+				assert.NotEqual(t, codes.Unavailable, st.Code())
+				assert.NotEqual(t, codes.ResourceExhausted, st.Code())
+			}
+			assert.Contains(t, err.Error(), topology.NoWritableVolumes)
+			assert.Contains(t, err.Error(), `no volume server carries disk type "hdd"`)
+			assert.Less(t, elapsed, 2*time.Second)
+		})
+	}
 }

--- a/weed/server/master_grpc_server_assign_test.go
+++ b/weed/server/master_grpc_server_assign_test.go
@@ -228,3 +228,30 @@ func TestAssignShedsRetryablyBeforeCapacityRegisters(t *testing.T) {
 	assert.Equal(t, codes.ResourceExhausted, st.Code())
 	assert.Less(t, elapsed, 2*time.Second)
 }
+
+// A cluster serving only other media is not one still starting up: capacity for
+// the requested disk type will never register, so the startup shed would loop
+// until the client's deadline. Assign must fail fast with the real error and
+// name the unserved medium.
+func TestAssignFailsFastWhenDiskTypeUnserved(t *testing.T) {
+	ms := newLeaderMaster()
+	// ssd capacity registered, but the request asks for the default (hdd).
+	ms.Topo.GetOrCreateDataCenter("dc1").GetOrCreateRack("rack1").
+		GetOrCreateDataNode("127.0.0.1", 8080, 18080, "127.0.0.1", "dn1", map[string]uint32{"ssd": 1})
+
+	req := &master_pb.AssignRequest{Count: 1, Replication: "000", Collection: "fresh"}
+
+	start := time.Now()
+	resp, err := ms.Assign(context.Background(), req)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.Nil(t, resp)
+	if st, ok := status.FromError(err); ok {
+		assert.NotEqual(t, codes.Unavailable, st.Code())
+		assert.NotEqual(t, codes.ResourceExhausted, st.Code())
+	}
+	assert.Contains(t, err.Error(), topology.NoWritableVolumes)
+	assert.Contains(t, err.Error(), `no volume server carries disk type "hdd"`)
+	assert.Less(t, elapsed, 2*time.Second)
+}

--- a/weed/topology/node.go
+++ b/weed/topology/node.go
@@ -320,6 +320,18 @@ func (n *NodeImpl) CapacityFor(option *VolumeGrowOption) int64 {
 	return atomic.LoadInt64(&t.maxVolumeCount) + atomic.LoadInt64(&t.remoteVolumeCount)
 }
 
+// CapacityForAnyDisk is the total registered volume slots across every disk
+// type. CapacityFor answers zero both while a cluster is still starting and
+// when it never serves the option's medium; this tells the two apart.
+func (n *NodeImpl) CapacityForAnyDisk() (total int64) {
+	n.diskUsages.RLock()
+	defer n.diskUsages.RUnlock()
+	for _, t := range n.diskUsages.usages {
+		total += atomic.LoadInt64(&t.maxVolumeCount) + atomic.LoadInt64(&t.remoteVolumeCount)
+	}
+	return
+}
+
 // AvailableSpaceForReservation returns available space considering existing reservations
 func (n *NodeImpl) AvailableSpaceForReservation(option *VolumeGrowOption) int64 {
 	baseAvailable := n.AvailableSpaceFor(option)


### PR DESCRIPTION
## What

#11032 made Assign shed a retryable `ResourceExhausted` ("no volume server capacity registered yet") when the requested disk type has zero registered capacity, so a first write could ride out the cluster-startup window. But the check is per disk type: on a cluster that serves only other media (e.g. ssd + a custom tag, no default hdd), capacity for the requested medium will **never** register, so every such assign sheds retryably until the client's deadline. A write asking for an unserved medium now hangs 30–120s inside the filer's retry loops and surfaces `context deadline exceeded` where it used to fail fast with `No writable volumes`.

## Fix

Shed retryably only while **no disk type at all** has registered capacity — the actual "volume servers have not heartbeated yet" signal from #11032's motivation. If other media have capacity but the requested one has none, fail fast with the real error, and name the unserved medium: `No writable volumes ... and no volume server carries disk type "hdd" for {...}`.

- `topology`: add `CapacityForAnyDisk()` beside `CapacityFor()` (max + remote slots summed across disk types).
- `master_grpc_server_assign.go`: gate the shed on `CapacityForAnyDisk() == 0`; extend the fail-fast error wrap to name the unserved disk type.
- Regression test `TestAssignFailsFastWhenDiskTypeUnserved`: ssd-only topology, default-medium assign → fast failure, not `ResourceExhausted`. The startup-window shed test from #11032 still passes.

Verified with `go test ./weed/server/ ./weed/topology/` and `go vet` on both packages.

https://claude.ai/code/session_01TF7FQghfDkpdoZgakTMX4R

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved volume growth failures when the requested disk type is unavailable.
  - Error messages now identify the unsupported disk type instead of returning a generic retryable capacity error.
  - Volume assignment no longer unnecessarily retries when capacity exists only on incompatible disk types.
  - Requests now fail faster for followers and when volume growth is disabled if no server supports the selected disk type.
  - Retryable capacity handling is preserved when no capacity is available for any disk type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->