### PR TITLE
helm: name both replication keys in the enableReplication comment

### DIFF
--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -55,7 +55,7 @@ global:
       gatewayHost: null
       gatewayPort: null
       additionalLabels: {}
-    # if enabled will use global.seaweedfs.replicationPlacement and override master & filer defaultReplicaPlacement config
+    # if enabled will use global.seaweedfs.replicationPlacement and override master.defaultReplication & filer.defaultReplicaPlacement config
     enableReplication: false
     #  replication type is XYZ:
     # X number of replica in other data centers


### PR DESCRIPTION
Reported in https://github.com/seaweedfs/seaweedfs/discussions/11089.

The comment above `global.seaweedfs.enableReplication` said it overrides "master & filer defaultReplicaPlacement", but the two components do not share a key:

- `master-statefulset.yaml` renders `-defaultReplication={{ .Values.master.defaultReplication }}`
- `filer-statefulset.yaml` renders `-defaultReplicaPlacement={{ .Values.filer.defaultReplicaPlacement }}`

Name both.

https://claude.ai/code/session_014Yr1Asxq3qTjJo2r9G4cLX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `replicationPlacement` overrides the default replication settings for masters and filers when replication is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->