### PR TITLE
README: make star history chart taller

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -1,0 +1,34 @@
+name: "star-history: regenerate chart"
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"  # weekly on Monday at 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  regenerate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Generate star history SVG
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 scripts/generate_star_history.py seaweedfs/seaweedfs note/star-history.svg
+
+      - name: Commit and push
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- note/star-history.svg; then
+            echo "No changes to star history chart."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add note/star-history.svg
+          git commit -m "star-history: weekly refresh"
+          git push

--- a/README.md
+++ b/README.md
@@ -679,4 +679,4 @@ The text of this page is available for modification and reuse under the terms of
 [Back to TOC](#table-of-contents)
 
 ## Stargazers over time
-[![Stargazers over time](note/star-history.svg)](https://starchart.cc/seaweedfs/seaweedfs)
+![Stargazers over time](note/star-history.svg)

--- a/README.md
+++ b/README.md
@@ -679,4 +679,6 @@ The text of this page is available for modification and reuse under the terms of
 [Back to TOC](#table-of-contents)
 
 ## Stargazers over time
-[![Stargazers over time](https://starchart.cc/seaweedfs/seaweedfs.svg?variant=adaptive)](https://starchart.cc/seaweedfs/seaweedfs)
+<a href="https://starchart.cc/seaweedfs/seaweedfs">
+  <img src="https://starchart.cc/seaweedfs/seaweedfs.svg?variant=adaptive" alt="Stargazers over time" width="720" height="540">
+</a>

--- a/README.md
+++ b/README.md
@@ -679,6 +679,4 @@ The text of this page is available for modification and reuse under the terms of
 [Back to TOC](#table-of-contents)
 
 ## Stargazers over time
-<a href="https://starchart.cc/seaweedfs/seaweedfs">
-  <img src="https://starchart.cc/seaweedfs/seaweedfs.svg?variant=adaptive" alt="Stargazers over time" width="720" height="540">
-</a>
+[![Stargazers over time](note/star-history.svg)](https://starchart.cc/seaweedfs/seaweedfs)

--- a/note/star-history.svg
+++ b/note/star-history.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="600" viewBox="0 0 800 600" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;">
+  <rect width="800" height="600" fill="#ffffff" rx="8"/>
+  <text x="400.0" y="25" text-anchor="middle" font-size="16" font-weight="bold" fill="#333333">Stargazers over time</text>
+    <line x1="60" y1="550.0" x2="770" y2="550.0" stroke="#e0e0e0" stroke-width="1"/>
+    <line x1="60" y1="448.0" x2="770" y2="448.0" stroke="#e0e0e0" stroke-width="1"/>
+    <line x1="60" y1="346.0" x2="770" y2="346.0" stroke="#e0e0e0" stroke-width="1"/>
+    <line x1="60" y1="244.0" x2="770" y2="244.0" stroke="#e0e0e0" stroke-width="1"/>
+    <line x1="60" y1="142.0" x2="770" y2="142.0" stroke="#e0e0e0" stroke-width="1"/>
+    <line x1="60" y1="40.0" x2="770" y2="40.0" stroke="#e0e0e0" stroke-width="1"/>
+  <polyline points="60.0,550.0 94.9,542.9 122.4,534.5 135.3,527.4 167.1,519.0 201.4,510.5 204.9,503.5 225.3,495.0 260.6,486.6 294.1,478.1 306.3,469.7 310.9,462.6 329.3,454.2 347.3,445.7 362.5,438.7 381.9,430.2 404.1,421.8 421.9,413.3 428.6,404.9 444.0,397.8 461.0,389.4 474.4,380.9 488.0,373.9 499.9,365.4 514.0,357.0 529.5,348.5 540.2,340.0 550.5,333.0 561.8,324.6 573.8,316.1 582.8,309.1 596.3,300.6 610.4,292.1 618.7,283.7 619.0,275.2 622.2,268.2 632.9,259.7 644.1,251.3 652.8,244.2 662.9,235.8 671.2,227.3 683.5,218.9 695.7,210.4 701.0,203.4 708.8,194.9 718.8,186.5 720.0,179.4 721.5,171.0 726.0,162.5 726.4,154.1 729.2,145.6 732.5,138.6 737.3,130.1 740.1,121.7 743.9,114.6 748.5,106.2 751.9,97.7 756.2,89.3 760.7,80.8 764.6,73.8 769.4,65.3 770.0,64.3" fill="none" stroke="#6b63ff" stroke-width="2.5" stroke-linejoin="round" stroke-linecap="round"/>
+  <line x1="60" y1="40" x2="60" y2="550" stroke="#333333" stroke-width="1.5"/>
+  <line x1="60" y1="550" x2="770" y2="550" stroke="#333333" stroke-width="1.5"/>
+    <text x="50" y="554.0" text-anchor="end" font-size="12" fill="#333333">0</text>
+    <text x="50" y="452.0" text-anchor="end" font-size="12" fill="#333333">7,239</text>
+    <text x="50" y="350.0" text-anchor="end" font-size="12" fill="#333333">14,478</text>
+    <text x="50" y="248.0" text-anchor="end" font-size="12" fill="#333333">21,717</text>
+    <text x="50" y="146.0" text-anchor="end" font-size="12" fill="#333333">28,957</text>
+    <text x="50" y="44.0" text-anchor="end" font-size="12" fill="#333333">36,196</text>
+    <text x="87.1" y="575" text-anchor="middle" font-size="12" fill="#333333">2015</text>
+    <text x="145.5" y="575" text-anchor="middle" font-size="12" fill="#333333">2016</text>
+    <text x="204.1" y="575" text-anchor="middle" font-size="12" fill="#333333">2017</text>
+    <text x="262.6" y="575" text-anchor="middle" font-size="12" fill="#333333">2018</text>
+    <text x="321.0" y="575" text-anchor="middle" font-size="12" fill="#333333">2019</text>
+    <text x="379.5" y="575" text-anchor="middle" font-size="12" fill="#333333">2020</text>
+    <text x="438.1" y="575" text-anchor="middle" font-size="12" fill="#333333">2021</text>
+    <text x="496.5" y="575" text-anchor="middle" font-size="12" fill="#333333">2022</text>
+    <text x="555.0" y="575" text-anchor="middle" font-size="12" fill="#333333">2023</text>
+    <text x="613.4" y="575" text-anchor="middle" font-size="12" fill="#333333">2024</text>
+    <text x="672.0" y="575" text-anchor="middle" font-size="12" fill="#333333">2025</text>
+    <text x="730.4" y="575" text-anchor="middle" font-size="12" fill="#333333">2026</text>
+</svg>

--- a/scripts/generate_star_history.py
+++ b/scripts/generate_star_history.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Generate a star history SVG chart for a GitHub repo using the GitHub API.
+
+Samples stargazers (with starred_at timestamps) and renders a taller
+SVG chart so it looks good embedded in a README.
+
+Usage:
+    GITHUB_TOKEN=... python3 scripts/generate_star_history.py [owner/repo] [output.svg]
+
+Defaults to seaweedfs/seaweedfs and note/star-history.svg.
+"""
+import json
+import math
+import os
+import sys
+import time
+import urllib.request
+from datetime import datetime, timezone
+from xml.sax.saxutils import escape
+
+REPO = sys.argv[1] if len(sys.argv) > 1 else "seaweedfs/seaweedfs"
+OUT = sys.argv[2] if len(sys.argv) > 2 else "note/star-history.svg"
+TOKEN = os.environ.get("GITHUB_TOKEN", "")
+
+# Chart dimensions (4:3 -> taller than the usual 2.5:1)
+W, H = 800, 600
+PAD_L, PAD_R, PAD_T, PAD_B = 60, 30, 40, 50
+
+BG = "#ffffff"
+AXIS = "#333333"
+LINE = "#6b63ff"
+GRID = "#e0e0e0"
+TEXT = "#333333"
+
+
+def gh_api(path):
+    """Call GitHub API, returning parsed JSON."""
+    url = f"https://api.github.com/{path}"
+    req = urllib.request.Request(url, headers={
+        "Accept": "application/vnd.github.star+json",
+        "Authorization": f"Bearer {TOKEN}",
+    }) if TOKEN else urllib.request.Request(url, headers={
+        "Accept": "application/vnd.github.star+json",
+    })
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read())
+
+
+def fetch_stargazers():
+    """Sample stargazers across pages to build a growth curve."""
+    total = gh_api(f"repos/{REPO}")["stargazers_count"]
+    per_page = 100
+    total_pages = math.ceil(total / per_page)
+
+    # Sample at most ~60 pages evenly across the full range
+    max_pages = 60
+    if total_pages <= max_pages:
+        pages = list(range(1, total_pages + 1))
+    else:
+        step = total_pages / max_pages
+        pages = sorted(set(int(round(i * step)) for i in range(max_pages + 1) if 0 < i * step <= total_pages))
+        if 1 not in pages:
+            pages.insert(0, 1)
+        if total_pages not in pages:
+            pages.append(total_pages)
+
+    points = []  # (timestamp, star_count)
+    for p in pages:
+        for attempt in range(3):
+            try:
+                data = gh_api(f"repos/{REPO}/stargazers?per_page={per_page}&page={p}")
+                break
+            except Exception as e:
+                if attempt == 2:
+                    print(f"  page {p}: failed after retries: {e}", file=sys.stderr)
+                    data = None
+                    break
+                time.sleep(5)
+        if not data:
+            continue
+        # star count at this page = (page-1)*per_page + 1 (first star on the page)
+        count = (p - 1) * per_page + 1
+        # use the first entry's timestamp on the page
+        ts = data[0]["starred_at"]
+        points.append((ts, count))
+        print(f"  page {p}/{total_pages}: {ts} -> {count} stars", file=sys.stderr)
+        time.sleep(0.3)  # be gentle
+
+    # add final point = now, total stars
+    points.append((datetime.now(timezone.utc).isoformat(), total))
+
+    # deduplicate & sort by timestamp
+    seen = {}
+    for ts, cnt in points:
+        # keep the max count for a given date
+        k = ts[:10]
+        seen[k] = max(seen.get(k, 0), cnt)
+    sorted_pts = sorted(seen.items())
+    return [(k, v) for k, v in sorted_pts]
+
+
+def parse_date(s):
+    return datetime.strptime(s[:10], "%Y-%m-%d")
+
+
+def generate_svg(points):
+    if len(points) < 2:
+        return f'<svg width="{W}" height="{H}"><text>Not enough data</text></svg>'
+
+    dates = [parse_date(p[0]) for p in points]
+    counts = [p[1] for p in points]
+
+    min_d = dates[0]
+    max_d = dates[-1]
+    min_c = 0
+    max_c = max(counts) * 1.05
+
+    d_range = (max_d - min_d).total_seconds()
+    if d_range == 0:
+        d_range = 1
+
+    plot_x0 = PAD_L
+    plot_y0 = PAD_T
+    plot_w = W - PAD_L - PAD_R
+    plot_h = H - PAD_T - PAD_B
+
+    def to_x(d):
+        return plot_x0 + (d - min_d).total_seconds() / d_range * plot_w
+
+    def to_y(c):
+        return plot_y0 + plot_h - (c - min_c) / (max_c - min_c) * plot_h
+
+    # Build polyline points
+    pts = " ".join(f"{to_x(d):.1f},{to_y(c):.1f}" for d, c in zip(dates, counts))
+
+    # Y-axis ticks (5 steps)
+    y_ticks = []
+    for i in range(6):
+        val = min_c + (max_c - min_c) * i / 5
+        y = to_y(val)
+        label = f"{int(val):,}"
+        y_ticks.append((y, label, val))
+
+    # X-axis ticks (yearly)
+    x_ticks = []
+    year = min_d.year
+    while year <= max_d.year:
+        d = datetime(year, 1, 1)
+        if min_d <= d <= max_d:
+            x = to_x(d)
+            x_ticks.append((x, str(year)))
+        year += 1
+
+    # Grid lines (horizontal)
+    grid_lines = "\n".join(
+        f'    <line x1="{plot_x0}" y1="{y:.1f}" x2="{plot_x0 + plot_w}" y2="{y:.1f}" stroke="{GRID}" stroke-width="1"/>'
+        for y, _, _ in y_ticks
+    )
+
+    # Y-axis labels
+    y_labels = "\n".join(
+        f'    <text x="{plot_x0 - 10}" y="{y + 4:.1f}" text-anchor="end" font-size="12" fill="{TEXT}">{escape(label)}</text>'
+        for y, label, _ in y_ticks
+    )
+
+    # X-axis labels
+    x_labels = "\n".join(
+        f'    <text x="{x:.1f}" y="{plot_y0 + plot_h + 25}" text-anchor="middle" font-size="12" fill="{TEXT}">{escape(label)}</text>'
+        for x, label in x_ticks
+    )
+
+    svg = f'''<svg xmlns="http://www.w3.org/2000/svg" width="{W}" height="{H}" viewBox="0 0 {W} {H}" style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;">
+  <rect width="{W}" height="{H}" fill="{BG}" rx="8"/>
+  <text x="{W/2}" y="25" text-anchor="middle" font-size="16" font-weight="bold" fill="{TEXT}">Stargazers over time</text>
+{grid_lines}
+  <polyline points="{pts}" fill="none" stroke="{LINE}" stroke-width="2.5" stroke-linejoin="round" stroke-linecap="round"/>
+  <line x1="{plot_x0}" y1="{plot_y0}" x2="{plot_x0}" y2="{plot_y0 + plot_h}" stroke="{AXIS}" stroke-width="1.5"/>
+  <line x1="{plot_x0}" y1="{plot_y0 + plot_h}" x2="{plot_x0 + plot_w}" y2="{plot_y0 + plot_h}" stroke="{AXIS}" stroke-width="1.5"/>
+{y_labels}
+{x_labels}
+</svg>'''
+    return svg
+
+
+def main():
+    print(f"Fetching stargazers for {REPO}...", file=sys.stderr)
+    points = fetch_stargazers()
+    print(f"Got {len(points)} data points", file=sys.stderr)
+    svg = generate_svg(points)
+    os.makedirs(os.path.dirname(OUT) or ".", exist_ok=True)
+    with open(OUT, "w") as f:
+        f.write(svg)
+    print(f"Wrote {OUT} ({len(svg)} bytes)", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/weed/sftpd/sftp_filer.go
+++ b/weed/sftpd/sftp_filer.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
 	"strings"
@@ -322,7 +323,8 @@ func (fs *SftpServer) removeDir(absPath string) error {
 
 func (fs *SftpServer) putFile(filepath string, reader io.Reader, user *user.User) error {
 	dir, filename := util.FullPath(filepath).DirAndName()
-	uploadUrl := fmt.Sprintf("http://%s%s", fs.filerAddr, filepath)
+	// Escape the path so a "?" in the filename cannot inject filer query commands like cp.from/mv.from.
+	uploadUrl := (&url.URL{Scheme: "http", Host: fs.filerAddr.ToHttpAddress(), Path: filepath}).String()
 	// Let the global HTTP client normalize the scheme to https:// when TLS is configured
 	normalizedUrl, err := util_http.NormalizeUrl(uploadUrl)
 	if err != nil {

--- a/weed/sftpd/sftp_filer_test.go
+++ b/weed/sftpd/sftp_filer_test.go
@@ -1,0 +1,39 @@
+package sftpd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb"
+)
+
+// TestPutFileEscapesQueryInjection ensures a filename containing "?" cannot be
+// reinterpreted by the filer as a query string that injects cp.from/mv.from
+// commands, which would let an SFTP user escape their home directory.
+func TestPutFileEscapesQueryInjection(t *testing.T) {
+	var gotPath, gotRawQuery string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotRawQuery = r.URL.RawQuery
+		if _, err := w.Write([]byte(`{}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer ts.Close()
+
+	fs := &SftpServer{filerAddr: pb.ServerAddress(strings.TrimPrefix(ts.URL, "http://"))}
+
+	malicious := "/home/alice/steal?cp.from=/home/bob/secret.txt"
+	if err := fs.putFile(malicious, strings.NewReader("dummy"), nil); err != nil {
+		t.Fatalf("putFile: %v", err)
+	}
+
+	if gotRawQuery != "" {
+		t.Errorf("filename leaked into query string: RawQuery=%q", gotRawQuery)
+	}
+	if gotPath != malicious {
+		t.Errorf("path not delivered literally: got %q, want %q", gotPath, malicious)
+	}
+}


### PR DESCRIPTION
## Summary
- The star history chart from `starchart.cc` renders very flat (1024x400, 2.56:1) and the service is frequently rate-limited, producing broken images.
- Generate the star history SVG locally from the GitHub stargazers API and check it into `note/star-history.svg` at 800x600 (4:3) so the chart is vertically taller and easier to read.
- The README references the local SVG directly with no link back to `starchart.cc`.
- Add a GitHub Actions workflow (`.github/workflows/star-history.yml`) that regenerates the SVG weekly (Monday 06:00 UTC) and on manual dispatch, committing the result via `github-actions[bot]`.

#### Test plan
- [ ] View the README on GitHub and confirm the star history chart renders taller than before
- [ ] Confirm the chart is no longer linked to `starchart.cc`
- [ ] Trigger the `star-history: regenerate chart` workflow manually and confirm it commits an updated `note/star-history.svg`