### PR TITLE
ci: pin actions/setup-python to v7 in star_history workflow

### DIFF
--- a/.github/workflows/star_history.yml
+++ b/.github/workflows/star_history.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v8
+        uses: actions/setup-python@v7
         with:
           python-version: "3.x"
           cache: pip


### PR DESCRIPTION
## Summary
- The `Star History` workflow failed at the "Set up job" step with `Unable to resolve action 'actions/setup-python@v8', unable to find version 'v8'` (see [failing run](https://github.com/seaweedfs/seaweedfs/actions/runs/34002052571/job/101402549563)).
- `actions/setup-python@v8` does not exist; the latest release is `v7`. This pins the workflow to `actions/setup-python@v7`, matching the version already used by the other workflows (e.g. `s3tests.yml`, `s3-parquet-tests.yml`, `helm_ci.yml`).

#### Test plan
- [ ] Re-run the `Star History` workflow and confirm the `Set up Python` step succeeds.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs/pull/11191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the automated star-history workflow’s Python setup step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->