### PR TITLE
admin: bind to loopback by default, guard public unauthenticated bind

### DIFF
--- a/weed/command/admin.go
+++ b/weed/command/admin.go
@@ -42,6 +42,7 @@ var (
 type AdminOptions struct {
 	port             *int
 	grpcPort         *int
+	ip               *string
 	master           *string
 	masters          *string // deprecated, for backward compatibility
 	filerGroup       *string
@@ -75,6 +76,7 @@ func init() {
 	cmdAdmin.Run = runAdmin // break init cycle
 	a.port = cmdAdmin.Flag.Int("port", 23646, "admin server port")
 	a.grpcPort = cmdAdmin.Flag.Int("port.grpc", 0, "gRPC server port for worker connections (default: http port + 10000)")
+	a.ip = cmdAdmin.Flag.String("ip", "127.0.0.1", "ip address to listen on. Default is loopback; set to 0.0.0.0 to listen on all interfaces (requires -adminPassword or [https.admin] mTLS in security.toml).")
 	a.master = cmdAdmin.Flag.String("master", "localhost:9333", "comma-separated master servers")
 	a.masters = cmdAdmin.Flag.String("masters", "", "comma-separated master servers (deprecated, use -master instead)")
 	a.filerGroup = cmdAdmin.Flag.String("filerGroup", "", "filerGroup for the filers, brokers, and S3 servers")
@@ -136,6 +138,13 @@ var cmdAdmin = &Command{
     - Credentials can also be set via security.toml [admin] section or environment variables:
       WEED_ADMIN_USER, WEED_ADMIN_PASSWORD, WEED_ADMIN_READONLY_USER, WEED_ADMIN_READONLY_PASSWORD
     - Precedence: CLI flag > env var / security.toml > default value
+
+  Network Binding:
+    - By default the admin server binds to 127.0.0.1 (loopback only).
+    - Use -ip=0.0.0.0 to listen on all interfaces.
+    - When binding to a non-loopback address, authentication MUST be enabled
+      (-adminPassword) or mTLS configured ([https.admin] key and ca in security.toml).
+      Otherwise the server refuses to start.
 
   Security Configuration:
     - The admin server reads TLS configuration from security.toml
@@ -273,12 +282,30 @@ func runAdmin(cmd *Command, args []string) bool {
 		*a.grpcPort = *a.port + 10000
 	}
 
+	// Security validation: refuse to bind a non-loopback address without
+	// authentication or mTLS. This prevents accidental exposure of the
+	// unauthenticated admin REST API on the network. Server-only TLS
+	// (https.admin.key without ca) encrypts transport but does not authenticate
+	// clients, so it is not sufficient — the operator must also set a password
+	// or configure mTLS (both key and ca).
+	hasMTLS := viper.GetString("https.admin.key") != "" && viper.GetString("https.admin.ca") != ""
+	if !isLoopbackIp(*a.ip) && *a.adminPassword == "" && !hasMTLS {
+		fmt.Printf("Error: the admin server is configured to bind to %s (non-loopback) with\n", *a.ip)
+		fmt.Printf("       authentication disabled. This would expose the admin API unauthenticated\n")
+		fmt.Printf("       on the network.\n")
+		fmt.Printf("       To fix this, either:\n")
+		fmt.Printf("         - set -adminPassword to enable authentication, or\n")
+		fmt.Printf("         - configure [https.admin] key and ca in security.toml for mTLS, or\n")
+		fmt.Printf("         - set -ip=127.0.0.1 to bind to loopback only.\n")
+		return false
+	}
+
 	// Security warnings
-	if *a.adminPassword == "" {
+	if *a.adminPassword == "" && isLoopbackIp(*a.ip) {
 		fmt.Println("WARNING: Admin interface is running without authentication!")
 		fmt.Println("         Set -adminPassword for production use")
 	}
-	fmt.Printf("Starting SeaweedFS Admin Interface on port %d\n", *a.port)
+	fmt.Printf("Starting SeaweedFS Admin Interface on %s\n", util.JoinHostPort(*a.ip, *a.port))
 	fmt.Printf("Worker gRPC server will run on port %d\n", *a.grpcPort)
 	fmt.Printf("Masters: %s\n", *a.master)
 	fmt.Printf("Filers will be discovered automatically from masters\n")
@@ -438,7 +465,7 @@ func startAdminServer(ctx context.Context, options AdminOptions, enableUI bool, 
 	adminHandlers.SetupRoutes(r, authRequired, *options.adminUser, *options.adminPassword, *options.readOnlyUser, *options.readOnlyPassword, enableUI)
 
 	// Server configuration
-	addr := fmt.Sprintf(":%d", *options.port)
+	addr := util.JoinHostPort(*options.ip, *options.port)
 	var handler http.Handler = r
 	if urlPrefix != "" {
 		stripped := http.StripPrefix(urlPrefix, r)
@@ -505,10 +532,10 @@ func startAdminServer(ctx context.Context, options AdminOptions, enableUI bool, 
 	// and not forwarded.
 	serveErrCh := make(chan error, 1)
 	go func() {
-		glog.Infof("Starting SeaweedFS Admin Server on port %d", *options.port)
+		glog.Infof("Starting SeaweedFS Admin Server on %s", addr)
 		var serveErr error
 		if useTLS {
-			glog.Infof("Starting SeaweedFS Admin Server with TLS on port %d", *options.port)
+			glog.Infof("Starting SeaweedFS Admin Server with TLS on %s", addr)
 			serveErr = server.ListenAndServeTLS("", "")
 		} else {
 			serveErr = server.ListenAndServe()
@@ -701,4 +728,19 @@ func applyViperFallback(cmd *Command, flagPtr *string, flagName, viperKey string
 			*flagPtr = v
 		}
 	}
+}
+
+// isLoopbackIp reports whether the given bind address is loopback.
+// An empty string or "0.0.0.0" / "::" is treated as non-loopback (all
+// interfaces), since those expose the server to the network.
+func isLoopbackIp(ip string) bool {
+	if ip == "" {
+		return false
+	}
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		// Unresolved hostname — treat as non-loopback to be safe.
+		return false
+	}
+	return parsed.IsLoopback()
 }

--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -1272,6 +1272,10 @@ func runMini(cmd *Command, args []string) bool {
 	miniOptions.v.bindIp = miniBindIp
 	miniOptions.v.masters = pb.ServerAddresses(actualPeersForComponents).ToAddresses()
 	miniOptions.v.idleConnectionTimeout = miniTimeout
+	// Admin server binds to the same address as the other mini services.
+	// The public-bind-without-auth guard in `weed admin` does not apply here
+	// because mini calls startAdminServer directly, not runAdmin.
+	miniAdminOptions.ip = miniBindIp
 	miniOptions.v.dataCenter = miniDataCenter
 	miniOptions.v.rack = miniRack
 


### PR DESCRIPTION
## Summary

Addresses GHSA-m3m8-mrgq-hf9h (weed admin HTTP server exposes all write operations unauthenticated by default).

The admin HTTP server (port 23646) defaulted to binding `0.0.0.0` with authentication disabled when `-adminPassword` was not supplied. This exposed the full admin REST API — S3 user creation, plaintext access-key issuance, bucket deletion, filer file deletion, plugin job execution — unauthenticated on the network. The no-auth mode itself is by design for local dev; the footgun is that the default bind address made it reachable from the network.

This PR keeps the no-auth mode but removes the network exposure:

- **`-ip` flag (default `127.0.0.1`)** — the admin server now binds to loopback only unless the operator explicitly chooses a public address (`-ip=0.0.0.0`). This matches the convention used by the master/volume/filer `-ip` flags.
- **Startup guard** — if the resolved bind address is non-loopback AND `-adminPassword` is empty AND mTLS is not configured (both `https.admin.key` AND `https.admin.ca` in `security.toml`), the server refuses to start. Server-only TLS (key without ca) is not sufficient because it encrypts transport but does not authenticate clients — any network client could still connect and call the admin API.
- **`weed mini`** — sets the admin `-ip` from its existing `-ip.bind`. The guard does not apply because mini calls `startAdminServer` directly, not `runAdmin`.
- **IPv6-safe address construction** — uses `util.JoinHostPort` for the bind address so IPv6 literals (e.g. `::1`) are correctly bracketed.

### Behavior after this change

| Configuration | Before | After |
|---|---|---|
| `weed admin` (no flags) | binds `0.0.0.0:23646`, no auth | binds `127.0.0.1:23646`, no auth |
| `weed admin -ip=0.0.0.0` (no password) | binds `0.0.0.0`, no auth | **refuses to start** (guard) |
| `weed admin -ip=0.0.0.0 -adminPassword=secret` | binds `0.0.0.0`, auth enabled | binds `0.0.0.0`, auth enabled |
| `weed admin -ip=0.0.0.0` + `[https.admin] key` only | binds `0.0.0.0`, no auth | **refuses to start** (server-only TLS not sufficient) |
| `weed admin -ip=0.0.0.0` + `[https.admin] key + ca` | binds `0.0.0.0`, no auth | binds `0.0.0.0`, mTLS (guard satisfied) |
| `weed admin -ip=::1` | n/a | binds `[::1]:23646` (IPv6-safe) |
| `weed mini` (no flags) | binds `0.0.0.0:23646`, no auth | unchanged (guard not applied) |

#### Test plan
- [x] `go build ./...` passes
- [x] `go vet ./weed/command/` passes
- [x] `go test ./weed/command/ -run TestApplyMiniAdminCredentialFallbackFromEnv` passes
- [ ] Manual: `weed admin` with no flags binds to 127.0.0.1 only
- [ ] Manual: `weed admin -ip=0.0.0.0` without password refuses to start with clear error
- [ ] Manual: `weed admin -ip=0.0.0.0 -adminPassword=x` starts normally
- [ ] Manual: `weed admin -ip=::1` starts and binds to `[::1]:23646`
- [ ] Manual: `weed mini` starts normally (guard not applied)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable IP binding for the admin server, defaulting to `127.0.0.1`.
  - Startup output and logs now display the configured bind IP.
  - Mini services now use the same bind IP for their admin interface.

- **Bug Fixes**
  - External admin bindings now require an admin password or configured mutual TLS authentication.
  - Unauthenticated access warnings are shown only when binding to a loopback address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->