### PR TITLE
sftp: reject an empty password

### DIFF
--- a/weed/sftpd/user/filestore.go
+++ b/weed/sftpd/user/filestore.go
@@ -154,6 +154,11 @@ func (s *FileStore) ValidatePassword(username string, password []byte) bool {
 		return false
 	}
 
+	// An empty stored or supplied password is never a match: a public-key-only
+	// user has no password, and equal-length zero slices would otherwise compare equal.
+	if len(user.Password) == 0 || len(password) == 0 {
+		return false
+	}
 	// Compare plaintext password using constant time comparison for security
 	return subtle.ConstantTimeCompare([]byte(user.Password), password) == 1
 }

--- a/weed/sftpd/user/filestore_test.go
+++ b/weed/sftpd/user/filestore_test.go
@@ -1,0 +1,36 @@
+package user
+
+import "testing"
+
+func newTestStore(users ...*User) *FileStore {
+	s := &FileStore{users: make(map[string]*User)}
+	for _, u := range users {
+		s.users[u.Username] = u
+	}
+	return s
+}
+
+func TestValidatePasswordRejectsEmpty(t *testing.T) {
+	s := newTestStore(
+		&User{Username: "keyonly", Password: "", PublicKeys: []string{"ssh-ed25519 AAAA"}},
+		&User{Username: "haspass", Password: "s3cret"},
+	)
+
+	cases := []struct {
+		username string
+		password string
+		want     bool
+	}{
+		{"keyonly", "", false}, // public-key-only user must not accept an empty password
+		{"keyonly", "wrong", false},
+		{"haspass", "", false}, // a real password is never matched by an empty one
+		{"haspass", "s3cret", true},
+		{"haspass", "wrong", false},
+		{"missing", "", false},
+	}
+	for _, c := range cases {
+		if got := s.ValidatePassword(c.username, []byte(c.password)); got != c.want {
+			t.Errorf("ValidatePassword(%q, %q) = %v, want %v", c.username, c.password, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
### Problem

`FileStore.ValidatePassword` compares the stored password against the supplied one with `subtle.ConstantTimeCompare`, which returns `1` when both slices are zero length:

```go
return subtle.ConstantTimeCompare([]byte(user.Password), password) == 1
```

A user set up for public-key (or certificate) auth only has no stored password, so `user.Password == ""`. When such a client sends an empty password and `password` is in `-sftp.authMethods` (the default is `password,publickey`), the two empty slices compare equal and the user is authenticated with just a valid username — no key or secret needed.

### Fix

Treat an empty stored or supplied password as a non-match before the constant-time compare. A key-only user can no longer be logged in with an empty password, and a normal password login is unchanged.

Added a unit test covering key-only users, password users, and the empty-vs-empty case; it fails on the old code and passes on the new.

https://claude.ai/code/session_011QqNaxZwnpHgMoAZNp3RkY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented password authentication with empty credentials, including for public-key-only accounts.
  - Preserved valid password authentication while rejecting empty or incorrect passwords.

- **Tests**
  - Added coverage for empty, valid, and invalid password scenarios across existing and missing users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->