### PR TITLE
mount: add -volumeName to name the disk explicitly

### DIFF
--- a/weed/command/fuse_std.go
+++ b/weed/command/fuse_std.go
@@ -124,6 +124,8 @@ func runFuse(cmd *Command, args []string) bool {
 			mountOptions.filer = &parameter.value
 		case "filer.path":
 			mountOptions.filerMountRootPath = &parameter.value
+		case "volumeName":
+			mountOptions.volumeName = &parameter.value
 		case "dirAutoCreate":
 			if parsed, err := strconv.ParseBool(parameter.value); err == nil {
 				mountOptions.dirAutoCreate = &parsed

--- a/weed/command/fuse_std_test.go
+++ b/weed/command/fuse_std_test.go
@@ -36,3 +36,32 @@ func TestRunFuseDoesNotSkipOptionAfterConcurrentWriters(t *testing.T) {
 		"child=1,concurrentWriters=2,concurrentReaders=bad,umask=bad",
 	})
 }
+
+func TestRunFuseSetsVolumeName(t *testing.T) {
+	oldVolumeName := mountOptions.volumeName
+	oldConcurrentReaders := mountOptions.concurrentReaders
+	oldDir := mountOptions.dir
+	defer func() {
+		gotVolumeName := mountOptions.volumeName
+		mountOptions.volumeName = oldVolumeName
+		mountOptions.concurrentReaders = oldConcurrentReaders
+		mountOptions.dir = oldDir
+
+		recovered := recover()
+		if recovered == nil {
+			t.Fatal("expected invalid concurrentReaders option to be parsed")
+		}
+		if gotVolumeName == nil {
+			t.Fatal("expected -o volumeName=MyDisk to set mountOptions.volumeName, got nil")
+		}
+		if *gotVolumeName != "MyDisk" {
+			t.Fatalf("expected -o volumeName=MyDisk to set mountOptions.volumeName, got %q", *gotVolumeName)
+		}
+	}()
+
+	runFuse(cmdMount, []string{
+		"/mnt",
+		"-o",
+		"volumeName=MyDisk,concurrentReaders=bad",
+	})
+}

--- a/weed/command/mount.go
+++ b/weed/command/mount.go
@@ -93,7 +93,7 @@ func init() {
 	mountOptions.filer = cmdMount.Flag.String("filer", "localhost:8888", "comma-separated weed filer location")
 	mountOptions.filerMountRootPath = cmdMount.Flag.String("filer.path", "/", "mount this remote path from filer server")
 	mountOptions.dir = cmdMount.Flag.String("dir", ".", "mount weed filer to this directory")
-	mountOptions.volumeName = cmdMount.Flag.String("volumeName", "", "macOS and Windows only: name the disk in Finder/Explorer, overriding the name taken from -filer.path or -dir")
+	mountOptions.volumeName = cmdMount.Flag.String("volumeName", "", "name the mount shown by the platform (Finder/Explorer, or \"mount\"/\"df\" on Linux and FreeBSD), overriding the name taken from -filer.path or -dir")
 	mountOptions.dirAutoCreate = cmdMount.Flag.Bool("dirAutoCreate", false, "auto create the directory to mount to")
 	mountOptions.collection = cmdMount.Flag.String("collection", "", "collection to create the files")
 	mountOptions.collectionQuota = cmdMount.Flag.Int("collectionQuotaMB", 0, "quota for the collection")
@@ -191,7 +191,7 @@ var cmdMount = &Command{
   -dir=\\seaweedfs\Images labels the disk "Images" while still mounting
   everything, and only a bare drive letter falls back to the filer address.
   -volumeName overrides whatever name either of those would otherwise give it,
-  on macOS and Windows; Linux has no such label to override.
+  including what Linux and FreeBSD show for the mount in "mount" and "df".
 
   `,
 }

--- a/weed/command/mount.go
+++ b/weed/command/mount.go
@@ -9,6 +9,7 @@ type MountOptions struct {
 	filer                *string
 	filerMountRootPath   *string
 	dir                  *string
+	volumeName           *string
 	dirAutoCreate        *bool
 	collection           *string
 	collectionQuota      *int
@@ -92,6 +93,7 @@ func init() {
 	mountOptions.filer = cmdMount.Flag.String("filer", "localhost:8888", "comma-separated weed filer location")
 	mountOptions.filerMountRootPath = cmdMount.Flag.String("filer.path", "/", "mount this remote path from filer server")
 	mountOptions.dir = cmdMount.Flag.String("dir", ".", "mount weed filer to this directory")
+	mountOptions.volumeName = cmdMount.Flag.String("volumeName", "", "name the disk in Finder/Explorer, overriding the name taken from -filer.path or -dir")
 	mountOptions.dirAutoCreate = cmdMount.Flag.Bool("dirAutoCreate", false, "auto create the directory to mount to")
 	mountOptions.collection = cmdMount.Flag.String("collection", "", "collection to create the files")
 	mountOptions.collectionQuota = cmdMount.Flag.Int("collectionQuotaMB", 0, "quota for the collection")

--- a/weed/command/mount.go
+++ b/weed/command/mount.go
@@ -190,6 +190,7 @@ var cmdMount = &Command{
   the whole tree takes the name from the mount point instead, so
   -dir=\\seaweedfs\Images labels the disk "Images" while still mounting
   everything, and only a bare drive letter falls back to the filer address.
+  -volumeName overrides whatever name either of those would otherwise give it.
 
   `,
 }

--- a/weed/command/mount.go
+++ b/weed/command/mount.go
@@ -93,7 +93,7 @@ func init() {
 	mountOptions.filer = cmdMount.Flag.String("filer", "localhost:8888", "comma-separated weed filer location")
 	mountOptions.filerMountRootPath = cmdMount.Flag.String("filer.path", "/", "mount this remote path from filer server")
 	mountOptions.dir = cmdMount.Flag.String("dir", ".", "mount weed filer to this directory")
-	mountOptions.volumeName = cmdMount.Flag.String("volumeName", "", "name the disk in Finder/Explorer, overriding the name taken from -filer.path or -dir")
+	mountOptions.volumeName = cmdMount.Flag.String("volumeName", "", "macOS and Windows only: name the disk in Finder/Explorer, overriding the name taken from -filer.path or -dir")
 	mountOptions.dirAutoCreate = cmdMount.Flag.Bool("dirAutoCreate", false, "auto create the directory to mount to")
 	mountOptions.collection = cmdMount.Flag.String("collection", "", "collection to create the files")
 	mountOptions.collectionQuota = cmdMount.Flag.Int("collectionQuotaMB", 0, "quota for the collection")
@@ -190,7 +190,8 @@ var cmdMount = &Command{
   the whole tree takes the name from the mount point instead, so
   -dir=\\seaweedfs\Images labels the disk "Images" while still mounting
   everything, and only a bare drive letter falls back to the filer address.
-  -volumeName overrides whatever name either of those would otherwise give it.
+  -volumeName overrides whatever name either of those would otherwise give it,
+  on macOS and Windows; Linux has no such label to override.
 
   `,
 }

--- a/weed/command/mount_common.go
+++ b/weed/command/mount_common.go
@@ -278,10 +278,14 @@ func resolveCacheDirs(option *MountOptions) (string, string) {
 }
 
 // volumeName labels the mount where the platform shows one, in Finder and in
-// Explorer. The mounted path names the disk, then the mount point; the filer
-// address, which every mount from one filer shares, is the last resort.
-func volumeName(filer, filerMountRootPath, dir string) string {
-	name := lastSegment(filerMountRootPath)
+// Explorer. An explicit override always wins; failing that, the mounted path
+// names the disk, then the mount point; the filer address, which every mount
+// from one filer shares, is the last resort.
+func volumeName(filer, filerMountRootPath, dir, override string) string {
+	name := override
+	if name == "" {
+		name = lastSegment(filerMountRootPath)
+	}
 	if name == "" {
 		name = lastSegment(dir)
 	}

--- a/weed/command/mount_common_test.go
+++ b/weed/command/mount_common_test.go
@@ -10,8 +10,24 @@ func Test_volumeName(t *testing.T) {
 		filer              string
 		filerMountRootPath string
 		dir                string
+		override           string
 		expected           string
 	}{
+		{
+			name:               "an override outranks the mounted path and the mount point",
+			filer:              "127.0.0.1:8888",
+			filerMountRootPath: "/buckets/videos",
+			dir:                `\\seaweedfs\Images`,
+			override:           "MyDisk",
+			expected:           "MyDisk",
+		},
+		{
+			name:               "an override still gets commas replaced",
+			filer:              "127.0.0.1:8888",
+			filerMountRootPath: "/",
+			override:           "My, Disk",
+			expected:           "My+ Disk",
+		},
 		{
 			name:               "a drive letter leaves only the filer to fall back on",
 			filer:              "127.0.0.1:8888",
@@ -80,8 +96,8 @@ func Test_volumeName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := volumeName(tt.filer, tt.filerMountRootPath, tt.dir); got != tt.expected {
-				t.Errorf("volumeName(%q, %q, %q) = %q, want %q", tt.filer, tt.filerMountRootPath, tt.dir, got, tt.expected)
+			if got := volumeName(tt.filer, tt.filerMountRootPath, tt.dir, tt.override); got != tt.expected {
+				t.Errorf("volumeName(%q, %q, %q, %q) = %q, want %q", tt.filer, tt.filerMountRootPath, tt.dir, tt.override, got, tt.expected)
 			}
 		})
 	}

--- a/weed/command/mount_std.go
+++ b/weed/command/mount_std.go
@@ -118,6 +118,9 @@ func RunMount(option *MountOptions, umask os.FileMode) bool {
 	// When autofs/systemd-mount is used, FsName must be "fuse" so util-linux/mount can recognize
 	// it as a pseudo filesystem. Otherwise, preserve the descriptive name for mount/df output.
 	fsName := serverFriendlyName + ":" + filerMountRootPath
+	if *option.volumeName != "" {
+		fsName = *option.volumeName
+	}
 	if skipAutofs {
 		fsName = "fuse"
 	}

--- a/weed/command/mount_std.go
+++ b/weed/command/mount_std.go
@@ -179,7 +179,7 @@ func RunMount(option *MountOptions, umask os.FileMode) bool {
 			fuseMountOptions.Options = append(fuseMountOptions.Options, "novncache")
 		}
 		fuseMountOptions.Options = append(fuseMountOptions.Options, "slow_statfs")
-		fuseMountOptions.Options = append(fuseMountOptions.Options, "volname="+volumeName(*option.filer, filerMountRootPath, dir, ""))
+		fuseMountOptions.Options = append(fuseMountOptions.Options, "volname="+volumeName(*option.filer, filerMountRootPath, dir, *option.volumeName))
 		fuseMountOptions.Options = append(fuseMountOptions.Options, fmt.Sprintf("iosize=%d", ioSizeMB*1024*1024))
 	}
 	// Last, so an option given on the command line wins over the default

--- a/weed/command/mount_std.go
+++ b/weed/command/mount_std.go
@@ -179,7 +179,7 @@ func RunMount(option *MountOptions, umask os.FileMode) bool {
 			fuseMountOptions.Options = append(fuseMountOptions.Options, "novncache")
 		}
 		fuseMountOptions.Options = append(fuseMountOptions.Options, "slow_statfs")
-		fuseMountOptions.Options = append(fuseMountOptions.Options, "volname="+volumeName(*option.filer, filerMountRootPath, dir))
+		fuseMountOptions.Options = append(fuseMountOptions.Options, "volname="+volumeName(*option.filer, filerMountRootPath, dir, ""))
 		fuseMountOptions.Options = append(fuseMountOptions.Options, fmt.Sprintf("iosize=%d", ioSizeMB*1024*1024))
 	}
 	// Last, so an option given on the command line wins over the default

--- a/weed/command/mount_windows.go
+++ b/weed/command/mount_windows.go
@@ -104,7 +104,7 @@ func RunMount(option *MountOptions, umask os.FileMode) bool {
 	}
 
 	host := winfsp.New(seaweedFileSystem, winfsp.Options{
-		VolumeName:   volumeName(*option.filer, *option.filerMountRootPath, dir),
+		VolumeName:   volumeName(*option.filer, *option.filerMountRootPath, dir, ""),
 		Uid:          ownedByMounter,
 		Gid:          ownedByMounter,
 		CacheTimeout: windowsCacheTimeout,

--- a/weed/command/mount_windows.go
+++ b/weed/command/mount_windows.go
@@ -104,7 +104,7 @@ func RunMount(option *MountOptions, umask os.FileMode) bool {
 	}
 
 	host := winfsp.New(seaweedFileSystem, winfsp.Options{
-		VolumeName:   volumeName(*option.filer, *option.filerMountRootPath, dir, ""),
+		VolumeName:   volumeName(*option.filer, *option.filerMountRootPath, dir, *option.volumeName),
 		Uid:          ownedByMounter,
 		Gid:          ownedByMounter,
 		CacheTimeout: windowsCacheTimeout,


### PR DESCRIPTION
Fixes #11155.

`weed mount` names the disk it shows in Finder/Explorer from `-filer.path`, then `-dir`, then the filer address, with no way to override it (#11114). That auto-derived name can land on something the user does not want - e.g. mounting `-dir=\\seaweedfs\Images` labels the disk "Images" purely because that is the UNC share name, which conflicted with what the reporter expected from their existing setup.

`-volumeName` names the disk explicitly, overriding whatever `-filer.path`/`-dir` would otherwise produce, on every platform.

#### Test plan
- `go test ./weed/command/...`
- `GOOS=windows`, `GOOS=darwin`, `GOOS=freebsd` builds of `./weed/command/...`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs/pull/11165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `-volumeName` option to the mount command for specifying custom names for mounted volumes.
  - Custom names override automatically derived names across supported platforms, including names shown by `mount` and `df` on Linux and FreeBSD.
  - Without a custom name, volume names continue to be derived automatically.
  - Documented the option in the mount command’s help text.

- **Tests**
  - Added coverage for custom names, precedence, comma handling, and option parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->