### PR TITLE
s3: validate the version-id header used as a filer path segment

### DIFF
--- a/weed/s3api/s3api_object_handlers.go
+++ b/weed/s3api/s3api_object_handlers.go
@@ -3381,7 +3381,9 @@ func (s3a *S3ApiServer) doCacheRemoteObject(ctx context.Context, dir, name strin
 }
 
 func (s3a *S3ApiServer) buildVersionedRemoteObjectPath(bucket, object, versionId string) (dir, name string) {
-	if versionId != "" && versionId != "null" {
+	// versionId names a .versions file, so a value that is not a valid path
+	// segment falls back to the unversioned remote path rather than escaping it.
+	if versionId != "" && versionId != "null" && isValidVersionID(versionId) {
 		normalizedObject := s3_constants.NormalizeObjectKey(object)
 		return s3a.bucketDir(bucket) + "/" + normalizedObject + s3_constants.VersionsFolder, s3a.getVersionFileName(versionId)
 	}

--- a/weed/s3api/s3api_object_handlers_put.go
+++ b/weed/s3api/s3api_object_handlers_put.go
@@ -788,8 +788,14 @@ func (s3a *S3ApiServer) putToFiler(r *http.Request, filePath string, dataReader 
 	// Set object owner according to bucket ownership settings.
 	s3a.setObjectOwnerFromRequest(r, bucket, entry)
 
-	// Set version ID if present
+	// Set version ID if present. It is later used as a filer path segment, so a
+	// value carrying "/", "\\" or ".." must never be stored.
 	if versionIdHeader := r.Header.Get(s3_constants.ExtVersionIdKey); versionIdHeader != "" {
+		if !isValidVersionID(versionIdHeader) {
+			glog.Warningf("putToFiler: rejecting invalid version ID %q for object %s", versionIdHeader, filePath)
+			s3a.deleteOrphanedChunks(chunkResult.FileChunks)
+			return "", s3err.ErrInvalidRequest, SSEResponseMetadata{}
+		}
 		entry.Extended[s3_constants.ExtVersionIdKey] = []byte(versionIdHeader)
 		glog.V(3).Infof("putToFiler: setting version ID %s for object %s", versionIdHeader, filePath)
 	}

--- a/weed/s3api/s3api_object_retention.go
+++ b/weed/s3api/s3api_object_retention.go
@@ -282,7 +282,9 @@ func (s3a *S3ApiServer) setObjectRetention(bucket, object, versionId string, ret
 			if entry.Extended != nil {
 				if versionIdBytes, exists := entry.Extended[s3_constants.ExtVersionIdKey]; exists {
 					versionId = string(versionIdBytes)
-					if versionId != "null" {
+					// A stored version id must be a valid path segment before it can
+					// name a .versions file; otherwise fall back to the regular object.
+					if versionId != "null" && isValidVersionID(versionId) {
 						entryPath = object + ".versions/" + s3a.getVersionFileName(versionId)
 					}
 				}
@@ -425,7 +427,9 @@ func (s3a *S3ApiServer) setObjectLegalHold(bucket, object, versionId string, leg
 			if entry.Extended != nil {
 				if versionIdBytes, exists := entry.Extended[s3_constants.ExtVersionIdKey]; exists {
 					versionId = string(versionIdBytes)
-					if versionId != "null" {
+					// A stored version id must be a valid path segment before it can
+					// name a .versions file; otherwise fall back to the regular object.
+					if versionId != "null" && isValidVersionID(versionId) {
 						entryPath = object + ".versions/" + s3a.getVersionFileName(versionId)
 					}
 				}

--- a/weed/s3api/s3api_remote_versioned_path_test.go
+++ b/weed/s3api/s3api_remote_versioned_path_test.go
@@ -1,0 +1,29 @@
+package s3api
+
+import "testing"
+
+func TestBuildVersionedRemoteObjectPathRejectsTraversal(t *testing.T) {
+	s3a := &S3ApiServer{option: &S3ApiServerOption{BucketsPath: "/buckets"}}
+
+	tests := []struct {
+		name      string
+		versionId string
+		wantDir   string
+		wantName  string
+	}{
+		{"valid version", "opaque_123", "/buckets/mybkt/obj.versions", "v_opaque_123"},
+		{"traversal drops to unversioned", "v1/../../../buckets/victim/pwn", "/buckets/mybkt", "obj"},
+		{"backslash drops to unversioned", `v1\..\victim`, "/buckets/mybkt", "obj"},
+		{"empty is unversioned", "", "/buckets/mybkt", "obj"},
+		{"null is unversioned", "null", "/buckets/mybkt", "obj"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir, name := s3a.buildVersionedRemoteObjectPath("mybkt", "obj", tt.versionId)
+			if dir != tt.wantDir || name != tt.wantName {
+				t.Errorf("buildVersionedRemoteObjectPath(mybkt, obj, %q) = (%q, %q), want (%q, %q)",
+					tt.versionId, dir, name, tt.wantDir, tt.wantName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Problem

The S3 gateway accepts a client-supplied `Seaweed-X-Amz-Version-Id` header and `putToFiler` stores it verbatim into object metadata with no validation. That stored value is later read back and used as a filer path component when building the `.versions/v_<id>` path. Unlike the eight other consumers of a version id, a few of these paths skipped `isValidVersionID`, so a value containing `/`, `\` or `..` collapsed under `filepath.Join` and could steer a write or read outside the object's own bucket tree:

- `PutObjectRetention` / `PutObjectLegalHold` build `object + ".versions/" + getVersionFileName(versionId)` and write it, creating directory entries at the collapsed path.
- On a remote-only object, `resolvedSourceVersionId` feeds the same value into the remote-cache lookup/write path.

An unversioned `PUT` reaches `putToFiler` on the default branch, so the header is stored as-is; once versioning is enabled on the bucket the retention path reads it back off the pre-versioning entry.

### Fix

1. Reject the header at ingest in `putToFiler` when it is not a valid path segment (`isValidVersionID`), the same check the versioned read paths already use. Server-set version ids (`"null"`, generated hex) pass unchanged.
2. Guard the three read sinks (retention, legal hold, remote-cache resolver) to fall back to the regular object path when a stored version id is not a valid segment, so they match the other consumers.

`isValidVersionID` traversal coverage already exists in `TestIsValidVersionID`; added a `resolvedSourceVersionId` test for the drop-and-fall-back behavior. Full `weed/s3api/...` suite passes.

https://claude.ai/code/session_011QqNaxZwnpHgMoAZNp3RkY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved S3 object version handling to reject invalid or potentially unsafe version IDs.
  * Prevented malformed version IDs from creating unintended object paths or being stored.
  * Invalid version IDs now fall back to standard object paths or return a request error where appropriate.
  * Added coverage for traversal attempts using forward slashes, backslashes, empty values, and `null` version IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->