### PR TITLE
rust volume: bump redb 3.1.3 -> 4.2.0

### DIFF
--- a/seaweed-volume/Cargo.lock
+++ b/seaweed-volume/Cargo.lock
@@ -3160,9 +3160,9 @@ dependencies = [
 
 [[package]]
 name = "redb"
-version = "3.1.3"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba239c1c1693315d3cc0e601db3b3965543afbf48c41730fdca2f069f510f4a"
+checksum = "de6c3b63e007e90ce536ec2ae4690826136a20ec8dbbbb400daef1bb999d2e36"
 dependencies = [
  "libc",
 ]

--- a/seaweed-volume/Cargo.toml
+++ b/seaweed-volume/Cargo.toml
@@ -57,7 +57,7 @@ rustls-pemfile = "2"
 rusty-leveldb = "3"
 
 # Disk-backed needle map (alternative to in-memory HashMap)
-redb = "3"
+redb = "4"
 
 # Reed-Solomon erasure coding
 reed-solomon-erasure = "6"


### PR DESCRIPTION
## What

Bump `redb` from 3.1.3 to 4.2.0 in `seaweed-volume`. Cargo.toml and Cargo.lock only.

## Why

Related to #11179. redb 4.1 and 4.2 carry memory and write-path improvements for exactly the workload the redb-backed needle index runs:

- 4.1.0: "Optimize cache usage, and general write performance. Around 1.5x speedup on some benchmarks. Optimize memory usage."
- 4.2.0: `Durability::None` commits about 2x faster; pages freed by a durable transaction are reused by the very next transaction; fix for a crash during recovery from an earlier crash silently rolling back or corrupting durable commits.
- 4.0.0 breaking changes (`Drop` on `AccessGuardMut`, removal of the `Legacy` type) do not touch this crate.

## Compatibility

- API used by `RedbNeedleMap` (`Database::create/open/builder`, `set_cache_size`, `set_durability`, tables, iterators) is unchanged; the crate compiles with no source changes.
- On-disk format is still v3, so existing `.rdb` files open as-is.
- redb 4.2.0 declares `rust-version = 1.90`; CI uses `dtolnay/rust-toolchain@stable`.

## Tests

`cd seaweed-volume && cargo test`: 492 passed on master with the bump; the full suite also passes with the two #11179 fix PRs merged on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019x36FiSeyePh77YXao15kK

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs/pull/11181" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an underlying storage dependency to a newer major version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->