### PR TITLE
deps: drop the apache/thrift replace, v0.24.0 carries the 32-bit fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -516,13 +516,6 @@ require (
 
 // replace github.com/seaweedfs/raft => /Users/chrislu/go/src/github.com/seaweedfs/raft
 
-// apache/thrift v0.23.0 fixes CVE-2026-41602 but compares int against the
-// untyped math.MaxUint32 in lib/go/thrift/framed_transport.go, which overflows
-// int on 32-bit GOARCHes (e.g. openbsd/arm, linux/arm) and fails to compile.
-// Upstream fixed the range check post-release; pin to that commit until the
-// next tagged release carries both the CVE fix and the 32-bit fix.
-replace github.com/apache/thrift => github.com/apache/thrift v0.23.1-0.20260429145742-d2acd3c49e58
-
 // tyler-smith/go-bip39 was deleted from GitHub, so `go mod download` fails for
 // anyone resolving it directly (GOPROXY=direct). It only reaches us transitively
 // through rclone's internxt backend, which calls IsMnemonicValid and NewSeed.

--- a/go.sum
+++ b/go.sum
@@ -692,8 +692,9 @@ github.com/apache/cassandra-gocql-driver/v2 v2.1.2 h1:lu/p0Db2av18enHJvWJQoChLss
 github.com/apache/cassandra-gocql-driver/v2 v2.1.2/go.mod h1:QH/asJjB3mHvY6Dot6ZKMMpTcOrWJ8i9GhsvG1g0PK4=
 github.com/apache/iceberg-go v0.6.0 h1:tOVhC5BhBOEgPTowo5AVrPnAgsDo00qEbUPprFcLd4s=
 github.com/apache/iceberg-go v0.6.0/go.mod h1:kESfDlyaW/6hK0WW6TzA4EWps+0NMhhrDYE4qajVjlo=
-github.com/apache/thrift v0.23.1-0.20260429145742-d2acd3c49e58 h1:rDLE+tSW60VzRD7v5I+DU22Mjhmm+mfLc5Xl5dHkx6w=
-github.com/apache/thrift v0.23.1-0.20260429145742-d2acd3c49e58/go.mod h1:zPt6WxgvTOM6hF92y8C+MkEM5LMxZuk4JcQOiU4Esvs=
+github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
+github.com/apache/thrift v0.24.0 h1:zy31L1a49QTNB2bG1BBfMXol3yJrTH975G3pPubQVLQ=
+github.com/apache/thrift v0.24.0/go.mod h1:zPt6WxgvTOM6hF92y8C+MkEM5LMxZuk4JcQOiU4Esvs=
 github.com/apple/foundationdb/bindings/go v0.0.0-20250911184653-27f7192f47c3 h1:WZaTKNHCfcw7fWSR6/RKnCldVzvYZC+Y20Su4lffEIg=
 github.com/apple/foundationdb/bindings/go v0.0.0-20250911184653-27f7192f47c3/go.mod h1:OMVSB21p9+xQUIqlGizHPZfjK+SHws1ht+ZytVDoz9U=
 github.com/appscode/go-querystring v0.0.0-20170504095604-0126cfb3f1dc h1:LoL75er+LKDHDUfU5tRvFwxH0LjPpZN8OoG8Ll+liGU=


### PR DESCRIPTION
The replace in go.mod pinned apache/thrift to a post-v0.23.0 master commit so 32-bit GOARCHes would compile. The rclone bump in #10595 raised the require to v0.24.0, which tags that fix, but the replace kept overriding it, so go.sum and the build stayed on the pseudo-version and below the CVE-2026-43871 fix.

Drops the replace and retidies. thrift resolves to v0.24.0 and `GOOS=linux GOARCH=386 go build ./...` passes.

Fixes #11074

https://claude.ai/code/session_01C5BpSeYD3yULWmfVXwPRmB


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a version override for the Apache Thrift library.
  * No user-facing functionality or interface changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->