### PR TITLE
Sign the published Docker images with cosign

### DIFF
--- a/.github/actions/sign-image/action.yml
+++ b/.github/actions/sign-image/action.yml
@@ -15,7 +15,7 @@ runs:
   using: composite
   steps:
     - name: Install cosign
-      uses: sigstore/cosign-installer@v4.1.2
+      uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
     - name: Sign
       shell: bash

--- a/.github/actions/sign-image/action.yml
+++ b/.github/actions/sign-image/action.yml
@@ -1,0 +1,39 @@
+name: Sign container images
+description: >
+  Keyless cosign signature on each image, then a verification pass against the
+  identity the signature should carry, so a misconfigured job fails here and not
+  on someone's cluster. That identity is the calling workflow's own,
+  https://github.com/<owner>/<repo>/.github/workflows/<file>@<ref>.
+  The calling job needs `id-token: write` and a registry login for every image.
+
+inputs:
+  images:
+    description: Image references by digest (name@sha256:...), whitespace separated.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install cosign
+      uses: sigstore/cosign-installer@v4.1.2
+
+    - name: Sign
+      shell: bash
+      env:
+        IMAGES: ${{ inputs.images }}
+      run: |
+        set -euo pipefail
+        # The .sig tag layout: the OCI-referrer bundle cosign 3 writes by default
+        # is not read by the Kyverno and policy-controller releases in use today.
+        cosign sign --yes --recursive --new-bundle-format=false $IMAGES
+
+    - name: Verify
+      shell: bash
+      env:
+        IMAGES: ${{ inputs.images }}
+      run: |
+        set -euo pipefail
+        cosign verify \
+          --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+          --certificate-identity "https://github.com/$GITHUB_WORKFLOW_REF" \
+          $IMAGES

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 updates:
 - package-ecosystem: "github-actions"
-  directory: "/"
+  directories:
+    - "/"
+    - "/.github/actions/sign-image"
   schedule:
       interval: "weekly"
 - package-ecosystem: gomod

--- a/.github/workflows/container_dev.yml
+++ b/.github/workflows/container_dev.yml
@@ -101,6 +101,9 @@ jobs:
   build-dev-containers:
     needs: [build-rust-binaries]
     runs-on: [ubuntu-latest]
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout
@@ -180,6 +183,7 @@ jobs:
           password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Build
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: ./docker
@@ -188,3 +192,11 @@ jobs:
           platforms: linux/amd64, linux/arm64
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
+
+      - name: Sign
+        if: github.event_name != 'pull_request'
+        uses: ./.github/actions/sign-image
+        with:
+          images: >-
+            chrislusf/seaweedfs@${{ steps.build.outputs.digest }}
+            ghcr.io/chrislusf/seaweedfs@${{ steps.build.outputs.digest }}

--- a/.github/workflows/container_dev.yml
+++ b/.github/workflows/container_dev.yml
@@ -107,10 +107,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Download pre-built Rust binaries
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: rust-bins-*
           merge-multiple: true
@@ -139,7 +139,7 @@ jobs:
 
       - name: Docker meta
         id: docker_meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: |
             chrislusf/seaweedfs
@@ -152,7 +152,7 @@ jobs:
             org.opencontainers.image.vendor=Chris Lu
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4.2.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Create BuildKit config
         run: |
@@ -162,21 +162,21 @@ jobs:
           EOF
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
         with:
           buildkitd-flags: "--debug"
           buildkitd-config: /tmp/buildkitd.toml
 
       - name: Login to Docker Hub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4.6.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Login to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4.6.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ secrets.GHCR_USERNAME }}
@@ -184,7 +184,7 @@ jobs:
 
       - name: Build
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: ./docker
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/container_foundationdb_version.yml
+++ b/.github/workflows/container_foundationdb_version.yml
@@ -30,6 +30,9 @@ permissions:
 jobs:
   build-foundationdb-image:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout
@@ -154,6 +157,7 @@ jobs:
           fi
 
       - name: Build and push image
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: ./docker
@@ -171,3 +175,8 @@ jobs:
             org.opencontainers.image.description=SeaweedFS is a distributed storage system for blobs, objects, files, and data lake, to store and serve billions of files fast!
             org.opencontainers.image.vendor=Chris Lu
 
+      - name: Sign
+        if: github.event_name != 'pull_request'
+        uses: ./.github/actions/sign-image
+        with:
+          images: chrislusf/seaweedfs@${{ steps.build.outputs.digest }}

--- a/.github/workflows/container_foundationdb_version.yml
+++ b/.github/workflows/container_foundationdb_version.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 
@@ -61,7 +61,7 @@ jobs:
           sudo ldconfig
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: go.mod
 
@@ -129,14 +129,14 @@ jobs:
           echo "seaweedfs_ref=$seaweed" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4.2.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
 
       - name: Login to Docker Hub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4.6.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -158,7 +158,7 @@ jobs:
 
       - name: Build and push image
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: ./docker
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/container_latest.yml
+++ b/.github/workflows/container_latest.yml
@@ -441,6 +441,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [setup, build, trivy-scan]
     if: needs.setup.outputs.publish == 'true' && github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       matrix:
         variant: ${{ fromJSON(needs.setup.outputs.variants) }}
@@ -545,3 +548,14 @@ jobs:
               ghcr.io/chrislusf/seaweedfs:${BASE_TAG}${SUFFIX}-arm \
               ghcr.io/chrislusf/seaweedfs:${BASE_TAG}${SUFFIX}-386
           fi
+
+      - name: Resolve the published digests
+        id: digests
+        run: |
+          tag="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.image_tag || 'latest' }}${{ steps.config.outputs.tag_suffix }}"
+          echo "images=ghcr.io/chrislusf/seaweedfs@$(crane digest "ghcr.io/chrislusf/seaweedfs:${tag}") chrislusf/seaweedfs@$(crane digest "chrislusf/seaweedfs:${tag}")" >> "$GITHUB_OUTPUT"
+
+      - name: Sign
+        uses: ./.github/actions/sign-image
+        with:
+          images: ${{ steps.digests.outputs.images }}

--- a/.github/workflows/container_latest.yml
+++ b/.github/workflows/container_latest.yml
@@ -448,11 +448,12 @@ jobs:
       matrix:
         variant: ${{ fromJSON(needs.setup.outputs.variants) }}
     steps:
-      - name: Checkout
+      - name: Checkout the signing action
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.source_ref || github.ref }}
-      
+          sparse-checkout: .github/actions
+          persist-credentials: false
+
       - name: Configure variant
         id: config
         run: |

--- a/.github/workflows/container_latest.yml
+++ b/.github/workflows/container_latest.yml
@@ -551,8 +551,11 @@ jobs:
 
       - name: Resolve the published digests
         id: digests
+        env:
+          BASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.image_tag || 'latest' }}
+          SUFFIX: ${{ steps.config.outputs.tag_suffix }}
         run: |
-          tag="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.image_tag || 'latest' }}${{ steps.config.outputs.tag_suffix }}"
+          tag="${BASE_TAG}${SUFFIX}"
           echo "images=ghcr.io/chrislusf/seaweedfs@$(crane digest "ghcr.io/chrislusf/seaweedfs:${tag}") chrislusf/seaweedfs@$(crane digest "chrislusf/seaweedfs:${tag}")" >> "$GITHUB_OUTPUT"
 
       - name: Sign

--- a/.github/workflows/container_latest.yml
+++ b/.github/workflows/container_latest.yml
@@ -501,12 +501,13 @@ jobs:
           # Create manifest on GHCR first (no rate limits)
           echo "Creating GHCR manifest (no rate limits)..."
           docker buildx imagetools create -t ghcr.io/chrislusf/seaweedfs:${BASE_TAG}${SUFFIX} \
+            --metadata-file /tmp/manifest.json \
             ghcr.io/chrislusf/seaweedfs:${BASE_TAG}${SUFFIX}-amd64 \
             ghcr.io/chrislusf/seaweedfs:${BASE_TAG}${SUFFIX}-arm64 \
             ghcr.io/chrislusf/seaweedfs:${BASE_TAG}${SUFFIX}-arm \
             ghcr.io/chrislusf/seaweedfs:${BASE_TAG}${SUFFIX}-386
-          # The copy and the signature below use this digest, not whatever the tag points at by then.
-          DIGEST=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' ghcr.io/chrislusf/seaweedfs:${BASE_TAG}${SUFFIX})
+          # The copy and the signature below use the digest this run pushed, not whatever the tag points at by then.
+          DIGEST=$(jq -er '."containerimage.descriptor".digest' /tmp/manifest.json)
           echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
           
           # Copy the complete multi-arch image from GHCR to Docker Hub

--- a/.github/workflows/container_latest.yml
+++ b/.github/workflows/container_latest.yml
@@ -489,9 +489,10 @@ jobs:
           sudo mv crane /usr/local/bin/
           crane version
       - name: Create and push manifest
+        env:
+          BASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.image_tag || 'latest' }}
         run: |
           SUFFIX="${{ steps.config.outputs.tag_suffix }}"
-          BASE_TAG="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.image_tag || 'latest' }}"
           
           # Create manifest on GHCR first (no rate limits)
           echo "Creating GHCR manifest (no rate limits)..."

--- a/.github/workflows/container_latest.yml
+++ b/.github/workflows/container_latest.yml
@@ -449,7 +449,7 @@ jobs:
         variant: ${{ fromJSON(needs.setup.outputs.variants) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.source_ref || github.ref }}
       
@@ -464,19 +464,19 @@ jobs:
 
       - name: Docker meta
         id: docker_meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: |
             chrislusf/seaweedfs
             ghcr.io/chrislusf/seaweedfs
           tags: type=raw,value=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.image_tag || 'latest' }},suffix=${{ steps.config.outputs.tag_suffix }}
       - name: Login to Docker Hub
-        uses: docker/login-action@v4.6.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Login to GHCR
-        uses: docker/login-action@v4.6.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ secrets.GHCR_USERNAME }}
@@ -485,10 +485,13 @@ jobs:
         run: |
           # Install crane for efficient multi-arch image copying
           cd $(mktemp -d)
-          curl -sL "https://github.com/google/go-containerregistry/releases/latest/download/go-containerregistry_Linux_x86_64.tar.gz" | tar xz
+          curl -sLO https://github.com/google/go-containerregistry/releases/download/v0.22.0/go-containerregistry_Linux_x86_64.tar.gz
+          echo "edb74d53fad9a596860f59d1c5d04a43dfb5f441dc71f57060dd0bf39483c833  go-containerregistry_Linux_x86_64.tar.gz" | sha256sum -c -
+          tar xzf go-containerregistry_Linux_x86_64.tar.gz crane
           sudo mv crane /usr/local/bin/
           crane version
       - name: Create and push manifest
+        id: manifest
         env:
           BASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.image_tag || 'latest' }}
         run: |
@@ -501,6 +504,9 @@ jobs:
             ghcr.io/chrislusf/seaweedfs:${BASE_TAG}${SUFFIX}-arm64 \
             ghcr.io/chrislusf/seaweedfs:${BASE_TAG}${SUFFIX}-arm \
             ghcr.io/chrislusf/seaweedfs:${BASE_TAG}${SUFFIX}-386
+          # The copy and the signature below use this digest, not whatever the tag points at by then.
+          DIGEST=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' ghcr.io/chrislusf/seaweedfs:${BASE_TAG}${SUFFIX})
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
           
           # Copy the complete multi-arch image from GHCR to Docker Hub
           # This only requires one pull from GHCR (no rate limit) and one push to Docker Hub
@@ -536,10 +542,10 @@ jobs:
           # Use crane or skopeo to copy, fallback to docker if not available
           if command -v crane &> /dev/null; then
             echo "Using crane to copy..."
-            retry_with_backoff crane copy ghcr.io/chrislusf/seaweedfs:${BASE_TAG}${SUFFIX} chrislusf/seaweedfs:${BASE_TAG}${SUFFIX}
+            retry_with_backoff crane copy ghcr.io/chrislusf/seaweedfs@${DIGEST} chrislusf/seaweedfs:${BASE_TAG}${SUFFIX}
           elif command -v skopeo &> /dev/null; then
             echo "Using skopeo to copy..."
-            retry_with_backoff skopeo copy --all docker://ghcr.io/chrislusf/seaweedfs:${BASE_TAG}${SUFFIX} docker://chrislusf/seaweedfs:${BASE_TAG}${SUFFIX}
+            retry_with_backoff skopeo copy --all docker://ghcr.io/chrislusf/seaweedfs@${DIGEST} docker://chrislusf/seaweedfs:${BASE_TAG}${SUFFIX}
           else
             echo "Using docker buildx imagetools (pulling 4 images from Docker Hub)..."
             # Fallback: create manifest directly on Docker Hub (pulls from Docker Hub - rate limited)
@@ -550,16 +556,9 @@ jobs:
               ghcr.io/chrislusf/seaweedfs:${BASE_TAG}${SUFFIX}-386
           fi
 
-      - name: Resolve the published digests
-        id: digests
-        env:
-          BASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.image_tag || 'latest' }}
-          SUFFIX: ${{ steps.config.outputs.tag_suffix }}
-        run: |
-          tag="${BASE_TAG}${SUFFIX}"
-          echo "images=ghcr.io/chrislusf/seaweedfs@$(crane digest "ghcr.io/chrislusf/seaweedfs:${tag}") chrislusf/seaweedfs@$(crane digest "chrislusf/seaweedfs:${tag}")" >> "$GITHUB_OUTPUT"
-
       - name: Sign
         uses: ./.github/actions/sign-image
         with:
-          images: ${{ steps.digests.outputs.images }}
+          images: >-
+            ghcr.io/chrislusf/seaweedfs@${{ steps.manifest.outputs.digest }}
+            chrislusf/seaweedfs@${{ steps.manifest.outputs.digest }}

--- a/.github/workflows/container_release_foundationdb.yml
+++ b/.github/workflows/container_release_foundationdb.yml
@@ -28,11 +28,11 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       -
         name: Docker meta
         id: docker_meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: |
             chrislusf/seaweedfs
@@ -46,14 +46,14 @@ jobs:
             org.opencontainers.image.vendor=Chris Lu
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v4.2.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
       -
         name: Login to Docker Hub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4.6.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -69,7 +69,7 @@ jobs:
       -
         name: Build
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: ./docker
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/container_release_foundationdb.yml
+++ b/.github/workflows/container_release_foundationdb.yml
@@ -21,6 +21,9 @@ jobs:
 
   build-large-release-container_foundationdb:
     runs-on: [ubuntu-latest]
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       -
@@ -65,6 +68,7 @@ jobs:
           fi
       -
         name: Build
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: ./docker
@@ -76,4 +80,10 @@ jobs:
           platforms: linux/amd64
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
+      -
+        name: Sign
+        if: github.event_name != 'pull_request'
+        uses: ./.github/actions/sign-image
+        with:
+          images: chrislusf/seaweedfs@${{ steps.build.outputs.digest }}
 

--- a/.github/workflows/container_release_unified.yml
+++ b/.github/workflows/container_release_unified.yml
@@ -295,10 +295,14 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  # Assemble each variant's per-platform digests into one tag, then mirror to Docker Hub.
+  # Assemble each variant's per-platform digests into one tag, mirror it to
+  # Docker Hub, and sign the result on both registries.
   merge:
     needs: [build]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -309,6 +313,12 @@ jobs:
           - { variant: large_disk_full, tag_suffix: _large_disk_full }
           - { variant: rocksdb,         tag_suffix: _large_disk_rocksdb }
     steps:
+      - name: Checkout the signing action
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.variant == 'all' || github.event.inputs.variant == matrix.variant
+        uses: actions/checkout@v7
+        with:
+          sparse-checkout: .github/actions
+
       - name: Download digests
         if: github.event_name != 'workflow_dispatch' || github.event.inputs.variant == 'all' || github.event.inputs.variant == matrix.variant
         uses: actions/download-artifact@v8
@@ -384,6 +394,19 @@ jobs:
             chrislusf/seaweedfs:${{ env.RELEASE_TAG }}${{ matrix.tag_suffix }}
           echo "Copied ${{ matrix.variant }} to Docker Hub"
 
+      - name: Resolve the published digests
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.variant == 'all' || github.event.inputs.variant == matrix.variant
+        id: digests
+        run: |
+          tag="${RELEASE_TAG}${{ matrix.tag_suffix }}"
+          echo "images=${IMAGE}@$(crane digest "${IMAGE}:${tag}") chrislusf/seaweedfs@$(crane digest "chrislusf/seaweedfs:${tag}")" >> "$GITHUB_OUTPUT"
+
+      - name: Sign ${{ matrix.variant }}
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.variant == 'all' || github.event.inputs.variant == matrix.variant
+        uses: ./.github/actions/sign-image
+        with:
+          images: ${{ steps.digests.outputs.images }}
+
   # Report-only trivy scan: uploads fixable HIGH/CRITICAL findings to GitHub
   # Security for visibility, but never blocks the release. Releases (including
   # `latest`) ship regardless — vulnerabilities are tracked, not gated, since
@@ -439,7 +462,8 @@ jobs:
   # image. crane tag adds an extra tag to an existing manifest — no rebuild,
   # no QEMU, no separate workflow. Replaces the old container_latest.yml
   # rebuild that often failed or lagged behind the release. Independent of
-  # trivy-scan: vuln findings are reported but do not block `latest`.
+  # trivy-scan: vuln findings are reported but do not block `latest`. The
+  # cosign signature is attached to the digest, so `latest` carries it too.
   tag-latest:
     runs-on: ubuntu-latest
     needs: [merge]

--- a/.github/workflows/container_release_unified.yml
+++ b/.github/workflows/container_release_unified.yml
@@ -315,7 +315,7 @@ jobs:
     steps:
       - name: Checkout the signing action
         if: github.event_name != 'workflow_dispatch' || github.event.inputs.variant == 'all' || github.event.inputs.variant == matrix.variant
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           sparse-checkout: .github/actions
 

--- a/.github/workflows/container_release_unified.yml
+++ b/.github/workflows/container_release_unified.yml
@@ -318,10 +318,11 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           sparse-checkout: .github/actions
+          persist-credentials: false
 
       - name: Download digests
         if: github.event_name != 'workflow_dispatch' || github.event.inputs.variant == 'all' || github.event.inputs.variant == matrix.variant
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: digest-${{ matrix.variant }}-*
           merge-multiple: true
@@ -329,11 +330,11 @@ jobs:
 
       - name: Set up Docker Buildx
         if: github.event_name != 'workflow_dispatch' || github.event.inputs.variant == 'all' || github.event.inputs.variant == matrix.variant
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
 
       - name: Login to GHCR
         if: github.event_name != 'workflow_dispatch' || github.event.inputs.variant == 'all' || github.event.inputs.variant == matrix.variant
-        uses: docker/login-action@v4.6.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ secrets.GHCR_USERNAME }}
@@ -341,16 +342,19 @@ jobs:
 
       - name: Create multi-arch tag on GHCR
         if: github.event_name != 'workflow_dispatch' || github.event.inputs.variant == 'all' || github.event.inputs.variant == matrix.variant
+        id: manifest
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create \
             -t ${{ env.IMAGE }}:${{ env.RELEASE_TAG }}${{ matrix.tag_suffix }} \
             $(printf '${{ env.IMAGE }}@sha256:%s ' *)
           docker buildx imagetools inspect ${{ env.IMAGE }}:${{ env.RELEASE_TAG }}${{ matrix.tag_suffix }}
+          # The copy and the signature below use this digest, not whatever the tag points at by then.
+          echo "digest=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' ${{ env.IMAGE }}:${{ env.RELEASE_TAG }}${{ matrix.tag_suffix }})" >> "$GITHUB_OUTPUT"
 
       - name: Login to Docker Hub
         if: github.event_name != 'workflow_dispatch' || github.event.inputs.variant == 'all' || github.event.inputs.variant == matrix.variant
-        uses: docker/login-action@v4.6.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -359,7 +363,9 @@ jobs:
         if: github.event_name != 'workflow_dispatch' || github.event.inputs.variant == 'all' || github.event.inputs.variant == matrix.variant
         run: |
           cd $(mktemp -d)
-          curl -sL "https://github.com/google/go-containerregistry/releases/latest/download/go-containerregistry_Linux_x86_64.tar.gz" | tar xz
+          curl -sLO https://github.com/google/go-containerregistry/releases/download/v0.22.0/go-containerregistry_Linux_x86_64.tar.gz
+          echo "edb74d53fad9a596860f59d1c5d04a43dfb5f441dc71f57060dd0bf39483c833  go-containerregistry_Linux_x86_64.tar.gz" | sha256sum -c -
+          tar xzf go-containerregistry_Linux_x86_64.tar.gz crane
           sudo mv crane /usr/local/bin/
           crane version
 
@@ -390,22 +396,17 @@ jobs:
 
           echo "Copying ${{ matrix.variant }} from GHCR to Docker Hub..."
           retry_with_backoff crane copy \
-            ${{ env.IMAGE }}:${{ env.RELEASE_TAG }}${{ matrix.tag_suffix }} \
+            ${{ env.IMAGE }}@${{ steps.manifest.outputs.digest }} \
             chrislusf/seaweedfs:${{ env.RELEASE_TAG }}${{ matrix.tag_suffix }}
           echo "Copied ${{ matrix.variant }} to Docker Hub"
-
-      - name: Resolve the published digests
-        if: github.event_name != 'workflow_dispatch' || github.event.inputs.variant == 'all' || github.event.inputs.variant == matrix.variant
-        id: digests
-        run: |
-          tag="${RELEASE_TAG}${{ matrix.tag_suffix }}"
-          echo "images=${IMAGE}@$(crane digest "${IMAGE}:${tag}") chrislusf/seaweedfs@$(crane digest "chrislusf/seaweedfs:${tag}")" >> "$GITHUB_OUTPUT"
 
       - name: Sign ${{ matrix.variant }}
         if: github.event_name != 'workflow_dispatch' || github.event.inputs.variant == 'all' || github.event.inputs.variant == matrix.variant
         uses: ./.github/actions/sign-image
         with:
-          images: ${{ steps.digests.outputs.images }}
+          images: >-
+            ${{ env.IMAGE }}@${{ steps.manifest.outputs.digest }}
+            chrislusf/seaweedfs@${{ steps.manifest.outputs.digest }}
 
   # Report-only trivy scan: uploads fixable HIGH/CRITICAL findings to GitHub
   # Security for visibility, but never blocks the release. Releases (including
@@ -492,7 +493,9 @@ jobs:
       - name: Install crane
         run: |
           cd $(mktemp -d)
-          curl -sL "https://github.com/google/go-containerregistry/releases/latest/download/go-containerregistry_Linux_x86_64.tar.gz" | tar xz
+          curl -sLO https://github.com/google/go-containerregistry/releases/download/v0.22.0/go-containerregistry_Linux_x86_64.tar.gz
+          echo "edb74d53fad9a596860f59d1c5d04a43dfb5f441dc71f57060dd0bf39483c833  go-containerregistry_Linux_x86_64.tar.gz" | sha256sum -c -
+          tar xzf go-containerregistry_Linux_x86_64.tar.gz crane
           sudo mv crane /usr/local/bin/
           crane version
 

--- a/.github/workflows/container_release_unified.yml
+++ b/.github/workflows/container_release_unified.yml
@@ -347,10 +347,12 @@ jobs:
         run: |
           docker buildx imagetools create \
             -t ${{ env.IMAGE }}:${{ env.RELEASE_TAG }}${{ matrix.tag_suffix }} \
+            --metadata-file /tmp/manifest.json \
             $(printf '${{ env.IMAGE }}@sha256:%s ' *)
           docker buildx imagetools inspect ${{ env.IMAGE }}:${{ env.RELEASE_TAG }}${{ matrix.tag_suffix }}
-          # The copy and the signature below use this digest, not whatever the tag points at by then.
-          echo "digest=$(docker buildx imagetools inspect --format '{{.Manifest.Digest}}' ${{ env.IMAGE }}:${{ env.RELEASE_TAG }}${{ matrix.tag_suffix }})" >> "$GITHUB_OUTPUT"
+          # The copy and the signature below use the digest this run pushed, not whatever the tag points at by then.
+          digest=$(jq -er '."containerimage.descriptor".digest' /tmp/manifest.json)
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
 
       - name: Login to Docker Hub
         if: github.event_name != 'workflow_dispatch' || github.event.inputs.variant == 'all' || github.event.inputs.variant == matrix.variant

--- a/.github/workflows/container_rocksdb_version.yml
+++ b/.github/workflows/container_rocksdb_version.yml
@@ -22,6 +22,9 @@ permissions:
 jobs:
   build-rocksdb-image:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout
@@ -94,6 +97,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push image
+        id: build
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v2
         with:
           context: ./docker
@@ -108,3 +112,8 @@ jobs:
             org.opencontainers.image.title=seaweedfs
             org.opencontainers.image.description=SeaweedFS is a distributed storage system for blobs, objects, files, and data lake, to store and serve billions of files fast!
             org.opencontainers.image.vendor=Chris Lu
+
+      - name: Sign
+        uses: ./.github/actions/sign-image
+        with:
+          images: chrislusf/seaweedfs@${{ steps.build.outputs.digest }}

--- a/docker/README.md
+++ b/docker/README.md
@@ -42,20 +42,36 @@ cosign verify \
   chrislusf/seaweedfs:latest
 ```
 
-The identity ends in the git ref the workflow ran for: `refs/tags/<version>` for a release, `refs/heads/master` when a variant was republished by hand. The other images name the workflow that built them. `dev` is `container_dev.yml`, a `latest` rebuilt by hand is `container_latest.yml`, the `_large_disk_foundationdb` release image is `container_release_foundationdb.yml`, and the per-version FoundationDB and RocksDB builds are `container_foundationdb_version.yml` and `container_rocksdb_version.yml`.
+cosign prints the digest it verified. Deploy by that digest, or let an admission controller resolve the tag, so what runs is what was checked.
 
-The same check as a Kyverno policy:
+The identity is `https://github.com/seaweedfs/seaweedfs/.github/workflows/<workflow>@<ref>`. The ref is `refs/tags/<version>` for a release and `refs/heads/master` when a variant was republished by hand. The workflow is `container_release_unified.yml` for the release images, `container_dev.yml` for `dev`, `container_latest.yml` for a `latest` rebuilt by hand, `container_release_foundationdb.yml` for the `_large_disk_foundationdb` release image, and `container_foundationdb_version.yml` or `container_rocksdb_version.yml` for the per-version builds. The regexp above accepts release images only; `container_[a-z_]+\.yml@` accepts everything this repository publishes, `dev` included.
+
+The same check as a Kyverno policy, release images only:
 
 ```yaml
-verifyImages:
-  - imageReferences:
-      - "chrislusf/seaweedfs:*"
-      - "ghcr.io/chrislusf/seaweedfs:*"
-    attestors:
-      - entries:
-          - keyless:
-              issuer: https://token.actions.githubusercontent.com
-              subject: https://github.com/seaweedfs/seaweedfs/.github/workflows/container_release_unified.yml@refs/tags/*
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: verify-seaweedfs-images
+spec:
+  validationFailureAction: Enforce
+  webhookTimeoutSeconds: 30
+  rules:
+    - name: signed-by-the-release-workflow
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      verifyImages:
+        - imageReferences:
+            - "docker.io/chrislusf/seaweedfs:*"
+            - "ghcr.io/chrislusf/seaweedfs:*"
+          attestors:
+            - entries:
+                - keyless:
+                    issuer: https://token.actions.githubusercontent.com
+                    subject: https://github.com/seaweedfs/seaweedfs/.github/workflows/container_release_unified.yml@refs/tags/*
 ```
 
 ## Local Development

--- a/docker/README.md
+++ b/docker/README.md
@@ -31,6 +31,33 @@ docker compose -f seaweedfs-dev-compose.yml -p seaweedfs up
 
 ```
 
+## Verify an image signature
+
+Every image CI pushes to `chrislusf/seaweedfs` and `ghcr.io/chrislusf/seaweedfs` is signed with [cosign](https://docs.sigstore.dev/cosign/verifying/verify/), keyless, by the GitHub Actions workflow that built it, so there is no key to fetch or pin. The signature is attached to the image digest and covers the multi-arch index and each platform image in it; `latest` is the release image under another tag and verifies the same way. Images published before September 2026 predate signing.
+
+```bash
+cosign verify \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp '^https://github.com/seaweedfs/seaweedfs/\.github/workflows/container_release_unified\.yml@' \
+  chrislusf/seaweedfs:latest
+```
+
+The identity ends in the git ref the workflow ran for: `refs/tags/<version>` for a release, `refs/heads/master` when a variant was republished by hand. The other images name the workflow that built them. `dev` is `container_dev.yml`, a `latest` rebuilt by hand is `container_latest.yml`, the `_large_disk_foundationdb` release image is `container_release_foundationdb.yml`, and the per-version FoundationDB and RocksDB builds are `container_foundationdb_version.yml` and `container_rocksdb_version.yml`.
+
+The same check as a Kyverno policy:
+
+```yaml
+verifyImages:
+  - imageReferences:
+      - "chrislusf/seaweedfs:*"
+      - "ghcr.io/chrislusf/seaweedfs:*"
+    attestors:
+      - entries:
+          - keyless:
+              issuer: https://token.actions.githubusercontent.com
+              subject: https://github.com/seaweedfs/seaweedfs/.github/workflows/container_release_unified.yml@refs/tags/*
+```
+
 ## Local Development
 
 ```bash


### PR DESCRIPTION
Closes #11123.

Every image CI pushes to `chrislusf/seaweedfs` and `ghcr.io/chrislusf/seaweedfs` now gets a keyless cosign signature from the workflow that built it: the release variants, `latest`, `dev`, the FoundationDB release image, and the per-version FoundationDB and RocksDB builds. Nothing to generate or rotate; the identity is the workflow's own GitHub OIDC identity, and Rekor keeps the transparency record.

```bash
cosign verify \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
  --certificate-identity-regexp '^https://github.com/seaweedfs/seaweedfs/\.github/workflows/container_release_unified\.yml@' \
  chrislusf/seaweedfs:latest
```

How it fits the release flow:

- The signature is attached to the digest, so signing once in the `merge` job covers the multi-arch index on both registries, and `latest` picks it up when `tag-latest` re-tags the same manifest. `--recursive` also signs each platform image under the index for consumers that pull by platform digest.
- A `verify` step runs right after signing with the identity the signature should carry, so a wrong identity fails the publish instead of surfacing on someone's cluster.
- Signatures are written in the `.sig` tag layout rather than the OCI-referrer bundle that cosign 3 writes by default. Every verifier reads the tag layout today, including the Kyverno and policy-controller releases people run; cosign 3's own `verify` falls back to it automatically. The flag is deprecated upstream, so this is a one-line change when the ecosystem catches up.
- The install, sign, and verify steps live in one composite action so the six workflows stay in sync, and dependabot is pointed at it so the cosign-installer pin keeps moving.

The publishing jobs get `id-token: write`; nothing else about their permissions or secrets changes. Verified locally against a throwaway registry that the flag combination signs a multi-arch index recursively, that the index and a platform child both verify, and that a wrong key is rejected. The first signed images land with the next release; `docker/README.md` documents the verify command and a Kyverno policy, and I will put the same on the wiki once a signed release is out to check against.

https://claude.ai/code/session_01A5zMqzaUg1Snur4Yg8xJGa


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Container images published through supported build and release workflows are now signed with keyless Cosign signatures and verified against their GitHub Actions identity.
  * Signatures cover published images across Docker Hub and GitHub Container Registry, including multi-platform images.
  * Image signatures are attached to immutable digests for more reliable verification and deployment.

* **Documentation**
  * Added guidance for verifying image signatures with Cosign and enforcing signature validation with Kyverno.
  * Documented signature coverage, identity mapping, and digest-based deployment for newly published images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->