### PR TITLE
s3: ListParts on a completed or unknown upload answers NoSuchUpload

### DIFF
--- a/weed/s3api/filer_multipart.go
+++ b/weed/s3api/filer_multipart.go
@@ -1105,6 +1105,23 @@ func (s3a *S3ApiServer) listObjectParts(input *s3.ListPartsInput) (output *ListP
 
 	glog.V(2).Infof("listObjectParts input %v", input)
 
+	// complete/abort delete the upload directory, but most stores list a missing
+	// directory as empty instead of erroring, so listing alone cannot tell a
+	// completed upload (NoSuchUpload on AWS) from an open upload with no parts
+	// yet (200 with an empty list). Probe the upload record instead.
+	pentry, err := s3a.getEntry(s3a.genUploadsFolder(*input.Bucket), *input.UploadId)
+	if err != nil {
+		if errors.Is(err, filer_pb.ErrNotFound) {
+			return nil, s3err.ErrNoSuchUpload
+		}
+		glog.Errorf("listObjectParts %s %s error: %v", *input.Bucket, *input.UploadId, err)
+		return nil, s3err.ErrInternalError
+	}
+	// only createMultipartUpload stamps the key; a directory a part write left behind is not an upload
+	if !isMultipartUploadEntry(pentry) {
+		return nil, s3err.ErrNoSuchUpload
+	}
+
 	output = &ListPartsResult{
 		Bucket:           input.Bucket,
 		Key:              objectKey(input.Key),

--- a/weed/s3api/s3api_list_parts_no_such_upload_test.go
+++ b/weed/s3api/s3api_list_parts_no_such_upload_test.go
@@ -9,19 +9,27 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // fakePartsFiler serves the two lookups listObjectParts makes: the .uploads/<id>
 // record via LookupDirectoryEntry, and the part listing via ListEntries. A nil
 // uploadEntry answers the lookup with not-found, the way a filer does after
 // complete/abort removed the directory or for an upload id that never existed.
+// Any other directory is refused, so a path built wrong fails the test rather
+// than passing on the fixture.
 type fakePartsFiler struct {
 	filer_pb.UnimplementedSeaweedFilerServer
+	uploadsDir  string
 	uploadEntry *filer_pb.Entry
 	parts       []*filer_pb.Entry
 }
 
 func (f *fakePartsFiler) LookupDirectoryEntry(ctx context.Context, req *filer_pb.LookupDirectoryEntryRequest) (*filer_pb.LookupDirectoryEntryResponse, error) {
+	if req.Directory != f.uploadsDir {
+		return nil, status.Errorf(codes.Internal, "unexpected lookup in %s", req.Directory)
+	}
 	if f.uploadEntry != nil && req.Name == f.uploadEntry.Name {
 		return &filer_pb.LookupDirectoryEntryResponse{Entry: f.uploadEntry}, nil
 	}
@@ -29,6 +37,9 @@ func (f *fakePartsFiler) LookupDirectoryEntry(ctx context.Context, req *filer_pb
 }
 
 func (f *fakePartsFiler) ListEntries(req *filer_pb.ListEntriesRequest, stream filer_pb.SeaweedFiler_ListEntriesServer) error {
+	if f.uploadEntry == nil || req.Directory != f.uploadsDir+"/"+f.uploadEntry.Name {
+		return status.Errorf(codes.Internal, "unexpected listing of %s", req.Directory)
+	}
 	// most stores list a missing directory as empty rather than erroring, which
 	// is exactly the behavior under test
 	for _, entry := range f.parts {
@@ -37,6 +48,12 @@ func (f *fakePartsFiler) ListEntries(req *filer_pb.ListEntriesRequest, stream fi
 		}
 	}
 	return nil
+}
+
+func newListPartsServer(t *testing.T, f *fakePartsFiler) *S3ApiServer {
+	t.Helper()
+	f.uploadsDir = (&S3ApiServer{option: &S3ApiServerOption{}}).genUploadsFolder("b")
+	return newFailoverTestServer(t, startFakeFiler(t, f))
 }
 
 func uploadRecordEntry(uploadId string) *filer_pb.Entry {
@@ -71,7 +88,7 @@ func listPartsInput(uploadId string) *s3.ListPartsInput {
 // the resumable-upload offset from the part sizes) read every completed upload
 // as one with zero bytes received.
 func TestListPartsGoneUploadAnswersNoSuchUpload(t *testing.T) {
-	s3a := newFailoverTestServer(t, startFakeFiler(t, &fakePartsFiler{}))
+	s3a := newListPartsServer(t, &fakePartsFiler{})
 
 	_, code := s3a.listObjectParts(listPartsInput("gone-upload"))
 
@@ -85,7 +102,7 @@ func TestListPartsGoneUploadAnswersNoSuchUpload(t *testing.T) {
 func TestListPartsResurrectedDirectoryAnswersNoSuchUpload(t *testing.T) {
 	entry := uploadRecordEntry("resurrected-upload")
 	entry.Extended = nil
-	s3a := newFailoverTestServer(t, startFakeFiler(t, &fakePartsFiler{uploadEntry: entry}))
+	s3a := newListPartsServer(t, &fakePartsFiler{uploadEntry: entry})
 
 	_, code := s3a.listObjectParts(listPartsInput("resurrected-upload"))
 
@@ -98,9 +115,9 @@ func TestListPartsResurrectedDirectoryAnswersNoSuchUpload(t *testing.T) {
 // an empty list: the upload directory is the marker that the upload exists,
 // and an offset of zero is the truth here.
 func TestListPartsOpenUploadWithNoPartsAnswersEmptyList(t *testing.T) {
-	s3a := newFailoverTestServer(t, startFakeFiler(t, &fakePartsFiler{
+	s3a := newListPartsServer(t, &fakePartsFiler{
 		uploadEntry: uploadRecordEntry("open-upload"),
-	}))
+	})
 
 	output, code := s3a.listObjectParts(listPartsInput("open-upload"))
 
@@ -113,13 +130,13 @@ func TestListPartsOpenUploadWithNoPartsAnswersEmptyList(t *testing.T) {
 }
 
 func TestListPartsOpenUploadListsParts(t *testing.T) {
-	s3a := newFailoverTestServer(t, startFakeFiler(t, &fakePartsFiler{
+	s3a := newListPartsServer(t, &fakePartsFiler{
 		uploadEntry: uploadRecordEntry("open-upload"),
 		parts: []*filer_pb.Entry{
 			partEntry("0001.part", 5),
 			partEntry("0002.part", 3),
 		},
-	}))
+	})
 
 	output, code := s3a.listObjectParts(listPartsInput("open-upload"))
 

--- a/weed/s3api/s3api_list_parts_no_such_upload_test.go
+++ b/weed/s3api/s3api_list_parts_no_such_upload_test.go
@@ -1,0 +1,135 @@
+package s3api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
+)
+
+// fakePartsFiler serves the two lookups listObjectParts makes: the .uploads/<id>
+// record via LookupDirectoryEntry, and the part listing via ListEntries. A nil
+// uploadEntry answers the lookup with not-found, the way a filer does after
+// complete/abort removed the directory or for an upload id that never existed.
+type fakePartsFiler struct {
+	filer_pb.UnimplementedSeaweedFilerServer
+	uploadEntry *filer_pb.Entry
+	parts       []*filer_pb.Entry
+}
+
+func (f *fakePartsFiler) LookupDirectoryEntry(ctx context.Context, req *filer_pb.LookupDirectoryEntryRequest) (*filer_pb.LookupDirectoryEntryResponse, error) {
+	if f.uploadEntry != nil && req.Name == f.uploadEntry.Name {
+		return &filer_pb.LookupDirectoryEntryResponse{Entry: f.uploadEntry}, nil
+	}
+	return nil, filer_pb.ErrNotFound
+}
+
+func (f *fakePartsFiler) ListEntries(req *filer_pb.ListEntriesRequest, stream filer_pb.SeaweedFiler_ListEntriesServer) error {
+	// most stores list a missing directory as empty rather than erroring, which
+	// is exactly the behavior under test
+	for _, entry := range f.parts {
+		if err := stream.Send(&filer_pb.ListEntriesResponse{Entry: entry}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func uploadRecordEntry(uploadId string) *filer_pb.Entry {
+	return &filer_pb.Entry{
+		Name:        uploadId,
+		IsDirectory: true,
+		Extended:    map[string][]byte{s3_constants.ExtMultipartObjectKey: []byte("a.bin")},
+	}
+}
+
+func partEntry(name string, size uint64) *filer_pb.Entry {
+	return &filer_pb.Entry{
+		Name:       name,
+		Attributes: &filer_pb.FuseAttributes{FileSize: size},
+	}
+}
+
+func listPartsInput(uploadId string) *s3.ListPartsInput {
+	return &s3.ListPartsInput{
+		Bucket:           aws.String("b"),
+		Key:              aws.String("a.bin"),
+		UploadId:         aws.String(uploadId),
+		MaxParts:         aws.Int64(1000),
+		PartNumberMarker: aws.Int64(0),
+	}
+}
+
+// A completed (or aborted, or never-created) upload has no .uploads/<id>
+// record, and AWS answers ListParts on it with NoSuchUpload. Answering 200
+// with an empty list instead is indistinguishable from an open upload with no
+// parts yet, and clients that derive upload state from ListParts (tusd derives
+// the resumable-upload offset from the part sizes) read every completed upload
+// as one with zero bytes received.
+func TestListPartsGoneUploadAnswersNoSuchUpload(t *testing.T) {
+	s3a := newFailoverTestServer(t, startFakeFiler(t, &fakePartsFiler{}))
+
+	_, code := s3a.listObjectParts(listPartsInput("gone-upload"))
+
+	if code != s3err.ErrNoSuchUpload {
+		t.Fatalf("code = %v, want ErrNoSuchUpload", code)
+	}
+}
+
+// Only createMultipartUpload stamps the destination key on the record; a
+// directory a late part write resurrected after an abort is not an upload.
+func TestListPartsResurrectedDirectoryAnswersNoSuchUpload(t *testing.T) {
+	entry := uploadRecordEntry("resurrected-upload")
+	entry.Extended = nil
+	s3a := newFailoverTestServer(t, startFakeFiler(t, &fakePartsFiler{uploadEntry: entry}))
+
+	_, code := s3a.listObjectParts(listPartsInput("resurrected-upload"))
+
+	if code != s3err.ErrNoSuchUpload {
+		t.Fatalf("code = %v, want ErrNoSuchUpload", code)
+	}
+}
+
+// An open upload that has not received a part yet must keep answering 200 with
+// an empty list: the upload directory is the marker that the upload exists,
+// and an offset of zero is the truth here.
+func TestListPartsOpenUploadWithNoPartsAnswersEmptyList(t *testing.T) {
+	s3a := newFailoverTestServer(t, startFakeFiler(t, &fakePartsFiler{
+		uploadEntry: uploadRecordEntry("open-upload"),
+	}))
+
+	output, code := s3a.listObjectParts(listPartsInput("open-upload"))
+
+	if code != s3err.ErrNone {
+		t.Fatalf("code = %v, want ErrNone", code)
+	}
+	if len(output.Part) != 0 {
+		t.Fatalf("parts = %d, want 0", len(output.Part))
+	}
+}
+
+func TestListPartsOpenUploadListsParts(t *testing.T) {
+	s3a := newFailoverTestServer(t, startFakeFiler(t, &fakePartsFiler{
+		uploadEntry: uploadRecordEntry("open-upload"),
+		parts: []*filer_pb.Entry{
+			partEntry("0001.part", 5),
+			partEntry("0002.part", 3),
+		},
+	}))
+
+	output, code := s3a.listObjectParts(listPartsInput("open-upload"))
+
+	if code != s3err.ErrNone {
+		t.Fatalf("code = %v, want ErrNone", code)
+	}
+	if len(output.Part) != 2 {
+		t.Fatalf("parts = %d, want 2", len(output.Part))
+	}
+	if *output.Part[0].PartNumber != 1 || *output.Part[0].Size != 5 {
+		t.Fatalf("part[0] = %d/%d, want 1/5", *output.Part[0].PartNumber, *output.Part[0].Size)
+	}
+}


### PR DESCRIPTION
# What problem are we solving?

`ListParts` on a multipart upload that has been completed, aborted, or never existed currently answers `200` with an empty `Parts` list. AWS S3 answers `NoSuchUpload` here, and Ceph/RGW and MinIO answer with an error as well (Ceph returns `NoSuchKey`, a known variant).

`completeMultipartUpload` and `abortMultipartUpload` delete the `.uploads/<id>` directory, but most filer stores list a missing directory as empty rather than returning an error, so `listObjectParts` never reaches its `isFilerNotFound` branch and walks an empty listing instead. The result is byte-identical to the response an open upload with no parts yet gets, so a client cannot tell the two states apart.

Clients lean on the AWS behavior. [tusd](https://github.com/tus/tusd) with the S3 store does not persist the resumable-upload offset anywhere; it derives it from `ListParts`: a part list means "upload in progress, offset = sum of part sizes", a `NoSuchUpload`/`NoSuchKey` error means "upload completed, offset = file size". Against SeaweedFS, tusd read every completed upload as "created, zero bytes received": `HEAD` answered `Upload-Offset: 0` and `GET` answered `204 No Content` for every successfully finished file. This is not fixable on the client side.

Observed on tusd v1.3.0. The current tusd v2.10 does not show the symptom against SeaweedFS, but the S3 response itself is still wrong, and any other client that reads upload state from `ListParts` hits the same ambiguity.

Reproduction with aws-cli only:

```bash
EP=<seaweedfs-s3-endpoint>; B=<bucket>
UID=$(aws --endpoint-url $EP s3api create-multipart-upload --bucket $B --key test-mpu --query UploadId --output text)
dd if=/dev/urandom of=/tmp/part1 bs=1M count=6
ETAG=$(aws --endpoint-url $EP s3api upload-part --bucket $B --key test-mpu --upload-id $UID --part-number 1 --body /tmp/part1 --query ETag --output text)
aws --endpoint-url $EP s3api complete-multipart-upload --bucket $B --key test-mpu --upload-id $UID \
  --multipart-upload "{\"Parts\":[{\"PartNumber\":1,\"ETag\":$ETAG}]}"
aws --endpoint-url $EP s3api head-object --bucket $B --key test-mpu   # object exists

aws --endpoint-url $EP s3api list-parts --bucket $B --key test-mpu --upload-id $UID
```

SeaweedFS before this change (`200`):

```json
{ "ChecksumAlgorithm": null, "Initiator": null, "Owner": null, "StorageClass": "STANDARD" }
```

AWS S3:

```
An error occurred (NoSuchUpload) when calling the ListParts operation: The specified
upload does not exist. The upload ID may be invalid, or the upload may have been
aborted or completed.
```

A completely made-up `--upload-id` gets the same `200` + empty list.

# How are we solving the problem?

`listObjectParts` probes the `.uploads/<id>` record before listing, the same way `completeMultipartUpload` already does since #11025:

- record not found: `NoSuchUpload`
- record present but without the destination key (a directory a late part write resurrected after an abort): `NoSuchUpload`
- record present with the key: list the parts as before, so an open upload with no parts still answers `200` with an empty list

The existing `isFilerNotFound` branch after the listing is kept for stores that do report a missing directory as an error. The change is 17 lines in `weed/s3api/filer_multipart.go`.

# How is the PR tested?

Unit tests in `weed/s3api/s3api_list_parts_no_such_upload_test.go` drive `listObjectParts` against a fake filer that lists a missing directory as empty, which is the behavior under test:

- completed/aborted/unknown upload id answers `NoSuchUpload`
- a resurrected directory without the upload record answers `NoSuchUpload`
- an open upload with no parts still answers `200` with an empty list (regression guard)
- an open upload with parts lists them

```
go test ./weed/s3api/ -run 'TestListParts|TestIsMultipartUploadEntry'
```

The aws-cli reproduction above was run against a production SeaweedFS cluster to confirm the bug; the fix restores the AWS behavior for the completed and unknown upload id cases while the open upload case is unchanged.

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Multipart upload part listing now correctly reports when an upload does not exist or is no longer an active multipart upload.
  * Open multipart uploads with no parts now return an empty list successfully.
  * Existing uploads continue to display their stored part numbers and sizes accurately.
  * Unexpected storage errors are now reported consistently instead of being mistaken for missing uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->