### PR TITLE
filer_pb: walk the whole tree when the BFS start path ends in a slash

### DIFF
--- a/weed/pb/filer_pb/filer_client_bfs.go
+++ b/weed/pb/filer_pb/filer_client_bfs.go
@@ -15,6 +15,10 @@ import (
 func TraverseBfs(ctx context.Context, filerClient FilerClient, parentPath util.FullPath, fn func(parentPath util.FullPath, entry *Entry) error) (err error) {
 	K := 5
 
+	// callers hand in user-typed paths, and every entry is reported relative
+	// to this one, so a trailing slash must not reach the callback
+	parentPath = util.NormalizePath(string(parentPath))
+
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/weed/pb/filer_pb/filer_client_bfs.go
+++ b/weed/pb/filer_pb/filer_client_bfs.go
@@ -102,11 +102,7 @@ func processOneDirectory(ctx context.Context, filerClient FilerClient, parentPat
 		}
 
 		if entry.IsDirectory {
-			subDir := fmt.Sprintf("%s/%s", parentPath, entry.Name)
-			if parentPath == "/" {
-				subDir = "/" + entry.Name
-			}
-			if !enqueue(util.FullPath(subDir)) {
+			if !enqueue(parentPath.Child(entry.Name)) {
 				return ctx.Err()
 			}
 		}

--- a/weed/pb/filer_pb/filer_client_bfs_test.go
+++ b/weed/pb/filer_pb/filer_client_bfs_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"reflect"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -148,5 +150,42 @@ func TestReadDirAllEntriesStuckPagination(t *testing.T) {
 		}
 	case <-time.After(30 * time.Second):
 		t.Fatal("listing loops forever on a non-advancing store")
+	}
+}
+
+// A start path with a trailing slash must still descend into subdirectories.
+func TestTraverseBfsTrailingSlashRoot(t *testing.T) {
+	server := &stubFiler{}
+	server.listings = func(req *ListEntriesRequest, send func(*Entry) error) error {
+		if req.StartFromFileName != "" {
+			return nil
+		}
+		// the filer trims a single trailing slash, nothing more
+		switch strings.TrimSuffix(req.Directory, "/") {
+		case "/buckets/data":
+			return send(&Entry{Name: "sub", IsDirectory: true})
+		case "/buckets/data/sub":
+			return send(&Entry{Name: "a.txt"})
+		}
+		return nil
+	}
+	filerClient := startStubFiler(t, server)
+
+	var mu sync.Mutex
+	var seen []string
+	err := TraverseBfs(context.Background(), filerClient, "/buckets/data/", func(parentPath util.FullPath, entry *Entry) error {
+		mu.Lock()
+		seen = append(seen, string(parentPath.Child(entry.Name)))
+		mu.Unlock()
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sort.Strings(seen)
+	want := []string{"/buckets/data/sub", "/buckets/data/sub/a.txt"}
+	if !reflect.DeepEqual(seen, want) {
+		t.Fatalf("visited %v, want %v", seen, want)
 	}
 }

--- a/weed/pb/filer_pb/filer_client_bfs_test.go
+++ b/weed/pb/filer_pb/filer_client_bfs_test.go
@@ -175,7 +175,7 @@ func TestTraverseBfsTrailingSlashRoot(t *testing.T) {
 	var seen []string
 	err := TraverseBfs(context.Background(), filerClient, "/buckets/data/", func(parentPath util.FullPath, entry *Entry) error {
 		mu.Lock()
-		seen = append(seen, string(parentPath.Child(entry.Name)))
+		seen = append(seen, fmt.Sprintf("%s -> %s", parentPath, entry.Name))
 		mu.Unlock()
 		return nil
 	})
@@ -184,7 +184,7 @@ func TestTraverseBfsTrailingSlashRoot(t *testing.T) {
 	}
 
 	sort.Strings(seen)
-	want := []string{"/buckets/data/sub", "/buckets/data/sub/a.txt"}
+	want := []string{"/buckets/data -> sub", "/buckets/data/sub -> a.txt"}
 	if !reflect.DeepEqual(seen, want) {
 		t.Fatalf("visited %v, want %v", seen, want)
 	}


### PR DESCRIPTION
Fixes #11084.

`weed filer.meta.backup -filerDir=/buckets/x/ -restart` copied only the first level of the tree and then moved on to incremental streaming.

`TraverseBfs` built each subdirectory as `fmt.Sprintf("%s/%s", parentPath, entry.Name)`, so a start path with a trailing slash produced `/buckets/x//sub`. The filer trims a single *trailing* slash and nothing else, so those listings came back empty and the walk ended after one level. Same for `weed filer.backup -filerPath=/dir/` and the `fs.meta.save` / `fs.verify` / `fs.meta.notify` shell commands.

Reproduced against a local filer with 3 directories, 6 subdirectories and 18 files under `/buckets/repro`:

```
-filerDir=/buckets/repro     27 entries copied
-filerDir=/buckets/repro/     3 entries copied   <- only the top level
```

Both now copy 27.

Two commits:

- build child paths with `FullPath.Child`, which already handles the trailing slash and the root, so the `parentPath == "/"` special case goes away
- normalize the start path, so entries directly under it are no longer reported with the caller's trailing slash — `filer.meta.backup` was writing those under `/buckets/x/`, a directory the incremental stream never names again, so later updates and deletes landed on a different row than the initial copy

https://claude.ai/code/session_01Jp9tXRpBv9gvh8fkaVFqxQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory traversal when the starting path includes a trailing slash.
  * Ensured visited child paths remain consistent and correctly relative to the normalized starting path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->