### PR TITLE
test: write more files than the master grows volumes at a time

### DIFF
--- a/test/fuse_failover/volume_failover_test.go
+++ b/test/fuse_failover/volume_failover_test.go
@@ -215,10 +215,12 @@ func TestReadAfterCachedLocationDies(t *testing.T) {
 	c := startFailoverCluster(t, 3, 2)
 
 	// Small files so each is a single chunk on a single volume, which keeps the
-	// mapping from file to server unambiguous.
+	// mapping from file to server unambiguous. The master grows six 001 volumes
+	// at a time, so seven files put two of them on one volume however the
+	// writes are spread.
 	const fileSize = 256 << 10
 	payloads := make(map[string][]byte)
-	for i := 0; i < 6; i++ {
+	for i := 0; i < 7; i++ {
 		name := fmt.Sprintf("smallfile-%d", i)
 		data := make([]byte, fileSize)
 		_, err := rand.Read(data)


### PR DESCRIPTION
`TestReadAfterCachedLocationDies` needs two files on one volume, but it wrote six files into the six volumes a 001 layout starts with, and every so often each file landed on its own volume and the test failed before it had anything to probe. Seven files leave no way to spread them out.

Seen on https://github.com/seaweedfs/seaweedfs/actions/runs/33782956901/job/100740809189.

https://claude.ai/code/session_011NYXuzGttwrTMsfLYvmQFs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated failover test coverage to create seven small files.
  * Added documentation clarifying volume allocation behavior.
  * Continued validating cache failover when multiple files share a volume.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->