### PR TITLE
telemetry: type MinDiskBytes so a 32-bit int cannot hold it by accident

### DIFF
--- a/telemetry/proto/floor.go
+++ b/telemetry/proto/floor.go
@@ -4,4 +4,4 @@ package proto
 // the server keeps the report: fresh `weed server` runs, CI jobs and throwaway
 // containers each mint their own cluster id, and they were most of the counted
 // clusters while holding almost none of the bytes.
-const MinDiskBytes = 10 << 30
+const MinDiskBytes uint64 = 10 << 30


### PR DESCRIPTION
The 32-bit vet job on #11138 failed:

```
weed/telemetry/collector.go:138:103: cannot use proto.MinDiskBytes (untyped int constant 10737418240) as int value in argument to glog.V(2).Infof (overflows)
```

https://github.com/seaweedfs/seaweedfs/actions/runs/33797119957/job/100787388413

`MinDiskBytes` was an untyped constant, so at the variadic `Infof` call it defaulted to `int`, which is 32 bits on linux/386. Typing it as `uint64` fixes that, and matches every field it is compared against (`TotalDiskBytes`, `Size`, `TotalDisk`). `GOOS=linux GOARCH=386 go vet ./...` is clean in both the root and `telemetry/server` modules, and the telemetry tests pass.

https://claude.ai/code/session_015rYAmF8hV9yypb9yvy4A1z


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Clarified the data type of a disk-space threshold for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->