### PR TITLE
topology: fix fatal concurrent map read/write on VolumeLayout.crowded

### DIFF
--- a/weed/topology/crowded_writable_test.go
+++ b/weed/topology/crowded_writable_test.go
@@ -1,6 +1,7 @@
 package topology
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -72,4 +73,53 @@ func TestCrowdedCountStillMatchesWritables(t *testing.T) {
 	if writable != 1 || crowded != 1 {
 		t.Errorf("writable=%d crowded=%d, want 1 and 1", writable, crowded)
 	}
+}
+
+// SetVolumeCrowded mutates the crowded map while GetWritableVolumeCount reads
+// it on the Assign hot path. Under RLock both could run at once and the Go
+// runtime aborts with "concurrent map read and map write". Run with -race to
+// reproduce the original bug; the write lock makes this pass.
+func TestSetVolumeCrowdedNoRaceWithGetWritableVolumeCount(t *testing.T) {
+	rp, _ := super_block.NewReplicaPlacementFromString("000")
+	vl := NewVolumeLayout(rp, needle.EMPTY_TTL, types.HardDriveType, 10000, false)
+	// GetWritableVolumeCount iterates vl.writables, so give it something to
+	// read while the crowded map is being mutated.
+	vl.writables = []needle.VolumeId{1, 2, 3}
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					vl.SetVolumeCrowded(needle.VolumeId(2))
+				}
+			}
+		}()
+	}
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					vl.GetWritableVolumeCount()
+				}
+			}
+		}()
+	}
+
+	// The race detector needs only a brief window to flag a concurrent
+	// map read/write; let the goroutines hammer the lock briefly.
+	time.Sleep(50 * time.Millisecond)
+	close(stop)
+	wg.Wait()
 }

--- a/weed/topology/volume_layout.go
+++ b/weed/topology/volume_layout.go
@@ -1066,11 +1066,14 @@ func (vl *VolumeLayout) setVolumeCrowded(vid needle.VolumeId) {
 }
 
 func (vl *VolumeLayout) SetVolumeCrowded(vid needle.VolumeId) {
-	// since delete is guarded by accessLock.Lock(),
-	// and is always called in sequential order,
-	// RLock() should be safe enough
-	vl.accessLock.RLock()
-	defer vl.accessLock.RUnlock()
+	// setVolumeCrowded mutates the crowded map, and GetWritableVolumeCount
+	// reads it under RLock on the Assign hot path. Two concurrent RLock
+	// holders with one writing the map triggers a fatal
+	// "concurrent map read and map write". Take the write lock: this path
+	// is a low-frequency single consumer driven by the crowded-volume
+	// event loop, and every other mutation of crowded already holds Lock().
+	vl.accessLock.Lock()
+	defer vl.accessLock.Unlock()
 
 	vl.setVolumeCrowded(vid)
 }


### PR DESCRIPTION
## Summary

`VolumeLayout.SetVolumeCrowded` mutated the `crowded` map while holding only `accessLock.RLock()`. `GetWritableVolumeCount` — called on the Assign hot path — reads the same map under `RLock()`. Two concurrent `RLock` holders, one writing a map another is reading, triggers a fatal `concurrent map read and map write` that kills the master process. Unlike a panic, a fatal error cannot be recovered, so the master is down until restarted.

The write-under-`RLock` was an intentional bet (noted in the old comment) that held until #10522 added a per-vid read of `vl.crowded` inside `GetWritableVolumeCount`, turning the assumption into a live race on the Assign path.

### Fix

Give the event path the write lock:

```go
func (vl *VolumeLayout) SetVolumeCrowded(vid needle.VolumeId) {
    vl.accessLock.Lock()
    defer vl.accessLock.Unlock()
    vl.setVolumeCrowded(vid)
}
```

This path is a low-frequency single consumer driven by the crowded-volume event loop (`chanCrowdedVolumes` -> `Topology.SetVolumeCrowded`), and every other mutation of `writables`/`crowded` already holds `Lock()`. `setVolumeCrowded` takes no nested locks, so there is no deadlock path. The hot readers (`GetWritableVolumeCount`, `CloneWritableVolumes`) keep using `RLock`.

### Regression test

`TestSetVolumeCrowdedNoRaceWithGetWritableVolumeCount` runs concurrent `SetVolumeCrowded` against `GetWritableVolumeCount`. With `-race` it fails (race detected) on the old `RLock` and passes with the write lock.

#### Test plan
- [x] `go test -race -run 'TestSetVolumeCrowdedNoRaceWithGetWritableVolumeCount|TestCrowdedCountStillMatchesWritables|TestCrowdedVolumesAreOnesThatCanTakeWrites' ./weed/topology/` passes
- [x] `go test -race ./weed/topology/` passes
- [x] Reverting the fix to `RLock` makes the new test fail with `race detected`

Fixes #11211
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs/pull/11216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when volume crowding updates occur concurrently with writable-volume count checks.
  * Prevented potential runtime failures caused by concurrent access during topology updates.

* **Tests**
  * Added coverage for concurrent volume crowding and writable-volume count operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->