### PR TITLE
shell: clean up the target copy when a merge upload fails

### DIFF
--- a/weed/shell/command_fs_merge_volumes.go
+++ b/weed/shell/command_fs_merge_volumes.go
@@ -176,7 +176,7 @@ func (c *commandFsMergeVolumes) Do(args []string, commandEnv *CommandEnv, writer
 					}
 					oldManifestFid := chunk.GetFileIdString()
 					oldManifestVid := chunk.Fid.VolumeId
-					newChunk, changed, subSources, mErr := c.rewriteManifestChunk(context.Background(), commandEnv, lookupFn, plan, entryPath, chunk, *apply)
+					newChunk, changed, rewritten, mErr := c.rewriteManifestChunk(context.Background(), commandEnv, lookupFn, plan, entryPath, chunk, *apply)
 					if mErr != nil {
 						fmt.Printf("failed to rewrite manifest %s(%s): %v\n", entryPath, oldManifestFid, mErr)
 						continue
@@ -186,7 +186,7 @@ func (c *commandFsMergeVolumes) Do(args []string, commandEnv *CommandEnv, writer
 					}
 					entry.Chunks[i] = newChunk
 					entryChanged = true
-					movedSources = append(movedSources, subSources...)
+					movedSources = append(movedSources, rewritten.sources...)
 					// The old manifest needle is always orphaned when we
 					// replace it with a freshly uploaded one, even when the
 					// rewrite was triggered by sub-chunk moves rather than the
@@ -244,6 +244,14 @@ func (c *commandFsMergeVolumes) Do(args []string, commandEnv *CommandEnv, writer
 type orphanedNeedle struct {
 	volumeId uint32
 	fileId   string
+}
+
+// rewrittenNeedles is the bookkeeping a manifest rewrite hands back: sources
+// whose references have moved, deletable once the filer commits, and the new
+// copies on the target volumes, which orphan if it never does.
+type rewrittenNeedles struct {
+	sources []orphanedNeedle
+	targets []orphanedNeedle
 }
 
 // deleteOrphanedNeedles fans out BatchDelete RPCs to every replica of each
@@ -655,34 +663,43 @@ func (c *commandFsMergeVolumes) rewriteManifestChunk(
 	entryPath util.FullPath,
 	chunk *filer_pb.FileChunk,
 	apply bool,
-) (*filer_pb.FileChunk, bool, []orphanedNeedle, error) {
+) (*filer_pb.FileChunk, bool, rewrittenNeedles, error) {
 	if !chunk.IsChunkManifest {
-		return chunk, false, nil, fmt.Errorf("not a manifest chunk: %s", chunk.GetFileIdString())
+		return chunk, false, rewrittenNeedles{}, fmt.Errorf("not a manifest chunk: %s", chunk.GetFileIdString())
 	}
 
 	subChunks, err := filer.ResolveOneChunkManifest(ctx, lookupFn, chunk)
 	if err != nil {
-		return chunk, false, nil, err
+		return chunk, false, rewrittenNeedles{}, err
 	}
 
-	var movedSources []orphanedNeedle
+	var rewritten rewrittenNeedles
+	// Every path out of here that is not the successful return abandons the
+	// rewrite with the filer still pointing at the old manifest, so whatever
+	// already landed on the target volumes belongs to nobody.
+	abandon := func() {
+		deleteOrphanedNeedles(commandEnv, entryPath, rewritten.targets, true)
+	}
 	anySubChanged := false
 	for i, sub := range subChunks {
 		if sub.IsChunkManifest {
 			oldSubManifestFid := sub.GetFileIdString()
 			oldSubManifestVid := sub.Fid.VolumeId
-			newSub, changed, nestedSources, rErr := c.rewriteManifestChunk(ctx, commandEnv, lookupFn, plan, entryPath, sub, apply)
+			newSub, changed, nested, rErr := c.rewriteManifestChunk(ctx, commandEnv, lookupFn, plan, entryPath, sub, apply)
 			if rErr != nil {
-				return chunk, false, nil, rErr
+				abandon()
+				return chunk, false, rewrittenNeedles{}, rErr
 			}
 			if changed {
 				subChunks[i] = newSub
 				anySubChanged = true
 				if apply {
-					movedSources = append(movedSources, nestedSources...)
+					rewritten.sources = append(rewritten.sources, nested.sources...)
 					// Nested manifest got replaced — its old needle is now
 					// orphan on the same volume it used to live on.
-					movedSources = append(movedSources, orphanedNeedle{volumeId: oldSubManifestVid, fileId: oldSubManifestFid})
+					rewritten.sources = append(rewritten.sources, orphanedNeedle{volumeId: oldSubManifestVid, fileId: oldSubManifestFid})
+					rewritten.targets = append(rewritten.targets, nested.targets...)
+					rewritten.targets = append(rewritten.targets, orphanedNeedle{volumeId: newSub.Fid.VolumeId, fileId: newSub.GetFileIdString()})
 				}
 			}
 			continue
@@ -709,14 +726,15 @@ func (c *commandFsMergeVolumes) rewriteManifestChunk(
 			continue
 		}
 		anySubChanged = true
-		movedSources = append(movedSources, orphanedNeedle{volumeId: oldSubVid, fileId: oldSubFid})
+		rewritten.sources = append(rewritten.sources, orphanedNeedle{volumeId: oldSubVid, fileId: oldSubFid})
+		rewritten.targets = append(rewritten.targets, orphanedNeedle{volumeId: uint32(toVid), fileId: sub.GetFileIdString()})
 	}
 
 	manifestVid := needle.VolumeId(chunk.Fid.VolumeId)
 	manifestMustMove := plan.isSource(manifestVid)
 
 	if !anySubChanged && !manifestMustMove {
-		return chunk, false, nil, nil
+		return chunk, false, rewrittenNeedles{}, nil
 	}
 
 	fmt.Printf("rewrite manifest %s(%s)\n", entryPath, chunk.GetFileIdString())
@@ -724,14 +742,15 @@ func (c *commandFsMergeVolumes) rewriteManifestChunk(
 		// Propagate "would change" so nested callers also announce their
 		// rewrites in dry-run mode. The top-level caller gates any actual
 		// filer writes on *apply, so returning true here is safe.
-		return chunk, true, nil, nil
+		return chunk, true, rewrittenNeedles{}, nil
 	}
 
 	filer_pb.BeforeEntrySerialization(subChunks)
 	defer filer_pb.AfterEntryDeserialization(subChunks)
 	data, err := proto.Marshal(&filer_pb.FileChunkManifest{Chunks: subChunks})
 	if err != nil {
-		return chunk, false, nil, fmt.Errorf("marshal manifest: %w", err)
+		abandon()
+		return chunk, false, rewrittenNeedles{}, fmt.Errorf("marshal manifest: %w", err)
 	}
 
 	collection := ""
@@ -740,7 +759,8 @@ func (c *commandFsMergeVolumes) rewriteManifestChunk(
 	}
 	newChunk, err := c.uploadManifestChunk(ctx, commandEnv, entryPath, collection, plan, data)
 	if err != nil {
-		return chunk, false, nil, fmt.Errorf("upload new manifest: %w", err)
+		abandon()
+		return chunk, false, rewrittenNeedles{}, fmt.Errorf("upload new manifest: %w", err)
 	}
 
 	newChunk.IsChunkManifest = true
@@ -751,7 +771,7 @@ func (c *commandFsMergeVolumes) rewriteManifestChunk(
 	}
 	newChunk.FileId = ""
 
-	return newChunk, true, movedSources, nil
+	return newChunk, true, rewritten, nil
 }
 
 // uploadManifestChunk assigns a fresh file id via the filer and uploads the

--- a/weed/shell/command_fs_merge_volumes.go
+++ b/weed/shell/command_fs_merge_volumes.go
@@ -168,7 +168,7 @@ func (c *commandFsMergeVolumes) Do(args []string, commandEnv *CommandEnv, writer
 			// look like mergeVolumes hadn't done anything. Track the old fids
 			// and delete them below after the filer update commits, so the
 			// filer never points at a fid we already deleted.
-			var movedSources []movedSourceNeedle
+			var movedSources []orphanedNeedle
 			for i, chunk := range entry.Chunks {
 				if chunk.IsChunkManifest {
 					if !c.manifestMayReferencePlan(plan, planCollections, needle.VolumeId(chunk.Fid.VolumeId)) {
@@ -191,7 +191,7 @@ func (c *commandFsMergeVolumes) Do(args []string, commandEnv *CommandEnv, writer
 					// replace it with a freshly uploaded one, even when the
 					// rewrite was triggered by sub-chunk moves rather than the
 					// manifest volume itself being in the plan.
-					movedSources = append(movedSources, movedSourceNeedle{volumeId: oldManifestVid, fileId: oldManifestFid})
+					movedSources = append(movedSources, orphanedNeedle{volumeId: oldManifestVid, fileId: oldManifestFid})
 					continue
 				}
 
@@ -211,13 +211,13 @@ func (c *commandFsMergeVolumes) Do(args []string, commandEnv *CommandEnv, writer
 				if !*apply {
 					continue
 				}
-				if mvErr := moveChunk(chunk, toVolumeId, commandEnv.MasterClient); mvErr != nil {
+				if mvErr := moveChunk(commandEnv, entryPath, chunk, toVolumeId); mvErr != nil {
 					fmt.Printf("failed to move %s(%s): %v\n", entryPath, oldFid, mvErr)
 					plan.release(chunkVolumeId, toVolumeId, chunk.Size)
 					continue
 				}
 				entryChanged = true
-				movedSources = append(movedSources, movedSourceNeedle{volumeId: oldVid, fileId: oldFid})
+				movedSources = append(movedSources, orphanedNeedle{volumeId: oldVid, fileId: oldFid})
 			}
 			if entryChanged {
 				if uErr := filer_pb.UpdateEntry(context.Background(), filerClient, &filer_pb.UpdateEntryRequest{
@@ -230,38 +230,39 @@ func (c *commandFsMergeVolumes) Do(args []string, commandEnv *CommandEnv, writer
 					// entry and let fsck reconcile later.
 					return nil
 				}
-				c.deleteMovedSourceNeedles(commandEnv, entryPath, movedSources)
+				deleteOrphanedNeedles(commandEnv, entryPath, movedSources)
 			}
 			return nil
 		})
 	})
 }
 
-// movedSourceNeedle is a needle that was copied out of its source volume by
-// a move/rewrite operation and is safe to delete once the filer update that
-// re-pointed references to the new location has committed.
-type movedSourceNeedle struct {
+// orphanedNeedle is a needle no filer entry references any more: either a
+// source needle whose references have been re-pointed at the new location, or
+// a copy left on a target volume by a write that failed before the filer could
+// be updated.
+type orphanedNeedle struct {
 	volumeId uint32
 	fileId   string
 }
 
-// deleteMovedSourceNeedles fans out BatchDelete RPCs to every replica of each
-// source volume. Errors are logged but never returned — the source data is
-// already orphan at this point, so a failed cleanup just leaves work for a
-// later fsck. Propagating an error here would abort TraverseBfs and strand
-// the remaining entries mid-merge, which is strictly worse.
-func (c *commandFsMergeVolumes) deleteMovedSourceNeedles(commandEnv *CommandEnv, entryPath util.FullPath, sources []movedSourceNeedle) {
-	if len(sources) == 0 {
+// deleteOrphanedNeedles fans out BatchDelete RPCs to every replica of each
+// needle's volume. Errors are logged but never returned — the data is already
+// orphan at this point, so a failed cleanup just leaves work for a later fsck.
+// Propagating an error here would abort TraverseBfs and strand the remaining
+// entries mid-merge, which is strictly worse.
+func deleteOrphanedNeedles(commandEnv *CommandEnv, entryPath util.FullPath, needles []orphanedNeedle) {
+	if len(needles) == 0 {
 		return
 	}
 	byVolume := make(map[uint32][]string)
-	for _, s := range sources {
-		byVolume[s.volumeId] = append(byVolume[s.volumeId], s.fileId)
+	for _, n := range needles {
+		byVolume[n.volumeId] = append(byVolume[n.volumeId], n.fileId)
 	}
 	for vid, fids := range byVolume {
 		locations, found := commandEnv.MasterClient.GetLocations(vid)
 		if !found {
-			fmt.Printf("source cleanup %s: no locations for volume %d\n", entryPath, vid)
+			fmt.Printf("orphan cleanup %s: no locations for volume %d\n", entryPath, vid)
 			continue
 		}
 		for _, loc := range locations {
@@ -293,9 +294,9 @@ func (c *commandFsMergeVolumes) deleteMovedSourceNeedles(commandEnv *CommandEnv,
 				errCount++
 			}
 			if errCount == 1 {
-				fmt.Printf("source cleanup %s: delete %s on %v: %s\n", entryPath, firstFid, loc.ServerAddress(), firstErr)
+				fmt.Printf("orphan cleanup %s: delete %s on %v: %s\n", entryPath, firstFid, loc.ServerAddress(), firstErr)
 			} else if errCount > 1 {
-				fmt.Printf("source cleanup %s: %d/%d needles failed on %v (e.g. %s: %s)\n",
+				fmt.Printf("orphan cleanup %s: %d/%d needles failed on %v (e.g. %s: %s)\n",
 					entryPath, errCount, len(fids), loc.ServerAddress(), firstFid, firstErr)
 			}
 		}
@@ -647,7 +648,7 @@ func (c *commandFsMergeVolumes) rewriteManifestChunk(
 	entryPath util.FullPath,
 	chunk *filer_pb.FileChunk,
 	apply bool,
-) (*filer_pb.FileChunk, bool, []movedSourceNeedle, error) {
+) (*filer_pb.FileChunk, bool, []orphanedNeedle, error) {
 	if !chunk.IsChunkManifest {
 		return chunk, false, nil, fmt.Errorf("not a manifest chunk: %s", chunk.GetFileIdString())
 	}
@@ -657,7 +658,7 @@ func (c *commandFsMergeVolumes) rewriteManifestChunk(
 		return chunk, false, nil, err
 	}
 
-	var movedSources []movedSourceNeedle
+	var movedSources []orphanedNeedle
 	anySubChanged := false
 	for i, sub := range subChunks {
 		if sub.IsChunkManifest {
@@ -674,7 +675,7 @@ func (c *commandFsMergeVolumes) rewriteManifestChunk(
 					movedSources = append(movedSources, nestedSources...)
 					// Nested manifest got replaced — its old needle is now
 					// orphan on the same volume it used to live on.
-					movedSources = append(movedSources, movedSourceNeedle{volumeId: oldSubManifestVid, fileId: oldSubManifestFid})
+					movedSources = append(movedSources, orphanedNeedle{volumeId: oldSubManifestVid, fileId: oldSubManifestFid})
 				}
 			}
 			continue
@@ -695,13 +696,13 @@ func (c *commandFsMergeVolumes) rewriteManifestChunk(
 			anySubChanged = true
 			continue
 		}
-		if mErr := moveChunk(sub, toVid, commandEnv.MasterClient); mErr != nil {
+		if mErr := moveChunk(commandEnv, entryPath, sub, toVid); mErr != nil {
 			fmt.Printf("failed to move %s(%s): %v\n", entryPath, oldSubFid, mErr)
 			plan.release(subVid, toVid, sub.Size)
 			continue
 		}
 		anySubChanged = true
-		movedSources = append(movedSources, movedSourceNeedle{volumeId: oldSubVid, fileId: oldSubFid})
+		movedSources = append(movedSources, orphanedNeedle{volumeId: oldSubVid, fileId: oldSubFid})
 	}
 
 	manifestVid := needle.VolumeId(chunk.Fid.VolumeId)
@@ -761,6 +762,7 @@ func (c *commandFsMergeVolumes) uploadManifestChunk(
 ) (*filer_pb.FileChunk, error) {
 	const manifestAssignAttempts = 10
 	var assignResp *filer_pb.AssignVolumeResponse
+	var assignedVid uint32
 	if err := commandEnv.WithFilerClient(false, func(client filer_pb.SeaweedFilerClient) error {
 		for attempt := 1; attempt <= manifestAssignAttempts; attempt++ {
 			resp, err := client.AssignVolume(ctx, &filer_pb.AssignVolumeRequest{
@@ -785,6 +787,7 @@ func (c *commandFsMergeVolumes) uploadManifestChunk(
 			}
 			if !plan.isSource(needle.VolumeId(fid.VolumeId)) {
 				assignResp = resp
+				assignedVid = fid.VolumeId
 				return nil
 			}
 			fmt.Printf("rejecting manifest assignment to merge-source volume %d (attempt %d/%d)\n",
@@ -818,17 +821,22 @@ func (c *commandFsMergeVolumes) uploadManifestChunk(
 		UploadUrl: uploadUrl,
 		Jwt:       jwt,
 	})
-	if err != nil {
-		return nil, err
+	if err == nil && uploadResult.Error != "" {
+		err = fmt.Errorf("upload: %s", uploadResult.Error)
 	}
-	if uploadResult.Error != "" {
-		return nil, fmt.Errorf("upload: %s", uploadResult.Error)
+	if err != nil {
+		// Same partial-write window as moveChunk: the needle can be on the
+		// volume even though the upload reported failure, and the caller drops
+		// this manifest instead of pointing the filer at it.
+		deleteOrphanedNeedles(commandEnv, entryPath, []orphanedNeedle{{volumeId: assignedVid, fileId: assignResp.FileId}})
+		return nil, err
 	}
 
 	return uploadResult.ToPbFileChunk(assignResp.FileId, 0, time.Now().UnixNano()), nil
 }
 
-func moveChunk(chunk *filer_pb.FileChunk, toVolumeId needle.VolumeId, masterClient *wdclient.MasterClient) error {
+func moveChunk(commandEnv *CommandEnv, entryPath util.FullPath, chunk *filer_pb.FileChunk, toVolumeId needle.VolumeId) error {
+	masterClient := commandEnv.MasterClient
 	fromFid := needle.NewFileId(needle.VolumeId(chunk.Fid.VolumeId), chunk.Fid.FileKey, chunk.Fid.Cookie)
 	toFid := needle.NewFileId(toVolumeId, chunk.Fid.FileKey, chunk.Fid.Cookie)
 
@@ -891,6 +899,11 @@ func moveChunk(chunk *filer_pb.FileChunk, toVolumeId needle.VolumeId, masterClie
 		Jwt:               security.EncodedJwt(jwt),
 	})
 	if err != nil {
+		// A replicated write commits the needle to the local volume before it
+		// fans out to the other replicas, so an upload that reports failure can
+		// still have left a copy on the target. The caller skips the filer
+		// update for this chunk, so nothing will ever reference that copy.
+		deleteOrphanedNeedles(commandEnv, entryPath, []orphanedNeedle{{volumeId: uint32(toVolumeId), fileId: toFid.String()}})
 		return err
 	}
 	chunk.Fid.VolumeId = uint32(toVolumeId)

--- a/weed/shell/command_fs_merge_volumes.go
+++ b/weed/shell/command_fs_merge_volumes.go
@@ -230,7 +230,7 @@ func (c *commandFsMergeVolumes) Do(args []string, commandEnv *CommandEnv, writer
 					// entry and let fsck reconcile later.
 					return nil
 				}
-				deleteOrphanedNeedles(commandEnv, entryPath, movedSources)
+				deleteOrphanedNeedles(commandEnv, entryPath, movedSources, false)
 			}
 			return nil
 		})
@@ -251,7 +251,14 @@ type orphanedNeedle struct {
 // orphan at this point, so a failed cleanup just leaves work for a later fsck.
 // Propagating an error here would abort TraverseBfs and strand the remaining
 // entries mid-merge, which is strictly worse.
-func deleteOrphanedNeedles(commandEnv *CommandEnv, entryPath util.FullPath, needles []orphanedNeedle) {
+//
+// includeCookie makes the volume server verify the needle is the one we mean
+// before deleting it. Source needles are the ones the filer just pointed at,
+// so they delete by id like every other filer-driven delete. A target needle
+// is one an upload may or may not have written, and the id alone would also
+// match a same-key needle that a restored or re-sequenced volume put there
+// first, so those always verify.
+func deleteOrphanedNeedles(commandEnv *CommandEnv, entryPath util.FullPath, needles []orphanedNeedle, includeCookie bool) {
 	if len(needles) == 0 {
 		return
 	}
@@ -266,7 +273,7 @@ func deleteOrphanedNeedles(commandEnv *CommandEnv, entryPath util.FullPath, need
 			continue
 		}
 		for _, loc := range locations {
-			results := operation.DeleteFileIdsAtOneVolumeServer(loc.ServerAddress(), commandEnv.option.GrpcDialOption, fids, false)
+			results := operation.DeleteFileIdsAtOneVolumeServer(loc.ServerAddress(), commandEnv.option.GrpcDialOption, fids, includeCookie)
 			// Summarize per server: an unreachable volume server returns one
 			// error per needle, which for manifest-heavy files can mean
 			// hundreds of near-identical lines. Keep the first error as the
@@ -828,7 +835,7 @@ func (c *commandFsMergeVolumes) uploadManifestChunk(
 		// Same partial-write window as moveChunk: the needle can be on the
 		// volume even though the upload reported failure, and the caller drops
 		// this manifest instead of pointing the filer at it.
-		deleteOrphanedNeedles(commandEnv, entryPath, []orphanedNeedle{{volumeId: assignedVid, fileId: assignResp.FileId}})
+		deleteOrphanedNeedles(commandEnv, entryPath, []orphanedNeedle{{volumeId: assignedVid, fileId: assignResp.FileId}}, true)
 		return nil, err
 	}
 
@@ -903,7 +910,7 @@ func moveChunk(commandEnv *CommandEnv, entryPath util.FullPath, chunk *filer_pb.
 		// fans out to the other replicas, so an upload that reports failure can
 		// still have left a copy on the target. The caller skips the filer
 		// update for this chunk, so nothing will ever reference that copy.
-		deleteOrphanedNeedles(commandEnv, entryPath, []orphanedNeedle{{volumeId: uint32(toVolumeId), fileId: toFid.String()}})
+		deleteOrphanedNeedles(commandEnv, entryPath, []orphanedNeedle{{volumeId: uint32(toVolumeId), fileId: toFid.String()}}, true)
 		return err
 	}
 	chunk.Fid.VolumeId = uint32(toVolumeId)

--- a/weed/shell/command_fs_merge_volumes.go
+++ b/weed/shell/command_fs_merge_volumes.go
@@ -246,12 +246,20 @@ type orphanedNeedle struct {
 	fileId   string
 }
 
+// reservation is the plan capacity a successful move consumed, remembered so
+// an abandoned rewrite can hand it back with the copy it deletes.
+type reservation struct {
+	src, dst needle.VolumeId
+	size     uint64
+}
+
 // rewrittenNeedles is the bookkeeping a manifest rewrite hands back: sources
 // whose references have moved, deletable once the filer commits, and the new
 // copies on the target volumes, which orphan if it never does.
 type rewrittenNeedles struct {
-	sources []orphanedNeedle
-	targets []orphanedNeedle
+	sources      []orphanedNeedle
+	targets      []orphanedNeedle
+	reservations []reservation
 }
 
 // deleteOrphanedNeedles fans out BatchDelete RPCs to every replica of each
@@ -676,9 +684,14 @@ func (c *commandFsMergeVolumes) rewriteManifestChunk(
 	var rewritten rewrittenNeedles
 	// Every path out of here that is not the successful return abandons the
 	// rewrite with the filer still pointing at the old manifest, so whatever
-	// already landed on the target volumes belongs to nobody.
+	// already landed on the target volumes belongs to nobody. Give the plan
+	// back the room those copies were holding, or a multi-target merge keeps
+	// counting bytes it just deleted and skips later chunks for no reason.
 	abandon := func() {
 		deleteOrphanedNeedles(commandEnv, entryPath, rewritten.targets, true)
+		for _, r := range rewritten.reservations {
+			plan.release(r.src, r.dst, r.size)
+		}
 	}
 	anySubChanged := false
 	for i, sub := range subChunks {
@@ -700,6 +713,7 @@ func (c *commandFsMergeVolumes) rewriteManifestChunk(
 					rewritten.sources = append(rewritten.sources, orphanedNeedle{volumeId: oldSubManifestVid, fileId: oldSubManifestFid})
 					rewritten.targets = append(rewritten.targets, nested.targets...)
 					rewritten.targets = append(rewritten.targets, orphanedNeedle{volumeId: newSub.Fid.VolumeId, fileId: newSub.GetFileIdString()})
+					rewritten.reservations = append(rewritten.reservations, nested.reservations...)
 				}
 			}
 			continue
@@ -728,6 +742,7 @@ func (c *commandFsMergeVolumes) rewriteManifestChunk(
 		anySubChanged = true
 		rewritten.sources = append(rewritten.sources, orphanedNeedle{volumeId: oldSubVid, fileId: oldSubFid})
 		rewritten.targets = append(rewritten.targets, orphanedNeedle{volumeId: uint32(toVid), fileId: sub.GetFileIdString()})
+		rewritten.reservations = append(rewritten.reservations, reservation{src: subVid, dst: toVid, size: sub.Size})
 	}
 
 	manifestVid := needle.VolumeId(chunk.Fid.VolumeId)


### PR DESCRIPTION
Reported in https://github.com/seaweedfs/seaweedfs/issues/11009#issuecomment-5508071217: "fs.mergeVolumes with volumes that are replicated creates a LOT of orphans".

That is right, for one specific reason. `topology.ReplicatedWrite` commits the needle to the local volume *before* it fans out to the other replicas, so an upload that reports failure can still have left a copy on the target. `moveChunk` returns the error, `fs.mergeVolumes` prints "failed to move" and carries on to the next chunk, and that copy stays behind forever: the filer is never re-pointed at it, so nothing will ever reference or delete it.

One sick replica orphans roughly half the chunks of a merge (two thirds with three copies): the entry node is picked at random by `LookupVolumeServerUrl`, and the replica upload uses `MaxAttempts: 1` ("fail fast on a dead replica; the client write retries") — except here there is no retrying client, so a single transient timeout per chunk is enough. A volume with a single copy has no such window: `GetWritableRemoteReplications` returns early, and the write is one local append that either succeeds or leaves nothing behind.

This deletes the needle we may have written, on every replica of the target, before continuing. The source side already did exactly this after a successful move, so `deleteMovedSourceNeedles` is renamed to `deleteOrphanedNeedles` and reused for both ends. The freshly assigned manifest needle in `uploadManifestChunk` has the same window and gets the same treatment.

## Verified on a 2-node cluster, replication 001

Merge with a healthy target: source needles deleted on both replicas, `volume.fsck` clean. Unchanged by this PR.

Merge into a target whose replica cannot accept the write (`volume.mark -node=... -readonly` on one copy):

before
```
dataNode:127.0.0.1:21002  volume:5  entries:11  orphan:3  27.27%  1572924B
Total                                entries:125  orphan:3   2.40%  1572924B
```
The target volume's replicas were left permanently divergent, 11 live needles vs 8.

after
```
Total                                entries:122  orphan:0   0.00%  0B
no orphan data
```
The stranded copies are written and then deleted (`FileCount 19 DeleteCount 10` vs `17/8`), so both replicas agree on 9 live needles and the dead bytes are reclaimable by vacuum. All 60 files read back byte-identical.

Note for anyone reproducing this: `volume.fsck`'s `-cutoffTimeAgo` defaults to 5 hours, so a run straight after a merge reports `orphan:0` either way. The runs above pass `-cutoffTimeAgo=1s`.

## Not addressed here

The same report asks for two other things. Marking the source read-only before draining it would not have fixed these orphans (they land on the *target*), and `createMergePlan` currently rejects a read-only source outright — `IsReadOnly()` is true for `readonlyCanDelete` too, so even `volume.mark -readonlyCanDelete` would not get past the plan. Having `fs.mergeVolumes` delete the drained volumes itself is a separate feature.

https://claude.ai/code/session_01XjiMGK72F4Gs3yWNJhnVjy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of orphaned data left behind after failed volume moves or uploads.
  * Added cleanup for partially written manifest data when uploads fail or operations are abandoned.
  * Ensured temporary data and reserved capacity are released consistently after interrupted rewrites.
  * Added validation to reject invalid source and destination volume IDs before processing.
  * Prevented source volume IDs exceeding the supported maximum from being accepted.
  * Improved cleanup logging to make volume-operation issues easier to diagnose.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## From review

- `a7afb2e3e` — target deletes now verify the cookie. `BatchDelete` matches on the needle id alone, and while ids come from one global sequence, a volume restored from another cluster or written either side of a master sequence reset can hold a colliding one; a failed move would then delete a live needle out from under its filer entry. Source deletes still match on id, as every other filer-driven delete does.
- `7379735f3` — `rewriteManifestChunk` now deletes the target copies it leaves when it is abandoned partway. It moves sub-chunks one at a time and only uploads the rewritten manifest at the end, so a nested rewrite failing, the marshal, or the manifest upload each returned leaving those copies behind, one orphan per sub-chunk moved so far. Nested rewrites hand theirs up so an outer failure clears the whole subtree.

  Verified on the same cluster shape with `ManifestBatch` temporarily lowered from 10000 to 3 in a throwaway binary, so a 5MB file manifestizes. No fault injection needed: sub-chunk moves are direct writes to the target volume server and succeed on their own, while the manifest re-upload has to `AssignVolume`, which fails once every volume is past `-volumeSizeLimitMB` and both volume servers are at `-max`. Before, three sub-chunk copies stranded on both replicas of the target (`orphan:6`, 6.3MB from two 5MB files); after, `orphan:0`. `-findMissingChunksInFiler` reports nothing missing either way and both files read back byte-identical, so only the abandoned copies go and the sources the old manifest still points at stay.

A failed `UpdateEntry` still leaks its target copies, deliberately. That error can also mean the filer applied the update and lost the response, in which case those copies are what the entry now points at, and deleting them would turn a leak into data loss.

