### PR TITLE
s3api: push the listing prefix down to the filer in ListObjectVersions

### DIFF
--- a/weed/s3api/s3api_object_versioning.go
+++ b/weed/s3api/s3api_object_versioning.go
@@ -550,6 +550,37 @@ func (vc *versionCollector) computeStartFrom(relativePath string) (startFrom str
 	return remainder, true
 }
 
+// computeListPrefix returns the name prefix that every entry of the directory
+// at relativePath must carry to be relevant to vc.prefix: the next path
+// component of the requested prefix under that directory. Pushing it into the
+// filer listing stops unrelated siblings from being transferred and scanned at
+// every level on the way down to the prefix. A name can hold no slash, so a
+// directory whose name does not start with this component cannot contain a
+// matching key, and a file whose name does not start with it cannot be one.
+// Inside the prefix zone (and without a prefix) it returns "" - no constraint.
+func (vc *versionCollector) computeListPrefix(relativePath string) string {
+	if vc.prefix == "" {
+		return ""
+	}
+
+	var remainder string
+	if relativePath == "" {
+		remainder = vc.prefix
+	} else if strings.HasPrefix(vc.prefix, relativePath+"/") {
+		remainder = vc.prefix[len(relativePath)+1:]
+	} else {
+		// The walk only enters a directory that matches the prefix or can
+		// descend toward it; one the prefix does not extend into means the
+		// whole directory is inside the prefix zone.
+		return ""
+	}
+
+	if idx := strings.Index(remainder, "/"); idx >= 0 {
+		return remainder[:idx]
+	}
+	return remainder
+}
+
 // shouldSkipObjectForMarker returns true if the object should be skipped based on keyMarker
 func (vc *versionCollector) shouldSkipObjectForMarker(objectKey string) bool {
 	if vc.keyMarker == "" {
@@ -794,12 +825,13 @@ func (vc *versionCollector) collectVersions(currentPath, relativePath string) er
 		startFrom = markerStart
 		inclusive = true
 	}
+	listPrefix := vc.computeListPrefix(relativePath)
 	for {
 		if vc.isFull() {
 			return nil
 		}
 
-		entries, isLast, err := vc.s3a.list(currentPath, "", startFrom, inclusive, filer.PaginationSize)
+		entries, isLast, err := vc.s3a.list(currentPath, listPrefix, startFrom, inclusive, filer.PaginationSize)
 		// After the first batch, use exclusive mode for standard pagination
 		inclusive = false
 		if err != nil {

--- a/weed/s3api/s3api_object_versioning_list_prefix_test.go
+++ b/weed/s3api/s3api_object_versioning_list_prefix_test.go
@@ -1,0 +1,41 @@
+package s3api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The component handed to the filer must keep every entry that can match or
+// descend toward the requested prefix at that directory level, while excluding
+// siblings that cannot: a name holds no slash, so a directory not starting
+// with the component cannot contain a matching key.
+func TestComputeListPrefix(t *testing.T) {
+	cases := []struct {
+		prefix       string
+		relativePath string
+		want         string
+	}{
+		{"", "", ""},
+		{"", "a/b", ""},
+		{"a/b/c", "", "a"},
+		{"a/b/c", "a", "b"},
+		{"a/b/c", "a/b", "c"},
+		// at or inside the prefix zone: no constraint
+		{"a/b/c", "a/b/c", ""},
+		{"a/b/", "a/b", ""},
+		{"a", "a/sub", ""},
+		// partial component narrows the listing but keeps deeper matches
+		// ("a/bc" keeps dir "bc", file "bcd", and "bc.versions" at level "a")
+		{"a/bc", "a", "bc"},
+		{"abc", "", "abc"},
+		// a directory off the prefix path is inside the zone by construction
+		{"a/b/c", "x", ""},
+	}
+
+	for _, tc := range cases {
+		vc := &versionCollector{prefix: tc.prefix}
+		assert.Equal(t, tc.want, vc.computeListPrefix(tc.relativePath),
+			"prefix %q at %q", tc.prefix, tc.relativePath)
+	}
+}


### PR DESCRIPTION
Part of a ListObjectVersions performance series (with #11067 and #11068), from a field case: an S3 gateway pinned at 4-4.5 cores with 365 goroutines inside the version-listing walk on ~37M-row versioned buckets.

## What

The recursive version walk called `s3a.list(dir, "", startFrom, …)` with an **empty prefix** at every directory level, then filtered gateway-side in `matchesPrefixFilter`. Two costs follow on every page of every request:

- every directory along the requested prefix's path is transferred and proto-decoded in full, 1024 entries per batch, however many siblings are irrelevant (all the other orgs/jobs/mailboxes next to the one being listed);
- the loop has no early stop, so it keeps paging a directory even after names sort past the point where anything can still match.

This derives the next path component of the requested prefix for each directory level (`computeListPrefix`) and hands it to the filer listing — the same prefix parameter the regular ListObjects path already uses. Filer stores with native prefixed listing (sql, leveldb, …) turn it into a range scan that also ends the stream at the end of the prefix zone, killing both costs.

## Why the component is safe

An entry name can hold no slash. So at a level where the remaining prefix is `bc` or `bc/…`: a directory whose name does not start with `bc` cannot contain a matching key (its keys all continue with `/` where the prefix demands `c`), a file whose name does not start with `bc` cannot be one, and an object's `.versions` directory (`<name>.versions`) starts with its object's name. Names that start with the component but ultimately don't match still arrive and still get dropped by the existing gateway-side filter — the pushdown only removes entries that provably cannot matter. Inside the prefix zone (and with no prefix) the component is empty and behavior is byte-for-byte today's.

## Tests

- `TestComputeListPrefix` unit-tests the component derivation (root/deep/partial-component/inside-zone/off-path cases).
- `go test ./weed/s3api/...` green.
- Full `test/s3/versioning` integration suite run locally against a `weed mini` built from this branch: green — delimiter, list-marker, listing-parity (incl. partial key fragments and prefix-is-exactly-an-object), deleted-prefix, hidden-version, deep-prefix, plus the three pagination stress tests with `ENABLE_STRESS_TESTS=true`. The one failure, `TestVersionedObjectAcl`, fails identically against a stock master binary under the same local harness (PutObjectAcl 403 with the compose s3.json), i.e. pre-existing and environmental.

https://claude.ai/code/session_01FquvGtTD2zA3uMZGQHAuV4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved object version listing so requests with prefixes avoid scanning or transferring unrelated sibling entries.
  * Ensured listings follow the requested path more precisely, including partial and nested prefixes.

* **Tests**
  * Added coverage for empty, partial, trailing-slash, and nested prefix scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->