### PR TITLE
ci: disable signing config for legacy cosign signatures

### DIFF
--- a/.github/actions/sign-image/action.yml
+++ b/.github/actions/sign-image/action.yml
@@ -25,7 +25,8 @@ runs:
         set -euo pipefail
         # The .sig tag layout: the OCI-referrer bundle cosign 3 writes by default
         # is not read by the Kyverno and policy-controller releases in use today.
-        cosign sign --yes --recursive --new-bundle-format=false $IMAGES
+        # Its signing config only supports bundles, so disable that path too.
+        cosign sign --yes --recursive --new-bundle-format=false --use-signing-config=false $IMAGES
 
     - name: Verify
       shell: bash


### PR DESCRIPTION
## What this fixes

The `Sign` step in [docker: build dev containers](https://github.com/seaweedfs/seaweedfs/actions/runs/33797382867/job/100816861451) fails under Cosign 3.0.6 with:

```text
Error: must provide --new-bundle-format or --bundle where applicable with --signing-config or --use-signing-config
```

The shared composite action opts out of the new bundle format so current Kyverno and policy-controller releases can find the legacy `.sig` tags. Cosign 3 also enables its signing-config path by default, and that path requires bundle output.

## Change

Pass `--use-signing-config=false` alongside `--new-bundle-format=false`. This keeps the intended legacy signature layout while allowing Cosign 3.0.6 to sign the images.

## Validation

- Reproduced the CI validation error locally with Cosign 3.0.6
- Confirmed the paired flags against the Cosign 3.0.6 CLI defaults and validation logic
- Ran `actionlint` on all six workflows that call the shared signing action
- Parsed the composite action metadata and ran `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs/pull/11143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated image signing automation to disable the signing configuration path during signing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->