### PR TITLE
admin: redact S3 secret keys for read-only sessions

### DIFF
--- a/weed/admin/dash/admin_data.go
+++ b/weed/admin/dash/admin_data.go
@@ -113,6 +113,34 @@ type UserDetails struct {
 	Groups      []string        `json:"groups"`
 }
 
+// RoleReadOnly is the session role assigned to read-only (view-only) admin
+// accounts. It matches the value stored by HandleLogin when the read-only
+// credentials are used.
+const RoleReadOnly = "readonly"
+
+// IsReadOnlyRole reports whether the given admin session role grants only
+// view-only access. Any other role (admin, or the empty role used when auth
+// is disabled) is treated as non-read-only.
+func IsReadOnlyRole(role string) bool {
+	return role == RoleReadOnly
+}
+
+// RedactSecretKey clears the plaintext S3 secret key from an object-store
+// user record. The access key (a public identifier) is retained so the
+// identity can still be listed; only the reusable secret is removed.
+func (u *ObjectStoreUser) RedactSecretKey() {
+	u.SecretKey = ""
+}
+
+// RedactSecretKeys clears the plaintext S3 secret keys from a user's access
+// key records. Access key identifiers are retained so the set of keys remains
+// visible; only the reusable secrets are removed.
+func (d *UserDetails) RedactSecretKeys() {
+	for i := range d.AccessKeys {
+		d.AccessKeys[i].SecretKey = ""
+	}
+}
+
 type FilerNode struct {
 	Address     string    `json:"address"`
 	DataCenter  string    `json:"datacenter"`

--- a/weed/admin/dash/auth_middleware.go
+++ b/weed/admin/dash/auth_middleware.go
@@ -44,7 +44,7 @@ func (s *AdminServer) HandleLogin(store sessions.Store, adminUser, adminPassword
 			authenticated = true
 		} else if readOnlyPassword != "" && loginUsername == readOnlyUser && subtle.ConstantTimeCompare([]byte(loginPassword), []byte(readOnlyPassword)) == 1 {
 			// Check read-only credentials.
-			role = "readonly"
+			role = RoleReadOnly
 			authenticated = true
 		}
 

--- a/weed/admin/dash/readonly_secret_redaction_test.go
+++ b/weed/admin/dash/readonly_secret_redaction_test.go
@@ -1,0 +1,75 @@
+package dash
+
+import (
+	"testing"
+)
+
+// TestIsReadOnlyRole verifies that only the read-only session role is treated
+// as view-only. The admin role and the empty role (used when auth is
+// disabled) must not be treated as read-only, otherwise admins and no-auth
+// deployments would lose legitimate access to credentials.
+func TestIsReadOnlyRole(t *testing.T) {
+	if !IsReadOnlyRole(RoleReadOnly) {
+		t.Errorf("IsReadOnlyRole(%q) = false, want true", RoleReadOnly)
+	}
+	if !IsReadOnlyRole("readonly") {
+		t.Errorf("IsReadOnlyRole(\"readonly\") = false, want true")
+	}
+	if IsReadOnlyRole("admin") {
+		t.Errorf("IsReadOnlyRole(\"admin\") = true, want false")
+	}
+	if IsReadOnlyRole("") {
+		t.Errorf("IsReadOnlyRole(\"\") = true, want false; no-auth mode must not be redacted")
+	}
+}
+
+// TestObjectStoreUserRedactSecretKey verifies that redaction clears the
+// reusable secret while preserving the public access key identifier.
+func TestObjectStoreUserRedactSecretKey(t *testing.T) {
+	u := ObjectStoreUser{
+		Username:  "victim",
+		AccessKey: "AKIAEXAMPLEKEY",
+		SecretKey: "super-secret-value",
+	}
+	u.RedactSecretKey()
+	if u.SecretKey != "" {
+		t.Errorf("SecretKey = %q, want empty after redaction", u.SecretKey)
+	}
+	if u.AccessKey == "" {
+		t.Errorf("AccessKey was emptied; only the secret should be redacted")
+	}
+	if u.Username == "" {
+		t.Errorf("Username was emptied; only the secret should be redacted")
+	}
+}
+
+// TestUserDetailsRedactSecretKeys verifies that redaction clears every
+// access key's secret while preserving the access key identifiers.
+func TestUserDetailsRedactSecretKeys(t *testing.T) {
+	d := &UserDetails{
+		Username: "victim",
+		AccessKeys: []AccessKeyInfo{
+			{AccessKey: "AKIAONE", SecretKey: "secret-one"},
+			{AccessKey: "AKIATWO", SecretKey: "secret-two"},
+		},
+	}
+	d.RedactSecretKeys()
+	for i, ak := range d.AccessKeys {
+		if ak.SecretKey != "" {
+			t.Errorf("AccessKeys[%d].SecretKey = %q, want empty after redaction", i, ak.SecretKey)
+		}
+		if ak.AccessKey == "" {
+			t.Errorf("AccessKeys[%d].AccessKey was emptied; only the secret should be redacted", i)
+		}
+	}
+}
+
+// TestUserDetailsRedactSecretKeys_Empty verifies redaction is a no-op
+// (and does not panic) when there are no access keys.
+func TestUserDetailsRedactSecretKeys_Empty(t *testing.T) {
+	d := &UserDetails{Username: "victim"}
+	d.RedactSecretKeys()
+	if len(d.AccessKeys) != 0 {
+		t.Errorf("expected no access keys, got %d", len(d.AccessKeys))
+	}
+}

--- a/weed/admin/handlers/user_handlers.go
+++ b/weed/admin/handlers/user_handlers.go
@@ -55,6 +55,14 @@ func (h *UserHandlers) GetUsers(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusInternalServerError, "Failed to get users: "+err.Error())
 		return
 	}
+	// Read-only (view-only) admin sessions must never receive reusable
+	// object-store secrets. Redact the secret key before serializing so a
+	// viewer cannot lift another user's live S3 credential pair.
+	if dash.IsReadOnlyRole(dash.RoleFromContext(r.Context())) {
+		for i := range users {
+			users[i].RedactSecretKey()
+		}
+	}
 	writeJSON(w, http.StatusOK, map[string]interface{}{"users": users})
 }
 
@@ -154,6 +162,13 @@ func (h *UserHandlers) GetUserDetails(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		writeJSONError(w, http.StatusNotFound, "User not found: "+err.Error())
 		return
+	}
+
+	// Read-only (view-only) admin sessions must never receive reusable
+	// object-store secrets. Redact the secret keys before serializing so a
+	// viewer cannot lift another user's live S3 credential pair.
+	if dash.IsReadOnlyRole(dash.RoleFromContext(r.Context())) {
+		user.RedactSecretKeys()
 	}
 
 	writeJSON(w, http.StatusOK, user)
@@ -318,6 +333,14 @@ func (h *UserHandlers) getObjectStoreUsersData(r *http.Request) dash.ObjectStore
 			Users:       []dash.ObjectStoreUser{},
 			TotalUsers:  0,
 			LastUpdated: time.Now(),
+		}
+	}
+
+	// Read-only (view-only) admin sessions must never receive reusable
+	// object-store secrets, including via the rendered HTML users page.
+	if dash.IsReadOnlyRole(dash.RoleFromContext(r.Context())) {
+		for i := range users {
+			users[i].RedactSecretKey()
 		}
 	}
 


### PR DESCRIPTION
## Summary

This redacts the reusable `secret_key` whenever the requesting session has the read-only role, in:
- `GetUsers` (`GET /api/users`)
- `GetUserDetails` (`GET /api/users/{username}`)
- `getObjectStoreUsersData` (the rendered object-store users page)

The public `access_key` identifier is retained so identities remain browsable; only the reusable secret is stripped. Admin and no-auth sessions are unaffected.

### Changes
- `weed/admin/dash/admin_data.go`: add `RoleReadOnly` constant, `IsReadOnlyRole` helper, and `RedactSecretKey` / `RedactSecretKeys` methods on `ObjectStoreUser` / `UserDetails`.
- `weed/admin/dash/auth_middleware.go`: use the shared `RoleReadOnly` constant instead of a string literal.
- `weed/admin/handlers/user_handlers.go`: redact secrets for read-only sessions in the list, detail, and HTML-view data paths.
- `weed/admin/dash/readonly_secret_redaction_test.go`: unit tests for the redaction helpers and role check.

#### Test plan

- [x] `go build ./weed/admin/...`
- [x] `go test ./weed/admin/...` (all packages pass, including new `readonly_secret_redaction_test.go`)
- [x] End-to-end verification against a locally-built `weed mini` with `-admin.readOnlyUser` set:
  - read-only Admin write still returns `403`
  - read-only `GET /api/users/{username}` returns `access_key` but an empty `secret_key`
  - read-only `GET /api/users` returns no `secret_key` for any user
  - admin `GET /api/users/{username}` still returns the full `secret_key` (no regression)
  - an S3 `PUT` signed with the redacted (empty) secret is rejected with `403`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs/pull/11189" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Read-only admin sessions now hide object-store secret keys in user lists, user details, and rendered user-management pages.
  - Access-key identifiers remain visible while sensitive secret values are withheld.

- **Bug Fixes**
  - Prevented read-only viewers from receiving live object-store credentials through administrative responses.

- **Tests**
  - Added coverage for read-only role detection, secret redaction, identifier preservation, and empty credential scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->