### PR TITLE
shell: reset noLock in the admin script dispatcher too

### DIFF
--- a/weed/plugin/worker/admin_script_handler.go
+++ b/weed/plugin/worker/admin_script_handler.go
@@ -290,6 +290,11 @@ func (h *AdminScriptHandler) Execute(ctx context.Context, request *plugin_pb.Exe
 				continue
 			}
 			found = true
+			// The env is reused for every command in the script, and noLock
+			// belongs to the invocation that set it. ForceNoLock already exempts
+			// this path, so this changes nothing today -- it keeps the rule the
+			// same in all three dispatchers rather than resting on that.
+			commandEnv.SetNoLock(false)
 			if err := command.Do(cmd.Args, commandEnv, output); err != nil {
 				msg := fmt.Sprintf("%s: %v", cmd.Name, err)
 				errorMessages = append(errorMessages, msg)


### PR DESCRIPTION
Follow-up to #11052, which fixed two of three dispatchers.

Three reuse one `CommandEnv`: the interactive shell, the master's maintenance
script runner, and the plugin worker's admin script handler. #11052 reset the
first two; this is the third.

**It changes nothing today.** `buildAdminScriptCommandEnv` calls `ForceNoLock()`,
which short-circuits `confirmIsLocked` before `noLock` is consulted, and the env
is per-job so nothing crosses jobs either. The reset is here so the rule reads
the same in all three places rather than resting on that exemption staying in
place.

`weed/plugin/worker` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured each administrative script command consistently applies the configured locking rules, preventing settings from a previous command from affecting subsequent commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->