### PR TITLE
master: survive a volume layout deleted twice

### DIFF
--- a/weed/topology/collection.go
+++ b/weed/topology/collection.go
@@ -79,10 +79,8 @@ func (c *Collection) DeleteVolumeLayout(rp *super_block.ReplicaPlacement, ttl *n
 		keyString += string(diskType)
 	}
 	// Unpublish first so a racing registration re-resolves into a fresh layout.
-	vl, found := c.GetVolumeLayout(rp, ttl, diskType)
-	c.storageType2VolumeLayout.Delete(keyString)
-	if found {
-		vl.releaseLookupOwnership()
+	if vl, found := c.storageType2VolumeLayout.Delete(keyString); found {
+		vl.(*VolumeLayout).releaseLookupOwnership()
 	}
 }
 

--- a/weed/topology/collection.go
+++ b/weed/topology/collection.go
@@ -54,7 +54,10 @@ func (c *Collection) GetVolumeLayout(rp *super_block.ReplicaPlacement, ttl *need
 		keyString += string(diskType)
 	}
 	vl, ok := c.storageType2VolumeLayout.Find(keyString)
-	return vl.(*VolumeLayout), ok
+	if !ok {
+		return nil, false
+	}
+	return vl.(*VolumeLayout), true
 }
 
 func (c *Collection) GetAllVolumeLayouts() []*VolumeLayout {

--- a/weed/topology/collection_layout_delete_test.go
+++ b/weed/topology/collection_layout_delete_test.go
@@ -1,0 +1,72 @@
+package topology
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/master_pb"
+	"github.com/seaweedfs/seaweedfs/weed/sequence"
+	"github.com/seaweedfs/seaweedfs/weed/storage"
+	"github.com/seaweedfs/seaweedfs/weed/storage/needle"
+	"github.com/seaweedfs/seaweedfs/weed/storage/super_block"
+	"github.com/seaweedfs/seaweedfs/weed/storage/types"
+)
+
+func TestGetVolumeLayoutOfAbsentKey(t *testing.T) {
+	rp, _ := super_block.NewReplicaPlacementFromString("000")
+	c := NewCollection("c", 32*1024, false)
+
+	vl, found := c.GetVolumeLayout(rp, needle.EMPTY_TTL, types.HardDriveType)
+	if found || vl != nil {
+		t.Fatalf("absent layout: got (%v, %v), want (nil, false)", vl, found)
+	}
+}
+
+// Volume servers dropping the last replica of several volumes that share one
+// layout all see the layout go empty and all delete it. The losers used to
+// crash the master on a nil type assertion.
+func TestConcurrentLastReplicaRemoval(t *testing.T) {
+	const nodeCount = 8
+	ttl, _ := needle.ReadTTL("5m")
+	for round := 0; round < 500; round++ {
+		topo := NewTopology("weedfs", sequence.NewMemorySequencer(), 32*1024, 5, false)
+		rack := topo.GetOrCreateDataCenter("dc1").GetOrCreateRack("rack1")
+
+		// A second layout keeps the collection alive, so every remover reaches
+		// the layout deletion instead of stopping at a vanished collection.
+		keeper := rack.GetOrCreateDataNode("127.0.0.1", 9000, 0, "", "", map[string]uint32{"": 100})
+		topo.SyncDataNodeRegistration([]*master_pb.VolumeInformationMessage{{
+			Id: 999, Collection: "c", Version: uint32(needle.GetCurrentVersion()), Ttl: ttl.ToUint32(),
+		}}, keeper)
+
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		for i := 0; i < nodeCount; i++ {
+			dn := rack.GetOrCreateDataNode("127.0.0.1", 8080+i, 0, "", "", map[string]uint32{"": 100})
+			m := &master_pb.VolumeInformationMessage{
+				Id: uint32(i + 1), Collection: "c", Version: uint32(needle.GetCurrentVersion()),
+			}
+			topo.SyncDataNodeRegistration([]*master_pb.VolumeInformationMessage{m}, dn)
+			vi, err := storage.NewVolumeInfo(m)
+			if err != nil {
+				t.Fatalf("NewVolumeInfo: %v", err)
+			}
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				topo.UnRegisterVolumeLayout(vi, dn)
+			}()
+		}
+		close(start)
+		wg.Wait()
+
+		c, found := topo.FindCollection("c")
+		if !found {
+			t.Fatalf("round %d: collection dropped while a layout still had volumes", round)
+		}
+		if layouts := c.GetAllVolumeLayouts(); len(layouts) != 1 {
+			t.Fatalf("round %d: got %d layouts, want only the one still holding a volume", round, len(layouts))
+		}
+	}
+}

--- a/weed/topology/topology.go
+++ b/weed/topology/topology.go
@@ -533,12 +533,11 @@ func (t *Topology) DeleteCollection(collectionName string) {
 	// the node's held and servable digests apart forever, and the master asks
 	// for the full volume list on every heartbeat from then on.
 	// Unpublish first so a racing registration re-resolves into a fresh collection.
-	collection, found := t.FindCollection(collectionName)
-	t.collectionMap.Delete(collectionName)
+	collection, found := t.collectionMap.Delete(collectionName)
 	if !found {
 		return
 	}
-	for _, vl := range collection.GetAllVolumeLayouts() {
+	for _, vl := range collection.(*Collection).GetAllVolumeLayouts() {
 		vl.releaseLookupOwnership()
 	}
 }

--- a/weed/util/concurrent_read_map.go
+++ b/weed/util/concurrent_read_map.go
@@ -53,8 +53,12 @@ func (m *ConcurrentReadMap) Items() (itemsCopy []interface{}) {
 	return itemsCopy
 }
 
-func (m *ConcurrentReadMap) Delete(key string) {
+// Delete removes the key and returns what it held, so a caller that has to
+// wind the entry down does not race another deleter for it.
+func (m *ConcurrentReadMap) Delete(key string) (interface{}, bool) {
 	m.Lock()
+	value, ok := m.items[key]
 	delete(m.items, key)
 	m.Unlock()
+	return value, ok
 }


### PR DESCRIPTION
Fixes #11092.

Two volume servers dropping the last replica of volumes that share one
`VolumeLayout` key both see the layout go empty, and both walk
`UnRegisterVolumeLayout` -> `DeleteLayout` -> `DeleteVolumeLayout`. The loser's
lookup misses, and `Collection.GetVolumeLayout` asserted the type of the
result in a single-value form, so the nil interface panicked before the caller
could look at the found flag. The master died, and the same deletions killed it
again on restart.

The first commit guards the assertion; the second removes the reason there is a
loser at all, by having `ConcurrentReadMap.Delete` hand back what it removed so
the lookup and the removal are one step under the write lock. Before, two
deleters could each release the lookup ownership of the same layout, or one
could find nothing to release. `Topology.DeleteCollection` had the same
find-then-delete shape and takes the same treatment.

`TestConcurrentLastReplicaRemoval` reproduces the crash from the heartbeat path:
eight nodes drop the last replica of eight volumes sharing a layout, with a
ninth volume on a second layout to keep the collection alive so every remover
reaches the layout deletion. It panics on master in roughly half the runs and is
green after the fix, plain and under `-race`.

https://claude.ai/code/session_01WmX6Rchx298NQksHDXg7sk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when volume or collection layouts are absent, ensuring missing entries are reported consistently.
  * Prevented race conditions when concurrently removing the final replicas from shared volume layouts.
  * Made collection and layout removal safer by atomically identifying deleted entries and releasing associated resources only when applicable.

* **Tests**
  * Added regression coverage for absent layouts and concurrent last-replica removal scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->