### PR TITLE
rust worker: install rustls CryptoProvider to fix TLS panic (#11194)

### DIFF
--- a/seaweed-worker/Cargo.lock
+++ b/seaweed-worker/Cargo.lock
@@ -6556,11 +6556,13 @@ dependencies = [
  "lance-table",
  "prometheus",
  "reqwest 0.12.28",
+ "rustls",
  "seaweed-worker-core",
  "seaweed-worker-sort",
  "serde",
  "serde_json",
  "tokio",
+ "tonic",
  "tracing",
  "tracing-subscriber",
 ]

--- a/seaweed-worker/crates/lance/Cargo.toml
+++ b/seaweed-worker/crates/lance/Cargo.toml
@@ -35,6 +35,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 clap = { version = "4", features = ["derive", "env"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+rustls = "0.23"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio.workspace = true
@@ -43,6 +44,7 @@ tracing-subscriber.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true }
+tonic.workspace = true
 arrow-array = "58"
 arrow-schema = "58"
 arrow-cast = "58"

--- a/seaweed-worker/crates/lance/src/lib.rs
+++ b/seaweed-worker/crates/lance/src/lib.rs
@@ -10,5 +10,6 @@ pub mod dataset;
 pub mod jobs;
 pub mod metrics;
 pub mod preview;
+pub mod tls;
 
 pub use jobs::handlers;

--- a/seaweed-worker/crates/lance/src/main.rs
+++ b/seaweed-worker/crates/lance/src/main.rs
@@ -113,6 +113,8 @@ fn metrics_address(ip: &str, port: u16) -> Result<SocketAddr> {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    weed_lance_worker::tls::install_default_crypto_provider();
+
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()

--- a/seaweed-worker/crates/lance/src/tls.rs
+++ b/seaweed-worker/crates/lance/src/tls.rs
@@ -1,0 +1,35 @@
+use rustls::crypto::aws_lc_rs;
+
+// aws-lc-rs and ring both get linked transitively (lance's aws backend pulls
+// aws-lc-rs, reqwest's rustls-tls pulls ring), so rustls can't auto-select a
+// provider and tonic's client TLS panics on first use. Pin the default to
+// aws-lc-rs, matching the Rust volume server. Idempotent.
+pub fn install_default_crypto_provider() {
+    let _ = aws_lc_rs::default_provider().install_default();
+}
+
+#[cfg(test)]
+mod tests {
+    use tonic::transport::{Certificate, Channel, ClientTlsConfig, Identity};
+
+    use super::install_default_crypto_provider;
+
+    const TEST_CERT_PEM: &str = "-----BEGIN CERTIFICATE-----\nMIIBPDCB76ADAgECAhRuRPQgeAu43BT/M7EfAWSdapVdYDAFBgMrZXAwFDESMBAG\nA1UEAwwJbG9jYWxob3N0MB4XDTI2MDcwNTE2MTUyOVoXDTM2MDcwMjE2MTUyOVow\nFDESMBAGA1UEAwwJbG9jYWxob3N0MCowBQYDK2VwAyEAr/3bNIFI+8V32oCiY6y+\nXRFmZpdNQ2g//VtRkT+nQg+jUzBRMB0GA1UdDgQWBBTsy9tLf1zPiXCQfgci6zNi\ndEzRSjAfBgNVHSMEGDAWgBTsy9tLf1zPiXCQfgci6zNidEzRSjAPBgNVHRMBAf8E\nBTADAQH/MAUGAytlcANBAIvsdw0IbvOBBkb9cd7BfMJfIP9pQQrAL03pCRWJFnFh\nSysaLVgFXI4T078IiaM874oO+iB+5vNbWEpc7CkGow4=\n-----END CERTIFICATE-----\n";
+    const TEST_KEY_PEM: &str = "-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIHbyn71Kk+Y7KT3sBctit7uZpErpoH6qDbFj6P8qGaZH\n-----END PRIVATE KEY-----\n";
+
+    // Without install_default_crypto_provider this panics in the lance crate,
+    // where both aws-lc-rs and ring are linked. Mirrors the volume server's
+    // test_build_grpc_endpoint_with_tls_resolves_crypto_provider.
+    #[tokio::test]
+    async fn tls_channel_builds_after_crypto_provider_installed() {
+        install_default_crypto_provider();
+        let config = ClientTlsConfig::new()
+            .ca_certificate(Certificate::from_pem(TEST_CERT_PEM))
+            .identity(Identity::from_pem(TEST_CERT_PEM, TEST_KEY_PEM));
+        let endpoint = Channel::from_shared("https://127.0.0.1:9")
+            .unwrap()
+            .tls_config(config)
+            .unwrap();
+        assert_eq!(endpoint.uri().scheme_str(), Some("https"));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #11194.

The Rust `weed-worker` (the `worker-lance` sidecar) panics on startup when TLS is enabled:

```
thread 'main' panicked at rustls-0.23.43/src/crypto/mod.rs:249:14:
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
Call CryptoProvider::install_default() before this point, or make sure exactly one of the
'aws-lc-rs' and 'ring' features is enabled.
```

The lance crate links both `aws-lc-rs` (via lance's `aws` backend / aws-config) and `ring` (via reqwest's `rustls-tls`), so rustls 0.23 cannot auto-select a `CryptoProvider` and tonic's client TLS panics on the first admin dial. The Rust volume server already solved this in `seaweed-volume/src/security/tls.rs` with `install_default_crypto_provider()`; this mirrors that fix in the worker.

- Add `install_default_crypto_provider()` to the lance crate, pinning the default to `aws-lc-rs` (matching the volume server). It lives in the lance crate rather than `seaweed-worker-core` because the core crate only links `ring` (via tonic), so `rustls::crypto::aws_lc_rs` is not available there; the lance crate is where both providers are linked.
- Call it at the top of `main()`, before any TLS use, exactly as the volume server does.
- Add a regression test that builds a TLS channel. In this crate it panics without the install (verified) and passes with it.

#### Test plan

- [x] Reproduced the exact panic from the issue by running `weed-worker` with `--tls-ca/--tls-cert/--tls-key` against a dead admin port.
- [x] After the fix, the same invocation no longer panics; it logs a normal `transport error: Connection refused` and reconnects.
- [x] `cargo test -p weed-lance-worker --lib` passes (new regression test included).
- [x] `cargo fmt --check` and `cargo clippy` clean (no new warnings).
- [ ] CI: `cargo build --release` and `cargo test --release --workspace` in the Rust Plugin Worker Tests workflow.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs/pull/11196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved secure connection setup for the Lance maintenance worker by initializing its default TLS cryptography provider before startup.
  - Added validation to ensure TLS channel configuration succeeds when supported cryptographic backends are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->