### PR TITLE
iam: bind CreateServiceAccount ParentUser to the caller

### DIFF
--- a/weed/s3api/s3api_embedded_iam.go
+++ b/weed/s3api/s3api_embedded_iam.go
@@ -2485,6 +2485,17 @@ func iamRequiresSelfTarget(action string) bool {
 	return iamSelfTargetActions[action]
 }
 
+// iamTargetUserName returns the request's target identity for authorization.
+// Most IAM actions target UserName; CreateServiceAccount targets ParentUser.
+// Both IAM dispatch surfaces (AuthIamManagement and UnifiedPostHandler) use
+// this so the authorized target and the acted-on target cannot differ.
+func iamTargetUserName(action string, r *http.Request) string {
+	if action == "CreateServiceAccount" {
+		return r.PostForm.Get("ParentUser")
+	}
+	return r.PostForm.Get("UserName")
+}
+
 // AuthorizeIamAction authorizes an IAM management action for identity, with
 // targetUserName taken from the request's target parameter (UserName, or
 // ParentUser for CreateServiceAccount).
@@ -2548,13 +2559,8 @@ func (iam *IdentityAccessManagement) AuthIamManagement(f http.HandlerFunc) http.
 
 		// UserName comes from the body only, the same place the handlers read it
 		// from, so the authorized target and the acted-on target cannot differ.
-		// CreateServiceAccount targets ParentUser instead of UserName.
 		action := r.Form.Get("Action")
-		target := r.PostForm.Get("UserName")
-		if action == "CreateServiceAccount" {
-			target = r.PostForm.Get("ParentUser")
-		}
-		if errCode := iam.AuthorizeIamAction(r, identity, action, target); errCode != s3err.ErrNone {
+		if errCode := iam.AuthorizeIamAction(r, identity, action, iamTargetUserName(action, r)); errCode != s3err.ErrNone {
 			s3err.WriteErrorResponse(w, r, errCode)
 			return
 		}

--- a/weed/s3api/s3api_embedded_iam.go
+++ b/weed/s3api/s3api_embedded_iam.go
@@ -2474,8 +2474,20 @@ func iamRequiresAdminForOthers(action string) bool {
 	return iamSelfServiceActions[action]
 }
 
+// iamSelfTargetActions require an explicit iam:<Action> grant, but a non-admin
+// grant holder may only target their own identity. The target parameter is
+// action-specific (UserName for most, ParentUser for CreateServiceAccount).
+var iamSelfTargetActions = map[string]bool{
+	"CreateServiceAccount": true,
+}
+
+func iamRequiresSelfTarget(action string) bool {
+	return iamSelfTargetActions[action]
+}
+
 // AuthorizeIamAction authorizes an IAM management action for identity, with
-// targetUserName taken from the request's UserName parameter.
+// targetUserName taken from the request's target parameter (UserName, or
+// ParentUser for CreateServiceAccount).
 //
 // IAM management is not part of the S3 data plane, so the grant is checked as
 // iam:<Action>. A coarse S3 action would instead be matched by an ordinary
@@ -2496,7 +2508,13 @@ func (iam *IdentityAccessManagement) AuthorizeIamAction(r *http.Request, identit
 	if identity.isAdmin() {
 		return s3err.ErrNone
 	}
-	return iam.VerifyActionPermission(r, identity, Action("iam:"+action), "arn:aws:iam:::*", "")
+	if errCode := iam.VerifyActionPermission(r, identity, Action("iam:"+action), "arn:aws:iam:::*", ""); errCode != s3err.ErrNone {
+		return errCode
+	}
+	if iamRequiresSelfTarget(action) && targetUserName != "" && targetUserName != identity.Name {
+		return s3err.ErrAccessDenied
+	}
+	return s3err.ErrNone
 }
 
 // AuthIamManagement authenticates an IAM management request and authorizes the

--- a/weed/s3api/s3api_embedded_iam.go
+++ b/weed/s3api/s3api_embedded_iam.go
@@ -2548,7 +2548,13 @@ func (iam *IdentityAccessManagement) AuthIamManagement(f http.HandlerFunc) http.
 
 		// UserName comes from the body only, the same place the handlers read it
 		// from, so the authorized target and the acted-on target cannot differ.
-		if errCode := iam.AuthorizeIamAction(r, identity, r.Form.Get("Action"), r.PostForm.Get("UserName")); errCode != s3err.ErrNone {
+		// CreateServiceAccount targets ParentUser instead of UserName.
+		action := r.Form.Get("Action")
+		target := r.PostForm.Get("UserName")
+		if action == "CreateServiceAccount" {
+			target = r.PostForm.Get("ParentUser")
+		}
+		if errCode := iam.AuthorizeIamAction(r, identity, action, target); errCode != s3err.ErrNone {
 			s3err.WriteErrorResponse(w, r, errCode)
 			return
 		}

--- a/weed/s3api/s3api_embedded_iam_authz_test.go
+++ b/weed/s3api/s3api_embedded_iam_authz_test.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	dataPlanePolicy = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:*","Resource":"*"}]}`
-	iamAdminPolicy  = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"iam:*","Resource":"*"}]}`
+	dataPlanePolicy        = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:*","Resource":"*"}]}`
+	iamAdminPolicy         = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"iam:*","Resource":"*"}]}`
+	iamCreateSvcAcctPolicy = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["iam:CreateServiceAccount"],"Resource":["*"]}]}`
 )
 
 func newIamAuthzTestIam(t *testing.T) *IdentityAccessManagement {
@@ -92,4 +93,24 @@ func TestAuthorizeIamActionDeniesAnonymous(t *testing.T) {
 		iam.AuthorizeIamAction(iamPostRequest(""), anonymous, "CreateAccessKey", ""))
 	assert.Equal(t, s3err.ErrAccessDenied,
 		iam.AuthorizeIamAction(iamPostRequest(""), anonymous, "CreateUser", "victim"))
+}
+
+// CreateServiceAccount takes its target from the ParentUser parameter, not
+// UserName. A non-admin holding only iam:CreateServiceAccount must not be able
+// to mint a service account for another identity (privilege escalation to that
+// identity's permissions).
+func TestAuthorizeIamActionCreateServiceAccountBindsTargetToCaller(t *testing.T) {
+	iam := newIamAuthzTestIam(t)
+	require.NoError(t, iam.PutPolicy("CreateSvcAcctPolicy", iamCreateSvcAcctPolicy))
+	dev := &Identity{Name: "dev", PolicyNames: []string{"CreateSvcAcctPolicy"}}
+	admin := &Identity{Name: "admin", Actions: []Action{s3_constants.ACTION_ADMIN}}
+
+	assert.Equal(t, s3err.ErrNone,
+		iam.AuthorizeIamAction(iamPostRequest(""), dev, "CreateServiceAccount", "dev"))
+	assert.Equal(t, s3err.ErrNone,
+		iam.AuthorizeIamAction(iamPostRequest(""), dev, "CreateServiceAccount", ""))
+	assert.Equal(t, s3err.ErrAccessDenied,
+		iam.AuthorizeIamAction(iamPostRequest(""), dev, "CreateServiceAccount", "admin"))
+	assert.Equal(t, s3err.ErrNone,
+		iam.AuthorizeIamAction(iamPostRequest(""), admin, "CreateServiceAccount", "victim"))
 }

--- a/weed/s3api/s3api_server.go
+++ b/weed/s3api/s3api_server.go
@@ -742,7 +742,7 @@ func (s3a *S3ApiServer) UnifiedPostHandler(w http.ResponseWriter, r *http.Reques
 
 		// UserName comes from the body only, the same place DoActions reads it
 		// from, so the authorized target and the acted-on target cannot differ.
-		if s3a.iam.AuthorizeIamAction(r, identity, action, r.PostForm.Get("UserName")) != s3err.ErrNone {
+		if s3a.iam.AuthorizeIamAction(r, identity, action, iamTargetUserName(action, r)) != s3err.ErrNone {
 			s3err.WriteErrorResponse(w, r, s3err.ErrAccessDenied)
 			return
 		}

--- a/weed/s3api/s3api_server_routing_test.go
+++ b/weed/s3api/s3api_server_routing_test.go
@@ -205,6 +205,72 @@ func TestRouting_AuthenticatedIAM(t *testing.T) {
 	assert.Contains(t, []int{http.StatusBadRequest, http.StatusForbidden}, rr.Code, "Should route to IAM handler (400/403 due to invalid signature)")
 }
 
+// setupRoutingTestServerWithCreator seeds a non-admin identity (creator) that
+// holds only the iam:CreateServiceAccount action, plus a victim identity, so a
+// SigV4-signed CreateServiceAccount request can exercise UnifiedPostHandler's
+// authorization against the ParentUser target.
+func setupRoutingTestServerWithCreator(t *testing.T) *S3ApiServer {
+	s3a := setupRoutingTestServer(t)
+	const creatorAK, creatorSK = "creator-ak", "creator-sk"
+	creator := &Identity{
+		Name:     "creator",
+		Actions:  []Action{Action("iam:CreateServiceAccount")},
+		IsStatic: true,
+		Credentials: []*Credential{{
+			AccessKey: creatorAK,
+			SecretKey: creatorSK,
+		}},
+	}
+	victim := &Identity{Name: "victim", IsStatic: true}
+	s3a.iam.m.Lock()
+	s3a.iam.identities = append(s3a.iam.identities, creator, victim)
+	s3a.iam.accessKeyIdent[creatorAK] = creator
+	s3a.iam.nameToIdentity["creator"] = creator
+	s3a.iam.nameToIdentity["victim"] = victim
+	s3a.iam.m.Unlock()
+	s3a.cb = NewCircuitBreaker(s3a.option)
+	return s3a
+}
+
+// TestRouting_CreateServiceAccountBindsParentUser verifies that on the S3-port
+// IAM route a non-admin holding iam:CreateServiceAccount cannot mint a service
+// account for another identity (ParentUser=victim), and can for itself.
+func TestRouting_CreateServiceAccountBindsParentUser(t *testing.T) {
+	router := mux.NewRouter()
+	s3a := setupRoutingTestServerWithCreator(t)
+	s3a.registerRouter(router)
+
+	signCreator := func(t *testing.T, req *http.Request, body string) {
+		t.Helper()
+		creds := credentials.NewStaticCredentials("creator-ak", "creator-sk", "")
+		if _, err := v4.NewSigner(creds).Sign(req, strings.NewReader(body), "iam", "us-east-1", time.Now()); err != nil {
+			t.Fatalf("sign request: %v", err)
+		}
+	}
+
+	makeReq := func(parentUser string) *http.Request {
+		data := url.Values{}
+		data.Set("Action", "CreateServiceAccount")
+		data.Set("Version", "2010-05-08")
+		data.Set("ParentUser", parentUser)
+		body := data.Encode()
+		req, _ := http.NewRequest("POST", "http://localhost/", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		signCreator(t, req, body)
+		return req
+	}
+
+	// Targeting another identity must be denied at authorization.
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, makeReq("victim"))
+	assert.Equal(t, http.StatusForbidden, rr.Code, "cross-identity ParentUser must be denied; got body=%s", rr.Body.String())
+
+	// Targeting self must pass authorization (handler may still error, but not 403).
+	rr2 := httptest.NewRecorder()
+	router.ServeHTTP(rr2, makeReq("creator"))
+	assert.NotEqual(t, http.StatusForbidden, rr2.Code, "self ParentUser must pass authorization; got body=%s", rr2.Body.String())
+}
+
 // TestRouting_IAMMatcherLogic verifies the iamMatcher correctly distinguishes auth types
 func TestRouting_IAMMatcherLogic(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary
- `CreateServiceAccount` accepted a client-controlled `ParentUser` and only checked the caller held `iam:CreateServiceAccount`, never that the target matched the caller. A non-admin with that single grant could mint a service account for any identity (including admin) and authenticate as it.
- `AuthorizeIamAction` now treats `CreateServiceAccount` as a self-target action: a granted non-admin may only target its own identity (or omit the target); admins remain unrestricted.
- `AuthIamManagement` now authorizes `CreateServiceAccount` against its `ParentUser` parameter (not `UserName`), so the binding applies on the live request path.

Addresses GHSA-f6rh-hw92-h9rx.

#### Test plan
- [x] `go test ./weed/s3api/...`
- [x] New regression test `TestAuthorizeIamActionCreateServiceAccountBindsTargetToCaller` (fails before the fix, passes after)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs/pull/11218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Restricted service-account creation so non-administrators can create accounts only for themselves.
  - Prevented requests from bypassing authorization by specifying a different target identity.
  - Preserved administrator access to create service accounts for other identities.

- **Tests**
  - Added coverage for self-target authorization and request routing, including denied cross-identity attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->