### PR TITLE
admin: reject IAM policy deletion while still attached to a user/group

### DIFF
--- a/weed/admin/dash/policies_management.go
+++ b/weed/admin/dash/policies_management.go
@@ -157,6 +157,53 @@ func (s *AdminServer) DeletePolicy(name string) error {
 	return policyManager.DeletePolicy(ctx, name)
 }
 
+// IsPolicyAttached returns the names of users and groups that still have the
+// given managed policy attached. The returned entries are prefixed with
+// "user:" or "group:". Returns nil when the policy is not attached anywhere.
+func (s *AdminServer) IsPolicyAttached(ctx context.Context, policyName string) ([]string, error) {
+	if s.credentialManager == nil {
+		return nil, fmt.Errorf("credential manager not available")
+	}
+
+	var attached []string
+
+	usernames, err := s.credentialManager.ListUsers(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list users: %w", err)
+	}
+	for _, username := range usernames {
+		policies, err := s.credentialManager.ListAttachedUserPolicies(ctx, username)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list policies for user %s: %w", username, err)
+		}
+		for _, p := range policies {
+			if p == policyName {
+				attached = append(attached, "user:"+username)
+				break
+			}
+		}
+	}
+
+	groupNames, err := s.credentialManager.ListGroups(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list groups: %w", err)
+	}
+	for _, groupName := range groupNames {
+		group, err := s.credentialManager.GetGroup(ctx, groupName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get group %s: %w", groupName, err)
+		}
+		for _, p := range group.PolicyNames {
+			if p == policyName {
+				attached = append(attached, "group:"+groupName)
+				break
+			}
+		}
+	}
+
+	return attached, nil
+}
+
 // GetPolicy retrieves a specific IAM policy
 func (s *AdminServer) GetPolicy(name string) (*IAMPolicy, error) {
 	policyManager := s.GetPolicyManager()

--- a/weed/admin/dash/policies_management.go
+++ b/weed/admin/dash/policies_management.go
@@ -2,13 +2,19 @@ package dash
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/seaweedfs/seaweedfs/weed/credential"
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/policy_engine"
 )
+
+// ErrPolicyStillAttached is returned when deleting a managed policy that is
+// still attached to one or more users or groups.
+var ErrPolicyStillAttached = errors.New("policy is still attached")
 
 type IAMPolicy struct {
 	Name         string                       `json:"name"`
@@ -146,7 +152,10 @@ func (s *AdminServer) UpdatePolicy(name string, document policy_engine.PolicyDoc
 	return policyManager.UpdatePolicy(ctx, name, document)
 }
 
-// DeletePolicy deletes an IAM policy
+// DeletePolicy deletes an IAM policy. Deletion is rejected while the policy is
+// still attached to any user or group, matching AWS IAM behavior and the IAM
+// API handler, so a deleted policy name never lingers in an attached policy
+// list.
 func (s *AdminServer) DeletePolicy(name string) error {
 	policyManager := s.GetPolicyManager()
 	if policyManager == nil {
@@ -154,6 +163,14 @@ func (s *AdminServer) DeletePolicy(name string) error {
 	}
 
 	ctx := context.Background()
+	attached, err := s.IsPolicyAttached(ctx, name)
+	if err != nil {
+		return fmt.Errorf("failed to check policy attachments: %w", err)
+	}
+	if len(attached) > 0 {
+		return fmt.Errorf("policy %s is still attached to: %s: %w", name, strings.Join(attached, ", "), ErrPolicyStillAttached)
+	}
+
 	return policyManager.DeletePolicy(ctx, name)
 }
 

--- a/weed/admin/dash/policies_management.go
+++ b/weed/admin/dash/policies_management.go
@@ -207,6 +207,9 @@ func (s *AdminServer) IsPolicyAttached(ctx context.Context, policyName string) (
 	}
 	for _, groupName := range groupNames {
 		group, err := s.credentialManager.GetGroup(ctx, groupName)
+		if errors.Is(err, credential.ErrGroupNotFound) {
+			continue
+		}
 		if err != nil {
 			return nil, fmt.Errorf("failed to get group %s: %w", groupName, err)
 		}

--- a/weed/admin/dash/policies_management_test.go
+++ b/weed/admin/dash/policies_management_test.go
@@ -92,8 +92,10 @@ func TestDeletePolicyRejectsWhenAttachedToUser(t *testing.T) {
 		t.Fatalf("expected ErrPolicyStillAttached, got %v", err)
 	}
 
-	if _, err := server.GetPolicy(policyName); err != nil {
+	if p, err := server.GetPolicy(policyName); err != nil {
 		t.Fatalf("policy should still exist after rejected deletion: %v", err)
+	} else if p == nil {
+		t.Fatal("policy should still exist after rejected deletion, got nil")
 	}
 
 	attached, err := server.credentialManager.ListAttachedUserPolicies(ctx, "bob")
@@ -109,6 +111,11 @@ func TestDeletePolicyRejectsWhenAttachedToUser(t *testing.T) {
 	}
 	if err := server.DeletePolicy(policyName); err != nil {
 		t.Fatalf("DeletePolicy after detach failed: %v", err)
+	}
+	if p, err := server.GetPolicy(policyName); err != nil {
+		t.Fatalf("GetPolicy after detach-delete: %v", err)
+	} else if p != nil {
+		t.Fatalf("policy should be gone after deletion, got %v", p)
 	}
 }
 
@@ -128,8 +135,10 @@ func TestDeletePolicyRejectsWhenAttachedToGroup(t *testing.T) {
 		t.Fatalf("expected ErrPolicyStillAttached, got %v", err)
 	}
 
-	if _, err := server.GetPolicy(policyName); err != nil {
+	if p, err := server.GetPolicy(policyName); err != nil {
 		t.Fatalf("policy should still exist after rejected deletion: %v", err)
+	} else if p == nil {
+		t.Fatal("policy should still exist after rejected deletion, got nil")
 	}
 }
 
@@ -143,7 +152,9 @@ func TestDeletePolicySucceedsWhenNotAttached(t *testing.T) {
 	if err := server.DeletePolicy(policyName); err != nil {
 		t.Fatalf("DeletePolicy for unattached policy failed: %v", err)
 	}
-	if _, err := server.GetPolicy(policyName); err != nil {
+	if p, err := server.GetPolicy(policyName); err != nil {
 		t.Fatalf("GetPolicy after delete: %v", err)
+	} else if p != nil {
+		t.Fatalf("policy should be gone after deletion, got %v", p)
 	}
 }

--- a/weed/admin/dash/policies_management_test.go
+++ b/weed/admin/dash/policies_management_test.go
@@ -1,0 +1,73 @@
+package dash
+
+import (
+	"context"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/credential"
+	_ "github.com/seaweedfs/seaweedfs/weed/credential/memory" // register memory store
+	"github.com/seaweedfs/seaweedfs/weed/pb/iam_pb"
+	"github.com/seaweedfs/seaweedfs/weed/s3api/policy_engine"
+)
+
+func newAdminServerWithMemoryStore(t *testing.T) *AdminServer {
+	t.Helper()
+	cm, err := credential.NewCredentialManagerWithDefaults(credential.StoreTypeMemory)
+	if err != nil {
+		t.Fatalf("failed to create credential manager: %v", err)
+	}
+	return &AdminServer{credentialManager: cm}
+}
+
+func samplePolicyDocument() policy_engine.PolicyDocument {
+	return policy_engine.PolicyDocument{
+		Version: "2012-10-17",
+		Statement: []policy_engine.PolicyStatement{{
+			Effect:   policy_engine.PolicyEffectAllow,
+			Action:   policy_engine.NewStringOrStringSlice("s3:GetObject"),
+			Resource: policy_engine.NewStringOrStringSlicePtr("arn:aws:s3:::test/*"),
+		}},
+	}
+}
+
+func TestIsPolicyAttached(t *testing.T) {
+	server := newAdminServerWithMemoryStore(t)
+	ctx := context.Background()
+	const policyName = "policy_a"
+
+	if err := server.CreatePolicy(policyName, samplePolicyDocument()); err != nil {
+		t.Fatalf("CreatePolicy: %v", err)
+	}
+
+	if attached, err := server.IsPolicyAttached(ctx, policyName); err != nil {
+		t.Fatalf("IsPolicyAttached: %v", err)
+	} else if len(attached) != 0 {
+		t.Fatalf("expected no attachments, got %v", attached)
+	}
+
+	if err := server.credentialManager.CreateUser(ctx, &iam_pb.Identity{Name: "alice"}); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if err := server.credentialManager.AttachUserPolicy(ctx, "alice", policyName); err != nil {
+		t.Fatalf("AttachUserPolicy: %v", err)
+	}
+
+	attached, err := server.IsPolicyAttached(ctx, policyName)
+	if err != nil {
+		t.Fatalf("IsPolicyAttached: %v", err)
+	}
+	if len(attached) != 1 || attached[0] != "user:alice" {
+		t.Fatalf("expected [user:alice], got %v", attached)
+	}
+
+	if err := server.credentialManager.CreateGroup(ctx, &iam_pb.Group{Name: "devs", PolicyNames: []string{policyName}}); err != nil {
+		t.Fatalf("CreateGroup: %v", err)
+	}
+	attached, err = server.IsPolicyAttached(ctx, policyName)
+	if err != nil {
+		t.Fatalf("IsPolicyAttached: %v", err)
+	}
+	if len(attached) != 2 {
+		t.Fatalf("expected 2 attachments, got %v", attached)
+	}
+}

--- a/weed/admin/dash/policies_management_test.go
+++ b/weed/admin/dash/policies_management_test.go
@@ -2,6 +2,7 @@ package dash
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/seaweedfs/seaweedfs/weed/credential"
@@ -69,5 +70,80 @@ func TestIsPolicyAttached(t *testing.T) {
 	}
 	if len(attached) != 2 {
 		t.Fatalf("expected 2 attachments, got %v", attached)
+	}
+}
+
+func TestDeletePolicyRejectsWhenAttachedToUser(t *testing.T) {
+	server := newAdminServerWithMemoryStore(t)
+	ctx := context.Background()
+	const policyName = "policy_u"
+
+	if err := server.CreatePolicy(policyName, samplePolicyDocument()); err != nil {
+		t.Fatalf("CreatePolicy: %v", err)
+	}
+	if err := server.credentialManager.CreateUser(ctx, &iam_pb.Identity{Name: "bob"}); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if err := server.credentialManager.AttachUserPolicy(ctx, "bob", policyName); err != nil {
+		t.Fatalf("AttachUserPolicy: %v", err)
+	}
+
+	if err := server.DeletePolicy(policyName); !errors.Is(err, ErrPolicyStillAttached) {
+		t.Fatalf("expected ErrPolicyStillAttached, got %v", err)
+	}
+
+	if _, err := server.GetPolicy(policyName); err != nil {
+		t.Fatalf("policy should still exist after rejected deletion: %v", err)
+	}
+
+	attached, err := server.credentialManager.ListAttachedUserPolicies(ctx, "bob")
+	if err != nil {
+		t.Fatalf("ListAttachedUserPolicies: %v", err)
+	}
+	if len(attached) != 1 || attached[0] != policyName {
+		t.Fatalf("expected policy %q to remain attached, got %v", policyName, attached)
+	}
+
+	if err := server.credentialManager.DetachUserPolicy(ctx, "bob", policyName); err != nil {
+		t.Fatalf("DetachUserPolicy: %v", err)
+	}
+	if err := server.DeletePolicy(policyName); err != nil {
+		t.Fatalf("DeletePolicy after detach failed: %v", err)
+	}
+}
+
+func TestDeletePolicyRejectsWhenAttachedToGroup(t *testing.T) {
+	server := newAdminServerWithMemoryStore(t)
+	ctx := context.Background()
+	const policyName = "policy_g"
+
+	if err := server.CreatePolicy(policyName, samplePolicyDocument()); err != nil {
+		t.Fatalf("CreatePolicy: %v", err)
+	}
+	if err := server.credentialManager.CreateGroup(ctx, &iam_pb.Group{Name: "team_g", PolicyNames: []string{policyName}}); err != nil {
+		t.Fatalf("CreateGroup: %v", err)
+	}
+
+	if err := server.DeletePolicy(policyName); !errors.Is(err, ErrPolicyStillAttached) {
+		t.Fatalf("expected ErrPolicyStillAttached, got %v", err)
+	}
+
+	if _, err := server.GetPolicy(policyName); err != nil {
+		t.Fatalf("policy should still exist after rejected deletion: %v", err)
+	}
+}
+
+func TestDeletePolicySucceedsWhenNotAttached(t *testing.T) {
+	server := newAdminServerWithMemoryStore(t)
+	const policyName = "policy_free"
+
+	if err := server.CreatePolicy(policyName, samplePolicyDocument()); err != nil {
+		t.Fatalf("CreatePolicy: %v", err)
+	}
+	if err := server.DeletePolicy(policyName); err != nil {
+		t.Fatalf("DeletePolicy for unattached policy failed: %v", err)
+	}
+	if _, err := server.GetPolicy(policyName); err != nil {
+		t.Fatalf("GetPolicy after delete: %v", err)
 	}
 }

--- a/weed/admin/handlers/policy_handlers.go
+++ b/weed/admin/handlers/policy_handlers.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -186,8 +187,13 @@ func (h *PolicyHandlers) DeletePolicy(w http.ResponseWriter, r *http.Request) {
 	// Delete the policy
 	err = h.adminServer.DeletePolicy(policyName)
 	if err != nil {
-		glog.Errorf("Failed to delete policy %s: %v", policyName, err)
-		writeJSONError(w, http.StatusInternalServerError, "Failed to delete policy: "+err.Error())
+		status := http.StatusInternalServerError
+		if errors.Is(err, dash.ErrPolicyStillAttached) {
+			status = http.StatusConflict
+		} else {
+			glog.Errorf("Failed to delete policy %s: %v", policyName, err)
+		}
+		writeJSONError(w, status, "Failed to delete policy: "+err.Error())
 		return
 	}
 


### PR DESCRIPTION
## Summary

Fixes #11225

Deleting an IAM policy from the admin dashboard's **IAM Policies** page did not check whether the policy was still attached to a user, so the deleted policy's name kept showing up indefinitely in that user's "Attached Policy Names" list.

The IAM API handler (`weed/iamapi`) already rejects deletion of an attached policy (matching AWS IAM's `DeleteConflictException`), but the admin UI path (`AdminServer.DeletePolicy`) deleted the policy unconditionally, leaving the stale user reference behind.

This PR makes the admin UI consistent with the IAM API by rejecting deletion while a policy is still attached to any user or group.

### Changes (one commit per logic change)
- **`admin: add IsPolicyAttached helper to detect user/group attachments`** — adds `AdminServer.IsPolicyAttached`, which lists the users and groups that still reference a managed policy, reusing the existing credential manager `ListUsers` / `ListAttachedUserPolicies` / `ListGroups` / `GetGroup` methods.
- **`admin: reject IAM policy deletion while still attached`** — guards `AdminServer.DeletePolicy` with that check and returns the typed `ErrPolicyStillAttached` error when the policy is still referenced, so the policy (and its user attachments) are left intact.
- **`admin: return 409 Conflict when deleting an attached IAM policy`** — maps `ErrPolicyStillAttached` to HTTP 409 Conflict in the admin UI `DeletePolicy` handler so the dashboard surfaces the conflict instead of a generic 500.

#### Test plan
- [x] New tests in `weed/admin/dash/policies_management_test.go` cover: `IsPolicyAttached` reporting user + group attachments; `DeletePolicy` rejected with `ErrPolicyStillAttached` when attached to a user (and succeeds after detaching); rejected when attached to a group; succeeds when not attached.
- [x] `go build ./...` passes
- [x] `go vet ./weed/admin/dash/ ./weed/admin/handlers/` passes
- [x] `go test ./weed/admin/dash/ ./weed/admin/handlers/ ./weed/credential/...` passes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs/pull/11230" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented deletion of policies that are still assigned to users or groups.
  - Policy deletion now returns a clear conflict response when attachments exist, while other failures continue to return server errors.
  - Policy details remain intact when deletion is blocked.
  - Policies can be deleted successfully once no users or groups are attached.
  - Attachment checks now handle groups that no longer exist without failing the request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->