### PR TITLE
filer: do not 404 a TUS session on a transient chunk-load failure

### DIFF
--- a/weed/server/filer_grpc_server_rename_test.go
+++ b/weed/server/filer_grpc_server_rename_test.go
@@ -29,6 +29,7 @@ type renameTestStore struct {
 	findCalls map[string]int
 	commitErr error
 	deleteErr error
+	listErr   error         // simulates a transient store/RPC failure from a directory listing
 	findDelay time.Duration // optional: widen check-then-act windows in tests
 }
 
@@ -107,6 +108,11 @@ func (s *renameTestStore) DeleteFolderChildren(_ context.Context, p util.FullPat
 
 func (s *renameTestStore) listDirectoryEntries(dirPath util.FullPath, startFileName string, includeStartFile bool, limit int64, prefix string, eachEntryFunc filer.ListEachEntryFunc) (string, error) {
 	s.mu.Lock()
+	if s.listErr != nil {
+		err := s.listErr
+		s.mu.Unlock()
+		return "", err
+	}
 	var entries []*filer.Entry
 	for path, entry := range s.entries {
 		if path == string(dirPath) {

--- a/weed/server/filer_server_tus_handlers.go
+++ b/weed/server/filer_server_tus_handlers.go
@@ -99,6 +99,10 @@ func (fs *FilerServer) tusHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		if err := fs.loadTusSessionChunks(ctx, session); err != nil {
 			glog.Errorf("Failed to load TUS session %s chunks: %v", uploadID, err)
+			if !errors.Is(err, filer_pb.ErrNotFound) {
+				http.Error(w, "Failed to load upload state", http.StatusInternalServerError)
+				return
+			}
 			writeTusSessionNotFound(w, r.Method)
 			return
 		}

--- a/weed/server/filer_server_tus_transient_test.go
+++ b/weed/server/filer_server_tus_transient_test.go
@@ -1,0 +1,86 @@
+package weed_server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+	"github.com/seaweedfs/seaweedfs/weed/util"
+)
+
+// TestFilerServer_tusHandler_TransientChunkLoadFailure reproduces #11151: a
+// transient failure listing a session's chunk directory (volume timeout,
+// canceled context) must not be reported as 404/204, since readTusSessionInfo
+// already proved the session exists. A false "not found" makes a compliant
+// client discard a live session and orphan every chunk it committed.
+func TestFilerServer_tusHandler_TransientChunkLoadFailure(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+	}{
+		{"HEAD", http.MethodHead},
+		{"PATCH", http.MethodPatch},
+		{"DELETE", http.MethodDelete},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs, store := newTusTestServer(t, map[string]string{tusTestUploadID: "/buckets/data/file.bin"})
+			store.listErr = context.Canceled
+
+			headers := map[string]string{"Authorization": "Bearer " + signFilerToken(t, tusTestWriteKey, nil, nil)}
+			if tt.method == http.MethodHead {
+				headers["Authorization"] = "Bearer " + signFilerToken(t, tusTestReadKey, nil, nil)
+			}
+			if tt.method == http.MethodPatch {
+				headers["Content-Type"] = "application/offset+octet-stream"
+				headers["Upload-Offset"] = "0"
+			}
+			req := tusRequest(tt.method, "/.tus/.uploads/"+tusTestUploadID, headers, "")
+			rec := httptest.NewRecorder()
+			fs.tusHandler(rec, req)
+
+			if rec.Code == http.StatusNotFound || rec.Code == http.StatusNoContent {
+				t.Fatalf("%s on a transient chunk-load failure = %d, want a server error, not a not-found status", tt.method, rec.Code)
+			}
+			if rec.Code < 500 {
+				t.Errorf("%s on a transient chunk-load failure = %d, want a 5xx status", tt.method, rec.Code)
+			}
+
+			store.listErr = nil
+			if _, err := store.FindEntry(context.Background(), util.FullPath(fs.tusSessionInfoPath(tusTestUploadID))); err != nil {
+				t.Errorf("session removed after a transient %s failure: %v", tt.method, err)
+			}
+		})
+	}
+}
+
+// TestFilerServer_tusHandler_ChunkLoadNotFoundStillNotFound verifies a chunk
+// listing failure that genuinely means "not found" is still reported as such,
+// so the fix for #11151 does not mask a real absence.
+func TestFilerServer_tusHandler_ChunkLoadNotFoundStillNotFound(t *testing.T) {
+	fs, store := newTusTestServer(t, map[string]string{tusTestUploadID: "/buckets/data/file.bin"})
+	store.listErr = filer_pb.ErrNotFound
+
+	req := tusRequest(http.MethodHead, "/.tus/.uploads/"+tusTestUploadID, map[string]string{
+		"Authorization": "Bearer " + signFilerToken(t, tusTestReadKey, nil, nil),
+	}, "")
+	rec := httptest.NewRecorder()
+	fs.tusHandler(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("HEAD on a genuinely missing session = %d, want %d", rec.Code, http.StatusNotFound)
+	}
+
+	deleteReq := tusRequest(http.MethodDelete, "/.tus/.uploads/"+tusTestUploadID, map[string]string{
+		"Authorization": "Bearer " + signFilerToken(t, tusTestWriteKey, nil, nil),
+	}, "")
+	deleteRec := httptest.NewRecorder()
+	fs.tusHandler(deleteRec, deleteReq)
+
+	if deleteRec.Code != http.StatusNoContent {
+		t.Fatalf("DELETE on a genuinely missing session = %d, want %d", deleteRec.Code, http.StatusNoContent)
+	}
+}


### PR DESCRIPTION
Fixes #11151.

# What problem are we solving?

If the filer fails to load a TUS session's chunk records for a transient reason (volume-server timeout, canceled request context), `tusHandler` answers `404 Not Found` to HEAD/PATCH and `204 No Content` to DELETE, the same as a genuinely missing session. Per the TUS spec, 404 means the upload is gone, so a compliant client stops resuming and starts a new one. The old session's `.info` file and every committed chunk record are untouched on disk; only the read failed, yet they become unreferenceable and sit on the volume until the 24h expiry sweep, or forever if the client never issues a DELETE.

`readTusSessionInfo` already succeeds immediately before `loadTusSessionChunks` is called, proving the session exists. `loadTusSessionChunks` pages `ListDirectoryEntries` over the session directory, so it surfaces store, RPC and context errors the same way it would surface a missing directory, and `writeTusSessionNotFound` cannot tell the two apart:

```go
if err := fs.loadTusSessionChunks(ctx, session); err != nil {
    glog.Errorf("Failed to load TUS session %s chunks: %v", uploadID, err)
    writeTusSessionNotFound(w, r.Method)   // -> 404 for HEAD and PATCH
    return
}
```

The issue's production trace shows this misclassifying ~250 times in 2 hours on one filer, from a sub-chunk upload stalling against a volume server and the request context being canceled mid-listing; the reporter measured 27.66 GB of dead bytes from abandoned sessions on a single, not-yet-vacuumed volume.

# How are we solving the problem?

Only report "not found" when the error actually is one. Everything else answers 500, so the client retries against the still-live session instead of discarding it:

```go
if err := fs.loadTusSessionChunks(ctx, session); err != nil {
    glog.Errorf("Failed to load TUS session %s chunks: %v", uploadID, err)
    if !errors.Is(err, filer_pb.ErrNotFound) {
        http.Error(w, "Failed to load upload state", http.StatusInternalServerError)
        return
    }
    writeTusSessionNotFound(w, r.Method)
    return
}
```

This is scoped to the exact call the issue reports. The safeguards the issue points out as already correct but unreachable - duplicate-offset PATCH rejected with 409, `completeTusUpload` freeing fully-covered duplicates, `deleteTusSession` freeing an unconsumed session's chunks, `cleanupExpiredTusSessions`, and a resume continuing from the exact committed watermark - all still apply unchanged; they just could never engage while every read failure looked like the session was gone.

# How is the PR tested?

Reproduced first: added a `listErr` hook to the in-memory filer store already shared by the TUS tests (`renameTestStore`, alongside its existing `commitErr`/`deleteErr`), confirmed `TestFilerServer_tusHandler_TransientChunkLoadFailure` fails against the old code (HEAD/PATCH 404, DELETE 204) with `store.listErr = context.Canceled`, then applied the fix and confirmed it now answers a 5xx on all three methods while the session stays on disk. `TestFilerServer_tusHandler_ChunkLoadNotFoundStillNotFound` pins the counterpart: a listing failure that really is `filer_pb.ErrNotFound` still answers 404 (204 for DELETE).

- `go build ./...`, `go vet ./...` (and `GOOS=linux GOARCH=386`) clean.
- `go test ./weed/server/...` and `go test -tags "elastic gocdk sqlite ydb tarantool tikv rclone" ./weed/server/...` green.
- `test/tus`: `make test-with-server` (full TUS protocol integration suite against real master/volume/filer processes) green.

# Checks
- [x] I have added unit tests if possible.
- [ ] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.

Generated with [Devin](https://devin.ai)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs/pull/11153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - TUS uploads now return a server error when upload-state data cannot be loaded due to a transient failure, instead of incorrectly reporting that the upload was not found.
  - Existing upload sessions are preserved when transient errors occur during HEAD, PATCH, or DELETE requests.
  - Genuine missing-upload cases continue to return the appropriate not-found responses.

- **Tests**
  - Added coverage for transient chunk-listing failures and legitimate missing-session behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->