### PR TITLE
fix(chart): add missing [grpc.s3] TLS section — S3 internal gRPC served plaintext while peers dial mTLS

### DIFF
--- a/k8s/charts/seaweedfs/templates/shared/security-configmap.yaml
+++ b/k8s/charts/seaweedfs/templates/shared/security-configmap.yaml
@@ -86,17 +86,13 @@ data:
       server serves its internal gRPC (IAM cache propagation, s3 lifecycle
       delete RPCs) as plaintext, while peers dial it with mTLS credentials:
       "tls: first record does not look like a TLS handshake".
-      Reuses the client certificate, already mounted on s3 pods by
-      s3-deployment.yaml (same pair the s3 HTTPS listener uses via the
-      seaweedfs.s3.tlsArgs helper unless s3.tlsSecret is set). */}}
+      Always uses the internal CA-signed client certificate (already mounted
+      on s3 pods by s3-deployment.yaml). Deliberately NOT s3.tlsSecret: that
+      secret is for the public HTTPS listener and may be issued by a public
+      CA which internal gRPC peers (trusting only grpc.ca) would reject. */}}
     [grpc.s3]
-    {{- if .Values.s3.tlsSecret }}
-    cert = "/usr/local/share/ca-certificates/s3/tls.crt"
-    key  = "/usr/local/share/ca-certificates/s3/tls.key"
-    {{- else }}
     cert = "/usr/local/share/ca-certificates/client/tls.crt"
     key  = "/usr/local/share/ca-certificates/client/tls.key"
-    {{- end }}
 
     # use this for any place needs a grpc client
     # i.e., "weed backup|benchmark|filer.copy|filer.replicate|mount|s3|upload"

--- a/k8s/charts/seaweedfs/templates/shared/security-configmap.yaml
+++ b/k8s/charts/seaweedfs/templates/shared/security-configmap.yaml
@@ -81,6 +81,23 @@ data:
     cert = "/usr/local/share/ca-certificates/worker/tls.crt"
     key  = "/usr/local/share/ca-certificates/worker/tls.key"
 
+    {{- /* S3 gRPC server identity (weed s3 -port.grpc, default httpPort+10000).
+      Without this section, LoadServerTLS("grpc.s3") returns nil and the S3
+      server serves its internal gRPC (IAM cache propagation, s3 lifecycle
+      delete RPCs) as plaintext, while peers dial it with mTLS credentials:
+      "tls: first record does not look like a TLS handshake".
+      Reuses the client certificate, already mounted on s3 pods by
+      s3-deployment.yaml (same pair the s3 HTTPS listener uses via the
+      seaweedfs.s3.tlsArgs helper unless s3.tlsSecret is set). */}}
+    [grpc.s3]
+    {{- if .Values.s3.tlsSecret }}
+    cert = "/usr/local/share/ca-certificates/s3/tls.crt"
+    key  = "/usr/local/share/ca-certificates/s3/tls.key"
+    {{- else }}
+    cert = "/usr/local/share/ca-certificates/client/tls.crt"
+    key  = "/usr/local/share/ca-certificates/client/tls.key"
+    {{- end }}
+
     # use this for any place needs a grpc client
     # i.e., "weed backup|benchmark|filer.copy|filer.replicate|mount|s3|upload"
     [grpc.client]


### PR DESCRIPTION
## Problem

With `global.seaweedfs.enableSecurity=true`, the `security.toml` generated by the Helm chart has **no `[grpc.s3]` section**. In `weed/command/s3.go`, the S3 server mounts its internal gRPC listener (`-port.grpc`, default `httpPort+10000` = 18333) via:

```go
security.LoadServerTLS(util.GetViper(), "grpc.s3")
```

`LoadServerTLS` returns `nil` when `grpc.s3.cert`/`grpc.s3.key` are empty (`weed/security/tls.go`), so **the S3 server serves this gRPC port as plaintext** even though everything else in the cluster runs mTLS.

Meanwhile, clients dial that port with TLS credentials:

- the `s3_lifecycle` worker dials with `[grpc.worker]` credentials (`weed/worker/tasks/s3_lifecycle/handler.go`) → every `LifecycleDelete` dispatch fails with:

  ```
  rpc error: code = Unavailable desc = connection error: desc =
  "transport: authentication handshake failed: tls: first record does not look like a TLS handshake"
  ```

- S3→S3 IAM cache propagation (`weed/credential/propagating_store.go`) dials with `[grpc.client]` credentials → fails the same way (currently only logged as warnings, so identity/policy changes between S3 replicas silently do not propagate).

All other gRPC server sections (`volume`, `master`, `filer`, `admin`, `worker`, `client`) are rendered — `grpc.s3` was simply missed when the S3 gRPC server was added (present since 3.03, commit 29198720f).

## Fix

Add a `[grpc.s3]` section to the chart's security configmap, using the internal CA-signed client certificate that is already mounted on the S3 pods (`/usr/local/share/ca-certificates/client/`). Deliberately independent of `s3.tlsSecret`: that secret serves the public HTTPS listener (possibly a public-CA cert) which internal gRPC peers trusting only `grpc.ca` would reject.

No new secrets, no new values keys — the cert pair already exists on the S3 pods.

## Tested

- `helm lint` passes
- `helm template` renders `[grpc.s3]` correctly, including with `s3.tlsSecret` set (gRPC keeps the internal CA-signed cert)
- Deployed on a live 4.44 cluster: after `helm upgrade` + `kubectl rollout restart` of the s3 deployment, the s3_lifecycle worker's `LifecycleDelete` RPCs succeed (verified via `openssl s_client` on 18333 and clean worker logs)

Note: the security configmap is mounted via `subPath`, so s3 pods need a restart to pick up the changed `security.toml`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * S3 gRPC connections now consistently use the internally CA-signed client certificate and key.
  * Public S3 HTTPS certificate and key selection is no longer used for gRPC connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->