### PR TITLE
deps: update golang.org/x/image to v0.45.0 for CVE-2026-46603

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -92,7 +92,7 @@ require (
 	gocloud.dev/pubsub/rabbitpubsub v0.46.0
 	golang.org/x/crypto v0.55.0
 	golang.org/x/exp v0.0.0-20260709172345-9ea1abe57597
-	golang.org/x/image v0.44.0
+	golang.org/x/image v0.45.0
 	golang.org/x/net v0.58.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sys v0.47.0

--- a/go.sum
+++ b/go.sum
@@ -2217,8 +2217,8 @@ golang.org/x/image v0.0.0-20210607152325-775e3b0c77b9/go.mod h1:023OzeP/+EPmXeap
 golang.org/x/image v0.0.0-20210628002857-a66eb6448b8d/go.mod h1:023OzeP/+EPmXeapQh35lcL3II3LrY8Ic+EFFKVhULM=
 golang.org/x/image v0.0.0-20211028202545-6944b10bf410/go.mod h1:023OzeP/+EPmXeapQh35lcL3II3LrY8Ic+EFFKVhULM=
 golang.org/x/image v0.0.0-20220302094943-723b81ca9867/go.mod h1:023OzeP/+EPmXeapQh35lcL3II3LrY8Ic+EFFKVhULM=
-golang.org/x/image v0.44.0 h1:+tDekMZED9+LrtB3G5xzRggpVh9CARjZqROla3R3R+I=
-golang.org/x/image v0.44.0/go.mod h1:V8K3KE9KKKE+pLpQDOeN18w9oacNSvy1tDOirTu4xtY=
+golang.org/x/image v0.45.0 h1:FMb1nTbH5H9vF55SriQHgFw5GnNL9Jg6L25BwXKzhB0=
+golang.org/x/image v0.45.0/go.mod h1:n62x/7RqlwXDvGsSU4u6IUTUf6KghUZ9Bt7cG/T9Fx4=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=


### PR DESCRIPTION
# What problem are we solving?

`golang.org/x/image` is pinned at `v0.44.0`, which is affected by **CVE-2026-46603** (GO-2026-6222): a denial of service via excessive memory allocation when decoding malformed VP8L (lossless WebP) data. It is fixed in `v0.45.0`, released 2026-08-11.

This is reachable from SeaweedFS rather than a dormant SBOM entry: `weed/images/resizing.go` blank-imports `_ "golang.org/x/image/webp"`, which registers the VP8L decoder with `image.Decode`, so the filer image-resizing path decodes attacker-supplied WebP data with the affected version.

Practical impact: container scanners flag `usr/bin/weed` as HIGH. On `chrislusf/seaweedfs:4.44` and `4.45` this is currently the only remaining finding, since `apache/thrift` was already addressed on master by #11077.

# How are we solving the problem?

Bumping the dependency to the fixed release. `go.mod`/`go.sum` only — 3 lines total, no other dependency moved:

```
-	golang.org/x/image v0.44.0
+	golang.org/x/image v0.45.0
```

Produced with:

```
go get golang.org/x/image@v0.45.0 && go mod tidy
```

# How is the PR tested?

On top of `a0b1272`, with Go 1.26:

- `go build ./weed/` — ok
- `go vet ./weed/images/...` — ok
- `go test ./weed/images/...` — `ok github.com/seaweedfs/seaweedfs/weed/images`
- `go mod verify` — `all modules verified`

# Checks
- [x] I have added unit tests if possible. — not applicable: dependency-only change, no behaviour change to test. The existing `weed/images` tests cover the decode path and pass.
- [ ] I will add related wiki document changes and link to this PR after merging. — not applicable.
- [x] All AI code review comments have been addressed. No more comments to fix if reviewed again.

# Checks for AI generated PRs
- [x] I have reviewed every line of code. — the change is 3 lines in `go.mod`/`go.sum`, generated by `go get`/`go mod tidy` and reviewed in full.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.

> Disclosure: this change was prepared with AI assistance and the commit carries a `Co-Authored-By` trailer. The diff was verified by building and testing against Go 1.26 as listed above.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs/pull/11164" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated an internal dependency to its latest available version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->