### PR TITLE
shell: exit non-zero when a piped command fails

### DIFF
--- a/weed/command/command.go
+++ b/weed/command/command.go
@@ -97,3 +97,21 @@ func (c *Command) Usage() {
 func (c *Command) Runnable() bool {
 	return c.Run != nil
 }
+
+// commandExitStatus is a non-zero exit status a command wants the process to
+// end with. Commands record it instead of calling os.Exit so the failure still
+// travels through main's normal shutdown path (atexit hooks, sentry flush).
+var commandExitStatus int
+
+// SetCommandExitStatus records a non-zero exit status for main to apply after
+// the command returns. The highest requested status wins.
+func SetCommandExitStatus(n int) {
+	if n > commandExitStatus {
+		commandExitStatus = n
+	}
+}
+
+// CommandExitStatus returns the exit status recorded by the command, 0 when none.
+func CommandExitStatus() int {
+	return commandExitStatus
+}

--- a/weed/command/command.go
+++ b/weed/command/command.go
@@ -98,20 +98,16 @@ func (c *Command) Runnable() bool {
 	return c.Run != nil
 }
 
-// commandExitStatus is a non-zero exit status a command wants the process to
-// end with. Commands record it instead of calling os.Exit so the failure still
-// travels through main's normal shutdown path (atexit hooks, sentry flush).
+// Recorded, not os.Exit'ed, so the failure still travels through main's
+// shutdown path. The highest requested status wins.
 var commandExitStatus int
 
-// SetCommandExitStatus records a non-zero exit status for main to apply after
-// the command returns. The highest requested status wins.
 func SetCommandExitStatus(n int) {
 	if n > commandExitStatus {
 		commandExitStatus = n
 	}
 }
 
-// CommandExitStatus returns the exit status recorded by the command, 0 when none.
 func CommandExitStatus() int {
 	return commandExitStatus
 }

--- a/weed/command/shell.go
+++ b/weed/command/shell.go
@@ -68,7 +68,14 @@ func runShell(command *Command, args []string) bool {
 		fmt.Fprintf(os.Stderr, "master: %s filer: %s\n", *shellOptions.Masters, shellOptions.FilerAddress)
 	}
 
-	shell.RunShell(shellOptions)
+	if err := shell.RunShell(shellOptions); err != nil {
+		// Non-interactive (piped) mode surfaced a command failure. The command
+		// already printed "error: ..."; exit non-zero so scripts and CronJobs
+		// see the failure -- previously a run that aborted partway (e.g.
+		// s3.lifecycle.run-shard dying mid-walk) still exited 0 and schedulers
+		// reported it green.
+		os.Exit(2)
+	}
 
 	return true
 

--- a/weed/command/shell.go
+++ b/weed/command/shell.go
@@ -71,7 +71,7 @@ func runShell(command *Command, args []string) bool {
 	if err := shell.RunShell(shellOptions); err != nil {
 		// The command already printed the error; a piped run has to fail the
 		// script wrapping it too.
-		SetCommandExitStatus(2)
+		SetCommandExitStatus(1)
 	}
 
 	return true

--- a/weed/command/shell.go
+++ b/weed/command/shell.go
@@ -73,8 +73,9 @@ func runShell(command *Command, args []string) bool {
 		// already printed "error: ..."; exit non-zero so scripts and CronJobs
 		// see the failure -- previously a run that aborted partway (e.g.
 		// s3.lifecycle.run-shard dying mid-walk) still exited 0 and schedulers
-		// reported it green.
-		os.Exit(2)
+		// reported it green. Recorded rather than os.Exit'ed so the process
+		// still goes through main's shutdown path (atexit hooks, sentry flush).
+		SetCommandExitStatus(2)
 	}
 
 	return true

--- a/weed/command/shell.go
+++ b/weed/command/shell.go
@@ -69,12 +69,8 @@ func runShell(command *Command, args []string) bool {
 	}
 
 	if err := shell.RunShell(shellOptions); err != nil {
-		// Non-interactive (piped) mode surfaced a command failure. The command
-		// already printed "error: ..."; exit non-zero so scripts and CronJobs
-		// see the failure -- previously a run that aborted partway (e.g.
-		// s3.lifecycle.run-shard dying mid-walk) still exited 0 and schedulers
-		// reported it green. Recorded rather than os.Exit'ed so the process
-		// still goes through main's shutdown path (atexit hooks, sentry flush).
+		// The command already printed the error; a piped run has to fail the
+		// script wrapping it too.
 		SetCommandExitStatus(2)
 	}
 

--- a/weed/shell/shell_liner.go
+++ b/weed/shell/shell_liner.go
@@ -24,11 +24,8 @@ import (
 
 var historyPath = path.Join(os.TempDir(), "weed-shell")
 
-// RunShell drives the admin shell. In interactive mode it always returns nil
-// (errors are shown to the operator and the session continues). In
-// non-interactive mode (commands piped on stdin -- the scriptable path
-// CronJobs use) it returns the LAST command failure, so a wrapper can exit
-// non-zero instead of reporting success for a run that printed "error: ...".
+// Piped stdin returns the last command failure; an interactive session shows
+// the error to the operator and keeps going.
 func RunShell(options ShellOptions) error {
 	slices.SortFunc(Commands, func(a, b command) int {
 		return strings.Compare(a.Name(), b.Name())
@@ -113,9 +110,6 @@ func RunShell(options ShellOptions) error {
 			}
 		}
 	} else {
-		// Non-interactive: remember failures so the process can exit non-zero.
-		// A CronJob piping "s3.lifecycle.run-shard ..." into weed shell
-		// otherwise reports green while the run aborted partway.
 		var lastErr error
 		scanner := bufio.NewScanner(os.Stdin)
 		for scanner.Scan() {

--- a/weed/shell/shell_liner.go
+++ b/weed/shell/shell_liner.go
@@ -24,7 +24,12 @@ import (
 
 var historyPath = path.Join(os.TempDir(), "weed-shell")
 
-func RunShell(options ShellOptions) {
+// RunShell drives the admin shell. In interactive mode it always returns nil
+// (errors are shown to the operator and the session continues). In
+// non-interactive mode (commands piped on stdin -- the scriptable path
+// CronJobs use) it returns the LAST command failure, so a wrapper can exit
+// non-zero instead of reporting success for a run that printed "error: ...".
+func RunShell(options ShellOptions) error {
 	slices.SortFunc(Commands, func(a, b command) int {
 		return strings.Compare(a.Name(), b.Name())
 	})
@@ -94,7 +99,7 @@ func RunShell(options ShellOptions) {
 				if err != io.EOF {
 					fmt.Fprintf(os.Stderr, "%v\n", err)
 				}
-				return
+				return nil
 			}
 
 			if strings.TrimSpace(cmd) != "" {
@@ -102,32 +107,42 @@ func RunShell(options ShellOptions) {
 			}
 
 			for _, c := range util.StringSplit(cmd, ";") {
-				if processEachCmd(c, commandEnv) {
-					return
+				if exit, _ := processEachCmd(c, commandEnv); exit {
+					return nil
 				}
 			}
 		}
 	} else {
+		// Non-interactive: remember failures so the process can exit non-zero.
+		// A CronJob piping "s3.lifecycle.run-shard ..." into weed shell
+		// otherwise reports green while the run aborted partway.
+		var lastErr error
 		scanner := bufio.NewScanner(os.Stdin)
 		for scanner.Scan() {
 			cmd := scanner.Text()
 			for _, c := range util.StringSplit(cmd, ";") {
-				if processEachCmd(c, commandEnv) {
-					return
+				exit, err := processEachCmd(c, commandEnv)
+				if err != nil {
+					lastErr = err
+				}
+				if exit {
+					return lastErr
 				}
 			}
 		}
 		if err := scanner.Err(); err != nil {
 			fmt.Fprintf(os.Stderr, "error reading stdin: %v\n", err)
+			lastErr = err
 		}
+		return lastErr
 	}
 }
 
-func processEachCmd(cmd string, commandEnv *CommandEnv) bool {
+func processEachCmd(cmd string, commandEnv *CommandEnv) (exit bool, cmdErr error) {
 	cmds := splitCommandLine(cmd)
 
 	if len(cmds) == 0 {
-		return false
+		return false, nil
 	} else {
 
 		args := cmds[1:]
@@ -136,7 +151,7 @@ func processEachCmd(cmd string, commandEnv *CommandEnv) bool {
 		if cmd == "help" || cmd == "?" {
 			printHelp(cmds)
 		} else if cmd == "exit" || cmd == "quit" {
-			return true
+			return true, nil
 		} else {
 			foundCommand := false
 			for _, c := range Commands {
@@ -149,17 +164,19 @@ func processEachCmd(cmd string, commandEnv *CommandEnv) bool {
 					commandEnv.SetNoLock(false)
 					if err := c.Do(args, commandEnv, os.Stdout); err != nil {
 						fmt.Fprintf(os.Stderr, "error: %v\n", err)
+						cmdErr = err
 					}
 					foundCommand = true
 				}
 			}
 			if !foundCommand {
 				fmt.Fprintf(os.Stderr, "unknown command: %v\n", cmd)
+				cmdErr = fmt.Errorf("unknown command: %v", cmd)
 			}
 		}
 
 	}
-	return false
+	return false, cmdErr
 }
 
 func splitCommandLine(line string) []string {

--- a/weed/shell/shell_liner_test.go
+++ b/weed/shell/shell_liner_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 )
 
-// fakeCommand lets the tests drive the REGISTERED-command path of
-// processEachCmd with a controlled Do result.
 type fakeCommand struct {
 	name string
 	err  error
@@ -19,12 +17,8 @@ func (c *fakeCommand) Help() string                              { return "test 
 func (c *fakeCommand) HasTag(CommandTag) bool                    { return false }
 func (c *fakeCommand) Do([]string, *CommandEnv, io.Writer) error { return c.err }
 
-// Non-interactive shell runs must be able to report failure: processEachCmd
-// returns the command error so RunShell can propagate it to a non-zero process
-// exit (previously a failed piped run printed "error: ..." and exited 0).
 func TestProcessEachCmdReturnsErrors(t *testing.T) {
 
-	// An unknown command is an error a script must see.
 	exit, err := processEachCmd("definitely.not.a.command", nil)
 	if exit {
 		t.Errorf("unknown command must not request exit")
@@ -36,7 +30,6 @@ func TestProcessEachCmdReturnsErrors(t *testing.T) {
 		t.Errorf("unexpected error for unknown command: %v", err)
 	}
 
-	// "exit"/"quit" end the session without an error.
 	exit, err = processEachCmd("exit", nil)
 	if !exit {
 		t.Errorf("exit must request exit")
@@ -45,16 +38,12 @@ func TestProcessEachCmdReturnsErrors(t *testing.T) {
 		t.Errorf("exit must not return an error, got: %v", err)
 	}
 
-	// A blank line is a no-op.
 	exit, err = processEachCmd("   ", nil)
 	if exit || err != nil {
 		t.Errorf("blank input must be a no-op, got exit=%v err=%v", exit, err)
 	}
 }
 
-// The registered-command path: a command whose Do fails must surface that
-// exact error (this is what RunShell propagates and the weed shell command
-// turns into a non-zero process exit); a succeeding command must not.
 func TestProcessEachCmdPreservesRegisteredCommandError(t *testing.T) {
 	doErr := errors.New("daily_run: shard=3: recovery walk failed")
 	failing := &fakeCommand{name: "test.failing.command", err: doErr}

--- a/weed/shell/shell_liner_test.go
+++ b/weed/shell/shell_liner_test.go
@@ -1,9 +1,23 @@
 package shell
 
 import (
+	"errors"
+	"io"
 	"strings"
 	"testing"
 )
+
+// fakeCommand lets the tests drive the REGISTERED-command path of
+// processEachCmd with a controlled Do result.
+type fakeCommand struct {
+	name string
+	err  error
+}
+
+func (c *fakeCommand) Name() string                              { return c.name }
+func (c *fakeCommand) Help() string                              { return "test helper" }
+func (c *fakeCommand) HasTag(CommandTag) bool                    { return false }
+func (c *fakeCommand) Do([]string, *CommandEnv, io.Writer) error { return c.err }
 
 // Non-interactive shell runs must be able to report failure: processEachCmd
 // returns the command error so RunShell can propagate it to a non-zero process
@@ -35,5 +49,29 @@ func TestProcessEachCmdReturnsErrors(t *testing.T) {
 	exit, err = processEachCmd("   ", nil)
 	if exit || err != nil {
 		t.Errorf("blank input must be a no-op, got exit=%v err=%v", exit, err)
+	}
+}
+
+// The registered-command path: a command whose Do fails must surface that
+// exact error (this is what RunShell propagates and the weed shell command
+// turns into a non-zero process exit); a succeeding command must not.
+func TestProcessEachCmdPreservesRegisteredCommandError(t *testing.T) {
+	doErr := errors.New("daily_run: shard=3: recovery walk failed")
+	failing := &fakeCommand{name: "test.failing.command", err: doErr}
+	succeeding := &fakeCommand{name: "test.succeeding.command"}
+	Commands = append(Commands, failing, succeeding)
+	t.Cleanup(func() { Commands = Commands[:len(Commands)-2] })
+
+	exit, err := processEachCmd("test.failing.command -some -args", nil)
+	if exit {
+		t.Errorf("a failing command must not request exit")
+	}
+	if !errors.Is(err, doErr) {
+		t.Errorf("the command's own error must be preserved, got: %v", err)
+	}
+
+	exit, err = processEachCmd("test.succeeding.command", nil)
+	if exit || err != nil {
+		t.Errorf("a succeeding command must return no error, got exit=%v err=%v", exit, err)
 	}
 }

--- a/weed/shell/shell_liner_test.go
+++ b/weed/shell/shell_liner_test.go
@@ -1,0 +1,39 @@
+package shell
+
+import (
+	"strings"
+	"testing"
+)
+
+// Non-interactive shell runs must be able to report failure: processEachCmd
+// returns the command error so RunShell can propagate it to a non-zero process
+// exit (previously a failed piped run printed "error: ..." and exited 0).
+func TestProcessEachCmdReturnsErrors(t *testing.T) {
+
+	// An unknown command is an error a script must see.
+	exit, err := processEachCmd("definitely.not.a.command", nil)
+	if exit {
+		t.Errorf("unknown command must not request exit")
+	}
+	if err == nil {
+		t.Errorf("unknown command must return an error")
+	}
+	if err != nil && !strings.Contains(err.Error(), "unknown command") {
+		t.Errorf("unexpected error for unknown command: %v", err)
+	}
+
+	// "exit"/"quit" end the session without an error.
+	exit, err = processEachCmd("exit", nil)
+	if !exit {
+		t.Errorf("exit must request exit")
+	}
+	if err != nil {
+		t.Errorf("exit must not return an error, got: %v", err)
+	}
+
+	// A blank line is a no-op.
+	exit, err = processEachCmd("   ", nil)
+	if exit || err != nil {
+		t.Errorf("blank input must be a no-op, got exit=%v err=%v", exit, err)
+	}
+}

--- a/weed/weed.go
+++ b/weed/weed.go
@@ -102,6 +102,9 @@ func main() {
 				// Command execution failed - general error
 				setExitStatus(1)
 			}
+			// A command that ran may still have recorded a failure status
+			// (e.g. a piped `weed shell` whose command errored).
+			setExitStatus(command.CommandExitStatus())
 			exit()
 			return
 		}
@@ -200,5 +203,8 @@ func exit() {
 	for _, f := range atexitFuncs {
 		f()
 	}
+	// os.Exit skips deferred functions, so main's deferred sentry.Flush never
+	// ran on this path; flush here so buffered events survive the exit.
+	sentry.Flush(2 * time.Second)
 	os.Exit(exitStatus)
 }

--- a/weed/weed.go
+++ b/weed/weed.go
@@ -102,8 +102,7 @@ func main() {
 				// Command execution failed - general error
 				setExitStatus(1)
 			}
-			// A command that ran may still have recorded a failure status
-			// (e.g. a piped `weed shell` whose command errored).
+			// A command can also record a failure without returning false.
 			setExitStatus(command.CommandExitStatus())
 			exit()
 			return
@@ -203,8 +202,7 @@ func exit() {
 	for _, f := range atexitFuncs {
 		f()
 	}
-	// os.Exit skips deferred functions, so main's deferred sentry.Flush never
-	// ran on this path; flush here so buffered events survive the exit.
+	// os.Exit below skips main's deferred flush.
 	sentry.Flush(2 * time.Second)
 	os.Exit(exitStatus)
 }


### PR DESCRIPTION
Split out of #11110 so the two halves of https://github.com/seaweedfs/seaweedfs/issues/11106 land as separate commits. The three shell commits are @carlos-leyva-guerrero's, unchanged; the last two are review follow-ups.

# What problem are we solving?

A failed command in a piped `weed shell` run printed `error: ...` and still exited 0, so a CronJob wrapping

    printf 's3.lifecycle.run-shard -shards 0-15 ...\n' | weed shell -master=...

reported green while the run aborted partway and shards went unwalked. An unknown command exited 0 too.

# How are we solving the problem?

`RunShell` returns the last command failure from the non-interactive stdin path, unknown commands included, and the shell command records a non-zero exit status for `main` to apply after the normal shutdown path (atexit hooks, sentry flush) rather than calling `os.Exit` itself. `exit()` now flushes sentry, which `main`'s deferred flush never did on this path.

Interactive sessions are unchanged: errors are shown and the session continues, exit 0 as before.

The status is 1, not 2: `weed.go` already spends 1 on a command that failed and 2 on a usage or syntax error, and `runShell` returns true precisely so the usage dump is skipped.

# How is the PR tested?

`TestProcessEachCmdReturnsErrors` and `TestProcessEachCmdPreservesRegisteredCommandError` cover the error propagation, including the registered-command dispatch path. End to end against a live master:

| piped input | exit |
|---|---|
| unknown command | 1 |
| a command whose Do fails | 1 |
| a command that succeeds | 0 |
| a bad flag | 2 |

https://claude.ai/code/session_018DWwctzD4T2DmnczPRM47t


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Shell command failures now propagate correctly and produce a non-zero exit status.
  * Errors from piped and unknown shell commands are reported more reliably.
  * Buffered error-reporting events are flushed before the application exits.

* **Tests**
  * Added coverage for shell command errors, successful execution, exit commands, blank input, and preservation of original errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->