### PR TITLE
master: delete replica_placement_mismatch labels when volumes leave topology

### DIFF
--- a/weed/topology/topology.go
+++ b/weed/topology/topology.go
@@ -569,7 +569,7 @@ func (t *Topology) RegisterVolumeLayout(v storage.VolumeInfo, dn *DataNode) {
 func (t *Topology) UnRegisterVolumeLayout(v storage.VolumeInfo, dn *DataNode) {
 	glog.Infof("removing volume info: %+v from %v", v, dn.id)
 	if v.ReplicaPlacement.GetCopyCount() > 1 {
-		stats.MasterReplicaPlacementMismatch.WithLabelValues(v.Collection, v.Id.String()).Set(0)
+		stats.MasterReplicaPlacementMismatch.DeleteLabelValues(v.Collection, v.Id.String())
 	}
 	diskType := types.ToDiskType(v.DiskType)
 	volumeLayout := t.GetVolumeLayout(v.Collection, v.ReplicaPlacement, v.Ttl, diskType)

--- a/weed/topology/topology.go
+++ b/weed/topology/topology.go
@@ -568,12 +568,15 @@ func (t *Topology) RegisterVolumeLayout(v storage.VolumeInfo, dn *DataNode) {
 
 func (t *Topology) UnRegisterVolumeLayout(v storage.VolumeInfo, dn *DataNode) {
 	glog.Infof("removing volume info: %+v from %v", v, dn.id)
-	if v.ReplicaPlacement.GetCopyCount() > 1 {
-		stats.MasterReplicaPlacementMismatch.DeleteLabelValues(v.Collection, v.Id.String())
-	}
 	diskType := types.ToDiskType(v.DiskType)
 	volumeLayout := t.GetVolumeLayout(v.Collection, v.ReplicaPlacement, v.Ttl, diskType)
 	volumeLayout.UnRegisterVolume(&v, dn)
+	// Drop the series only after the last placement is gone. Deleting while
+	// another data node still holds v would hide under-replication until the
+	// next CollectDeadNodeAndFullVolumes cycle recreates the label.
+	if v.ReplicaPlacement.GetCopyCount() > 1 && len(t.Lookup(v.Collection, v.Id)) == 0 {
+		stats.MasterReplicaPlacementMismatch.DeleteLabelValues(v.Collection, v.Id.String())
+	}
 	if volumeLayout.isEmpty() {
 		t.DeleteLayout(v.Collection, v.ReplicaPlacement, v.Ttl, diskType)
 	}

--- a/weed/topology/topology_test.go
+++ b/weed/topology/topology_test.go
@@ -2,17 +2,18 @@ package topology
 
 import (
 	"reflect"
+	"testing"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
 	"github.com/seaweedfs/seaweedfs/weed/sequence"
+	"github.com/seaweedfs/seaweedfs/weed/stats"
 	"github.com/seaweedfs/seaweedfs/weed/storage"
 	"github.com/seaweedfs/seaweedfs/weed/storage/erasure_coding"
 	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
 	"github.com/seaweedfs/seaweedfs/weed/storage/super_block"
 	"github.com/seaweedfs/seaweedfs/weed/storage/types"
-
-	"testing"
 )
 
 func TestRemoveDataCenter(t *testing.T) {
@@ -232,6 +233,44 @@ func TestAddRemoveVolume(t *testing.T) {
 
 	if _, hasCollection := topo.FindCollection(v.Collection); hasCollection {
 		t.Errorf("collection %v should not exist", v.Collection)
+	}
+}
+
+func TestUnRegisterVolumeLayoutClearsReplicaPlacementMismatchMetric(t *testing.T) {
+	stats.MasterReplicaPlacementMismatch.Reset()
+	t.Cleanup(stats.MasterReplicaPlacementMismatch.Reset)
+
+	topo := NewTopology("weedfs", sequence.NewMemorySequencer(), 32*1024, 5, false)
+
+	dc := topo.GetOrCreateDataCenter("dc1")
+	rack := dc.GetOrCreateRack("rack1")
+	maxVolumeCounts := map[string]uint32{"": 25}
+	dn := rack.GetOrCreateDataNode("127.0.0.1", 34534, 0, "127.0.0.1", "", maxVolumeCounts)
+
+	rp, err := super_block.NewReplicaPlacementFromString("001")
+	if err != nil {
+		t.Fatalf("NewReplicaPlacementFromString: %v", err)
+	}
+	v := storage.VolumeInfo{
+		Id:               needle.VolumeId(42),
+		Size:             100,
+		Collection:       "metrics-test",
+		ReplicaPlacement: rp,
+		Ttl:              needle.EMPTY_TTL,
+	}
+
+	dn.UpdateVolumes([]storage.VolumeInfo{v})
+	topo.RegisterVolumeLayout(v, dn)
+
+	stats.MasterReplicaPlacementMismatch.WithLabelValues(v.Collection, v.Id.String()).Set(1)
+	if n := testutil.CollectAndCount(stats.MasterReplicaPlacementMismatch); n != 1 {
+		t.Fatalf("expected 1 replica_placement_mismatch series, got %d", n)
+	}
+
+	topo.UnRegisterVolumeLayout(v, dn)
+
+	if n := testutil.CollectAndCount(stats.MasterReplicaPlacementMismatch); n != 0 {
+		t.Errorf("%d replica_placement_mismatch series left after volume left topology", n)
 	}
 }
 

--- a/weed/topology/topology_test.go
+++ b/weed/topology/topology_test.go
@@ -274,6 +274,56 @@ func TestUnRegisterVolumeLayoutClearsReplicaPlacementMismatchMetric(t *testing.T
 	}
 }
 
+func TestUnRegisterVolumeLayoutKeepsReplicaPlacementMismatchMetricWhilePlacementsRemain(t *testing.T) {
+	stats.MasterReplicaPlacementMismatch.Reset()
+	t.Cleanup(stats.MasterReplicaPlacementMismatch.Reset)
+
+	topo := NewTopology("weedfs", sequence.NewMemorySequencer(), 32*1024, 5, false)
+
+	dc := topo.GetOrCreateDataCenter("dc1")
+	rack := dc.GetOrCreateRack("rack1")
+	maxVolumeCounts := map[string]uint32{"": 25}
+	dn1 := rack.GetOrCreateDataNode("127.0.0.1", 34534, 0, "127.0.0.1", "", maxVolumeCounts)
+	dn2 := rack.GetOrCreateDataNode("127.0.0.1", 34535, 0, "127.0.0.1", "", maxVolumeCounts)
+
+	rp, err := super_block.NewReplicaPlacementFromString("001")
+	if err != nil {
+		t.Fatalf("NewReplicaPlacementFromString: %v", err)
+	}
+	v := storage.VolumeInfo{
+		Id:               needle.VolumeId(42),
+		Size:             100,
+		Collection:       "metrics-test",
+		ReplicaPlacement: rp,
+		Ttl:              needle.EMPTY_TTL,
+	}
+
+	dn1.UpdateVolumes([]storage.VolumeInfo{v})
+	dn2.UpdateVolumes([]storage.VolumeInfo{v})
+	topo.RegisterVolumeLayout(v, dn1)
+	topo.RegisterVolumeLayout(v, dn2)
+
+	stats.MasterReplicaPlacementMismatch.WithLabelValues(v.Collection, v.Id.String()).Set(1)
+	if n := testutil.CollectAndCount(stats.MasterReplicaPlacementMismatch); n != 1 {
+		t.Fatalf("expected 1 replica_placement_mismatch series, got %d", n)
+	}
+
+	topo.UnRegisterVolumeLayout(v, dn1)
+
+	if n := testutil.CollectAndCount(stats.MasterReplicaPlacementMismatch); n != 1 {
+		t.Errorf("expected series to remain while %s still holds the volume, got %d", dn2.Id(), n)
+	}
+	if got := len(topo.Lookup(v.Collection, v.Id)); got != 1 {
+		t.Fatalf("expected 1 remaining placement, got %d", got)
+	}
+
+	topo.UnRegisterVolumeLayout(v, dn2)
+
+	if n := testutil.CollectAndCount(stats.MasterReplicaPlacementMismatch); n != 0 {
+		t.Errorf("%d replica_placement_mismatch series left after last placement left", n)
+	}
+}
+
 func TestVolumeReadOnlyStatusChange(t *testing.T) {
 	topo := NewTopology("weedfs", sequence.NewMemorySequencer(), 32*1024, 5, false)
 


### PR DESCRIPTION
Fixes #10804

## What problem are we solving?

The master exposes `weed_master_replica_placement_mismatch{collection, id}` to flag volumes whose replica count falls short of the configured placement. When a volume leaves the topology (volume server offline, volume deleted, layout unregistered), `UnRegisterVolumeLayout` cleared the gauge by setting it to `0`.

Prometheus keeps a time series for every distinct label combination, even when the value is zero. In clusters with high volume churn, those stale `{collection, id}` series accumulated without bound, inflating master memory use and `/metrics` scrape size.

## How are we solving the problem?

In `UnRegisterVolumeLayout`, replace `Set(0)` with `DeleteLabelValues(collection, id)` so the label set is removed when the volume leaves the topology. Live volumes still get updated to `0` or `1` during heartbeat collection in `node.go`; only the unregister path drops the series entirely.

## How is the PR tested?

Added `TestUnRegisterVolumeLayoutClearsReplicaPlacementMismatchMetric`:
- register a replicated volume in topology and set the gauge to `1`
- call `UnRegisterVolumeLayout`
- assert `CollectAndCount` returns `0` (no stale series remain)

## Checks

- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

### Checks for AI generated PRs

- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed replica placement mismatch metrics remaining visible after all placements for a replicated volume were unregistered.
  * Metrics now remain available while placements still exist and are removed once the final placement is unregistered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs/pull/11062" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->