### PR TITLE
ci(mount-windows): clean up processes and don't let Logs step fail job

### DIFF
--- a/.github/workflows/mount-windows.yml
+++ b/.github/workflows/mount-windows.yml
@@ -185,8 +185,19 @@ jobs:
         if (Test-Path S:\walk) { throw "directory survived recursive delete" }
         Write-Host "::endgroup::"
 
+        # Tear down everything we started so the runner's later steps (Logs,
+        # post-checkout) launch into a clean environment. A WinFsp mount left
+        # active and a weed.exe holding winfsp-x64.dll have been seen to make
+        # the next step's pwsh.exe fail with STATUS_DLL_INIT_FAILED
+        # (0xC0000142), which fails a job whose actual test step passed.
+        try { Stop-Mount } catch { Write-Host "no mount to stop at teardown: $_" }
+        Get-CimInstance Win32_Process -Filter "Name = 'weed.exe'" |
+          ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+        Start-Sleep -Seconds 3
+
     - name: Logs
       if: always()
+      continue-on-error: true
       shell: pwsh
       run: |
         foreach ($f in 'C:\seaweed-mount.log','C:\seaweed-mount.err.log','C:\seaweed-remount.log','C:\seaweed-remount.err.log','C:\seaweed-remount2.log','C:\seaweed-remount2.err.log','C:\seaweed-dirmount.log','C:\seaweed-dirmount.err.log','C:\seaweed-mini.log','C:\seaweed-mini.err.log') {


### PR DESCRIPTION
## Summary

Fixes the flaky failure in run [33949295197](https://github.com/seaweedfs/seaweedfs/actions/runs/33949295197) (job `Mount on Windows`).

**Root cause:** the `Mount and exercise` step passed, but the job failed because the subsequent diagnostic `Logs` step's `pwsh.exe` exited with `STATUS_DLL_INIT_FAILED` (`0xC0000142` = `-1073741502`). The same code passed on the PR branch (#11165) and on the next master run, so this was a transient launch failure — but it was caused by an unclean environment and made fatal by a diagnostic step.

The `Mount and exercise` step never tore down what it started: the `weed.exe mini` server and the final `seaweed-remount2` WinFsp mount were left running when the step exited, so the runner's next process launched into an environment with an active WinFsp mount and a `weed.exe` holding `winfsp-x64.dll`.

**Fix:**
- Tear down all `weed.exe` processes (mount + mini server) at the end of the `Mount and exercise` step so the `Logs` and post-checkout steps launch into a clean environment.
- Mark the `Logs` step `continue-on-error: true` so a purely diagnostic step (`if: always()`) can never fail a job whose actual test step passed.

#### Test plan
- [ ] `mount: windows` workflow passes on this branch.
- [ ] Confirm the `Logs` step no longer fails the job even if `pwsh` has a transient init failure.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs/pull/11174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Windows workflow cleanup by stopping mounts and terminating remaining processes after exercise runs.
  * Ensured log collection continues even when the preceding step encounters an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->