### PR TITLE
release: wait for Go proxy propagation

### DIFF
--- a/.github/workflows/release_version_bump.yml
+++ b/.github/workflows/release_version_bump.yml
@@ -206,8 +206,9 @@ jobs:
 
           # The dispatched workflow pins seaweedfs with `go get -u ...@latest`, so
           # wait until the proxy serves the release commit as the tip. Asking for
-          # the commit by name is what makes the proxy fetch it.
-          for _ in $(seq 30); do
+          # the commit by name is what makes the proxy fetch it. The proxy can
+          # take longer than five minutes to refresh @latest after a new tag.
+          for _ in $(seq 120); do
             curl -sf "https://proxy.golang.org/${MODULE}/@v/${SHA}.info" >/dev/null || true
             TIP=$(curl -sf "https://proxy.golang.org/${MODULE}/@latest" | jq -r '.Origin.Hash // ""' || true)
             [ "$TIP" = "$SHA" ] && break


### PR DESCRIPTION
The downstream CSI-driver and operator releases can start before proxy.golang.org refreshes @latest to the newly tagged SeaweedFS commit.

Extend the readiness polling window from 5 to 20 minutes, preserving the existing guard against pinning the pre-release commit.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs/pull/11219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved release automation reliability by allowing additional time for newly published releases to become available through the Go module proxy.
  - Updated workflow guidance to reflect the longer propagation window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->