### PR TITLE
filer.remote.sync: skip an upload whose source entry was deleted or rewritten

### DIFF
--- a/weed/command/filer_remote_gateway_buckets.go
+++ b/weed/command/filer_remote_gateway_buckets.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"math/rand"
@@ -263,7 +264,11 @@ func (option *RemoteGatewayOptions) makeBucketedEventProcessor(filerSource *sour
 				return client.WriteDirectory(dest, message.NewEntry)
 			}
 			glog.V(0).Infof("create %s", remote_storage.FormatLocation(dest))
-			remoteEntry, writeErr := retriedWriteFile(client, filerSource, message.NewEntry, dest)
+			remoteEntry, writeErr := retriedWriteFile(client, filerSource, message.NewParentPath, message.NewEntry, dest)
+			if errors.Is(writeErr, errSuperseded) {
+				glog.Errorf("skipping %s: %v", remote_storage.FormatLocation(dest), writeErr)
+				return nil
+			}
 			if writeErr != nil {
 				return writeErr
 			}
@@ -349,7 +354,11 @@ func (option *RemoteGatewayOptions) makeBucketedEventProcessor(filerSource *sour
 						return client.UpdateFileMetadata(oldDest, message.OldEntry, message.NewEntry)
 					} else {
 						newDest := toRemoteStorageLocation(newBucket, util.NewFullPath(message.NewParentPath, message.NewEntry.Name), newRemoteStorageMountLocation)
-						remoteEntry, writeErr := retriedWriteFile(client, filerSource, message.NewEntry, newDest)
+						remoteEntry, writeErr := retriedWriteFile(client, filerSource, message.NewParentPath, message.NewEntry, newDest)
+						if errors.Is(writeErr, errSuperseded) {
+							glog.Errorf("skipping %s: %v", remote_storage.FormatLocation(newDest), writeErr)
+							return nil
+						}
 						if writeErr != nil {
 							return writeErr
 						}
@@ -386,7 +395,11 @@ func (option *RemoteGatewayOptions) makeBucketedEventProcessor(filerSource *sour
 				if message.NewEntry.IsDirectory {
 					return client.WriteDirectory(newDest, message.NewEntry)
 				}
-				remoteEntry, writeErr := retriedWriteFile(client, filerSource, message.NewEntry, newDest)
+				remoteEntry, writeErr := retriedWriteFile(client, filerSource, message.NewParentPath, message.NewEntry, newDest)
+				if errors.Is(writeErr, errSuperseded) {
+					glog.Errorf("skipping %s: %v", remote_storage.FormatLocation(newDest), writeErr)
+					return nil
+				}
 				if writeErr != nil {
 					return writeErr
 				}

--- a/weed/command/filer_remote_sync_dir.go
+++ b/weed/command/filer_remote_sync_dir.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -268,21 +269,30 @@ func (option *RemoteSyncOptions) makeEventProcessor(remoteStorage *remote_pb.Rem
 }
 
 // isSuperseded reports whether the filer has moved past the entry an event
-// described: it is deleted, or it now holds other content. The chunks the event
-// names are then gone from the volume servers, or about to be, and no retry of
-// the upload can succeed. A replay from an earlier offset (-timeAgo) re-emits
-// such events. Failing one holds the sync offset before it, so every restart of
-// the subscription replays it into the same dead chunks, and progress on
-// everything after it in the log is never persisted. Skipping is safe: the
-// event that superseded this one follows in the log, and the delete removes the
-// remote object or the rewrite uploads the current content. A lookup that fails
-// for any other reason keeps the write failure, so the event is retried.
+// described: it is deleted, or it no longer references every chunk the event
+// named. Those are the chunks the filer deletes when an entry is updated, so
+// they are gone from the volume servers, or about to be, and no retry of the
+// upload can succeed. Chunks are compared by file id, not content: a rewrite
+// stores even identical bytes under new ids and drops the old ones. A replay
+// from an earlier offset (-timeAgo) re-emits such events. Failing one holds the
+// sync offset before it, so every restart of the subscription replays it into
+// the same dead chunks, and progress on everything after it in the log is never
+// persisted. Skipping is safe: the event that superseded this one follows in
+// the log, and the delete removes the remote object or the rewrite uploads the
+// current content. A lookup that fails for any other reason keeps the write
+// failure, so the event is retried.
 func isSuperseded(filerClient filer_pb.FilerClient, dir string, entry *filer_pb.Entry) bool {
 	current, _, _, err := filer_pb.GetEntry(context.Background(), filerClient, util.NewFullPath(dir, entry.Name))
 	if errors.Is(err, filer_pb.ErrNotFound) {
 		return true
 	}
-	return err == nil && !filer.IsSameData(current, entry)
+	if err != nil {
+		return false
+	}
+	if len(entry.Content) > 0 || len(current.Content) > 0 {
+		return !bytes.Equal(entry.Content, current.Content)
+	}
+	return len(filer.DoMinusChunks(entry.GetChunks(), current.GetChunks())) > 0
 }
 
 func retriedWriteFile(client remote_storage.RemoteStorageClient, filerSource *source.FilerSource, newEntry *filer_pb.Entry, dest *remote_pb.RemoteStorageLocation) (remoteEntry *filer_pb.RemoteEntry, err error) {

--- a/weed/command/filer_remote_sync_dir.go
+++ b/weed/command/filer_remote_sync_dir.go
@@ -179,6 +179,10 @@ func (option *RemoteSyncOptions) makeEventProcessor(remoteStorage *remote_pb.Rem
 			glog.V(0).Infof("create %s", remote_storage.FormatLocation(dest))
 			remoteEntry, writeErr := retriedWriteFile(client, filerSource, message.NewEntry, dest)
 			if writeErr != nil {
+				if isSuperseded(option, message.NewParentPath, message.NewEntry) {
+					glog.Errorf("skipping %s: %s/%s deleted or rewritten since the event was logged: %v", remote_storage.FormatLocation(dest), message.NewParentPath, message.NewEntry.Name, writeErr)
+					return nil
+				}
 				return writeErr
 			}
 			// Skip updateLocalEntry for versioned rewrites: the logical
@@ -249,6 +253,10 @@ func (option *RemoteSyncOptions) makeEventProcessor(remoteStorage *remote_pb.Rem
 			}
 			remoteEntry, writeErr := retriedWriteFile(client, filerSource, message.NewEntry, dest)
 			if writeErr != nil {
+				if isSuperseded(option, message.NewParentPath, message.NewEntry) {
+					glog.Errorf("skipping %s: %s/%s deleted or rewritten since the event was logged: %v", remote_storage.FormatLocation(dest), message.NewParentPath, message.NewEntry.Name, writeErr)
+					return nil
+				}
 				return writeErr
 			}
 			return updateLocalEntry(option, message.NewParentPath, message.NewEntry, remoteEntry)
@@ -257,6 +265,24 @@ func (option *RemoteSyncOptions) makeEventProcessor(remoteStorage *remote_pb.Rem
 		return nil
 	}
 	return eachEntryFunc, nil
+}
+
+// isSuperseded reports whether the filer has moved past the entry an event
+// described: it is deleted, or it now holds other content. The chunks the event
+// names are then gone from the volume servers, or about to be, and no retry of
+// the upload can succeed. A replay from an earlier offset (-timeAgo) re-emits
+// such events. Failing one holds the sync offset before it, so every restart of
+// the subscription replays it into the same dead chunks, and progress on
+// everything after it in the log is never persisted. Skipping is safe: the
+// event that superseded this one follows in the log, and the delete removes the
+// remote object or the rewrite uploads the current content. A lookup that fails
+// for any other reason keeps the write failure, so the event is retried.
+func isSuperseded(filerClient filer_pb.FilerClient, dir string, entry *filer_pb.Entry) bool {
+	current, _, _, err := filer_pb.GetEntry(context.Background(), filerClient, util.NewFullPath(dir, entry.Name))
+	if errors.Is(err, filer_pb.ErrNotFound) {
+		return true
+	}
+	return err == nil && !filer.IsSameData(current, entry)
 }
 
 func retriedWriteFile(client remote_storage.RemoteStorageClient, filerSource *source.FilerSource, newEntry *filer_pb.Entry, dest *remote_pb.RemoteStorageLocation) (remoteEntry *filer_pb.RemoteEntry, err error) {

--- a/weed/command/filer_remote_sync_dir.go
+++ b/weed/command/filer_remote_sync_dir.go
@@ -178,12 +178,12 @@ func (option *RemoteSyncOptions) makeEventProcessor(remoteStorage *remote_pb.Rem
 				return client.WriteDirectory(dest, message.NewEntry)
 			}
 			glog.V(0).Infof("create %s", remote_storage.FormatLocation(dest))
-			remoteEntry, writeErr := retriedWriteFile(client, filerSource, message.NewEntry, dest)
+			remoteEntry, writeErr := retriedWriteFile(client, filerSource, message.NewParentPath, message.NewEntry, dest)
+			if errors.Is(writeErr, errSuperseded) {
+				glog.Errorf("skipping %s: %v", remote_storage.FormatLocation(dest), writeErr)
+				return nil
+			}
 			if writeErr != nil {
-				if isSuperseded(option, message.NewParentPath, message.NewEntry) {
-					glog.Errorf("skipping %s: %s/%s deleted or rewritten since the event was logged: %v", remote_storage.FormatLocation(dest), message.NewParentPath, message.NewEntry.Name, writeErr)
-					return nil
-				}
 				return writeErr
 			}
 			// Skip updateLocalEntry for versioned rewrites: the logical
@@ -252,12 +252,12 @@ func (option *RemoteSyncOptions) makeEventProcessor(remoteStorage *remote_pb.Rem
 					return nil
 				}
 			}
-			remoteEntry, writeErr := retriedWriteFile(client, filerSource, message.NewEntry, dest)
+			remoteEntry, writeErr := retriedWriteFile(client, filerSource, message.NewParentPath, message.NewEntry, dest)
+			if errors.Is(writeErr, errSuperseded) {
+				glog.Errorf("skipping %s: %v", remote_storage.FormatLocation(dest), writeErr)
+				return nil
+			}
 			if writeErr != nil {
-				if isSuperseded(option, message.NewParentPath, message.NewEntry) {
-					glog.Errorf("skipping %s: %s/%s deleted or rewritten since the event was logged: %v", remote_storage.FormatLocation(dest), message.NewParentPath, message.NewEntry.Name, writeErr)
-					return nil
-				}
 				return writeErr
 			}
 			return updateLocalEntry(option, message.NewParentPath, message.NewEntry, remoteEntry)
@@ -295,18 +295,28 @@ func isSuperseded(filerClient filer_pb.FilerClient, dir string, entry *filer_pb.
 	return len(filer.DoMinusChunks(entry.GetChunks(), current.GetChunks())) > 0
 }
 
-func retriedWriteFile(client remote_storage.RemoteStorageClient, filerSource *source.FilerSource, newEntry *filer_pb.Entry, dest *remote_pb.RemoteStorageLocation) (remoteEntry *filer_pb.RemoteEntry, err error) {
-	var writeErr error
-	err = util.Retry("writeFile", func() error {
+// errSuperseded marks an upload that failed for an entry the filer has since
+// moved past (isSuperseded). The caller skips the event instead of failing it.
+var errSuperseded = errors.New("deleted or rewritten since the event was logged")
+
+// retriedWriteFile uploads the entry, retrying transient failures. Every failed
+// attempt first asks the filer whether the entry is superseded, and stops at
+// once when it is: a dead chunk reads as a transient "RequestError" from the
+// SDK, and waiting out the backoff on it buys nothing.
+func retriedWriteFile(client remote_storage.RemoteStorageClient, filerSource filer_pb.FilerClient, dir string, newEntry *filer_pb.Entry, dest *remote_pb.RemoteStorageLocation) (remoteEntry *filer_pb.RemoteEntry, err error) {
+	err = util.RetryOnError("writeFile", func(err error) bool {
+		return !errors.Is(err, errSuperseded) && util.IsTransientError(err)
+	}, func() error {
 		reader := filer.NewFileReader(filerSource, newEntry)
 		glog.V(0).Infof("create %s", remote_storage.FormatLocation(dest))
+		var writeErr error
 		remoteEntry, writeErr = client.WriteFile(dest, newEntry, reader)
-		if writeErr != nil {
-			return writeErr
+		if writeErr != nil && isSuperseded(filerSource, dir, newEntry) {
+			return fmt.Errorf("%s %w: %w", util.NewFullPath(dir, newEntry.Name), errSuperseded, writeErr)
 		}
-		return nil
+		return writeErr
 	})
-	if err != nil {
+	if err != nil && !errors.Is(err, errSuperseded) {
 		glog.Errorf("write to %s: %v", dest, err)
 	}
 	return

--- a/weed/command/filer_remote_sync_dir_test.go
+++ b/weed/command/filer_remote_sync_dir_test.go
@@ -405,15 +405,20 @@ func TestIsMetadataOnlyUpdate(t *testing.T) {
 	}
 }
 
-// stubFilerClient serves one entry; nil means not found.
+// stubFilerClient serves one entry; nil means not found. A non-nil err fails
+// every lookup instead.
 type stubFilerClient struct {
 	filer_pb.SeaweedFilerClient
 	entry   *filer_pb.Entry
+	err     error
 	lookups int
 }
 
 func (c *stubFilerClient) LookupDirectoryEntry(context.Context, *filer_pb.LookupDirectoryEntryRequest, ...grpc.CallOption) (*filer_pb.LookupDirectoryEntryResponse, error) {
 	c.lookups++
+	if c.err != nil {
+		return nil, c.err
+	}
 	return &filer_pb.LookupDirectoryEntryResponse{Entry: c.entry}, nil
 }
 
@@ -480,6 +485,50 @@ func TestLiveRemoteEntry(t *testing.T) {
 		_, err := liveRemoteEntry(&stubFilerClient{}, dir, chunkedEntry("output.pdf", nil, "e1"))
 		if !errors.Is(err, filer_pb.ErrNotFound) {
 			t.Errorf("err = %v, want filer_pb.ErrNotFound so the update is skipped rather than uploaded from a deleted entry", err)
+		}
+	})
+}
+
+// TestIsSuperseded decides what a failed upload means for its event (#11148).
+// A replay from an earlier offset re-emits creates for entries the filer has
+// since deleted or rewritten; their chunks are gone, so the upload can never
+// succeed, and failing the event pins the offset before it forever. Those are
+// skipped. A failure to upload an entry the filer still holds as described is
+// a real failure and must keep failing the event so the subscription retries.
+func TestIsSuperseded(t *testing.T) {
+	const dir = "/buckets/ingest"
+	event := chunkedEntry("tmpjt9req69__Alan_Doe_Resume-1.pdf", nil, "e1", "e2")
+
+	tests := []struct {
+		name  string
+		filer *stubFilerClient
+		want  bool
+	}{
+		{name: "deleted since", filer: &stubFilerClient{}, want: true},
+		{name: "rewritten since", filer: &stubFilerClient{entry: chunkedEntry(event.Name, nil, "e1", "e3")}, want: true},
+		{name: "deleted and recreated under the same name", filer: &stubFilerClient{entry: chunkedEntry(event.Name, nil, "e9")}, want: true},
+		{name: "still as described", filer: &stubFilerClient{entry: chunkedEntry(event.Name, nil, "e1", "e2")}, want: false},
+		{name: "still as described, since replicated", filer: &stubFilerClient{entry: chunkedEntry(event.Name, &filer_pb.RemoteEntry{RemoteMtime: 1786096669}, "e1", "e2")}, want: false},
+		{name: "filer lookup failed", filer: &stubFilerClient{err: errors.New("rpc error: code = Unavailable")}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSuperseded(tt.filer, dir, event); got != tt.want {
+				t.Errorf("isSuperseded = %v, want %v", got, tt.want)
+			}
+			if tt.filer.lookups != 1 {
+				t.Errorf("looked up the filer %d times, want 1", tt.filer.lookups)
+			}
+		})
+	}
+
+	t.Run("inline content rewritten since", func(t *testing.T) {
+		event := &filer_pb.Entry{Name: "note.txt", Content: []byte("v1")}
+		if !isSuperseded(&stubFilerClient{entry: &filer_pb.Entry{Name: "note.txt", Content: []byte("v2")}}, dir, event) {
+			t.Error("isSuperseded = false, want true for an entry whose inline content has changed")
+		}
+		if isSuperseded(&stubFilerClient{entry: &filer_pb.Entry{Name: "note.txt", Content: []byte("v1")}}, dir, event) {
+			t.Error("isSuperseded = true, want false for an entry whose inline content is unchanged")
 		}
 	})
 }

--- a/weed/command/filer_remote_sync_dir_test.go
+++ b/weed/command/filer_remote_sync_dir_test.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/remote_pb"
+	"github.com/seaweedfs/seaweedfs/weed/remote_storage"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 	"github.com/seaweedfs/seaweedfs/weed/util"
 	"google.golang.org/grpc"
@@ -546,6 +549,83 @@ func TestIsSuperseded(t *testing.T) {
 		}
 		if isSuperseded(&stubFilerClient{entry: &filer_pb.Entry{Name: "note.txt", Content: []byte("v1")}}, dir, event) {
 			t.Error("isSuperseded = true, want false for an entry whose inline content is unchanged")
+		}
+	})
+}
+
+// failingRemote fails every WriteFile with err and counts the attempts.
+type failingRemote struct {
+	remote_storage.RemoteStorageClient
+	err    error
+	writes int
+}
+
+func (r *failingRemote) WriteFile(*remote_pb.RemoteStorageLocation, *filer_pb.Entry, io.Reader) (*filer_pb.RemoteEntry, error) {
+	r.writes++
+	return nil, r.err
+}
+
+// TestRetriedWriteFileStopsWhenSuperseded checks that a failed upload asks the
+// filer at once, and stops retrying when the entry is gone: the ~13s of backoff
+// util.Retry would spend on a dead chunk buys nothing. An upload of an entry the
+// filer still holds keeps the retry policy it had.
+func TestRetriedWriteFileStopsWhenSuperseded(t *testing.T) {
+	const dir = "/buckets/ingest"
+	event := entryWith("tmpjt9req69__Alan_Doe_Resume-1.pdf", nil, chunk("3,01", "e1"))
+	dest := &remote_pb.RemoteStorageLocation{Name: "b2", Bucket: "tier", Path: "/" + event.Name}
+	// What the S3 SDK reports when the volume server no longer has the chunk:
+	// "requesterror" makes IsTransientError retry it to exhaustion.
+	deadChunk := errors.New("RequestError: send request failed\ncaused by: Put \"https://s3.example.com/tier/x\": http://volume:8444/3,01?readDeleted=true: 404 Not Found: not found")
+
+	t.Run("superseded, one attempt", func(t *testing.T) {
+		remote := &failingRemote{err: deadChunk}
+		filerClient := &stubFilerClient{}
+		start := time.Now()
+		_, err := retriedWriteFile(remote, filerClient, dir, event, dest)
+		if !errors.Is(err, errSuperseded) {
+			t.Errorf("err = %v, want errSuperseded", err)
+		}
+		if !strings.Contains(err.Error(), "404 Not Found") {
+			t.Errorf("err = %v, want it to keep the write failure", err)
+		}
+		if remote.writes != 1 {
+			t.Errorf("wrote %d times, want 1: retrying a dead chunk cannot succeed", remote.writes)
+		}
+		if filerClient.lookups != 1 {
+			t.Errorf("looked up the filer %d times, want 1", filerClient.lookups)
+		}
+		if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+			t.Errorf("took %v, want no backoff", elapsed)
+		}
+	})
+
+	t.Run("still as described, transient failure keeps retrying", func(t *testing.T) {
+		prev := util.RetryWaitTime
+		util.RetryWaitTime = 1600 * time.Millisecond // two attempts: 1s, then 1.5s
+		t.Cleanup(func() { util.RetryWaitTime = prev })
+		remote := &failingRemote{err: deadChunk}
+		filerClient := &stubFilerClient{entry: entryWith(event.Name, nil, chunk("3,01", "e1"))}
+		_, err := retriedWriteFile(remote, filerClient, dir, event, dest)
+		if errors.Is(err, errSuperseded) {
+			t.Errorf("err = %v, want the write failure itself", err)
+		}
+		if remote.writes != 2 {
+			t.Errorf("wrote %d times, want 2: a transient failure on a live entry is still retried", remote.writes)
+		}
+		if filerClient.lookups != 2 {
+			t.Errorf("looked up the filer %d times, want one per failed attempt", filerClient.lookups)
+		}
+	})
+
+	t.Run("still as described, permanent failure not retried", func(t *testing.T) {
+		remote := &failingRemote{err: errors.New("AccessDenied: Access Denied")}
+		filerClient := &stubFilerClient{entry: entryWith(event.Name, nil, chunk("3,01", "e1"))}
+		_, err := retriedWriteFile(remote, filerClient, dir, event, dest)
+		if err == nil || errors.Is(err, errSuperseded) {
+			t.Errorf("err = %v, want the write failure itself", err)
+		}
+		if remote.writes != 1 {
+			t.Errorf("wrote %d times, want 1", remote.writes)
 		}
 	})
 }

--- a/weed/command/filer_remote_sync_dir_test.go
+++ b/weed/command/filer_remote_sync_dir_test.go
@@ -489,15 +489,29 @@ func TestLiveRemoteEntry(t *testing.T) {
 	})
 }
 
+func chunk(fileId, etag string) *filer_pb.FileChunk {
+	return &filer_pb.FileChunk{FileId: fileId, Size: 1024, ETag: etag}
+}
+
+func entryWith(name string, remote *filer_pb.RemoteEntry, chunks ...*filer_pb.FileChunk) *filer_pb.Entry {
+	return &filer_pb.Entry{Name: name, Attributes: &filer_pb.FuseAttributes{Mtime: 1786096669}, RemoteEntry: remote, Chunks: chunks}
+}
+
 // TestIsSuperseded decides what a failed upload means for its event (#11148).
 // A replay from an earlier offset re-emits creates for entries the filer has
 // since deleted or rewritten; their chunks are gone, so the upload can never
 // succeed, and failing the event pins the offset before it forever. Those are
 // skipped. A failure to upload an entry the filer still holds as described is
 // a real failure and must keep failing the event so the subscription retries.
+//
+// Every write stores its chunks under new file ids, so the entry is compared
+// by chunk identity, the way the filer itself decides which chunks an update
+// leaves for deletion. Content fingerprints would miss a delete-and-recreate
+// of identical bytes and fail the event forever on its dead chunks.
 func TestIsSuperseded(t *testing.T) {
 	const dir = "/buckets/ingest"
-	event := chunkedEntry("tmpjt9req69__Alan_Doe_Resume-1.pdf", nil, "e1", "e2")
+	event := entryWith("tmpjt9req69__Alan_Doe_Resume-1.pdf", nil, chunk("3,01", "e1"), chunk("3,02", "e2"))
+	stamped := &filer_pb.RemoteEntry{StorageName: "b2", RemoteMtime: 1786096669}
 
 	tests := []struct {
 		name  string
@@ -505,10 +519,13 @@ func TestIsSuperseded(t *testing.T) {
 		want  bool
 	}{
 		{name: "deleted since", filer: &stubFilerClient{}, want: true},
-		{name: "rewritten since", filer: &stubFilerClient{entry: chunkedEntry(event.Name, nil, "e1", "e3")}, want: true},
-		{name: "deleted and recreated under the same name", filer: &stubFilerClient{entry: chunkedEntry(event.Name, nil, "e9")}, want: true},
-		{name: "still as described", filer: &stubFilerClient{entry: chunkedEntry(event.Name, nil, "e1", "e2")}, want: false},
-		{name: "still as described, since replicated", filer: &stubFilerClient{entry: chunkedEntry(event.Name, &filer_pb.RemoteEntry{RemoteMtime: 1786096669}, "e1", "e2")}, want: false},
+		{name: "rewritten since", filer: &stubFilerClient{entry: entryWith(event.Name, nil, chunk("3,01", "e1"), chunk("4,07", "e3"))}, want: true},
+		{name: "recreated with identical content", filer: &stubFilerClient{entry: entryWith(event.Name, nil, chunk("5,11", "e1"), chunk("5,12", "e2"))}, want: true},
+		{name: "recreated with other content", filer: &stubFilerClient{entry: entryWith(event.Name, nil, chunk("6,01", "e9"))}, want: true},
+		{name: "truncated since", filer: &stubFilerClient{entry: entryWith(event.Name, nil, chunk("3,01", "e1"))}, want: true},
+		{name: "still as described", filer: &stubFilerClient{entry: entryWith(event.Name, nil, chunk("3,01", "e1"), chunk("3,02", "e2"))}, want: false},
+		{name: "still as described, since replicated", filer: &stubFilerClient{entry: entryWith(event.Name, stamped, chunk("3,01", "e1"), chunk("3,02", "e2"))}, want: false},
+		{name: "appended since, chunks still live", filer: &stubFilerClient{entry: entryWith(event.Name, nil, chunk("3,01", "e1"), chunk("3,02", "e2"), chunk("3,03", "e3"))}, want: false},
 		{name: "filer lookup failed", filer: &stubFilerClient{err: errors.New("rpc error: code = Unavailable")}, want: false},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #11148. Follow-up to #11146.

# What problem are we solving?

One entry whose chunks are gone stops `filer.remote.sync` for the whole mounted directory, permanently.

A replay from an earlier offset (`-timeAgo`, the documented way to re-seed a directory) re-emits create and update events for entries the filer has since deleted or rewritten. The event still names the old chunks, the volume servers no longer hold them, and `retriedWriteFile` fails with a 404 wrapped in the SDK's `RequestError`. The handler returns the error, the processor holds the sync offset before the event, and every restart of the subscription replays it into the same dead chunks. Progress on everything after it in the log is never persisted. The reporter measured 109 entries reprocessed 90 times each with the offset frozen for over an hour, while the pod stayed `1/1 Running` with a fresh log.

#11146 added the right check, `liveRemoteEntry` returning `ErrNotFound` so a deleted entry is skipped, but only on the metadata-only update path. The create path, which is what a replay hits, and the data-changing update path still fail the event.

# How are we solving the problem?

When an upload attempt in `retriedWriteFile` fails, `isSuperseded` looks the entry up on the filer before any retry. Two answers mean the event can never be applied: the retry loop stops at once and returns `errSuperseded`, and the caller skips the event with a `glog.Errorf` naming the destination, the source path and the write error:

- **Deleted since.** `GetEntry` returns `ErrNotFound`. The delete that follows in the log removes the remote object.
- **Rewritten since.** The entry exists but no longer references every chunk the event named, per `filer.DoMinusChunks(event.Chunks, current.Chunks)`, the helper the filer itself uses to decide which chunks an update leaves for deletion. Chunks are compared by file id, not content: a rewrite stores even identical bytes under new ids and drops the old ones, so an ETag comparison would keep failing a delete-and-recreate of the same file forever. This covers in-place rewrites, truncation, and delete-then-recreate under the same name, all routine in the reporter's ingest staging directory. The event that changed the content follows in the log and uploads the current content. Inline `Content` is compared with `bytes.Equal`.

Anything else keeps the write failure: the entry still references all the event's chunks (including when more were appended after it), so the failure is real (remote down, credentials, a genuinely lost chunk) and the event must keep failing so it is retried. A filer lookup that fails for any other reason also keeps the write failure.

The lookup happens only on a failed attempt, so the happy path pays nothing, and a superseded entry costs one upload attempt and one filer lookup instead of the ~13s backoff `util.Retry` would spend on it (the SDK reports a missing chunk as `RequestError`, which `IsTransientError` takes as worth retrying). `retriedWriteFile` uses `util.RetryOnError` with a predicate that stops on `errSuperseded` and otherwise keeps the transient policy it had. Issue #11148 also suggests teaching `IsTransientError` that `"requesterror"` alone does not mean transient; that touches every caller of `util.Retry`, so it is left out of this PR.

`filer.remote.gateway` shares `retriedWriteFile` and the same offset-pinning processor, so its three call sites skip a superseded event the same way.

# How is the PR tested?

`TestRetriedWriteFileStopsWhenSuperseded`, with a stub remote that fails every `WriteFile` with the SDK's `RequestError ... 404 Not Found` text from the issue:

- entry gone: one upload attempt, one filer lookup, `errSuperseded` carrying the write failure, no backoff
- entry still as described, transient failure: still retried, one filer lookup per failed attempt
- entry still as described, permanent failure (`AccessDenied`): not retried, write failure returned as is

`TestIsSuperseded`, using the stub filer client from #11146 (extended with an `err` field so a lookup can fail):

- deleted since: skip
- rewritten since (one chunk replaced under a new file id): skip
- recreated with identical content (same ETags, new file ids): skip
- recreated with other content, truncated since: skip
- still as described, with and without a `RemoteEntry` stamp: keep failing
- appended since, the event's chunks still live: keep failing
- filer lookup itself fails: keep failing
- inline `Content` rewritten vs unchanged

Each case asserts exactly one filer lookup. `go test ./weed/command/`, `go vet`, `gofmt` clean.

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.

Generated with [Devin](https://devin.ai)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs/pull/11149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Remote synchronization now safely skips uploads when the related filer entry was deleted, replaced, truncated, or appended after the event was recorded.
  * Superseded uploads stop retrying immediately, reducing unnecessary delays.
  * Transient upload failures continue to be retried, while permanent errors and filer lookup failures are still reported.
  * Improved synchronization handling for file creation, updates, and renames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

