### PR TITLE
filer: keep empty folders that are s3tables catalog entries

### DIFF
--- a/weed/filer/empty_folder_cleanup/empty_folder_cleaner.go
+++ b/weed/filer/empty_folder_cleanup/empty_folder_cleaner.go
@@ -239,6 +239,16 @@ func (efc *EmptyFolderCleaner) OnCreateEvent(directory string, entryName string,
 	if efc.cleanupQueue.Remove(directory) {
 		glog.V(3).Infof("EmptyFolderCleaner: cancelled cleanup for %s due to new entry", directory)
 	}
+
+	// A directory that has just been created is a new incarnation, so a cleanup
+	// queued against the one it replaces would delete it rather than the folder
+	// that was found empty.
+	if isDirectory {
+		recreated := string(util.NewFullPath(directory, entryName))
+		if efc.cleanupQueue.Remove(recreated) {
+			glog.V(3).Infof("EmptyFolderCleaner: cancelled cleanup for %s, recreated", recreated)
+		}
+	}
 }
 
 // cleanupProcessor runs in background and processes the cleanup queue

--- a/weed/filer/empty_folder_cleanup/empty_folder_cleaner.go
+++ b/weed/filer/empty_folder_cleanup/empty_folder_cleaner.go
@@ -529,6 +529,17 @@ func (efc *EmptyFolderCleaner) executeCleanup(folder string, triggeredBy string)
 		return
 	}
 
+	// An S3 Tables catalog entry - a namespace, a table whose files a rename left
+	// behind at the old path, a view that never had any - is the directory itself,
+	// so its being empty says nothing about whether the catalog still names it.
+	if extended, err := efc.filer.GetEntryAttributes(ctx, util.FullPath(folder)); err != nil {
+		glog.V(2).Infof("EmptyFolderCleaner: error reading attributes of %s: %v", folder, err)
+		return
+	} else if isCatalogEntry(extended) {
+		glog.V(3).Infof("EmptyFolderCleaner: skipping %s (triggered by %s), s3tables catalog entry", folder, triggeredBy)
+		return
+	}
+
 	// Observe it before the delete rather than after. A delete can fail partway and
 	// still leave the folder gone - the redis stores remove the folder before their
 	// parent-list member - so a failure return is not proof that it is still there.
@@ -615,6 +626,16 @@ func (efc *EmptyFolderCleaner) getBucketCleanupPolicy(ctx context.Context, folde
 	efc.mu.Unlock()
 
 	return bucketPath, autoRemove, "filer", attrValue, nil
+}
+
+// isCatalogEntry reports whether the directory is an s3tables catalog record.
+func isCatalogEntry(attrs map[string][]byte) bool {
+	for key := range attrs {
+		if strings.HasPrefix(key, s3_constants.ExtS3TablesPrefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func autoRemoveEmptyFoldersEnabled(attrs map[string][]byte) (bool, string) {

--- a/weed/filer/empty_folder_cleanup/empty_folder_cleaner_test.go
+++ b/weed/filer/empty_folder_cleanup/empty_folder_cleaner_test.go
@@ -1141,6 +1141,53 @@ func TestEmptyFolderCleaner_executeCleanup_directoryMarker(t *testing.T) {
 	}
 }
 
+func TestEmptyFolderCleaner_executeCleanup_skipsCatalogEntry(t *testing.T) {
+	lockRing := lock_manager.NewLockRing(5 * time.Second)
+	lockRing.SetSnapshot([]pb.ServerAddress{"filer1:8888"}, 0)
+
+	const namespace = "/buckets/warehouse/pedsnet"
+	const table = namespace + "/person"
+
+	var deleted []string
+	mock := &mockFilerOps{
+		countFn: func(_ util.FullPath) (int, error) {
+			return 0, nil
+		},
+		deleteFn: func(path util.FullPath) error {
+			deleted = append(deleted, string(path))
+			return nil
+		},
+		attrsFn: func(path util.FullPath) (map[string][]byte, error) {
+			if path == namespace || path == table {
+				return map[string][]byte{s3_constants.ExtS3TablesPrefix + "metadata": []byte("{}")}, nil
+			}
+			return nil, nil
+		},
+	}
+
+	cleaner := &EmptyFolderCleaner{
+		filer:          mock,
+		lockRing:       lockRing,
+		host:           "filer1:8888",
+		bucketPath:     "/buckets",
+		enabled:        true,
+		folderCounts:   make(map[string]*folderState),
+		cleanupQueue:   NewCleanupQueue(1000, time.Minute),
+		maxCountCheck:  1000,
+		cacheExpiry:    time.Minute,
+		processorSleep: time.Second,
+		stopCh:         make(chan struct{}),
+	}
+
+	// The dropped table left its metadata folder empty; the cascade up from it must
+	// stop at the table the rename put back, and at the namespace above it.
+	cleaner.executeCleanup(table+"/metadata", "v2.metadata.json")
+
+	if len(deleted) != 1 || deleted[0] != table+"/metadata" {
+		t.Fatalf("expected only %s to be deleted, got %v", table+"/metadata", deleted)
+	}
+}
+
 func TestEmptyFolderCleaner_restoreIfWrittenTo(t *testing.T) {
 	lockRing := lock_manager.NewLockRing(5 * time.Second)
 	lockRing.SetSnapshot([]pb.ServerAddress{"filer1:8888"}, 0)

--- a/weed/filer/empty_folder_cleanup/empty_folder_cleaner_test.go
+++ b/weed/filer/empty_folder_cleanup/empty_folder_cleaner_test.go
@@ -1141,6 +1141,38 @@ func TestEmptyFolderCleaner_executeCleanup_directoryMarker(t *testing.T) {
 	}
 }
 
+func TestEmptyFolderCleaner_OnCreateEvent_cancelsCleanupForRecreatedDirectory(t *testing.T) {
+	lockRing := lock_manager.NewLockRing(5 * time.Second)
+	lockRing.SetSnapshot([]pb.ServerAddress{"filer1:8888"}, 0)
+
+	cleaner := &EmptyFolderCleaner{
+		filer:          &mockFilerOps{},
+		lockRing:       lockRing,
+		host:           "filer1:8888",
+		bucketPath:     "/buckets",
+		enabled:        true,
+		folderCounts:   make(map[string]*folderState),
+		deleted:        make(map[string]*deletedFolder),
+		cleanupQueue:   NewCleanupQueue(1000, time.Minute),
+		maxCountCheck:  1000,
+		cacheExpiry:    time.Minute,
+		processorSleep: time.Second,
+		stopCh:         make(chan struct{}),
+	}
+
+	// Dropping the table queues the folder its children were removed from, then a
+	// rename puts a new table back under the same name.
+	cleaner.OnDeleteEvent("/buckets/warehouse/pedsnet/person", "metadata", true, time.Now())
+	if cleaner.GetPendingCleanupCount() != 1 {
+		t.Fatalf("expected the emptied folder to be queued, got %d", cleaner.GetPendingCleanupCount())
+	}
+
+	cleaner.OnCreateEvent("/buckets/warehouse/pedsnet", "person", true)
+	if cleaner.GetPendingCleanupCount() != 0 {
+		t.Fatalf("expected the recreated folder to leave the queue, got %d", cleaner.GetPendingCleanupCount())
+	}
+}
+
 func TestEmptyFolderCleaner_executeCleanup_skipsCatalogEntry(t *testing.T) {
 	lockRing := lock_manager.NewLockRing(5 * time.Second)
 	lockRing.SetSnapshot([]pb.ServerAddress{"filer1:8888"}, 0)

--- a/weed/s3api/s3_constants/extend_key.go
+++ b/weed/s3api/s3_constants/extend_key.go
@@ -49,6 +49,10 @@ const (
 	// Bucket Policy
 	ExtBucketPolicyKey = "Seaweed-X-Amz-Bucket-Policy"
 
+	// Every attribute the s3tables catalog stores on a table bucket, namespace,
+	// table or view directory entry starts with this.
+	ExtS3TablesPrefix = "s3tables."
+
 	// Object Retention and Legal Hold
 	ExtObjectLockModeKey     = "Seaweed-X-Amz-Object-Lock-Mode"
 	ExtRetentionUntilDateKey = "Seaweed-X-Amz-Retention-Until-Date"

--- a/weed/s3api/s3tables/handler.go
+++ b/weed/s3api/s3tables/handler.go
@@ -21,17 +21,17 @@ const (
 	DefaultRegion    = "us-east-1"
 
 	// Extended entry attributes for metadata storage
-	ExtendedKeyTableBucket     = "s3tables.tableBucket"
-	ExtendedKeyMetadata        = "s3tables.metadata"
-	ExtendedKeyMetadataVersion = "s3tables.metadataVersion"
-	ExtendedKeyPolicy          = "s3tables.policy"
-	ExtendedKeyTags            = "s3tables.tags"
-	ExtendedKeyMaintenance     = "s3tables.maintenance"
+	ExtendedKeyTableBucket     = s3_constants.ExtS3TablesPrefix + "tableBucket"
+	ExtendedKeyMetadata        = s3_constants.ExtS3TablesPrefix + "metadata"
+	ExtendedKeyMetadataVersion = s3_constants.ExtS3TablesPrefix + "metadataVersion"
+	ExtendedKeyPolicy          = s3_constants.ExtS3TablesPrefix + "policy"
+	ExtendedKeyTags            = s3_constants.ExtS3TablesPrefix + "tags"
+	ExtendedKeyMaintenance     = s3_constants.ExtS3TablesPrefix + "maintenance"
 	// Written by the maintenance worker, read by GetTableMaintenanceJobStatus.
 	// Separate from ExtendedKeyMaintenance so worker and operator writes do not
 	// contend on the same attribute.
-	ExtendedKeyMaintenanceStatus = "s3tables.maintenanceStatus"
-	ExtendedKeyEntryType         = "s3tables.entryType"
+	ExtendedKeyMaintenanceStatus = s3_constants.ExtS3TablesPrefix + "maintenanceStatus"
+	ExtendedKeyEntryType         = s3_constants.ExtS3TablesPrefix + "entryType"
 
 	// Entry-type marker values for ExtendedKeyEntryType. Absent or "table" means
 	// a table; views are stored like tables but tagged "view".


### PR DESCRIPTION
Fixes #11094.

The empty-folder cleaner was deleting S3 Tables catalog entries. A namespace, table or view is a filer directory whose extended attributes *are* the catalog record, and its files may live somewhere else entirely: a rename moves only the catalog pointer and leaves the data at the old path, and a view has no files at all. An empty one is still a live entry.

`DROP TABLE person` followed by `ALTER TABLE t RENAME TO person` hits this every time. The drop's recursive delete queues `person/metadata` and `person`; the rename then recreates `person` as the new catalog entry, which is empty because the data stayed under `t`. Two minutes later the cleaner pops the queue, finds `person` empty and deletes it, cascading up into the namespace. The table is gone from the catalog while the metadata it points at is still on disk — exactly what the report shows, including the `deleting empty folder .../person/metadata (triggered by v2.metadata.json)` line.

`executeCleanup` now reads the folder's own extended attributes and leaves it alone if any of them is a catalog attribute. Ordinary `data/`, `metadata/` and partition directories still get cleaned; the cascade simply stops at the table and at the namespace above it.

There is a second way in, on the queue side: a cleanup is queued against the folder that was found empty, but `OnCreateEvent` only cancelled the queue entry for the *parent* directory. When the drop removes `<ns>/person` and the rename puts a new one back under that name, the stale queue entry outlives the folder it was about and the next pass deletes the replacement. `OnCreateEvent` now drops the queue entry for the recreated path too. The attribute check still covers the other route, the cascade from a child folder up into a table or namespace that was never queued.

Also names the `s3tables.` attribute prefix once in `s3_constants` and builds the catalog keys from it, so the cleaner can recognize an entry without the filer package depending on `s3api/s3tables`.

Reproduced against `weed mini` with the Iceberg REST catalog:

```
== drop table person (purge): 204
== rename person_with_concept_name -> person: 204
== load person right after rename: 200 {"metadata-location":"s3://warehouse/pedsnet/person_with_concept_name/metadata/v1.metadata.json",...}
== waiting 170s for the empty folder cleaner ==
== load person after the cleanup delay: 404 {"error":{"message":"Table does not exist: person",...}}
== list tables: 200 {"identifiers":[]}
```

```
EmptyFolderCleaner: deleting empty folder /buckets/warehouse/pedsnet/person (triggered by metadata)
```

With the fix the same run keeps the table:

```
== load person after the cleanup delay: 200 {"metadata-location":"s3://warehouse/pedsnet/person_with_concept_name/metadata/v1.metadata.json",...}
== list tables: 200 {"identifiers":[{"namespace":["pedsnet"],"name":"person"}]}
```

```
EmptyFolderCleaner: skipping /buckets/warehouse/pedsnet/person (triggered by metadata), s3tables catalog entry
```

The new unit test drives the same cascade through `executeCleanup` and fails without the guard, deleting `person/metadata`, `person` and the `pedsnet` namespace.

https://claude.ai/code/session_01GfZsc4cyNB2yr6KYLRv9q1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented empty-folder cleanup from deleting newly recreated directories.
  * Preserved S3 Tables catalog entries during empty-folder cleanup.
  * Ensured cleanup removes only the intended metadata folder without affecting restored tables or namespaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->