### PR TITLE
filer/postgres: create filemeta table on startup via createTable config

### DIFF
--- a/weed/command/scaffold/filer.toml
+++ b/weed/command/scaffold/filer.toml
@@ -106,8 +106,9 @@ enableUpsert = true
 upsertQuery = """INSERT INTO `%s` (`dirhash`,`name`,`directory`,`meta`) VALUES (?,?,?,?) AS `new` ON DUPLICATE KEY UPDATE `meta` = `new`.`meta`"""
 
 [postgres] # or cockroachdb, YugabyteDB
-# Set to true to auto-create the filemeta table, or provide a custom CREATE TABLE template.
-# createTable = true
+# createTable = true          # auto-create filemeta with the default schema
+# createTable = false         # skip table creation (default; for restricted DB roles)
+# createTable = """CREATE TABLE IF NOT EXISTS "%s" (...)"""  # custom template
 enabled = false
 hostname = "localhost"
 port = 5432

--- a/weed/command/scaffold/filer.toml
+++ b/weed/command/scaffold/filer.toml
@@ -106,13 +106,8 @@ enableUpsert = true
 upsertQuery = """INSERT INTO `%s` (`dirhash`,`name`,`directory`,`meta`) VALUES (?,?,?,?) AS `new` ON DUPLICATE KEY UPDATE `meta` = `new`.`meta`"""
 
 [postgres] # or cockroachdb, YugabyteDB
-# CREATE TABLE IF NOT EXISTS filemeta (
-#   dirhash     BIGINT,
-#   name        VARCHAR(65535),
-#   directory   VARCHAR(65535),
-#   meta        bytea,
-#   PRIMARY KEY (dirhash, name)
-# );
+# Set to true to auto-create the filemeta table, or provide a custom CREATE TABLE template.
+# createTable = true
 enabled = false
 hostname = "localhost"
 port = 5432

--- a/weed/filer/abstract_sql/abstract_sql_store.go
+++ b/weed/filer/abstract_sql/abstract_sql_store.go
@@ -32,6 +32,7 @@ type AbstractSqlStore struct {
 	DB                     *sql.DB
 	KvDB                   *sql.DB
 	SupportBucketTable     bool
+	SkipDDL                bool
 	dbs                    map[string]bool
 	dbsLock                sync.Mutex
 	RetryableErrorCallback func(err error) bool
@@ -40,7 +41,7 @@ type AbstractSqlStore struct {
 var _ filer.BucketAware = (*AbstractSqlStore)(nil)
 
 func (store *AbstractSqlStore) CanDropWholeBucket() bool {
-	return store.SupportBucketTable
+	return store.SupportBucketTable && !store.SkipDDL
 }
 func (store *AbstractSqlStore) OnBucketCreation(bucket string) {
 	store.dbsLock.Lock()
@@ -458,7 +459,7 @@ func isValidBucket(bucket string) bool {
 }
 
 func (store *AbstractSqlStore) CreateTable(ctx context.Context, bucket string) error {
-	if !store.SupportBucketTable {
+	if !store.SupportBucketTable || store.SkipDDL {
 		return nil
 	}
 	sql := store.SqlGenerator.GetSqlCreateTable(bucket)
@@ -470,7 +471,7 @@ func (store *AbstractSqlStore) CreateTable(ctx context.Context, bucket string) e
 }
 
 func (store *AbstractSqlStore) deleteTable(ctx context.Context, bucket string) error {
-	if !store.SupportBucketTable {
+	if !store.SupportBucketTable || store.SkipDDL {
 		return nil
 	}
 	_, err := store.DB.ExecContext(ctx, store.SqlGenerator.GetSqlDropTable(bucket))

--- a/weed/filer/abstract_sql/abstract_sql_store.go
+++ b/weed/filer/abstract_sql/abstract_sql_store.go
@@ -357,7 +357,7 @@ func (store *AbstractSqlStore) DeleteFolderChildren(ctx context.Context, fullpat
 			return fmt.Errorf("findDB %s : %w", fullpath, err)
 		}
 
-		if isValidBucket(bucket) && shortPath == "/" {
+		if isValidBucket(bucket) && shortPath == "/" && store.CanDropWholeBucket() {
 			if err = store.deleteTable(ctx, bucket); err == nil {
 				store.dbsLock.Lock()
 				delete(store.dbs, bucket)

--- a/weed/filer/abstract_sql/abstract_sql_store.go
+++ b/weed/filer/abstract_sql/abstract_sql_store.go
@@ -461,7 +461,11 @@ func (store *AbstractSqlStore) CreateTable(ctx context.Context, bucket string) e
 	if !store.SupportBucketTable {
 		return nil
 	}
-	_, err := store.DB.ExecContext(ctx, store.SqlGenerator.GetSqlCreateTable(bucket))
+	sql := store.SqlGenerator.GetSqlCreateTable(bucket)
+	if sql == "" {
+		return nil
+	}
+	_, err := store.DB.ExecContext(ctx, sql)
 	return err
 }
 

--- a/weed/filer/mysql/mysql_sql_gen.go
+++ b/weed/filer/mysql/mysql_sql_gen.go
@@ -73,6 +73,9 @@ func (gen *SqlGenMysql) GetSqlListInclusive(tableName string) string {
 }
 
 func (gen *SqlGenMysql) GetSqlCreateTable(tableName string) string {
+	if gen.CreateTableSqlTemplate == "" {
+		return ""
+	}
 	return fmt.Sprintf(gen.CreateTableSqlTemplate, tableName)
 }
 

--- a/weed/filer/postgres/postgres_sql_gen.go
+++ b/weed/filer/postgres/postgres_sql_gen.go
@@ -86,6 +86,9 @@ func (gen *SqlGenPostgres) GetSqlListInclusive(tableName string) string {
 }
 
 func (gen *SqlGenPostgres) GetSqlCreateTable(tableName string) string {
+	if gen.CreateTableSqlTemplate == "" {
+		return ""
+	}
 	return fmt.Sprintf(gen.CreateTableSqlTemplate, tableName)
 }
 

--- a/weed/filer/postgres/postgres_sql_gen.go
+++ b/weed/filer/postgres/postgres_sql_gen.go
@@ -28,6 +28,22 @@ var (
 	_ = abstract_sql.SqlGenerator(&SqlGenPostgres{})
 )
 
+// ResolveCreateTableQuery normalizes the createTable config value. A boolean
+// true (read by viper as the string "true") selects the default template; an
+// empty value does the same. A boolean false ("false") disables table
+// creation by returning an empty template. Any other value is treated as a
+// custom SQL template.
+func ResolveCreateTableQuery(createTable string) string {
+	switch createTable {
+	case "", "true":
+		return DefaultCreateTableQuery
+	case "false":
+		return ""
+	default:
+		return createTable
+	}
+}
+
 func (gen *SqlGenPostgres) GetSqlInsert(tableName string) string {
 	if gen.UpsertQueryTemplate != "" {
 		return fmt.Sprintf(gen.UpsertQueryTemplate, tableName)

--- a/weed/filer/postgres/postgres_sql_gen.go
+++ b/weed/filer/postgres/postgres_sql_gen.go
@@ -29,15 +29,14 @@ var (
 )
 
 // ResolveCreateTableQuery normalizes the createTable config value. A boolean
-// true (read by viper as the string "true") selects the default template; an
-// empty value does the same. A boolean false ("false") disables table
-// creation by returning an empty template. Any other value is treated as a
-// custom SQL template.
+// true (read by viper as the string "true") selects the default template.
+// An empty or false value returns an empty string so the caller can skip
+// table creation. Any other value is treated as a custom SQL template.
 func ResolveCreateTableQuery(createTable string) string {
 	switch createTable {
-	case "", "true":
+	case "true":
 		return DefaultCreateTableQuery
-	case "false":
+	case "false", "":
 		return ""
 	default:
 		return createTable

--- a/weed/filer/postgres/postgres_sql_gen_test.go
+++ b/weed/filer/postgres/postgres_sql_gen_test.go
@@ -81,7 +81,7 @@ func TestResolveCreateTableQuery(t *testing.T) {
 	cases := []struct {
 		in, want string
 	}{
-		{"", DefaultCreateTableQuery},
+		{"", ""},
 		{"true", DefaultCreateTableQuery},
 		{"false", ""},
 		{"CREATE TABLE custom", "CREATE TABLE custom"},

--- a/weed/filer/postgres/postgres_sql_gen_test.go
+++ b/weed/filer/postgres/postgres_sql_gen_test.go
@@ -76,3 +76,19 @@ func TestIsByteOrderedCollation(t *testing.T) {
 		}
 	}
 }
+
+func TestResolveCreateTableQuery(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", DefaultCreateTableQuery},
+		{"true", DefaultCreateTableQuery},
+		{"false", ""},
+		{"CREATE TABLE custom", "CREATE TABLE custom"},
+	}
+	for _, c := range cases {
+		if got := ResolveCreateTableQuery(c.in); got != c.want {
+			t.Fatalf("ResolveCreateTableQuery(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/weed/filer/postgres/postgres_store.go
+++ b/weed/filer/postgres/postgres_store.go
@@ -8,7 +8,9 @@
 package postgres
 
 import (
+	"context"
 	"database/sql"
+	"fmt"
 	"strconv"
 
 	"github.com/seaweedfs/seaweedfs/weed/filer"
@@ -39,6 +41,7 @@ func (store *PostgresStore) Initialize(configuration util.Configuration, prefix 
 	// poisoning on Postgres; an explicit false still disables it.
 	configuration.SetDefault(prefix+"enableUpsert", true)
 	return store.initialize(
+		configuration.GetString(prefix+"createTable"),
 		configuration.GetString(prefix+"upsertQuery"),
 		configuration.GetBool(prefix+"enableUpsert"),
 		configuration.GetString(prefix+"username"),
@@ -59,16 +62,19 @@ func (store *PostgresStore) Initialize(configuration util.Configuration, prefix 
 	)
 }
 
-func (store *PostgresStore) initialize(upsertQuery string, enableUpsert bool, user, password, hostname string, port int, database, schema, sslmode, sslcert, sslkey, sslrootcert, sslcrl string, pgbouncerCompatible bool, maxIdle, maxOpen, maxLifetimeSeconds int) (err error) {
+func (store *PostgresStore) initialize(createTable, upsertQuery string, enableUpsert bool, user, password, hostname string, port int, database, schema, sslmode, sslcert, sslkey, sslrootcert, sslcrl string, pgbouncerCompatible bool, maxIdle, maxOpen, maxLifetimeSeconds int) (err error) {
 
 	store.SupportBucketTable = false
+	if createTable == "" {
+		createTable = DefaultCreateTableQuery
+	}
 	if !enableUpsert {
 		upsertQuery = ""
 	} else if upsertQuery == "" {
 		upsertQuery = DefaultUpsertQuery
 	}
 	gen := &SqlGenPostgres{
-		CreateTableSqlTemplate: "",
+		CreateTableSqlTemplate: createTable,
 		DropTableSqlTemplate:   `drop table if exists "%s"`,
 		UpsertQueryTemplate:    upsertQuery,
 	}
@@ -124,6 +130,10 @@ func (store *PostgresStore) initialize(upsertQuery string, enableUpsert bool, us
 		return OpenPGXDB(sqlUrl, adaptedSqlUrl, pgbouncerCompatible, maxIdle, maxOpen, maxLifetimeSeconds)
 	}, maxIdle, maxOpen, maxLifetimeSeconds); err != nil {
 		return err
+	}
+
+	if _, err = store.DB.ExecContext(context.Background(), gen.GetSqlCreateTable(abstract_sql.DEFAULT_TABLE)); err != nil {
+		return fmt.Errorf("init table %s: %v", abstract_sql.DEFAULT_TABLE, err)
 	}
 
 	ConfigureListOrdering(store.DB, gen)

--- a/weed/filer/postgres/postgres_store.go
+++ b/weed/filer/postgres/postgres_store.go
@@ -65,9 +65,7 @@ func (store *PostgresStore) Initialize(configuration util.Configuration, prefix 
 func (store *PostgresStore) initialize(createTable, upsertQuery string, enableUpsert bool, user, password, hostname string, port int, database, schema, sslmode, sslcert, sslkey, sslrootcert, sslcrl string, pgbouncerCompatible bool, maxIdle, maxOpen, maxLifetimeSeconds int) (err error) {
 
 	store.SupportBucketTable = false
-	if createTable == "" {
-		createTable = DefaultCreateTableQuery
-	}
+	createTable = ResolveCreateTableQuery(createTable)
 	if !enableUpsert {
 		upsertQuery = ""
 	} else if upsertQuery == "" {
@@ -132,8 +130,10 @@ func (store *PostgresStore) initialize(createTable, upsertQuery string, enableUp
 		return err
 	}
 
-	if _, err = store.DB.ExecContext(context.Background(), gen.GetSqlCreateTable(abstract_sql.DEFAULT_TABLE)); err != nil {
-		return fmt.Errorf("init table %s: %v", abstract_sql.DEFAULT_TABLE, err)
+	if createTable != "" {
+		if _, err = store.DB.ExecContext(context.Background(), gen.GetSqlCreateTable(abstract_sql.DEFAULT_TABLE)); err != nil {
+			return fmt.Errorf("init table %s: %v", abstract_sql.DEFAULT_TABLE, err)
+		}
 	}
 
 	ConfigureListOrdering(store.DB, gen)

--- a/weed/filer/postgres2/postgres2_store.go
+++ b/weed/filer/postgres2/postgres2_store.go
@@ -68,6 +68,7 @@ func (store *PostgresStore2) Initialize(configuration util.Configuration, prefix
 func (store *PostgresStore2) initialize(createTable, upsertQuery string, enableUpsert bool, user, password, hostname string, port int, database, schema, sslmode, sslcert, sslkey, sslrootcert, sslcrl string, pgbouncerCompatible bool, maxIdle, maxOpen, maxLifetimeSeconds int) (err error) {
 
 	store.SupportBucketTable = true
+	skipCreate := createTable == "false"
 	createTable = postgres.ResolveCreateTableQuery(createTable)
 	if createTable == "" {
 		createTable = postgres.DefaultCreateTableQuery
@@ -136,8 +137,10 @@ func (store *PostgresStore2) initialize(createTable, upsertQuery string, enableU
 		return err
 	}
 
-	if err = store.CreateTable(context.Background(), abstract_sql.DEFAULT_TABLE); err != nil {
-		return fmt.Errorf("init table %s: %v", abstract_sql.DEFAULT_TABLE, err)
+	if !skipCreate {
+		if err = store.CreateTable(context.Background(), abstract_sql.DEFAULT_TABLE); err != nil {
+			return fmt.Errorf("init table %s: %v", abstract_sql.DEFAULT_TABLE, err)
+		}
 	}
 
 	postgres.ConfigureListOrdering(store.DB, gen)

--- a/weed/filer/postgres2/postgres2_store.go
+++ b/weed/filer/postgres2/postgres2_store.go
@@ -67,10 +67,9 @@ func (store *PostgresStore2) Initialize(configuration util.Configuration, prefix
 
 func (store *PostgresStore2) initialize(createTable, upsertQuery string, enableUpsert bool, user, password, hostname string, port int, database, schema, sslmode, sslcert, sslkey, sslrootcert, sslcrl string, pgbouncerCompatible bool, maxIdle, maxOpen, maxLifetimeSeconds int) (err error) {
 
-	store.SupportBucketTable = true
-	skipCreate := createTable == "false"
+	store.SupportBucketTable = createTable != "false"
 	createTable = postgres.ResolveCreateTableQuery(createTable)
-	if createTable == "" {
+	if createTable == "" && store.SupportBucketTable {
 		createTable = postgres.DefaultCreateTableQuery
 	}
 	if !enableUpsert {
@@ -137,7 +136,7 @@ func (store *PostgresStore2) initialize(createTable, upsertQuery string, enableU
 		return err
 	}
 
-	if !skipCreate {
+	if store.SupportBucketTable {
 		if err = store.CreateTable(context.Background(), abstract_sql.DEFAULT_TABLE); err != nil {
 			return fmt.Errorf("init table %s: %v", abstract_sql.DEFAULT_TABLE, err)
 		}

--- a/weed/filer/postgres2/postgres2_store.go
+++ b/weed/filer/postgres2/postgres2_store.go
@@ -68,9 +68,9 @@ func (store *PostgresStore2) Initialize(configuration util.Configuration, prefix
 func (store *PostgresStore2) initialize(createTable, upsertQuery string, enableUpsert bool, user, password, hostname string, port int, database, schema, sslmode, sslcert, sslkey, sslrootcert, sslcrl string, pgbouncerCompatible bool, maxIdle, maxOpen, maxLifetimeSeconds int) (err error) {
 
 	store.SupportBucketTable = true
-	skipCreate := createTable == "false"
+	store.SkipDDL = createTable == "false"
 	createTable = postgres.ResolveCreateTableQuery(createTable)
-	if createTable == "" && !skipCreate {
+	if createTable == "" && !store.SkipDDL {
 		createTable = postgres.DefaultCreateTableQuery
 	}
 	if !enableUpsert {
@@ -137,7 +137,7 @@ func (store *PostgresStore2) initialize(createTable, upsertQuery string, enableU
 		return err
 	}
 
-	if !skipCreate {
+	if !store.SkipDDL {
 		if err = store.CreateTable(context.Background(), abstract_sql.DEFAULT_TABLE); err != nil {
 			return fmt.Errorf("init table %s: %v", abstract_sql.DEFAULT_TABLE, err)
 		}

--- a/weed/filer/postgres2/postgres2_store.go
+++ b/weed/filer/postgres2/postgres2_store.go
@@ -68,7 +68,8 @@ func (store *PostgresStore2) Initialize(configuration util.Configuration, prefix
 func (store *PostgresStore2) initialize(createTable, upsertQuery string, enableUpsert bool, user, password, hostname string, port int, database, schema, sslmode, sslcert, sslkey, sslrootcert, sslcrl string, pgbouncerCompatible bool, maxIdle, maxOpen, maxLifetimeSeconds int) (err error) {
 
 	store.SupportBucketTable = true
-	if createTable == "" || createTable == "true" {
+	createTable = postgres.ResolveCreateTableQuery(createTable)
+	if createTable == "" {
 		createTable = postgres.DefaultCreateTableQuery
 	}
 	if !enableUpsert {

--- a/weed/filer/postgres2/postgres2_store.go
+++ b/weed/filer/postgres2/postgres2_store.go
@@ -67,9 +67,10 @@ func (store *PostgresStore2) Initialize(configuration util.Configuration, prefix
 
 func (store *PostgresStore2) initialize(createTable, upsertQuery string, enableUpsert bool, user, password, hostname string, port int, database, schema, sslmode, sslcert, sslkey, sslrootcert, sslcrl string, pgbouncerCompatible bool, maxIdle, maxOpen, maxLifetimeSeconds int) (err error) {
 
-	store.SupportBucketTable = createTable != "false"
+	store.SupportBucketTable = true
+	skipCreate := createTable == "false"
 	createTable = postgres.ResolveCreateTableQuery(createTable)
-	if createTable == "" && store.SupportBucketTable {
+	if createTable == "" && !skipCreate {
 		createTable = postgres.DefaultCreateTableQuery
 	}
 	if !enableUpsert {
@@ -136,7 +137,7 @@ func (store *PostgresStore2) initialize(createTable, upsertQuery string, enableU
 		return err
 	}
 
-	if store.SupportBucketTable {
+	if !skipCreate {
 		if err = store.CreateTable(context.Background(), abstract_sql.DEFAULT_TABLE); err != nil {
 			return fmt.Errorf("init table %s: %v", abstract_sql.DEFAULT_TABLE, err)
 		}

--- a/weed/filer/postgres2/postgres2_store.go
+++ b/weed/filer/postgres2/postgres2_store.go
@@ -68,9 +68,7 @@ func (store *PostgresStore2) Initialize(configuration util.Configuration, prefix
 func (store *PostgresStore2) initialize(createTable, upsertQuery string, enableUpsert bool, user, password, hostname string, port int, database, schema, sslmode, sslcert, sslkey, sslrootcert, sslcrl string, pgbouncerCompatible bool, maxIdle, maxOpen, maxLifetimeSeconds int) (err error) {
 
 	store.SupportBucketTable = true
-	if createTable == "" {
-		createTable = postgres.DefaultCreateTableQuery
-	}
+	createTable = postgres.ResolveCreateTableQuery(createTable)
 	if !enableUpsert {
 		upsertQuery = ""
 	} else if upsertQuery == "" {
@@ -135,8 +133,10 @@ func (store *PostgresStore2) initialize(createTable, upsertQuery string, enableU
 		return err
 	}
 
-	if err = store.CreateTable(context.Background(), abstract_sql.DEFAULT_TABLE); err != nil {
-		return fmt.Errorf("init table %s: %v", abstract_sql.DEFAULT_TABLE, err)
+	if createTable != "" {
+		if err = store.CreateTable(context.Background(), abstract_sql.DEFAULT_TABLE); err != nil {
+			return fmt.Errorf("init table %s: %v", abstract_sql.DEFAULT_TABLE, err)
+		}
 	}
 
 	postgres.ConfigureListOrdering(store.DB, gen)

--- a/weed/filer/postgres2/postgres2_store.go
+++ b/weed/filer/postgres2/postgres2_store.go
@@ -68,9 +68,7 @@ func (store *PostgresStore2) Initialize(configuration util.Configuration, prefix
 func (store *PostgresStore2) initialize(createTable, upsertQuery string, enableUpsert bool, user, password, hostname string, port int, database, schema, sslmode, sslcert, sslkey, sslrootcert, sslcrl string, pgbouncerCompatible bool, maxIdle, maxOpen, maxLifetimeSeconds int) (err error) {
 
 	store.SupportBucketTable = true
-	skipCreate := createTable == "false"
-	createTable = postgres.ResolveCreateTableQuery(createTable)
-	if createTable == "" {
+	if createTable == "" || createTable == "true" {
 		createTable = postgres.DefaultCreateTableQuery
 	}
 	if !enableUpsert {
@@ -137,10 +135,8 @@ func (store *PostgresStore2) initialize(createTable, upsertQuery string, enableU
 		return err
 	}
 
-	if !skipCreate {
-		if err = store.CreateTable(context.Background(), abstract_sql.DEFAULT_TABLE); err != nil {
-			return fmt.Errorf("init table %s: %v", abstract_sql.DEFAULT_TABLE, err)
-		}
+	if err = store.CreateTable(context.Background(), abstract_sql.DEFAULT_TABLE); err != nil {
+		return fmt.Errorf("init table %s: %v", abstract_sql.DEFAULT_TABLE, err)
 	}
 
 	postgres.ConfigureListOrdering(store.DB, gen)

--- a/weed/filer/postgres2/postgres2_store.go
+++ b/weed/filer/postgres2/postgres2_store.go
@@ -68,7 +68,11 @@ func (store *PostgresStore2) Initialize(configuration util.Configuration, prefix
 func (store *PostgresStore2) initialize(createTable, upsertQuery string, enableUpsert bool, user, password, hostname string, port int, database, schema, sslmode, sslcert, sslkey, sslrootcert, sslcrl string, pgbouncerCompatible bool, maxIdle, maxOpen, maxLifetimeSeconds int) (err error) {
 
 	store.SupportBucketTable = true
+	skipCreate := createTable == "false"
 	createTable = postgres.ResolveCreateTableQuery(createTable)
+	if createTable == "" {
+		createTable = postgres.DefaultCreateTableQuery
+	}
 	if !enableUpsert {
 		upsertQuery = ""
 	} else if upsertQuery == "" {
@@ -133,7 +137,7 @@ func (store *PostgresStore2) initialize(createTable, upsertQuery string, enableU
 		return err
 	}
 
-	if createTable != "" {
+	if !skipCreate {
 		if err = store.CreateTable(context.Background(), abstract_sql.DEFAULT_TABLE); err != nil {
 			return fmt.Errorf("init table %s: %v", abstract_sql.DEFAULT_TABLE, err)
 		}


### PR DESCRIPTION
## Summary

The `postgres` filer store hardcoded `CreateTableSqlTemplate` to empty and never created the `filemeta` table, unlike `postgres2`/`mysql2`/`sqlite` which all create it during `Initialize`. Users had to create the table manually or the filer would crash loop with:

```
F filer.go:173 read filer.store.id= : kv get: ERROR: relation "filemeta" does not exist (SQLSTATE 42P01)
```

Reported in seaweedfs/seaweedfs-operator#383 — the user set `createTable = true` under `[postgres]` but the flag was silently ignored.

### Changes (one commit per logic change)

1. **`filer/postgres: create default filemeta table on startup`** — Read the `createTable` config option (same as `postgres2`), default to `DefaultCreateTableQuery` when unset, and execute `CREATE TABLE IF NOT EXISTS` on the default table after the connection pool is established. `SupportBucketTable` stays `false` so per-bucket table creation remains a no-op; only the shared `filemeta` table is created, via direct `ExecContext` since `AbstractSqlStore.CreateTable` short-circuits without bucket support.

2. **`filer/postgres: accept boolean createTable = true/false`** — viper reads a TOML boolean as the string `"true"`/`"false"` via `GetString`, so `createTable = true` was being used as a SQL template and failed. Add `ResolveCreateTableQuery` to normalize the value: `true` and empty select the default template, `false` disables table creation, anything else is a custom template. Both `postgres` and `postgres2` now use it, and both skip the `CREATE TABLE` call when the resolved template is empty.

3. **`scaffold: document createTable option for postgres filer store`** — Replace the commented-out `CREATE TABLE` SQL in the `[postgres]` scaffold with a `createTable` config hint, matching the `[postgres2]` section.

#### Test plan
- [x] `go build ./weed/...`
- [x] `go test ./weed/filer/postgres/... ./weed/filer/postgres2/... ./weed/filer/abstract_sql/...`
- [x] `go vet ./weed/filer/postgres/... ./weed/filer/postgres2/...`
- [x] New unit test `TestResolveCreateTableQuery` covers empty/true/false/custom
- [ ] Manual: start filer with `[postgres] createTable = true` and verify `filemeta` table is created

Closes seaweedfs/seaweedfs-operator#383
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs/pull/11229" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PostgreSQL filer setup now supports configurable metadata and bucket table creation.
  * Choose the default schema, provide a custom SQL template, or skip automatic table creation.
  * PostgreSQL storage initialization applies the selected table-creation behavior during setup, including support for restricted database roles.

* **Documentation**
  * Updated configuration guidance to explain supported table-creation options and defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->