### PR TITLE
helm: supply admin auth in CI renders that enable admin

### DIFF
--- a/.github/workflows/helm_ci.yml
+++ b/.github/workflows/helm_ci.yml
@@ -227,6 +227,9 @@ jobs:
           out = render({
               "global.seaweedfs.securityConfig.jwtSigning.filerWrite": "true",
               "admin.enabled": "true",
+              # admin.ip defaults to 0.0.0.0 (non-loopback), which weed admin 4.46
+              # refuses to bind without authentication.
+              "admin.secret.adminPassword": "ci-admin-password",
           })
           cm = configmap(out, "test-seaweedfs-security-config")
           if cm is None:
@@ -1141,6 +1144,9 @@ jobs:
               "s3.enabled": "true",
               "sftp.enabled": "true",
               "admin.enabled": "true",
+              # admin.ip defaults to 0.0.0.0 (non-loopback), which weed admin 4.46
+              # refuses to bind without authentication.
+              "admin.secret.adminPassword": "ci-admin-password",
               "worker.enabled": "true",
               "cosi.enabled": "true",
               "s3.createBuckets[0].name": "b",
@@ -1337,7 +1343,7 @@ jobs:
           # Which means egress on its own must render for a release that runs
           # neither COSI nor a resize: no component of it reaches the API server,
           # so nothing may demand a CIDR for one.
-          for label, values in {"defaults": {}, "admin": {"admin.enabled": "true"}}.items():
+          for label, values in {"defaults": {}, "admin": {"admin.enabled": "true", "admin.secret.adminPassword": "ci-admin-password"}}.items():
               try:
                   render(dict(values, **{"networkPolicy.enabled": "true",
                                          "networkPolicy.egress.enabled": "true"}))
@@ -1398,6 +1404,9 @@ jobs:
 
           ALL_ON = {
               "admin.enabled": "true",
+              # admin.ip defaults to 0.0.0.0 (non-loopback), which weed admin 4.46
+              # refuses to bind without authentication.
+              "admin.secret.adminPassword": "ci-admin-password",
               "s3.enabled": "true",
               "sftp.enabled": "true",
               "worker.enabled": "true",


### PR DESCRIPTION
## Summary

The `helm: lint and test charts` workflow is failing on master after #11236 merged. That PR added a render-time guard in `admin-statefulset.yaml` that fails the chart when `admin.ip` is non-loopback (default `0.0.0.0`) and admin auth is not configured — because `weed admin` 4.46 refuses to bind a non-loopback address without authentication.

The guard is correct, but several pre-existing `helm_ci.yml` test cases enable `admin.enabled=true` as part of "everything on" renders without a password, so `helm template` now exits non-zero and the `Verify template rendering` step fails (the `subprocess.check_output` calls raise).

This adds `admin.secret.adminPassword` to the four render calls that turn on admin without auth, using the same key the PR's own `ci/admin-values.yaml` already uses:

- IAM gRPC opt-in test (`filerWrite=true` + admin)
- NetworkPolicy `EVERYTHING` dict
- egress-without-`kubeApiServer.cidrs` test
- license `ALL_ON` dict

No chart changes — only the CI workflow fixtures are updated so the renders produce a valid admin StatefulSet.

#### Test plan

- [x] `ct lint --all --chart-dirs k8s/charts` passes
- [x] The four affected `helm template` renders succeed with the added password
- [x] Full local run of the `Verify template rendering` step: `All template rendering tests passed!`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs/pull/11239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Helm rendering tests to provide an administrator password when administrator access is enabled.
  * Expanded coverage across IAM, NetworkPolicy, licensing, and persistence scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->