### PR TITLE
ci: turn off cosign's signing config alongside the bundle format

### DIFF
--- a/.github/actions/sign-image/action.yml
+++ b/.github/actions/sign-image/action.yml
@@ -25,7 +25,12 @@ runs:
         set -euo pipefail
         # The .sig tag layout: the OCI-referrer bundle cosign 3 writes by default
         # is not read by the Kyverno and policy-controller releases in use today.
-        cosign sign --yes --recursive --new-bundle-format=false $IMAGES
+        # Cosign 3 also defaults to --use-signing-config, which insists on a
+        # bundle for its output; turning it off falls back to the default
+        # Fulcio and Rekor URLs, which is all the .sig layout ever used.
+        cosign sign --yes --recursive \
+          --new-bundle-format=false --use-signing-config=false \
+          $IMAGES
 
     - name: Verify
       shell: bash


### PR DESCRIPTION
## Summary

Fixes the `Sign` step that has failed in every image-publishing job since signing was introduced in #11129, e.g. https://github.com/seaweedfs/seaweedfs/actions/runs/33804833829/job/100836554582:

```
Error: must provide --new-bundle-format or --bundle where applicable with --signing-config or --use-signing-config
```

**Root cause.** Cosign 3 turned on two defaults, not one: `--new-bundle-format=true` *and* `--use-signing-config=true`. The action only disabled the first (to keep the `.sig` tag layout that Kyverno / policy-controller read), leaving the signing-config path active. That path stores its verification material in a bundle, so cosign rejects the combination up front in [`LoadTrustedMaterialAndSigningConfig`](https://github.com/sigstore/cosign/blob/v3.0.6/cmd/cosign/cli/signcommon/common.go#L659-L662).

**Fix.** Pass `--use-signing-config=false` too. Cosign then falls back to the default Fulcio and Rekor URLs, which is exactly what the `.sig` layout always used. One line in `.github/actions/sign-image/action.yml`; all six workflows that call the composite action pick it up.

The `Verify` step is unchanged: `cosign verify` looks for a referrer bundle first and [falls back to the `.sig` tag](https://github.com/sigstore/cosign/blob/v3.0.6/cmd/cosign/cli/verify/verify.go#L150-L157) when there is none, so it will accept what this now produces.

#### Test plan

- [x] Reproduced the exact CI error locally with the old flags against cosign v3.x, and confirmed the new flags get past the flag check.
- [x] End-to-end against a local `registry:2`: `cosign sign --recursive --new-bundle-format=false --use-signing-config=false` pushes a `sha256-<digest>.sig` tag, and `cosign verify` with the action's existing default flags auto-detects and verifies it.
- [ ] `docker: build dev containers` goes green on master after merge (keyless signing needs the workflow's own OIDC token, so it cannot be exercised from a PR).

Generated with [Devin](https://devin.ai)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs/pull/11144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated image signing to work with the default certificate and transparency-log services.
  * Improved compatibility by using the legacy signature bundle format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->