### PR TITLE
admin: allow insecurely binding to any IP if -allowInsecureNoAuth is set

### DIFF
--- a/weed/command/admin.go
+++ b/weed/command/admin.go
@@ -51,17 +51,17 @@ type AdminOptions struct {
 	readOnlyUser     *string
 	readOnlyPassword *string
 	// nil for callers other than runAdmin (e.g. `weed mini`)
-	allowInsecureNoAuth *bool
-	dataDir             *string
-	icebergPort         *int
-	lancePort           *int
-	urlPrefix           *string
-	metricsHttpPort     *int
-	metricsHttpIp       *string
-	debug               *bool
-	debugPort           *int
-	cpuProfile          *string
-	memProfile          *string
+	allowInsecureBind *bool
+	dataDir           *string
+	icebergPort       *int
+	lancePort         *int
+	urlPrefix         *string
+	metricsHttpPort   *int
+	metricsHttpIp     *string
+	debug             *bool
+	debugPort         *int
+	cpuProfile        *string
+	memProfile        *string
 
 	// workerGrpcListener, when set, is a listener already bound to grpcPort by
 	// the caller. `weed mini` reserves the port this way because the admin
@@ -88,7 +88,7 @@ func init() {
 	a.adminPassword = cmdAdmin.Flag.String("adminPassword", "", "admin interface password (if empty, auth is disabled)")
 	a.readOnlyUser = cmdAdmin.Flag.String("readOnlyUser", "", "read-only user username (optional, for view-only access)")
 	a.readOnlyPassword = cmdAdmin.Flag.String("readOnlyPassword", "", "read-only user password (optional, for view-only access; requires adminPassword to be set)")
-	a.allowInsecureNoAuth = cmdAdmin.Flag.Bool("allowInsecureNoAuth", false, "INSECURE: allow binding a non-loopback ip without adminPassword or mTLS, exposing the admin API unauthenticated on the network")
+	a.allowInsecureBind = cmdAdmin.Flag.Bool("allowInsecureBind", false, "INSECURE: allow binding a non-loopback ip without adminPassword or mTLS, exposing the admin API unauthenticated on the network")
 	a.icebergPort = cmdAdmin.Flag.Int("iceberg.port", 8181, "Iceberg REST Catalog port (0 to hide in UI)")
 	a.lancePort = cmdAdmin.Flag.Int("lance.port", 9101, "Lance Namespace port (0 to hide in UI)")
 	a.urlPrefix = cmdAdmin.Flag.String("urlPrefix", "", "URL path prefix when running behind a reverse proxy under a subdirectory (e.g. /seaweedfs)")
@@ -148,7 +148,7 @@ var cmdAdmin = &Command{
     - When binding to a non-loopback address, authentication MUST be enabled
       (-adminPassword) or mTLS configured ([https.admin] key and ca in security.toml).
       Otherwise the server refuses to start.
-    - Use -allowInsecureNoAuth to start anyway with an unauthenticated admin API
+    - Use -allowInsecureBind to start anyway with an unauthenticated admin API
       exposed on the network. INSECURE; only for trusted isolated networks.
 
   Security Configuration:
@@ -293,10 +293,10 @@ func runAdmin(cmd *Command, args []string) bool {
 	// (https.admin.key without ca) encrypts transport but does not authenticate
 	// clients, so it is not sufficient — the operator must also set a password
 	// or configure mTLS (both key and ca).
-	// -allowInsecureNoAuth opts out of this check for operators who knowingly
+	// -allowInsecureBind opts out of this check for operators who knowingly
 	// keep the pre-existing unauthenticated setup.
 	hasMTLS := viper.GetString("https.admin.key") != "" && viper.GetString("https.admin.ca") != ""
-	insecureAllowed := a.allowInsecureNoAuth != nil && *a.allowInsecureNoAuth
+	insecureAllowed := a.allowInsecureBind != nil && *a.allowInsecureBind
 	if !isLoopbackIp(*a.ip) && *a.adminPassword == "" && !hasMTLS {
 		if !insecureAllowed {
 			fmt.Printf("Error: the admin server is configured to bind to %s (non-loopback) with\n", *a.ip)
@@ -306,10 +306,10 @@ func runAdmin(cmd *Command, args []string) bool {
 			fmt.Printf("         - set -adminPassword to enable authentication, or\n")
 			fmt.Printf("         - configure [https.admin] key and ca in security.toml for mTLS, or\n")
 			fmt.Printf("         - set -ip=127.0.0.1 to bind to loopback only, or\n")
-			fmt.Printf("         - set -allowInsecureNoAuth to start anyway (INSECURE).\n")
+			fmt.Printf("         - set -allowInsecureBind to start anyway (INSECURE).\n")
 			return false
 		}
-		fmt.Printf("WARNING: -allowInsecureNoAuth is set: the admin API is exposed on %s without\n", *a.ip)
+		fmt.Printf("WARNING: -allowInsecureBind is set: the admin API is exposed on %s without\n", *a.ip)
 		fmt.Printf("         authentication. Anyone who can reach this address has full control\n")
 		fmt.Printf("         of the cluster. Set -adminPassword or configure mTLS instead.\n")
 	}

--- a/weed/command/admin.go
+++ b/weed/command/admin.go
@@ -50,16 +50,18 @@ type AdminOptions struct {
 	adminPassword    *string
 	readOnlyUser     *string
 	readOnlyPassword *string
-	dataDir          *string
-	icebergPort      *int
-	lancePort        *int
-	urlPrefix        *string
-	metricsHttpPort  *int
-	metricsHttpIp    *string
-	debug            *bool
-	debugPort        *int
-	cpuProfile       *string
-	memProfile       *string
+	// nil for callers other than runAdmin (e.g. `weed mini`)
+	allowInsecureNoAuth *bool
+	dataDir             *string
+	icebergPort         *int
+	lancePort           *int
+	urlPrefix           *string
+	metricsHttpPort     *int
+	metricsHttpIp       *string
+	debug               *bool
+	debugPort           *int
+	cpuProfile          *string
+	memProfile          *string
 
 	// workerGrpcListener, when set, is a listener already bound to grpcPort by
 	// the caller. `weed mini` reserves the port this way because the admin
@@ -86,6 +88,7 @@ func init() {
 	a.adminPassword = cmdAdmin.Flag.String("adminPassword", "", "admin interface password (if empty, auth is disabled)")
 	a.readOnlyUser = cmdAdmin.Flag.String("readOnlyUser", "", "read-only user username (optional, for view-only access)")
 	a.readOnlyPassword = cmdAdmin.Flag.String("readOnlyPassword", "", "read-only user password (optional, for view-only access; requires adminPassword to be set)")
+	a.allowInsecureNoAuth = cmdAdmin.Flag.Bool("allowInsecureNoAuth", false, "INSECURE: allow binding a non-loopback ip without adminPassword or mTLS, exposing the admin API unauthenticated on the network")
 	a.icebergPort = cmdAdmin.Flag.Int("iceberg.port", 8181, "Iceberg REST Catalog port (0 to hide in UI)")
 	a.lancePort = cmdAdmin.Flag.Int("lance.port", 9101, "Lance Namespace port (0 to hide in UI)")
 	a.urlPrefix = cmdAdmin.Flag.String("urlPrefix", "", "URL path prefix when running behind a reverse proxy under a subdirectory (e.g. /seaweedfs)")
@@ -145,6 +148,8 @@ var cmdAdmin = &Command{
     - When binding to a non-loopback address, authentication MUST be enabled
       (-adminPassword) or mTLS configured ([https.admin] key and ca in security.toml).
       Otherwise the server refuses to start.
+    - Use -allowInsecureNoAuth to start anyway with an unauthenticated admin API
+      exposed on the network. INSECURE; only for trusted isolated networks.
 
   Security Configuration:
     - The admin server reads TLS configuration from security.toml
@@ -288,16 +293,25 @@ func runAdmin(cmd *Command, args []string) bool {
 	// (https.admin.key without ca) encrypts transport but does not authenticate
 	// clients, so it is not sufficient — the operator must also set a password
 	// or configure mTLS (both key and ca).
+	// -allowInsecureNoAuth opts out of this check for operators who knowingly
+	// keep the pre-existing unauthenticated setup.
 	hasMTLS := viper.GetString("https.admin.key") != "" && viper.GetString("https.admin.ca") != ""
+	insecureAllowed := a.allowInsecureNoAuth != nil && *a.allowInsecureNoAuth
 	if !isLoopbackIp(*a.ip) && *a.adminPassword == "" && !hasMTLS {
-		fmt.Printf("Error: the admin server is configured to bind to %s (non-loopback) with\n", *a.ip)
-		fmt.Printf("       authentication disabled. This would expose the admin API unauthenticated\n")
-		fmt.Printf("       on the network.\n")
-		fmt.Printf("       To fix this, either:\n")
-		fmt.Printf("         - set -adminPassword to enable authentication, or\n")
-		fmt.Printf("         - configure [https.admin] key and ca in security.toml for mTLS, or\n")
-		fmt.Printf("         - set -ip=127.0.0.1 to bind to loopback only.\n")
-		return false
+		if !insecureAllowed {
+			fmt.Printf("Error: the admin server is configured to bind to %s (non-loopback) with\n", *a.ip)
+			fmt.Printf("       authentication disabled. This would expose the admin API unauthenticated\n")
+			fmt.Printf("       on the network.\n")
+			fmt.Printf("       To fix this, either:\n")
+			fmt.Printf("         - set -adminPassword to enable authentication, or\n")
+			fmt.Printf("         - configure [https.admin] key and ca in security.toml for mTLS, or\n")
+			fmt.Printf("         - set -ip=127.0.0.1 to bind to loopback only, or\n")
+			fmt.Printf("         - set -allowInsecureNoAuth to start anyway (INSECURE).\n")
+			return false
+		}
+		fmt.Printf("WARNING: -allowInsecureNoAuth is set: the admin API is exposed on %s without\n", *a.ip)
+		fmt.Printf("         authentication. Anyone who can reach this address has full control\n")
+		fmt.Printf("         of the cluster. Set -adminPassword or configure mTLS instead.\n")
 	}
 
 	// Security warnings


### PR DESCRIPTION
# What problem are we solving?
#11185 removed the possibility to expose the admin UI without mTLS or an admin password. 

However, this breaks deployments that don't need either of those. For example, one may prevent network access to the admin UI if not to authorized users, or use forward auth from an IdP to perform authentication on a gateway.

This PR is adding the possibility to opt-out of the new protection, allowing the user to run the admin UI in an "insecure" configuration.

# How are we solving the problem?
I've added a simple CLI flag to the admin options, called `allowInsecureNoAuth`, which allows to bypass the admin password and mTLS checks and start the admin UI anyway, without those. This flag is an opt-in, thus defaulting to the new behaviour introduced by #11185. When set, the flag also prints a warning to the user, though I think the flag name is pretty self-explanatory.

# How is the PR tested?
I don't believe there are tests that can be extended to verify this behaviour, but correct me if I missed them. Anyway, I don't think there is a need to add tests for a very simple CLI flag that is only used locally in a single file.

# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [ ] I have reviewed every line of code.
- [ ] The PR is kept as minimum as possible. Large PRs would not be accepted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an explicit option to allow unauthenticated admin access on non-loopback addresses.
  * Displays a clear warning when this insecure configuration is enabled.
  * Documents the security implications of enabling the option.

* **Bug Fixes**
  * Non-loopback unauthenticated admin access remains blocked unless explicitly permitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->