### PR TITLE
helm: values-driven labels on every ingress

### DIFF
--- a/.github/workflows/helm_ci.yml
+++ b/.github/workflows/helm_ci.yml
@@ -90,6 +90,12 @@ jobs:
             echo "S3 credentials reference the existing secret for $workload"
           done
 
+          echo "=== Testing ingress labels ==="
+          helm template test $CHART_DIR --set s3.enabled=true,s3.ingress.enabled=true \
+            --set s3.ingress.labels.external-dns=s3 > /tmp/s3-ingress-labels.yaml
+          grep -A 12 "^kind: Ingress" /tmp/s3-ingress-labels.yaml | grep -q "^    external-dns: s3"
+          echo "S3 ingress renders custom labels"
+
           echo "=== Testing with all-in-one mode ==="
           helm template test $CHART_DIR --set allInOne.enabled=true > /tmp/allinone.yaml
           grep -q "seaweedfs-all-in-one" /tmp/allinone.yaml

--- a/k8s/charts/seaweedfs/templates/admin/admin-ingress.yaml
+++ b/k8s/charts/seaweedfs/templates/admin/admin-ingress.yaml
@@ -23,6 +23,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: admin
+    {{- with .Values.admin.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if and (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) .Values.admin.ingress.className }}
   ingressClassName: {{ .Values.admin.ingress.className | quote }}

--- a/k8s/charts/seaweedfs/templates/filer/filer-grpc-ingressroutetcp.yaml
+++ b/k8s/charts/seaweedfs/templates/filer/filer-grpc-ingressroutetcp.yaml
@@ -24,6 +24,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: filer
+    {{- with .Values.filer.ingresses.grpc.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if $securityEnabled }}
   tls:

--- a/k8s/charts/seaweedfs/templates/filer/filer-ingress.yaml
+++ b/k8s/charts/seaweedfs/templates/filer/filer-ingress.yaml
@@ -29,6 +29,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: filer
+    {{- with .Values.filer.ingresses.http.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if and (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) .Values.filer.ingresses.http.className }}
   ingressClassName: {{ .Values.filer.ingresses.http.className | quote }}
@@ -87,6 +90,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: filer
+    {{- with .Values.filer.ingresses.grpc.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if and (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) .Values.filer.ingresses.grpc.className }}
   ingressClassName: {{ .Values.filer.ingresses.grpc.className | quote }}

--- a/k8s/charts/seaweedfs/templates/master/master-ingress.yaml
+++ b/k8s/charts/seaweedfs/templates/master/master-ingress.yaml
@@ -21,6 +21,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: master
+    {{- with .Values.master.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   ingressClassName: {{ .Values.master.ingress.className | quote }}
   tls:

--- a/k8s/charts/seaweedfs/templates/s3/s3-iceberg-ingress.yaml
+++ b/k8s/charts/seaweedfs/templates/s3/s3-iceberg-ingress.yaml
@@ -41,6 +41,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: s3-iceberg
+    {{- with .Values.s3.icebergIngress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if .Values.s3.icebergIngress.className }}
   ingressClassName: {{ .Values.s3.icebergIngress.className | quote }}

--- a/k8s/charts/seaweedfs/templates/s3/s3-ingress.yaml
+++ b/k8s/charts/seaweedfs/templates/s3/s3-ingress.yaml
@@ -32,6 +32,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: s3
+    {{- with .Values.s3.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   ingressClassName: {{ .Values.s3.ingress.className | quote }}
   tls:

--- a/k8s/charts/seaweedfs/templates/s3/s3-lance-ingress.yaml
+++ b/k8s/charts/seaweedfs/templates/s3/s3-lance-ingress.yaml
@@ -41,6 +41,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: s3-lance
+    {{- with .Values.s3.lanceIngress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if .Values.s3.lanceIngress.className }}
   ingressClassName: {{ .Values.s3.lanceIngress.className | quote }}

--- a/k8s/charts/seaweedfs/templates/volume/volume-ingress.yaml
+++ b/k8s/charts/seaweedfs/templates/volume/volume-ingress.yaml
@@ -27,6 +27,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: volume
+    {{- with .Values.volume.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- if and (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) .Values.volume.ingress.className }}
   ingressClassName: {{ .Values.volume.ingress.className | quote }}

--- a/k8s/charts/seaweedfs/values.yaml
+++ b/k8s/charts/seaweedfs/values.yaml
@@ -276,6 +276,7 @@ master:
     host: "master.seaweedfs.local"
     path: "/sw-master/?(.*)"
     pathType: ImplementationSpecific
+    labels: {}
     annotations: {}
       # nginx.ingress.kubernetes.io/auth-type: "basic"
       # nginx.ingress.kubernetes.io/auth-secret: "default/ingress-basic-auth-secret"
@@ -600,6 +601,7 @@ volume:
     host: "volume.seaweedfs.local"
     path: "/"
     pathType: Prefix
+    labels: {}
     annotations:
       nginx.ingress.kubernetes.io/app-root: /ui/index.html
       # nginx.ingress.kubernetes.io/use-regex: "true"
@@ -858,6 +860,7 @@ filer:
       host: "seaweedfs.cluster.local"
       path: "/sw-filer/?(.*)"
       pathType: ImplementationSpecific
+      labels: {}
       annotations: {}
         # nginx.ingress.kubernetes.io/backend-protocol: GRPC
         # nginx.ingress.kubernetes.io/auth-type: "basic"
@@ -884,6 +887,7 @@ filer:
       # whole host, not the HTTP UI's regex path.
       path: "/"
       pathType: Prefix
+      labels: {}
       annotations:
         # Ingress terminates TLS and re-originates gRPC (HTTP/2) to the filer.
         nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
@@ -1180,6 +1184,7 @@ s3:
     host: "seaweedfs.cluster.local"
     path: "/"
     pathType: Prefix
+    labels: {}
     # additional ingress annotations for the s3 endpoint
     annotations: {}
     tls: []
@@ -1205,6 +1210,7 @@ s3:
     host: "seaweedfs-iceberg.cluster.local"
     path: "/"
     pathType: Prefix
+    labels: {}
     annotations: {}
     tls: []
 
@@ -1214,6 +1220,7 @@ s3:
     host: "seaweedfs-lance.cluster.local"
     path: "/"
     pathType: Prefix
+    labels: {}
     annotations: {}
     tls: []
 
@@ -1445,6 +1452,7 @@ admin:
     host: "admin.seaweedfs.local"
     path: "/"
     pathType: Prefix
+    labels: {}
     annotations: {}
     tls: []
 


### PR DESCRIPTION
Fixes #11124

Each ingress in the chart already takes `annotations` from values, but `labels` was a fixed block, so there was no way to put a label on the rendered Ingress. Tools like ExternalDNS select ingresses by label filter, so a `labels:` key under `s3.ingress` was silently ignored.

Every ingress block now has a `labels: {}` map beside its `annotations`, rendered after the standard `app.kubernetes.io/*` labels: `master.ingress`, `volume.ingress`, `filer.ingresses.http`, `filer.ingresses.grpc` (both the Ingress and the Traefik `IngressRouteTCP` that shares those values), `s3.ingress`, `s3.icebergIngress`, `s3.lanceIngress`, `admin.ingress`.

With the labels unset, the rendered output is byte-identical to before. The helm CI job gets a render check that sets `s3.ingress.labels` and greps for it on the Ingress.

https://claude.ai/code/session_01L6eJGXtYkwe1W9QjGeUgr1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for applying custom Kubernetes labels to SeaweedFS master, volume, filer, S3, Iceberg, Lance, and admin ingress resources.
  - Added configurable label fields for each ingress type, empty by default.

- **Tests**
  - Added Helm template coverage verifying custom labels render correctly on ingress resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->