### PR TITLE
rust volume: optional redb insert_before bulk load

### DIFF
--- a/.github/workflows/rust-volume-server-tests.yml
+++ b/.github/workflows/rust-volume-server-tests.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Run Rust unit tests
         run: cd seaweed-volume && cargo test
 
+      - name: Run Rust unit tests (redb experimental cursor)
+        run: cd seaweed-volume && cargo test --features redb-experimental-cursor
+
   rust-integration-tests:
     name: Rust Integration Tests
     runs-on: ubuntu-22.04

--- a/.github/workflows/rust-volume-server-tests.yml
+++ b/.github/workflows/rust-volume-server-tests.yml
@@ -63,7 +63,7 @@ jobs:
         run: cd seaweed-volume && cargo test
 
       - name: Run Rust unit tests (redb experimental cursor)
-        run: cd seaweed-volume && cargo test --features redb-experimental-cursor
+        run: cd seaweed-volume && cargo test --features redb-experimental-cursor --lib storage::needle_map
 
   rust-integration-tests:
     name: Rust Integration Tests

--- a/seaweed-volume/Cargo.toml
+++ b/seaweed-volume/Cargo.toml
@@ -16,6 +16,9 @@ path = "src/main.rs"
 # Disable with --no-default-features for 4-byte offsets (32GB max volume size).
 default = ["5bytes"]
 5bytes = []
+# Unstable redb cursor bulk-load for full_rebuild. Off in production.
+# Pulls redb's experimental_cursor (and therefore experimental-api-5).
+redb-experimental-cursor = ["redb/experimental_cursor"]
 
 [dependencies]
 # Async runtime

--- a/seaweed-volume/src/storage/needle_map.rs
+++ b/seaweed-volume/src/storage/needle_map.rs
@@ -489,13 +489,16 @@ impl RedbNeedleMap {
     /// much of the .idx the table reflects, so a reload replays only the
     /// tail appended after it. When `sync_idx` is true the .idx is fsynced
     /// first (see [`checkpoint`](Self::checkpoint)).
+    /// Durable commit uses `set_quick_repair(true)` so the next open after a
+    /// crash does not scan the whole file.
     fn begin_checkpoint(&self, sync_idx: bool) -> io::Result<redb::WriteTransaction> {
         if sync_idx {
             self.sync()?;
         }
-        let txn = self.db.begin_write().map_err(|e| {
+        let mut txn = self.db.begin_write().map_err(|e| {
             io::Error::new(io::ErrorKind::Other, format!("redb begin_write: {}", e))
         })?;
+        txn.set_quick_repair(true);
         if self.idx_file.is_some() {
             let mut meta = txn.open_table(META_TABLE).map_err(|e| {
                 io::Error::new(io::ErrorKind::Other, format!("redb open meta: {}", e))

--- a/seaweed-volume/src/storage/needle_map.rs
+++ b/seaweed-volume/src/storage/needle_map.rs
@@ -13,6 +13,9 @@ use std::io::{self, Read, Seek, Write};
 use std::path::Path;
 use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 
+#[cfg(feature = "redb-experimental-cursor")]
+use std::ops::Bound;
+
 mod compact_map;
 pub mod file_pool;
 mod idx_metric;
@@ -570,14 +573,18 @@ impl RedbNeedleMap {
         let meta = txn
             .open_table(META_TABLE)
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("redb open meta: {}", e)))?;
-        match meta.get(META_IDX_SIZE) {
+        // experimental-api-5 drops inherent ReadOnlyTable::get ('static guard).
+        // ReadableTable::get guard borrows `meta`; bind the match so the
+        // temporary Result is dropped before `meta`.
+        let result = match meta.get(META_IDX_SIZE) {
             Ok(Some(guard)) => Ok(Some(guard.value())),
             Ok(None) => Ok(None),
             Err(e) => Err(io::Error::new(
                 io::ErrorKind::Other,
                 format!("redb get meta: {}", e),
             )),
-        }
+        };
+        result
     }
 
     /// Load from an .idx file, reusing an existing .rdb if it is consistent.
@@ -767,11 +774,38 @@ impl RedbNeedleMap {
                     })?;
                 }
 
-                for (key, nv) in &entries {
-                    let key_u64: u64 = (*key).into();
-                    let packed = pack_needle_value(nv);
-                    table.insert(key_u64, packed.as_slice()).map_err(|e| {
-                        io::Error::new(io::ErrorKind::Other, format!("redb insert: {}", e))
+                #[cfg(not(feature = "redb-experimental-cursor"))]
+                {
+                    for (key, nv) in &entries {
+                        let key_u64: u64 = (*key).into();
+                        let packed = pack_needle_value(nv);
+                        table.insert(key_u64, packed.as_slice()).map_err(|e| {
+                            io::Error::new(io::ErrorKind::Other, format!("redb insert: {}", e))
+                        })?;
+                    }
+                }
+                #[cfg(feature = "redb-experimental-cursor")]
+                {
+                    let mut cursor = table
+                        .upper_bound_mut(Bound::<u64>::Unbounded)
+                        .map_err(|e| {
+                            io::Error::new(
+                                io::ErrorKind::Other,
+                                format!("redb upper_bound_mut: {}", e),
+                            )
+                        })?;
+                    for (key, nv) in &entries {
+                        let key_u64: u64 = (*key).into();
+                        let packed = pack_needle_value(nv);
+                        cursor.insert_before(key_u64, packed.as_slice()).map_err(|e| {
+                            io::Error::new(
+                                io::ErrorKind::Other,
+                                format!("redb insert_before: {}", e),
+                            )
+                        })?;
+                    }
+                    cursor.close().map_err(|e| {
+                        io::Error::new(io::ErrorKind::Other, format!("redb cursor close: {}", e))
                     })?;
                 }
             }
@@ -867,14 +901,18 @@ impl RedbNeedleMap {
         let table = txn
             .open_table(NEEDLE_TABLE)
             .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("redb open_table: {}", e)))?;
-        match table.get(key_u64) {
+        // experimental-api-5 drops inherent ReadOnlyTable::get ('static guard).
+        // ReadableTable::get guard borrows `table`; bind the match so the
+        // temporary Result is dropped before `table`.
+        let result = match table.get(key_u64) {
             Ok(Some(guard)) => Ok(packed_to_needle_value(guard.value())),
             Ok(None) => Ok(None),
             Err(e) => Err(io::Error::new(
                 io::ErrorKind::Other,
                 format!("redb get: {}", e),
             )),
-        }
+        };
+        result
     }
 
     /// Mark a needle as deleted. Appends tombstone to .idx file, negates size in redb.
@@ -1613,6 +1651,27 @@ mod tests {
             reloaded.get(NeedleId(99)).unwrap().is_none(),
             "full_rebuild must not keep keys that are not in the .idx"
         );
+    }
+
+    #[cfg(feature = "redb-experimental-cursor")]
+    #[test]
+    fn test_redb_full_rebuild_insert_before_matches_shuffled_live_set() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.rdb");
+        let idx_data = shuffled_idx_with_overwrite_and_delete();
+        let mut cursor = Cursor::new(idx_data);
+        let nm = RedbNeedleMap::load_from_idx(
+            db_path.to_str().unwrap(),
+            &mut cursor,
+            Version::current(),
+            redb_test_cache(),
+        )
+        .unwrap();
+        let v10 = nm.get(NeedleId(10)).unwrap().unwrap();
+        assert_eq!(v10.size, Size(100));
+        let v1 = nm.get(NeedleId(1)).unwrap().unwrap();
+        assert_eq!(v1.size, Size(200));
+        assert!(nm.get(NeedleId(5)).unwrap().is_none());
     }
 
     #[test]

--- a/seaweed-volume/src/storage/needle_map.rs
+++ b/seaweed-volume/src/storage/needle_map.rs
@@ -1655,10 +1655,37 @@ mod tests {
 
     #[cfg(feature = "redb-experimental-cursor")]
     #[test]
-    fn test_redb_full_rebuild_insert_before_matches_shuffled_live_set() {
+    fn test_redb_full_rebuild_insert_before_reads_back_thousands_of_shuffled_keys() {
+        // Enough keys to split leaves. insert_before vs table.insert only
+        // diverges across page boundaries (pending-insert buffer / close).
+        const N: u64 = 4000;
+        let mut idx_data = Vec::new();
+        for i in (1..=N).rev() {
+            idx::write_index_entry(
+                &mut idx_data,
+                NeedleId(i),
+                Offset::from_actual_offset((8 * i) as i64),
+                Size(i as i32),
+            )
+            .unwrap();
+        }
+        idx::write_index_entry(
+            &mut idx_data,
+            NeedleId(1),
+            Offset::from_actual_offset(200),
+            Size(200),
+        )
+        .unwrap();
+        idx::write_index_entry(
+            &mut idx_data,
+            NeedleId(2),
+            Offset::default(),
+            TOMBSTONE_FILE_SIZE,
+        )
+        .unwrap();
+
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("test.rdb");
-        let idx_data = shuffled_idx_with_overwrite_and_delete();
         let mut cursor = Cursor::new(idx_data);
         let nm = RedbNeedleMap::load_from_idx(
             db_path.to_str().unwrap(),
@@ -1667,11 +1694,24 @@ mod tests {
             redb_test_cache(),
         )
         .unwrap();
-        let v10 = nm.get(NeedleId(10)).unwrap().unwrap();
-        assert_eq!(v10.size, Size(100));
+
         let v1 = nm.get(NeedleId(1)).unwrap().unwrap();
         assert_eq!(v1.size, Size(200));
-        assert!(nm.get(NeedleId(5)).unwrap().is_none());
+        assert_eq!(v1.offset, Offset::from_actual_offset(200));
+        assert!(nm.get(NeedleId(2)).unwrap().is_none());
+        let v_n = nm.get(NeedleId(N)).unwrap().unwrap();
+        assert_eq!(v_n.size, Size(N as i32));
+        let v3 = nm.get(NeedleId(3)).unwrap().unwrap();
+        assert_eq!(v3.size, Size(3));
+        assert_eq!(v3.offset, Offset::from_actual_offset(24));
+
+        let mut live = 0u64;
+        nm.ascending_visit(|_, _| {
+            live += 1;
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(live, N - 1);
     }
 
     #[test]


### PR DESCRIPTION
> **Stacked on #11203 (4/4).** This branch builds on the quick-repair change, so the diff here shows the full stack until that PR merges; only the `insert_before` commit is new. I'll rebase once #11203 lands.

## What

Behind a default-off cargo feature `redb-experimental-cursor`, `full_rebuild` bulk-loads with redb's experimental `CursorMut::insert_before`. The production binary stays on sorted `table.insert()`. CI unit tests run both feature settings.

## Why

redb 4.2.0 can pack even tighter with `insert_before` on an empty table, but the API is gated on `experimental_cursor` (and therefore `experimental-api-5`). That should not ship in the default volume-server binary.

## How

- `seaweed-volume` feature `redb-experimental-cursor = ["redb/experimental_cursor"]` is not in `default`.
- Default `full_rebuild` still inserts live keys in needle-id order via `table.insert()`.
- With the feature: `upper_bound_mut(Unbounded)` then ascending `insert_before`, then `close()`. `UnorderedKey` fails the rebuild (no `insert()` fallback); the existing error path drops the map and unlinks the `.rdb`.
- `experimental-api-5` drops inherent `'static ReadOnlyTable::get`. Lookups keep using `ReadableTable::get`; the match result is bound so the guard does not outlive the table. Lookup semantics are unchanged.
- CI: `rust-unit-tests` runs `cargo test` and `cargo test --features redb-experimental-cursor`. No `--features` on any `cargo build --release`.

## Tests

- Default: `cd seaweed-volume && cargo test --lib -- needle_map -- --test-threads=1` — 56 passed (cfg test compiled out).
- Feature on: `cargo test --lib --features redb-experimental-cursor -- needle_map -- --test-threads=1` — 57 passed, including `test_redb_full_rebuild_insert_before_matches_shuffled_live_set`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs/pull/11205" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved storage rebuild behavior, including correct handling of overwritten and deleted records.
  - Improved recovery when storage files are missing or rebuild operations encounter errors.
  - Fixed update and delete handling for invalid or mismatched stored values.
  - Improved checkpoint repair behavior for durable commits.

- **Tests**
  - Added coverage for rebuild consistency, cursor-based processing, overwrite metrics, and invalid deletion scenarios.
  - Added automated testing for the experimental cursor configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->