### PR TITLE
ci: let codespell past the sme variable in the mount tests

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -19,4 +19,5 @@ ignore-regex = \b[a-z]+[A-Z]\w*\b|\b[A-Z][a-z]+[A-Z]\w*\b
 # thirdparty: literal Maven groupId `org.apache.hadoop.thirdparty` (external, cannot rename)
 # unknwon: GitHub username / Go module path (`github.com/unknwon/goconfig`)
 # atleast: CLI mode literal string in test/benchmark/fuse_db/bin/sqlite_verify.py
-ignore-words-list = visibles,fo,te,ser,bject,unparseable,keep-alives,tread,anc,ue,auther,thirdparty,unknwon,atleast
+# sme: local variable for a *streamMutateError in mount tests
+ignore-words-list = visibles,fo,te,ser,bject,unparseable,keep-alives,tread,anc,ue,auther,thirdparty,unknwon,atleast,sme


### PR DESCRIPTION
The spelling check fails on master since #11079: `weedfs_stream_mutate_error_test.go` names its `*streamMutateError` local `sme`, and codespell reads that as a misspelling of same/some:

```
./weed/mount/weedfs_stream_mutate_error_test.go:94: sme ==> same, seme, some, sms
```

It went unnoticed because the check last ran on master on 2026-08-14, so it surfaces on every PR that carries #11079 forward (first seen on #11115). `sme` is an identifier, so this exempts it in `.codespellrc` beside the other variable-name entries. Verified with `codespell` over the whole tree: this was the only hit, and it is clean with the change.

https://claude.ai/code/session_01BYrb2AdJSckq9FdHuqseDJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated spelling-check configuration to recognize a valid test-specific abbreviation and document its meaning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->