### PR TITLE
filer: widen metadata-subscription readahead buffers

### DIFF
--- a/weed/filer/filer_notify.go
+++ b/weed/filer/filer_notify.go
@@ -375,7 +375,7 @@ func (f *Filer) ReadPersistedLogBuffer(ctx context.Context, startPosition log_bu
 
 	// Readahead: run the visitor in a background goroutine so volume server I/O
 	// for the next log file overlaps with event processing and gRPC delivery.
-	const readaheadSize = 1024
+	const readaheadSize = 8192
 	type entryOrErr struct {
 		entry *filer_pb.LogEntry
 		err   error

--- a/weed/pb/filer_pb_direct_read.go
+++ b/weed/pb/filer_pb_direct_read.go
@@ -19,7 +19,7 @@ import (
 type LogFileReaderFn func(chunks []*filer_pb.FileChunk) (io.ReadCloser, error)
 
 // logEntryChannelSize bounds decoded entries in flight per filer stream.
-const logEntryChannelSize = 512
+const logEntryChannelSize = 4096
 
 // maxLogEntrySize guards the per-entry allocation against a corrupt size
 // prefix, mirroring the filer package's unexported constant.


### PR DESCRIPTION
## Summary

- **Server-side** `ReadPersistedLogBuffer` readahead channel: 1024 to 8192 entries. The background visitor fills the small channel, blocks on the consumer's gRPC Send, and volume-server I/O for the next log file never overlaps with delivery of the current one. Each disk pass takes longer, and the subscribe loop re-lists log files (`ListDirectoryEntries` on the filer store) more often to drain the same backlog.
- **Client-side** `readFilersMerged` per-filer channel: 512 to 4096 entries. The same serialization on the `weed mount` chunk-mode path, where the client reads persisted log chunks directly from volume servers. A small channel means the producer stalls on the merge consumer's `processEventFn`, and the next log file's chunks are never fetched ahead.

The wider buffers keep the producer goroutines reading through a full log file while the consumer is still processing the previous one, turning serial read-process-read into pipelined read-parallel-process. This cuts the per-pass wall time that drives filer store listings and volume-server round-trips, reducing filer workload under backlog catch-up (e.g. CSI deployments where ~200 mounts reconnect on filer restart).

#### Test plan
- [x] `go build ./weed/...`
- [x] `go test -run 'TestSubscribeLoop|TestReadLogFileRefs|TestReadFilersMerged|TestReadPersistedLog' -count=1 ./weed/server/ ./weed/pb/ ./weed/filer/`
- [x] `go test -count=1 ./weed/util/log_buffer/`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs/pull/11237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved persisted-log and volume-read processing by allowing more entries to be read ahead.
  * Increased buffering to help overlap data retrieval and event delivery, potentially improving throughput and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->