### PR TITLE
filer: self-heal fetchWholeChunk on stale volume locations

### DIFF
--- a/weed/filer/fetch_whole_chunk_selfheal_test.go
+++ b/weed/filer/fetch_whole_chunk_selfheal_test.go
@@ -1,0 +1,184 @@
+package filer
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+
+	"google.golang.org/protobuf/proto"
+)
+
+// staleTrackingInvalidator records invalidation calls and lets the test
+// observe whether fetchWholeChunk triggered a cache drop after a fetch failure.
+type staleTrackingInvalidator struct {
+	invalidations atomic.Int32
+}
+
+func (inv *staleTrackingInvalidator) InvalidateCache(fileId string) {
+	inv.invalidations.Add(1)
+}
+
+// twoStageLookupFn returns staleUrls on the first call and freshUrls on every
+// subsequent call. Mirrors what a vidMapClient does after InvalidateCache: the
+// next LookupVolumeIdsWithFallback queries master and returns current locations.
+type twoStageLookupFn struct {
+	staleUrls []string
+	freshUrls []string
+	calls     atomic.Int32
+}
+
+func (l *twoStageLookupFn) lookup(ctx context.Context, fileId string) ([]string, error) {
+	n := l.calls.Add(1)
+	if n == 1 {
+		return l.staleUrls, nil
+	}
+	return l.freshUrls, nil
+}
+
+// TestFetchWholeChunkSelfHealOnStaleLocation verifies that when the first
+// retriedStreamFetchChunkData attempt fails (stale volume location returning
+// HTTP 500), fetchWholeChunk invalidates the cache, re-looks up, and retries
+// against the fresh location. Without this, mount reads of large multipart
+// files whose manifest chunk's volume has moved would permanently fail.
+func TestFetchWholeChunkSelfHealOnStaleLocation(t *testing.T) {
+	// Build a valid FileChunkManifest protobuf for the fresh response.
+	manifest := &filer_pb.FileChunkManifest{
+		Chunks: []*filer_pb.FileChunk{
+			{FileId: "100,abc", Offset: 0, Size: 8},
+			{FileId: "101,def", Offset: 8, Size: 8},
+		},
+	}
+	manifestBytes, err := proto.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("proto.Marshal: %v", err)
+	}
+
+	// Stale endpoint: 500 with a non-empty body so the streaming writer may
+	// have already appended some bytes to bytesBuffer before the error status
+	// was processed. This proves the bytesBuffer.Reset() before retry is needed.
+	staleSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("garbage-from-stale-server"))
+	}))
+	defer staleSrv.Close()
+
+	// Fresh endpoint: 200 with valid gzipped (since isFullChunk=true triggers
+	// gzip accept) or plain protobuf bytes. We use plain bytes because the
+	// stream reader only applies gzip when the response says so.
+	freshSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(manifestBytes)))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(manifestBytes)
+	}))
+	defer freshSrv.Close()
+
+	lookup := &twoStageLookupFn{
+		staleUrls: []string{staleSrv.URL + "/5,stale"},
+		freshUrls: []string{freshSrv.URL + "/5,stale"},
+	}
+	inv := &staleTrackingInvalidator{}
+
+	bytesBuffer := bytesBufferPool.Get().(*bytes.Buffer)
+	bytesBuffer.Reset()
+	defer bytesBufferPool.Put(bytesBuffer)
+
+	err = fetchWholeChunk(context.Background(), bytesBuffer, lookup.lookup, "5,stale", nil, false, inv)
+	if err != nil {
+		t.Fatalf("fetchWholeChunk returned error after self-heal: %v", err)
+	}
+
+	if got := inv.invalidations.Load(); got != 1 {
+		t.Errorf("expected exactly 1 InvalidateCache call, got %d", got)
+	}
+	if got := lookup.calls.Load(); got != 2 {
+		t.Errorf("expected exactly 2 lookup calls (initial + re-lookup), got %d", got)
+	}
+
+	// Buffer must contain only the fresh manifest bytes, never the stale
+	// "garbage-from-stale-server" prefix that the first attempt may have
+	// streamed before returning 500. If bytesBuffer.Reset() were skipped, the
+	// prefix would survive and proto.Unmarshal would fail.
+	got := bytesBuffer.Bytes()
+	if bytes.Contains(got, []byte("garbage-from-stale-server")) {
+		t.Errorf("bytesBuffer still contains stale prefix; Reset() before retry is missing")
+	}
+
+	decoded := &filer_pb.FileChunkManifest{}
+	if err := proto.Unmarshal(got, decoded); err != nil {
+		t.Fatalf("proto.Unmarshal of fetched buffer: %v", err)
+	}
+	if len(decoded.Chunks) != 2 {
+		t.Errorf("expected 2 manifest chunks, got %d", len(decoded.Chunks))
+	}
+	if decoded.Chunks[0].FileId != "100,abc" || decoded.Chunks[1].FileId != "101,def" {
+		t.Errorf("unexpected manifest chunks: %+v", decoded.Chunks)
+	}
+}
+
+// TestFetchWholeChunkNoInvalidatorSkipsRetry verifies that with a nil
+// invalidator, fetchWholeChunk returns the original fetch error without
+// retrying - preserving the existing semantics for non-mount callers that
+// don't participate in cache invalidation.
+func TestFetchWholeChunkNoInvalidatorSkipsRetry(t *testing.T) {
+	failSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer failSrv.Close()
+
+	lookup := &twoStageLookupFn{
+		staleUrls: []string{failSrv.URL + "/5,abc"},
+		freshUrls: []string{"http://unused:8080/5,abc"},
+	}
+
+	bytesBuffer := bytesBufferPool.Get().(*bytes.Buffer)
+	bytesBuffer.Reset()
+	defer bytesBufferPool.Put(bytesBuffer)
+
+	err := fetchWholeChunk(context.Background(), bytesBuffer, lookup.lookup, "5,abc", nil, false, nil)
+	if err == nil {
+		t.Fatal("expected fetchWholeChunk to return the original error when invalidator is nil")
+	}
+	if got := lookup.calls.Load(); got != 1 {
+		t.Errorf("expected only the initial lookup, got %d calls", got)
+	}
+}
+
+// TestFetchWholeChunkSameUrlsSkipsRetry verifies that when invalidation leads
+// to a re-lookup that returns the same stale URLs, fetchWholeChunk does not
+// retry (avoiding infinite retry loops against the same broken servers).
+func TestFetchWholeChunkSameUrlsSkipsRetry(t *testing.T) {
+	failSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer failSrv.Close()
+
+	// Both stale and fresh lookups return the same URL (the stale endpoint).
+	// This is what happens when the cache had the wrong info AND the master
+	// still returns the same wrong info - we must not loop.
+	lookup := &twoStageLookupFn{
+		staleUrls: []string{failSrv.URL + "/5,abc"},
+		freshUrls: []string{failSrv.URL + "/5,abc"},
+	}
+	inv := &staleTrackingInvalidator{}
+
+	bytesBuffer := bytesBufferPool.Get().(*bytes.Buffer)
+	bytesBuffer.Reset()
+	defer bytesBufferPool.Put(bytesBuffer)
+
+	err := fetchWholeChunk(context.Background(), bytesBuffer, lookup.lookup, "5,abc", nil, false, inv)
+	if err == nil {
+		t.Fatal("expected fetchWholeChunk to return error when locations unchanged after re-lookup")
+	}
+	if got := lookup.calls.Load(); got != 2 {
+		t.Errorf("expected initial + re-lookup (2 calls), got %d", got)
+	}
+	if got := inv.invalidations.Load(); got != 1 {
+		t.Errorf("expected exactly 1 InvalidateCache call, got %d", got)
+	}
+}

--- a/weed/filer/filechunk_group.go
+++ b/weed/filer/filechunk_group.go
@@ -18,6 +18,10 @@ type ChunkGroup struct {
 	sectionsLock      sync.RWMutex
 	readerCache       *ReaderCache
 	concurrentReaders int
+	// cacheInvalidator lets manifest resolution (SetChunks → fetchWholeChunk)
+	// drop stale volume locations and retry, mirroring what ReaderCache does
+	// for chunk reads.
+	cacheInvalidator CacheInvalidator
 }
 
 // NewChunkGroup creates a ChunkGroup with configurable concurrency.
@@ -43,6 +47,7 @@ func NewChunkGroup(lookupFn wdclient.LookupFileIdFunctionType, chunkCache chunk_
 		sections:          make(map[SectionIndex]*FileChunkSection),
 		readerCache:       NewReaderCache(readerCacheLimit, chunkCache, lookupFn, cacheInvalidator),
 		concurrentReaders: concurrentReaders,
+		cacheInvalidator:  cacheInvalidator,
 	}
 
 	err := group.SetChunks(chunks)
@@ -227,7 +232,7 @@ func (group *ChunkGroup) SetChunks(chunks []*filer_pb.FileChunk) error {
 			continue
 		}
 
-		resolvedChunks, err := ResolveOneChunkManifest(context.Background(), group.lookupFn, chunk)
+		resolvedChunks, err := ResolveOneChunkManifest(context.Background(), group.lookupFn, chunk, group.cacheInvalidator)
 		if err != nil {
 			return err
 		}

--- a/weed/filer/filechunk_manifest.go
+++ b/weed/filer/filechunk_manifest.go
@@ -49,7 +49,7 @@ func SeparateManifestChunks(chunks []*filer_pb.FileChunk) (manifestChunks, nonMa
 	return
 }
 
-func ResolveChunkManifest(ctx context.Context, lookupFileIdFn wdclient.LookupFileIdFunctionType, chunks []*filer_pb.FileChunk, startOffset, stopOffset int64) (dataChunks, manifestChunks []*filer_pb.FileChunk, manifestResolveErr error) {
+func ResolveChunkManifest(ctx context.Context, lookupFileIdFn wdclient.LookupFileIdFunctionType, chunks []*filer_pb.FileChunk, startOffset, stopOffset int64, invalidator CacheInvalidator) (dataChunks, manifestChunks []*filer_pb.FileChunk, manifestResolveErr error) {
 	// TODO maybe parallel this
 	for _, chunk := range chunks {
 
@@ -62,14 +62,14 @@ func ResolveChunkManifest(ctx context.Context, lookupFileIdFn wdclient.LookupFil
 			continue
 		}
 
-		resolvedChunks, err := ResolveOneChunkManifest(ctx, lookupFileIdFn, chunk)
+		resolvedChunks, err := ResolveOneChunkManifest(ctx, lookupFileIdFn, chunk, invalidator)
 		if err != nil {
 			return dataChunks, nil, err
 		}
 
 		manifestChunks = append(manifestChunks, chunk)
 		// recursive
-		subDataChunks, subManifestChunks, subErr := ResolveChunkManifest(ctx, lookupFileIdFn, resolvedChunks, startOffset, stopOffset)
+		subDataChunks, subManifestChunks, subErr := ResolveChunkManifest(ctx, lookupFileIdFn, resolvedChunks, startOffset, stopOffset, invalidator)
 		if subErr != nil {
 			return dataChunks, nil, subErr
 		}
@@ -79,7 +79,7 @@ func ResolveChunkManifest(ctx context.Context, lookupFileIdFn wdclient.LookupFil
 	return
 }
 
-func ResolveOneChunkManifest(ctx context.Context, lookupFileIdFn wdclient.LookupFileIdFunctionType, chunk *filer_pb.FileChunk) (dataChunks []*filer_pb.FileChunk, manifestResolveErr error) {
+func ResolveOneChunkManifest(ctx context.Context, lookupFileIdFn wdclient.LookupFileIdFunctionType, chunk *filer_pb.FileChunk, invalidator CacheInvalidator) (dataChunks []*filer_pb.FileChunk, manifestResolveErr error) {
 	if !chunk.IsChunkManifest {
 		return
 	}
@@ -88,7 +88,7 @@ func ResolveOneChunkManifest(ctx context.Context, lookupFileIdFn wdclient.Lookup
 	bytesBuffer := bytesBufferPool.Get().(*bytes.Buffer)
 	bytesBuffer.Reset()
 	defer bytesBufferPool.Put(bytesBuffer)
-	err := fetchWholeChunk(ctx, bytesBuffer, lookupFileIdFn, chunk.GetFileIdString(), chunk.CipherKey, chunk.IsCompressed)
+	err := fetchWholeChunk(ctx, bytesBuffer, lookupFileIdFn, chunk.GetFileIdString(), chunk.CipherKey, chunk.IsCompressed, invalidator)
 	if err != nil {
 		return nil, fmt.Errorf("fail to read manifest %s: %v", chunk.GetFileIdString(), err)
 	}
@@ -103,7 +103,7 @@ func ResolveOneChunkManifest(ctx context.Context, lookupFileIdFn wdclient.Lookup
 }
 
 // TODO fetch from cache for weed mount?
-func fetchWholeChunk(ctx context.Context, bytesBuffer *bytes.Buffer, lookupFileIdFn wdclient.LookupFileIdFunctionType, fileId string, cipherKey []byte, isGzipped bool) error {
+func fetchWholeChunk(ctx context.Context, bytesBuffer *bytes.Buffer, lookupFileIdFn wdclient.LookupFileIdFunctionType, fileId string, cipherKey []byte, isGzipped bool, invalidator CacheInvalidator) error {
 	urlStrings, err := lookupFileIdFn(ctx, fileId)
 	if err != nil {
 		glog.ErrorfCtx(ctx, "operation LookupFileId %s failed, err: %v", fileId, err)
@@ -112,9 +112,17 @@ func fetchWholeChunk(ctx context.Context, bytesBuffer *bytes.Buffer, lookupFileI
 	jwt := JwtForVolumeServer(fileId)
 	_, err = retriedStreamFetchChunkData(ctx, bytesBuffer, urlStrings, jwt, cipherKey, isGzipped, true, 0, 0)
 	if err != nil {
-		return err
+		// Self-heal: drop stale volume locations and retry once with fresh ones.
+		// The buffer must be reset before retry - retriedStreamFetchChunkData is
+		// streaming and may have written partial bytes that would corrupt the
+		// proto.Unmarshal of FileChunkManifest downstream.
+		err = retryFetchWithFreshLocations(ctx, invalidator, lookupFileIdFn, fileId, urlStrings, err, func(newUrls []string) error {
+			bytesBuffer.Reset()
+			_, err2 := retriedStreamFetchChunkData(ctx, bytesBuffer, newUrls, jwt, cipherKey, isGzipped, true, 0, 0)
+			return err2
+		})
 	}
-	return nil
+	return err
 }
 
 func fetchChunkRange(ctx context.Context, buffer []byte, lookupFileIdFn wdclient.LookupFileIdFunctionType, fileId string, cipherKey []byte, isGzipped bool, offset int64, refreshUrls util_http.RefreshUrlsFunc) (int, error) {

--- a/weed/filer/filechunks.go
+++ b/weed/filer/filechunks.go
@@ -102,11 +102,11 @@ func FindGarbageChunks(visibles *IntervalList[*VisibleInterval], start int64, st
 
 func MinusChunks(ctx context.Context, lookupFileIdFn wdclient.LookupFileIdFunctionType, as, bs []*filer_pb.FileChunk) (delta []*filer_pb.FileChunk, err error) {
 
-	aData, aMeta, aErr := ResolveChunkManifest(ctx, lookupFileIdFn, as, 0, math.MaxInt64)
+	aData, aMeta, aErr := ResolveChunkManifest(ctx, lookupFileIdFn, as, 0, math.MaxInt64, nil)
 	if aErr != nil {
 		return nil, aErr
 	}
-	bData, bMeta, bErr := ResolveChunkManifest(ctx, lookupFileIdFn, bs, 0, math.MaxInt64)
+	bData, bMeta, bErr := ResolveChunkManifest(ctx, lookupFileIdFn, bs, 0, math.MaxInt64, nil)
 	if bErr != nil {
 		return nil, bErr
 	}
@@ -271,7 +271,7 @@ func MergeIntoChunkViews(chunkViews *IntervalList[*ChunkView], start int64, stop
 // If the file chunk content is a chunk manifest
 func NonOverlappingVisibleIntervals(ctx context.Context, lookupFileIdFn wdclient.LookupFileIdFunctionType, chunks []*filer_pb.FileChunk, startOffset int64, stopOffset int64) (visibles *IntervalList[*VisibleInterval], err error) {
 
-	chunks, _, err = ResolveChunkManifest(ctx, lookupFileIdFn, chunks, startOffset, stopOffset)
+	chunks, _, err = ResolveChunkManifest(ctx, lookupFileIdFn, chunks, startOffset, stopOffset, nil)
 	if err != nil {
 		return
 	}

--- a/weed/filer/filer_deletion.go
+++ b/weed/filer/filer_deletion.go
@@ -602,7 +602,7 @@ func (f *Filer) doDeleteChunks(ctx context.Context, chunks []*filer_pb.FileChunk
 			f.FileIdDeletionQueue.EnQueue(chunk.GetFileIdString())
 			continue
 		}
-		dataChunks, manifestResolveErr := ResolveOneChunkManifest(ctx, f.MasterClient.LookupFileId, chunk)
+		dataChunks, manifestResolveErr := ResolveOneChunkManifest(ctx, f.MasterClient.LookupFileId, chunk, nil)
 		if manifestResolveErr != nil {
 			glog.V(0).InfofCtx(ctx, "failed to resolve manifest %s: %v", chunk.FileId, manifestResolveErr)
 		}

--- a/weed/filer/persisted_log_cache.go
+++ b/weed/filer/persisted_log_cache.go
@@ -190,7 +190,7 @@ func loadLogFileEntries(masterClient *wdclient.MasterClient, chunk *filer_pb.Fil
 	lookupFileIdFn := func(ctx context.Context, fileId string) (targetUrls []string, err error) {
 		return masterClient.LookupFileId(ctx, fileId)
 	}
-	if fetchErr := fetchWholeChunk(context.Background(), bytesBuffer, lookupFileIdFn, chunk.GetFileIdString(), chunk.CipherKey, chunk.IsCompressed); fetchErr != nil {
+	if fetchErr := fetchWholeChunk(context.Background(), bytesBuffer, lookupFileIdFn, chunk.GetFileIdString(), chunk.CipherKey, chunk.IsCompressed, nil); fetchErr != nil {
 		return nil, false, fetchErr
 	}
 	return decodeLogRecords(bytesBuffer.Bytes())

--- a/weed/mount/peer_fetcher.go
+++ b/weed/mount/peer_fetcher.go
@@ -65,7 +65,7 @@ func (fh *FileHandle) tryPeerRead(ctx context.Context, fileSize int64, buff []by
 	if readStop > fileSize {
 		readStop = fileSize
 	}
-	dataChunks, _, err := filer.ResolveChunkManifest(ctx, fh.wfs.LookupFn(), chunks, offset, readStop)
+	dataChunks, _, err := filer.ResolveChunkManifest(ctx, fh.wfs.LookupFn(), chunks, offset, readStop, fh.wfs.CacheInvalidator())
 	if err != nil {
 		return 0, 0, fmt.Errorf("resolve manifest: %w", err)
 	}

--- a/weed/replication/sink/filersink/fetch_write.go
+++ b/weed/replication/sink/filersink/fetch_write.go
@@ -195,7 +195,7 @@ func (fs *FilerSink) replicateOneManifestChunk(ctx context.Context, sourceChunk 
 	resolveName := fmt.Sprintf("resolve manifest %s", sourceChunk.GetFileIdString())
 	missingGate := fs.newMissingSourceChunkGate(sourceChunk.GetFileIdString())
 	err := util.RetryUntil(resolveName, func() error {
-		rc, e := filer.ResolveOneChunkManifest(ctx, fs.filerSource.LookupFileId, sourceChunk)
+		rc, e := filer.ResolveOneChunkManifest(ctx, fs.filerSource.LookupFileId, sourceChunk, nil)
 		if e != nil {
 			return e
 		}

--- a/weed/replication/sink/filersink/filer_sink.go
+++ b/weed/replication/sink/filersink/filer_sink.go
@@ -405,11 +405,11 @@ func (fs *FilerSink) UpdateEntry(key string, oldEntry *filer_pb.Entry, newParent
 
 }
 func compareChunks(ctx context.Context, lookupFileIdFn wdclient.LookupFileIdFunctionType, oldEntry, newEntry *filer_pb.Entry) (deletedChunks, newChunks []*filer_pb.FileChunk, err error) {
-	aData, aMeta, aErr := filer.ResolveChunkManifest(ctx, lookupFileIdFn, oldEntry.GetChunks(), 0, math.MaxInt64)
+	aData, aMeta, aErr := filer.ResolveChunkManifest(ctx, lookupFileIdFn, oldEntry.GetChunks(), 0, math.MaxInt64, nil)
 	if aErr != nil {
 		return nil, nil, aErr
 	}
-	bData, bMeta, bErr := filer.ResolveChunkManifest(ctx, lookupFileIdFn, newEntry.GetChunks(), 0, math.MaxInt64)
+	bData, bMeta, bErr := filer.ResolveChunkManifest(ctx, lookupFileIdFn, newEntry.GetChunks(), 0, math.MaxInt64, nil)
 	if bErr != nil {
 		return nil, nil, bErr
 	}

--- a/weed/s3api/s3api_chunk_manifest.go
+++ b/weed/s3api/s3api_chunk_manifest.go
@@ -65,7 +65,7 @@ func (s3a *S3ApiServer) flattenManifestChunks(ctx context.Context, entry *filer_
 	if entry == nil || !filer.HasChunkManifest(entry.GetChunks()) {
 		return nil, nil
 	}
-	dataChunks, manifestChunks, err := filer.ResolveChunkManifest(ctx, s3a.createLookupFileIdFunction(), entry.GetChunks(), 0, math.MaxInt64)
+	dataChunks, manifestChunks, err := filer.ResolveChunkManifest(ctx, s3a.createLookupFileIdFunction(), entry.GetChunks(), 0, math.MaxInt64, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -2140,7 +2140,7 @@ func (s3a *S3ApiServer) getEncryptedStreamFromVolumes(ctx context.Context, entry
 	lookupFileIdFn := s3a.createLookupFileIdFunction()
 
 	// Resolve chunks
-	resolvedChunks, _, err := filer.ResolveChunkManifest(ctx, lookupFileIdFn, chunks, offset, offset+size)
+	resolvedChunks, _, err := filer.ResolveChunkManifest(ctx, lookupFileIdFn, chunks, offset, offset+size, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/weed/server/filer_server_handlers_copy.go
+++ b/weed/server/filer_server_handlers_copy.go
@@ -600,7 +600,7 @@ func (fs *FilerServer) copyChunksWithManifest(ctx context.Context, srcChunks []*
 			return fs.filer.MasterClient.GetLookupFileIdFunction()(ctx, fileId)
 		}
 
-		resolvedChunks, err := filer.ResolveOneChunkManifest(ctx, lookupFileIdFn, manifestChunk)
+		resolvedChunks, err := filer.ResolveOneChunkManifest(ctx, lookupFileIdFn, manifestChunk, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve manifest chunk %s: %w", manifestChunk.GetFileIdString(), err)
 		}

--- a/weed/server/filer_server_handlers_read.go
+++ b/weed/server/filer_server_handlers_read.go
@@ -132,7 +132,7 @@ func (fs *FilerServer) GetOrHeadHandler(w http.ResponseWriter, r *http.Request) 
 			if entry.Chunks, _, err = filer.ResolveChunkManifest(
 				ctx,
 				fs.filer.MasterClient.GetLookupFileIdFunction(),
-				entry.GetChunks(), 0, math.MaxInt64); err != nil {
+				entry.GetChunks(), 0, math.MaxInt64, nil); err != nil {
 				err = fmt.Errorf("failed to resolve chunk manifest, err: %s", err.Error())
 				writeJsonError(w, r, http.StatusInternalServerError, err)
 				return

--- a/weed/shell/command_fs_distribute_chunks.go
+++ b/weed/shell/command_fs_distribute_chunks.go
@@ -255,7 +255,7 @@ func resolveEntryDataChunks(commandEnv *CommandEnv, entry *filer_pb.Entry) (data
 	if !filer.HasChunkManifest(chunks) {
 		return chunks, false, nil
 	}
-	dataChunks, _, err = filer.ResolveChunkManifest(context.Background(), filer.LookupFn(commandEnv), chunks, 0, math.MaxInt64)
+	dataChunks, _, err = filer.ResolveChunkManifest(context.Background(), filer.LookupFn(commandEnv), chunks, 0, math.MaxInt64, nil)
 	if err != nil {
 		return nil, true, fmt.Errorf("resolve chunk manifest: %v", err)
 	}

--- a/weed/shell/command_fs_merge_volumes.go
+++ b/weed/shell/command_fs_merge_volumes.go
@@ -652,7 +652,7 @@ func (c *commandFsMergeVolumes) rewriteManifestChunk(
 		return chunk, false, nil, fmt.Errorf("not a manifest chunk: %s", chunk.GetFileIdString())
 	}
 
-	subChunks, err := filer.ResolveOneChunkManifest(ctx, lookupFn, chunk)
+	subChunks, err := filer.ResolveOneChunkManifest(ctx, lookupFn, chunk, nil)
 	if err != nil {
 		return chunk, false, nil, err
 	}

--- a/weed/shell/command_fs_verify.go
+++ b/weed/shell/command_fs_verify.go
@@ -287,7 +287,7 @@ func (c *commandFsVerify) verifyTraverseBfs(path string) (fileCount uint64, errC
 					return nil
 				}
 			}
-			dataChunks, manifestChunks, resolveErr := filer.ResolveChunkManifest(context.Background(), filer.LookupFn(c.env), entry.Entry.GetChunks(), 0, math.MaxInt64)
+			dataChunks, manifestChunks, resolveErr := filer.ResolveChunkManifest(context.Background(), filer.LookupFn(c.env), entry.Entry.GetChunks(), 0, math.MaxInt64, nil)
 			if resolveErr != nil {
 				return fmt.Errorf("failed to ResolveChunkManifest: %+v", resolveErr)
 			}

--- a/weed/shell/command_volume_fsck.go
+++ b/weed/shell/command_volume_fsck.go
@@ -310,7 +310,7 @@ func (c *commandVolumeFsck) collectFilerFileIdAndPaths(dataNodeVolumeIdToVInfo m
 			if *c.verbose && entry.Entry.IsDirectory {
 				fmt.Fprintf(c.writer, "checking directory %s\n", util.NewFullPath(entry.Dir, entry.Entry.Name))
 			}
-			dataChunks, manifestChunks, resolveErr := filer.ResolveChunkManifest(ctx, filer.LookupFn(c.env), entry.Entry.GetChunks(), 0, math.MaxInt64)
+			dataChunks, manifestChunks, resolveErr := filer.ResolveChunkManifest(ctx, filer.LookupFn(c.env), entry.Entry.GetChunks(), 0, math.MaxInt64, nil)
 			if resolveErr != nil {
 				// Cancellation/deadline isn't manifest corruption; surface it
 				// so the BFS bails out cleanly without polluting the


### PR DESCRIPTION
# What problem are we solving?
#11087 

PR #10156 and #10800 wired cache invalidation into the buffer-based read paths, but chunk-manifest resolution still goes through `fetchWholeChunk`, which returns the raw fetch error on failure. When the cached volume locations are stale — a volume has been tiered to remote storage, a server has rolled, or a replica layout has changed — resolving a large multipart file fails permanently even though a healthy location exists on the master.

The mount hits this path whenever it opens a multipart file with chunk manifests (via `ChunkGroup.SetChunks` → `ResolveOneChunkManifest`→ `fetchWholeChunk`). Every retry against the same stale URL just fails again.


# How are we solving the problem?
This change threads the `ChunkGroup`'s `cacheInvalidator` through `ResolveChunkManifest` / `ResolveOneChunkManifest` / `fetchWholeChunk` and, on failure, invalidates the cached volume locations, re-looksthem up, and retries once via the existing `retryFetchWithFreshLocations` helper (from #10800). The retry only happens when the fresh locations actually differ from the stale ones, so we never loop against the same broken servers. The streaming `bytesBuffer` is reset before the retry so partial bytes from the failed attempt cannot corrupt the downstream `proto.Unmarshal` of `FileChunkManifest`.

Non-mount callers (`filer` deletion, `s3api`, `shell` fsck/verify/ distribute, replication sinks) pass `nil` for the new invalidator parameter and keep their existing semantics.


# How is the PR tested?
Tests:
- `weed/filer/fetch_whole_chunk_selfheal_test.go`:
- `TestFetchWholeChunkSelfHealOnStaleLocation` — first fetch returns 500 and may stream a partial prefix;
   verifies the invalidator is called, the lookup is re-issued, and the buffer contains only the fresh bytes (i.e. `Reset()` happened).
- `TestFetchWholeChunkNoInvalidatorSkipsRetry` — without an invalidator, the original error surfaces and no re-lookup is issued.
- `TestFetchWholeChunkSameUrlsSkipsRetry` — invalidation that yields the same URL set does not retry, to avoid loops.



# Checks
- [ ] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file and chunk reads when cached volume locations are stale.
  * Automatically refreshes stale locations and retries failed reads once.
  * Resets buffered data before retrying to prevent corrupted or duplicated output.
  * Prevents repeated retries when refreshed locations remain unchanged.

* **Tests**
  * Added coverage for successful recovery, unavailable cache invalidation, and unchanged stale locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->