### PR TITLE
rust volume: drop the extra redb read transaction on put/delete

### DIFF
--- a/seaweed-volume/src/storage/needle_map.rs
+++ b/seaweed-volume/src/storage/needle_map.rs
@@ -57,6 +57,15 @@ fn unpack_needle_value(bytes: &[u8; PACKED_NEEDLE_VALUE_SIZE]) -> NeedleValue {
     }
 }
 
+fn packed_to_needle_value(bytes: &[u8]) -> Option<NeedleValue> {
+    if bytes.len() != PACKED_NEEDLE_VALUE_SIZE {
+        return None;
+    }
+    let mut arr = [0u8; PACKED_NEEDLE_VALUE_SIZE];
+    arr.copy_from_slice(bytes);
+    Some(unpack_needle_value(&arr))
+}
+
 // ============================================================================
 // NeedleMapMetric
 // ============================================================================
@@ -689,16 +698,7 @@ impl RedbNeedleMap {
         key_u64: u64,
     ) -> io::Result<Option<NeedleValue>> {
         match table.get(key_u64) {
-            Ok(Some(guard)) => {
-                let bytes: &[u8] = guard.value();
-                if bytes.len() == PACKED_NEEDLE_VALUE_SIZE {
-                    let mut arr = [0u8; PACKED_NEEDLE_VALUE_SIZE];
-                    arr.copy_from_slice(bytes);
-                    Ok(Some(unpack_needle_value(&arr)))
-                } else {
-                    Ok(None)
-                }
-            }
+            Ok(Some(guard)) => Ok(packed_to_needle_value(guard.value())),
             Ok(None) => Ok(None),
             Err(e) => Err(io::Error::new(
                 io::ErrorKind::Other,
@@ -814,30 +814,35 @@ impl RedbNeedleMap {
         }
 
         let key_u64: u64 = key.into();
-        let nv = NeedleValue { offset, size };
-        let packed = pack_needle_value(&nv);
+        let packed = pack_needle_value(&NeedleValue { offset, size });
 
-        // Read old value for metric update
-        let old = self.get_internal(key_u64)?;
-
-        let txn = Self::begin_write_no_fsync(&self.db)?;
-        {
-            let mut table = txn.open_table(NEEDLE_TABLE).map_err(|e| {
-                io::Error::new(io::ErrorKind::Other, format!("redb open_table: {}", e))
+        let old = match (|| -> io::Result<Option<NeedleValue>> {
+            let txn = Self::begin_write_no_fsync(&self.db)?;
+            let old = {
+                let mut table = txn.open_table(NEEDLE_TABLE).map_err(|e| {
+                    io::Error::new(io::ErrorKind::Other, format!("redb open_table: {}", e))
+                })?;
+                let prev = table.insert(key_u64, packed.as_slice()).map_err(|e| {
+                    io::Error::new(io::ErrorKind::Other, format!("redb insert: {}", e))
+                })?;
+                prev.and_then(|g| packed_to_needle_value(g.value()))
+            };
+            txn.commit().map_err(|e| {
+                io::Error::new(io::ErrorKind::Other, format!("redb commit: {}", e))
             })?;
-            table
-                .insert(key_u64, packed.as_slice())
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("redb insert: {}", e)))?;
-        }
-        if let Err(e) = txn.commit() {
-            self.truncate_idx_to_offset();
-            return Err(io::Error::new(io::ErrorKind::Other, format!("redb commit: {}", e)));
-        }
+            Ok(old)
+        })() {
+            Ok(old) => old,
+            Err(e) => {
+                self.truncate_idx_to_offset();
+                return Err(e);
+            }
+        };
+
         if self.idx_file.is_some() {
             self.idx_file_offset += NEEDLE_MAP_ENTRY_SIZE as u64;
         }
         self.writes_since_checkpoint = self.writes_since_checkpoint.saturating_add(1);
-
         self.metric.on_put(key, old.as_ref(), size);
         Ok(())
     }
@@ -860,16 +865,7 @@ impl RedbNeedleMap {
             .open_table(NEEDLE_TABLE)
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("redb open_table: {}", e)))?;
         match table.get(key_u64) {
-            Ok(Some(guard)) => {
-                let bytes: &[u8] = guard.value();
-                if bytes.len() == PACKED_NEEDLE_VALUE_SIZE {
-                    let mut arr = [0u8; PACKED_NEEDLE_VALUE_SIZE];
-                    arr.copy_from_slice(bytes);
-                    Ok(Some(unpack_needle_value(&arr)))
-                } else {
-                    Ok(None)
-                }
-            }
+            Ok(Some(guard)) => Ok(packed_to_needle_value(guard.value())),
             Ok(None) => Ok(None),
             Err(e) => Err(io::Error::new(
                 io::ErrorKind::Other,
@@ -881,48 +877,56 @@ impl RedbNeedleMap {
     /// Mark a needle as deleted. Appends tombstone to .idx file, negates size in redb.
     pub fn delete(&mut self, key: NeedleId, offset: Offset) -> io::Result<Option<Size>> {
         let key_u64: u64 = key.into();
-
-        if let Some(old) = self.get_internal(key_u64)? {
-            if old.size.is_valid() {
-                // Persist tombstone to idx file BEFORE mutating redb. The
-                // offset is advanced only after the redb commit succeeds
-                // (see put).
-                if let Some(ref mut idx_file) = self.idx_file {
-                    idx::write_index_entry(idx_file, key, offset, TOMBSTONE_FILE_SIZE)?;
-                }
-
-                let deleted_size = Size(-(old.size.0));
-                // Keep original offset so readDeleted can find original data (matching Go behavior)
-                let deleted_nv = NeedleValue {
-                    offset: old.offset,
-                    size: deleted_size,
-                };
-                let packed = pack_needle_value(&deleted_nv);
-
-                let txn = Self::begin_write_no_fsync(&self.db)?;
-                {
-                    let mut table = txn.open_table(NEEDLE_TABLE).map_err(|e| {
-                        io::Error::new(io::ErrorKind::Other, format!("redb open_table: {}", e))
-                    })?;
-                    table.insert(key_u64, packed.as_slice()).map_err(|e| {
-                        io::Error::new(io::ErrorKind::Other, format!("redb insert: {}", e))
-                    })?;
-                }
-                if let Err(e) = txn.commit() {
-                    self.truncate_idx_to_offset();
-                    return Err(io::Error::new(io::ErrorKind::Other, format!("redb commit: {}", e)));
-                }
-                if self.idx_file.is_some() {
-                    self.idx_file_offset += NEEDLE_MAP_ENTRY_SIZE as u64;
-                }
-                self.writes_since_checkpoint = self.writes_since_checkpoint.saturating_add(1);
-
-                // Only now is the tombstone in the table the metrics describe.
-                self.metric.on_delete(&old);
-                return Ok(Some(old.size));
+        let txn = Self::begin_write_no_fsync(&self.db)?;
+        let mut table = txn.open_table(NEEDLE_TABLE).map_err(|e| {
+            io::Error::new(io::ErrorKind::Other, format!("redb open_table: {}", e))
+        })?;
+        let old = match table.get(key_u64) {
+            Ok(Some(guard)) => packed_to_needle_value(guard.value()),
+            Ok(None) => None,
+            Err(e) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("redb get: {}", e),
+                ));
             }
+        };
+        let Some(old) = old.filter(|nv| nv.size.is_valid()) else {
+            drop(table);
+            return Ok(None);
+        };
+
+        if let Some(ref mut idx_file) = self.idx_file {
+            idx::write_index_entry(idx_file, key, offset, TOMBSTONE_FILE_SIZE)?;
         }
-        Ok(None)
+
+        let deleted_nv = NeedleValue {
+            offset: old.offset,
+            size: Size(-(old.size.0)),
+        };
+        let packed = pack_needle_value(&deleted_nv);
+        let insert_res = table.insert(key_u64, packed.as_slice()).map(|_| ());
+        drop(table);
+        if let Err(e) = insert_res {
+            self.truncate_idx_to_offset();
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("redb insert: {}", e),
+            ));
+        }
+        if let Err(e) = txn.commit() {
+            self.truncate_idx_to_offset();
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("redb commit: {}", e),
+            ));
+        }
+        if self.idx_file.is_some() {
+            self.idx_file_offset += NEEDLE_MAP_ENTRY_SIZE as u64;
+        }
+        self.writes_since_checkpoint = self.writes_since_checkpoint.saturating_add(1);
+        self.metric.on_delete(&old);
+        Ok(Some(old.size))
     }
 
     // ---- Metrics accessors ----
@@ -1638,6 +1642,24 @@ mod tests {
     }
 
     #[test]
+    fn test_redb_put_overwrite_metrics_without_prior_get() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.rdb");
+        let mut nm = RedbNeedleMap::new(db_path.to_str().unwrap(), redb_test_cache()).unwrap();
+        nm.put(NeedleId(1), Offset::from_actual_offset(8), Size(100))
+            .unwrap();
+        nm.put(NeedleId(1), Offset::from_actual_offset(200), Size(200))
+            .unwrap();
+        assert_eq!(nm.file_count(), 2);
+        assert_eq!(nm.content_size(), 300);
+        assert_eq!(nm.deleted_count(), 1);
+        assert_eq!(nm.deleted_size(), 100);
+        let v = nm.get(NeedleId(1)).unwrap().unwrap();
+        assert_eq!(v.size, Size(200));
+        assert_eq!(v.offset, Offset::from_actual_offset(200));
+    }
+
+    #[test]
     fn test_redb_needle_map_delete() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("test.rdb");
@@ -1768,6 +1790,26 @@ mod tests {
             .unwrap();
         assert_eq!(r2, None);
         assert_eq!(nm.deleted_count(), 1); // not double counted
+    }
+
+    #[test]
+    fn test_redb_delete_wrong_length_value_is_absent_not_panic() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.rdb");
+        let mut nm = RedbNeedleMap::new(db_path.to_str().unwrap(), redb_test_cache()).unwrap();
+        {
+            let txn = RedbNeedleMap::begin_write_no_fsync(&nm.db).unwrap();
+            {
+                let mut table = txn.open_table(NEEDLE_TABLE).unwrap();
+                table.insert(1u64, &b"xx"[..]).unwrap();
+            }
+            txn.commit().unwrap();
+        }
+        let deleted = nm
+            .delete(NeedleId(1), Offset::from_actual_offset(0))
+            .unwrap();
+        assert_eq!(deleted, None);
+        assert_eq!(nm.deleted_count(), 0);
     }
 
     #[test]

--- a/seaweed-volume/src/storage/needle_map.rs
+++ b/seaweed-volume/src/storage/needle_map.rs
@@ -707,7 +707,12 @@ impl RedbNeedleMap {
         }
     }
 
-    /// Full rebuild: delete existing .rdb and rebuild from entire .idx file.
+    /// Full rebuild: unlink any existing .rdb and rebuild from the entire .idx.
+    ///
+    /// `Database::create` opens an existing file (`truncate(false)`). Unlink
+    /// must succeed (or the path must be absent) so the needles table is empty
+    /// before we insert. Inserts are in needle-id order so redb 4.2.0 packs
+    /// leaves.
     fn full_rebuild<R: Read + Seek>(
         db_path: &str,
         reader: &mut R,
@@ -715,49 +720,67 @@ impl RedbNeedleMap {
         version: Version,
         cache_bytes: usize,
     ) -> io::Result<Self> {
-        let _ = std::fs::remove_file(db_path);
-        let mut nm = RedbNeedleMap::new(db_path, cache_bytes)?;
+        match std::fs::remove_file(db_path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e),
+        }
 
-        // Collect entries from idx file, resolving duplicates/deletions
-        let mut entries: HashMap<NeedleId, Option<NeedleValue>> = HashMap::new();
-        idx::walk_index_file(reader, 0, |key, offset, size| {
-            if offset.is_zero() || size.is_deleted() {
-                entries.insert(key, None);
-            } else {
-                entries.insert(key, Some(NeedleValue { offset, size }));
+        let mut nm = match RedbNeedleMap::new(db_path, cache_bytes) {
+            Ok(nm) => nm,
+            Err(e) => {
+                let _ = std::fs::remove_file(db_path);
+                return Err(e);
             }
-            Ok(())
-        })?;
+        };
 
-        // Write all live entries to redb in a single transaction
-        let txn = Self::begin_write_no_fsync(&nm.db)?;
-        {
-            let mut table = txn.open_table(NEEDLE_TABLE).map_err(|e| {
-                io::Error::new(io::ErrorKind::Other, format!("redb open_table: {}", e))
+        let result = (|| -> io::Result<()> {
+            let mut entries: HashMap<NeedleId, Option<NeedleValue>> = HashMap::new();
+            idx::walk_index_file(reader, 0, |key, offset, size| {
+                if offset.is_zero() || size.is_deleted() {
+                    entries.insert(key, None);
+                } else {
+                    entries.insert(key, Some(NeedleValue { offset, size }));
+                }
+                Ok(())
             })?;
 
-            for (key, maybe_nv) in &entries {
-                let key_u64: u64 = (*key).into();
-                if let Some(nv) = maybe_nv {
+            let mut live: Vec<(NeedleId, NeedleValue)> = entries
+                .into_iter()
+                .filter_map(|(k, v)| v.map(|nv| (k, nv)))
+                .collect();
+            live.sort_by_key(|(k, _)| *k);
+
+            let txn = Self::begin_write_no_fsync(&nm.db)?;
+            {
+                let mut table = txn.open_table(NEEDLE_TABLE).map_err(|e| {
+                    io::Error::new(io::ErrorKind::Other, format!("redb open_table: {}", e))
+                })?;
+
+                for (key, nv) in &live {
+                    let key_u64: u64 = (*key).into();
                     let packed = pack_needle_value(nv);
                     table.insert(key_u64, packed.as_slice()).map_err(|e| {
                         io::Error::new(io::ErrorKind::Other, format!("redb insert: {}", e))
                     })?;
-                } else {
-                    // Entry was deleted — remove from redb if present
-                    table.remove(key_u64).map_err(|e| {
-                        io::Error::new(io::ErrorKind::Other, format!("redb remove: {}", e))
-                    })?;
                 }
             }
+            txn.commit()
+                .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("redb commit: {}", e)))?;
+
+            nm.save_idx_size_meta(idx_size)?;
+            nm.metric = metrics_from_idx(reader, version)?;
+            Ok(())
+        })();
+
+        match result {
+            Ok(()) => Ok(nm),
+            Err(e) => {
+                drop(nm);
+                let _ = std::fs::remove_file(db_path);
+                Err(e)
+            }
         }
-        txn.commit()
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("redb commit: {}", e)))?;
-
-        nm.save_idx_size_meta(idx_size)?;
-        nm.metric = metrics_from_idx(reader, version)?;
-
-        Ok(nm)
     }
 
     /// Set the index file for append-only writes.
@@ -1485,6 +1508,107 @@ mod tests {
             .unwrap();
         nm.set_idx_file(Box::new(writer), idx_size);
         (nm, db_path, idx_path)
+    }
+
+    /// .idx records in non-id order: 10, 1, 5, overwrite 1, delete 5.
+    fn shuffled_idx_with_overwrite_and_delete() -> Vec<u8> {
+        let mut idx_data = Vec::new();
+        idx::write_index_entry(
+            &mut idx_data,
+            NeedleId(10),
+            Offset::from_actual_offset(8),
+            Size(100),
+        )
+        .unwrap();
+        idx::write_index_entry(
+            &mut idx_data,
+            NeedleId(1),
+            Offset::from_actual_offset(128),
+            Size(50),
+        )
+        .unwrap();
+        idx::write_index_entry(
+            &mut idx_data,
+            NeedleId(5),
+            Offset::from_actual_offset(384),
+            Size(75),
+        )
+        .unwrap();
+        idx::write_index_entry(
+            &mut idx_data,
+            NeedleId(1),
+            Offset::from_actual_offset(200),
+            Size(200),
+        )
+        .unwrap();
+        idx::write_index_entry(
+            &mut idx_data,
+            NeedleId(5),
+            Offset::default(),
+            TOMBSTONE_FILE_SIZE,
+        )
+        .unwrap();
+        idx_data
+    }
+
+    #[test]
+    fn test_redb_full_rebuild_last_write_wins_from_shuffled_idx() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.rdb");
+        let idx_data = shuffled_idx_with_overwrite_and_delete();
+        let mut cursor = Cursor::new(idx_data);
+        let nm = RedbNeedleMap::load_from_idx(
+            db_path.to_str().unwrap(),
+            &mut cursor,
+            Version::current(),
+            redb_test_cache(),
+        )
+        .unwrap();
+
+        let v10 = nm.get(NeedleId(10)).unwrap().unwrap();
+        assert_eq!(v10.size, Size(100));
+        let v1 = nm.get(NeedleId(1)).unwrap().unwrap();
+        assert_eq!(v1.size, Size(200));
+        assert_eq!(v1.offset, Offset::from_actual_offset(200));
+        assert!(nm.get(NeedleId(5)).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_redb_full_rebuild_drops_keys_absent_from_idx() {
+        let dir = tempfile::tempdir().unwrap();
+        let (mut nm, db_path, idx_path) = open_writable_redb(dir.path());
+        nm.put(NeedleId(1), Offset::from_actual_offset(8), Size(100))
+            .unwrap();
+        nm.put(NeedleId(99), Offset::from_actual_offset(128), Size(50))
+            .unwrap();
+        nm.checkpoint(true).unwrap();
+        nm.close();
+        drop(nm);
+
+        // idx on disk is two entries; stored idx_size is two entries.
+        // Shrink the .idx so try_reuse_rdb rejects (stored > idx) and
+        // full_rebuild runs. Key 99 must not survive.
+        {
+            let f = std::fs::OpenOptions::new()
+                .write(true)
+                .open(&idx_path)
+                .unwrap();
+            f.set_len(NEEDLE_MAP_ENTRY_SIZE as u64).unwrap();
+        }
+
+        let mut idx = std::fs::File::open(&idx_path).unwrap();
+        let reloaded = RedbNeedleMap::load_from_idx(
+            db_path.to_str().unwrap(),
+            &mut idx,
+            Version::current(),
+            redb_test_cache(),
+        )
+        .unwrap();
+        assert!(reloaded.get(NeedleId(1)).unwrap().is_some());
+        assert!(
+            reloaded.get(NeedleId(99)).unwrap().is_none(),
+            "full_rebuild must not keep keys that are not in the .idx"
+        );
     }
 
     #[test]

--- a/seaweed-volume/src/storage/needle_map.rs
+++ b/seaweed-volume/src/storage/needle_map.rs
@@ -1031,10 +1031,7 @@ impl RedbNeedleMap {
             })?;
             let key_u64: u64 = key_guard.value();
             let bytes: &[u8] = val_guard.value();
-            if bytes.len() == PACKED_NEEDLE_VALUE_SIZE {
-                let mut arr = [0u8; PACKED_NEEDLE_VALUE_SIZE];
-                arr.copy_from_slice(bytes);
-                let nv = unpack_needle_value(&arr);
+            if let Some(nv) = packed_to_needle_value(bytes) {
                 if nv.size.is_valid() {
                     idx::write_index_entry(&mut file, NeedleId(key_u64), nv.offset, nv.size)?;
                 }
@@ -1062,10 +1059,7 @@ impl RedbNeedleMap {
             let (key_guard, val_guard) = entry.map_err(|e| format!("redb iter next: {}", e))?;
             let key_u64: u64 = key_guard.value();
             let bytes: &[u8] = val_guard.value();
-            if bytes.len() == PACKED_NEEDLE_VALUE_SIZE {
-                let mut arr = [0u8; PACKED_NEEDLE_VALUE_SIZE];
-                arr.copy_from_slice(bytes);
-                let nv = unpack_needle_value(&arr);
+            if let Some(nv) = packed_to_needle_value(bytes) {
                 f(NeedleId(key_u64), &nv)?;
             }
         }
@@ -1090,10 +1084,7 @@ impl RedbNeedleMap {
                 entry.map_err(|e| io::Error::other(format!("redb entry: {e}")))?;
             let key_u64: u64 = key_guard.value();
             let bytes: &[u8] = val_guard.value();
-            if bytes.len() == PACKED_NEEDLE_VALUE_SIZE {
-                let mut arr = [0u8; PACKED_NEEDLE_VALUE_SIZE];
-                arr.copy_from_slice(bytes);
-                let nv = unpack_needle_value(&arr);
+            if let Some(nv) = packed_to_needle_value(bytes) {
                 result.push((NeedleId(key_u64), nv));
             }
         }

--- a/seaweed-volume/src/storage/needle_map.rs
+++ b/seaweed-volume/src/storage/needle_map.rs
@@ -8,7 +8,7 @@
 //! Loaded from .idx file on volume mount. Supports Get, Put, Delete with
 //! metrics tracking (file count, byte count, deleted count, deleted bytes).
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::io::{self, Read, Seek, Write};
 use std::path::Path;
 use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
@@ -707,12 +707,13 @@ impl RedbNeedleMap {
         }
     }
 
-    /// Full rebuild: unlink any existing .rdb and rebuild from the entire .idx.
+    /// Full rebuild: prefer a fresh `.rdb`, then rebuild from the entire `.idx`.
     ///
     /// `Database::create` opens an existing file (`truncate(false)`). Unlink
-    /// must succeed (or the path must be absent) so the needles table is empty
-    /// before we insert. Inserts are in needle-id order so redb 4.2.0 packs
-    /// leaves.
+    /// is best-effort: if it fails (sticky bit, foreign owner) but the path is
+    /// still writable, clear the leftover needles table before inserting.
+    /// Live keys come from a `BTreeMap` so inserts are in needle-id order and
+    /// redb 4.2.0 packs leaves, without a second Vec + sort scratch.
     fn full_rebuild<R: Read + Seek>(
         db_path: &str,
         reader: &mut R,
@@ -720,11 +721,14 @@ impl RedbNeedleMap {
         version: Version,
         cache_bytes: usize,
     ) -> io::Result<Self> {
-        match std::fs::remove_file(db_path) {
-            Ok(()) => {}
-            Err(e) if e.kind() == io::ErrorKind::NotFound => {}
-            Err(e) => return Err(e),
-        }
+        let unlinked = match std::fs::remove_file(db_path) {
+            Ok(()) => true,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => true,
+            Err(e) => {
+                tracing::warn!("redb unlink before rebuild failed: {}", e);
+                false
+            }
+        };
 
         let mut nm = match RedbNeedleMap::new(db_path, cache_bytes) {
             Ok(nm) => nm,
@@ -735,29 +739,32 @@ impl RedbNeedleMap {
         };
 
         let result = (|| -> io::Result<()> {
-            let mut entries: HashMap<NeedleId, Option<NeedleValue>> = HashMap::new();
+            // Seek independently of walk_index_file. Run before the write txn
+            // so a metric-read error does not unlink a committed rebuild.
+            nm.metric = metrics_from_idx(reader, version)?;
+
+            let mut entries: BTreeMap<NeedleId, NeedleValue> = BTreeMap::new();
             idx::walk_index_file(reader, 0, |key, offset, size| {
                 if offset.is_zero() || size.is_deleted() {
-                    entries.insert(key, None);
+                    entries.remove(&key);
                 } else {
-                    entries.insert(key, Some(NeedleValue { offset, size }));
+                    entries.insert(key, NeedleValue { offset, size });
                 }
                 Ok(())
             })?;
-
-            let mut live: Vec<(NeedleId, NeedleValue)> = entries
-                .into_iter()
-                .filter_map(|(k, v)| v.map(|nv| (k, nv)))
-                .collect();
-            live.sort_by_key(|(k, _)| *k);
 
             let txn = Self::begin_write_no_fsync(&nm.db)?;
             {
                 let mut table = txn.open_table(NEEDLE_TABLE).map_err(|e| {
                     io::Error::new(io::ErrorKind::Other, format!("redb open_table: {}", e))
                 })?;
+                if !unlinked {
+                    table.retain(|_, _| false).map_err(|e| {
+                        io::Error::new(io::ErrorKind::Other, format!("redb retain: {}", e))
+                    })?;
+                }
 
-                for (key, nv) in &live {
+                for (key, nv) in &entries {
                     let key_u64: u64 = (*key).into();
                     let packed = pack_needle_value(nv);
                     table.insert(key_u64, packed.as_slice()).map_err(|e| {
@@ -769,7 +776,6 @@ impl RedbNeedleMap {
                 .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("redb commit: {}", e)))?;
 
             nm.save_idx_size_meta(idx_size)?;
-            nm.metric = metrics_from_idx(reader, version)?;
             Ok(())
         })();
 


### PR DESCRIPTION
> **Stacked on #11202 (2/4).** This branch builds on that PR's sorted rebuild, so the diff here shows both commits until #11202 merges; only the put/delete transaction commit is new. I'll rebase once #11202 lands.

## What

`put` uses `Table::insert()`'s previous value instead of a separate read transaction. `delete` gets then inserts the tombstone in the same write transaction. Truncate the `.idx` row on any failed redb write after the append.

## Why

Each put and each live delete opened a read transaction (`get_internal`) and then a write transaction. That is an extra btree walk and an extra txn per needle. redb 4.2.0 `Table::insert()` already returns the old value. `Table::entry()` is not used: in 4.2.0 `OccupiedEntry` stores only the key and `get()`/`insert()` walk the tree again.

A failed `begin_write` after the `.idx` append used to leave an orphan row; only `commit` failure truncated.

## How

- `packed_to_needle_value` length-checks before unpack so a corrupt blob is `None`, not a panic. `get_internal` and `get_via_table` share it.
- `put`: append `.idx` first, then one `Durability::None` write txn; previous row comes from `insert()`; any redb error after the append truncates.
- `delete`: open the write txn first, `table.get` + `table.insert` of the negated-size tombstone. Missing / already-deleted / wrong-length keys abort with no `.idx` write. Live delete still writes the `.idx` tombstone before the table mutation; insert/commit failure truncates.
- `idx_file_offset` and `writes_since_checkpoint` still advance only after a successful commit.

## Tests

- `test_redb_put_overwrite_metrics_without_prior_get`: overwrite metrics without a prior `get`.
- `test_redb_delete_wrong_length_value_is_absent_not_panic`: a 2-byte value deletes as `None` with no counter bump.
- Existing put/delete/double-delete/checkpoint tests still pass.
- `cd seaweed-volume && cargo test --lib -- needle_map -- --test-threads=1`: 56 passed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs/pull/11204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved storage consistency when updating or deleting entries.
  - Rebuilds now correctly reflect the latest index state, including removing entries no longer present.
  - Invalid stored values are handled safely instead of causing incorrect deletion behavior.
  - Updated metrics now remain accurate after overwriting entries.

- **Reliability**
  - Rebuild failures no longer leave behind potentially corrupted partial databases.
  - Rebuild processing is now deterministic, improving recovery and data integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->