### PR TITLE
s3api: stop retrying a definitive NotFound in getLatestObjectVersion

### DIFF
--- a/weed/s3api/s3api_object_versioning.go
+++ b/weed/s3api/s3api_object_versioning.go
@@ -1824,6 +1824,27 @@ func (s3a *S3ApiServer) getLatestObjectVersion(bucket, object string) (*filer_pb
 	return s3a.doGetLatestObjectVersion(bucket, object, 8)
 }
 
+// lookupVersionsEntryWithRetry retries a .versions directory lookup, but only
+// for errors that can change on retry (isRetryableFilerErr). A definitive
+// NotFound is an answer, not a transient failure: retrying it walks the whole
+// backoff ladder (12.7s at 8 attempts) before the caller's pre-versioning
+// fallback gets to run, stalling every missing-key retention/tagging/ACL call.
+func lookupVersionsEntryWithRetry(lookup func() (*filer_pb.Entry, error), maxRetries int) (entry *filer_pb.Entry, err error) {
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		entry, err = lookup()
+		if err == nil || !isRetryableFilerErr(err) {
+			return entry, err
+		}
+
+		if attempt < maxRetries {
+			// Exponential backoff with higher base: 100ms, 200ms, 400ms, 800ms, 1600ms, 3200ms, 6400ms
+			delay := time.Millisecond * time.Duration(100*(1<<(attempt-1)))
+			time.Sleep(delay)
+		}
+	}
+	return entry, err
+}
+
 func (s3a *S3ApiServer) doGetLatestObjectVersion(bucket, object string, maxRetries int) (*filer_pb.Entry, error) {
 	// Normalize object path to ensure consistency with toFilerPath behavior
 	normalizedObject := s3_constants.NormalizeObjectKey(object)
@@ -1834,20 +1855,9 @@ func (s3a *S3ApiServer) doGetLatestObjectVersion(bucket, object string, maxRetri
 	glog.V(1).Infof("doGetLatestObjectVersion: looking for latest version of %s/%s (normalized: %s, retries: %d)", bucket, object, normalizedObject, maxRetries)
 
 	// Get the .versions directory entry to read latest version metadata with retry logic for filer consistency
-	var versionsEntry *filer_pb.Entry
-	var err error
-	for attempt := 1; attempt <= maxRetries; attempt++ {
-		versionsEntry, err = s3a.getEntry(bucketDir, versionsObjectPath)
-		if err == nil {
-			break
-		}
-
-		if attempt < maxRetries {
-			// Exponential backoff with higher base: 100ms, 200ms, 400ms, 800ms, 1600ms, 3200ms, 6400ms
-			delay := time.Millisecond * time.Duration(100*(1<<(attempt-1)))
-			time.Sleep(delay)
-		}
-	}
+	versionsEntry, err := lookupVersionsEntryWithRetry(func() (*filer_pb.Entry, error) {
+		return s3a.getEntry(bucketDir, versionsObjectPath)
+	}, maxRetries)
 
 	if err != nil {
 		// .versions directory doesn't exist - this can happen for objects that existed

--- a/weed/s3api/s3api_object_versioning_lookup_retry_test.go
+++ b/weed/s3api/s3api_object_versioning_lookup_retry_test.go
@@ -1,0 +1,62 @@
+package s3api
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// A definitive NotFound (or an aborted request) is an answer, not a transient
+// failure. Walking the full backoff ladder before the pre-versioning fallback
+// turned every missing-key GetObjectRetention into a 12.7s stall in the field.
+func TestLookupVersionsEntryTerminalErrorsSkipTheLadder(t *testing.T) {
+	for _, terminal := range []error{
+		filer_pb.ErrNotFound,
+		fmt.Errorf("wrapped: %w", filer_pb.ErrNotFound),
+		status.Error(codes.NotFound, "gone"),
+		context.Canceled,
+		status.Error(codes.DeadlineExceeded, "context deadline exceeded"),
+	} {
+		calls := 0
+		entry, err := lookupVersionsEntryWithRetry(func() (*filer_pb.Entry, error) {
+			calls++
+			return nil, terminal
+		}, 8)
+		assert.Nil(t, entry)
+		assert.Equal(t, terminal, err)
+		assert.Equal(t, 1, calls, "%v is definitive, no retry", terminal)
+	}
+}
+
+// Transient filer errors keep the original retry-with-backoff behavior.
+func TestLookupVersionsEntryTransientErrorsStillRetry(t *testing.T) {
+	want := &filer_pb.Entry{Name: "obj" + ".versions"}
+	calls := 0
+	entry, err := lookupVersionsEntryWithRetry(func() (*filer_pb.Entry, error) {
+		calls++
+		if calls < 3 {
+			return nil, status.Error(codes.Unavailable, "transport is closing")
+		}
+		return want, nil
+	}, 8)
+	assert.NoError(t, err)
+	assert.Same(t, want, entry)
+	assert.Equal(t, 3, calls)
+}
+
+// Exhausting the attempts surfaces the last transient error to the caller.
+func TestLookupVersionsEntryTransientExhaustionReturnsLastErr(t *testing.T) {
+	calls := 0
+	entry, err := lookupVersionsEntryWithRetry(func() (*filer_pb.Entry, error) {
+		calls++
+		return nil, status.Error(codes.Unavailable, "still down")
+	}, 2)
+	assert.Nil(t, entry)
+	assert.Error(t, err)
+	assert.Equal(t, 2, calls)
+}


### PR DESCRIPTION
## What

`doGetLatestObjectVersion` retried the `.versions/` directory lookup on **any** error, including a definitive `filer_pb.ErrNotFound`. With 8 attempts and exponential backoff (100ms..6.4s) the ladder sums to exactly 12.7s before the cheap pre-versioning fallback ever runs, so on a versioned bucket every retention/tagging/ACL/attributes call for a missing key stalled 12.7s and then returned `NoSuchKey` anyway. Measured in the field at 12.73s per call (Veeam workloads probe object retention on keys that don't exist yet, so this bites continuously).

This gates the retry loop on `isRetryableFilerErr` — the same classifier `retryFilerOp` already uses — so a definitive NotFound (sentinel or gRPC `codes.NotFound`) falls through to the pre-versioning fallback immediately, and a canceled/deadline-exceeded caller stops burning goroutine time. Transient errors (`Unavailable`, network, store overload) keep the existing backoff behavior, and the retry count is unchanged.

## Why breaking on NotFound is safe

`GetObjectHandler` already treats NotFound on `.versions/` as definitive (the "quick check (no retries)" optimization) — that's why a plain GET of the same missing key returns instantly today while retention calls stall. This just brings all the other paths that resolve the latest version (`GetObjectRetention`/`PutObjectRetention`, tagging, ACL, attributes, versioned delete, copy) in line with the stance GET and `retryFilerOp` already took.

The ladder in `updateLatestVersionInDirectory` is deliberately left alone: there the same request just created `.versions/`, so a NotFound genuinely can be transient under an eventually-consistent filer setup.

## Tests

Extracted the loop into `lookupVersionsEntryWithRetry(lookup, maxRetries)` so it is unit-testable:
- terminal errors (NotFound sentinel, wrapped, gRPC NotFound, canceled, deadline) take exactly one attempt
- transient `Unavailable` still retries with backoff and succeeds
- exhaustion surfaces the last error

`go test ./weed/s3api/...` green.

https://claude.ai/code/session_01FquvGtTD2zA3uMZGQHAuV4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved object version lookups to retry temporary service errors while returning definitive errors immediately.
  - Preserved fallback handling for objects created before versioning was enabled.
  - Improved behavior when transient lookup failures continue through all retry attempts.

- **Tests**
  - Added coverage for terminal errors, temporary failures, cancellation, deadlines, and retry exhaustion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->