### PR TITLE
fix: rebase on latest master before pushing star history chart

### DIFF
--- a/.github/workflows/star_history.yml
+++ b/.github/workflows/star_history.yml
@@ -10,9 +10,11 @@ permissions:
   contents: write
 
 concurrency:
-  # Only one chart regeneration at a time; a newer run cancels an in-flight one
-  # so overlapping runs never conflict on note/star_history.svg during rebase.
-  group: star-history
+  # Only one chart regeneration per branch at a time; a newer run on the same
+  # branch cancels an in-flight one so overlapping runs never conflict on
+  # note/star_history.svg during rebase. Scoped by ref so a manual run on
+  # another branch can't cancel the daily master update.
+  group: star-history-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -55,7 +57,13 @@ jobs:
           # Rebase and retry so a concurrent push to master doesn't lose the chart.
           for attempt in 1 2 3 4 5; do
             if [ "$attempt" -gt 1 ]; then
-              git pull --rebase origin "$GITHUB_REF_NAME"
+              # Guard the rebase: a transient fetch error or conflict must not
+              # abort the fail-fast shell before the remaining attempts run.
+              if ! git pull --rebase origin "$GITHUB_REF_NAME"; then
+                echo "rebase failed (attempt ${attempt}); aborting and retrying"
+                git rebase --abort || true
+                continue
+              fi
             fi
             if git push origin HEAD:"$GITHUB_REF_NAME"; then
               exit 0

--- a/.github/workflows/star_history.yml
+++ b/.github/workflows/star_history.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          # Full history so the chart commit can rebase onto a moved master.
           fetch-depth: 0
 
       - name: Set up Python
@@ -45,5 +46,13 @@ jobs:
           fi
           git add note/star_history.svg
           git commit -m "docs: regenerate star history chart"
-          git pull --rebase origin "$GITHUB_REF_NAME"
-          git push
+          # Rebase and retry so a concurrent push to master doesn't lose the chart.
+          for attempt in 1 2 3 4 5; do
+            if git push origin HEAD:"$GITHUB_REF_NAME"; then
+              exit 0
+            fi
+            echo "push rejected (attempt ${attempt}); rebasing onto latest $GITHUB_REF_NAME"
+            git pull --rebase origin "$GITHUB_REF_NAME"
+          done
+          echo "::error::could not push star history chart after retries"
+          exit 1

--- a/.github/workflows/star_history.yml
+++ b/.github/workflows/star_history.yml
@@ -9,6 +9,12 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  # Only one chart regeneration at a time; a newer run cancels an in-flight one
+  # so overlapping runs never conflict on note/star_history.svg during rebase.
+  group: star-history
+  cancel-in-progress: true
+
 jobs:
   render:
     name: Regenerate star history chart
@@ -48,11 +54,13 @@ jobs:
           git commit -m "docs: regenerate star history chart"
           # Rebase and retry so a concurrent push to master doesn't lose the chart.
           for attempt in 1 2 3 4 5; do
+            if [ "$attempt" -gt 1 ]; then
+              git pull --rebase origin "$GITHUB_REF_NAME"
+            fi
             if git push origin HEAD:"$GITHUB_REF_NAME"; then
               exit 0
             fi
-            echo "push rejected (attempt ${attempt}); rebasing onto latest $GITHUB_REF_NAME"
-            git pull --rebase origin "$GITHUB_REF_NAME"
+            echo "push rejected (attempt ${attempt}); will rebase and retry"
           done
           echo "::error::could not push star history chart after retries"
           exit 1

--- a/.github/workflows/star_history.yml
+++ b/.github/workflows/star_history.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -43,4 +45,5 @@ jobs:
           fi
           git add note/star_history.svg
           git commit -m "docs: regenerate star history chart"
+          git pull --rebase origin "$GITHUB_REF_NAME"
           git push


### PR DESCRIPTION
## Summary

The daily Star History workflow ([run 34295946729](https://github.com/seaweedfs/seaweedfs/actions/runs/34295946729)) failed in the `Commit if changed` step:

```
! [rejected]        master -> master (fetch first)
error: failed to push some refs to 'https://github.com/seaweedfs/seaweedfs'
hint: Updates were rejected because the remote contains work that you do not
hint: have locally.
```

The chart rendered fine, but `git push` was rejected because new commits landed on `master` between `actions/checkout` and `git push` (the repo gets commits frequently, so this race is common on a daily schedule).

### Fix
- `actions/checkout` now uses `fetch-depth: 0` so the full history is available for a rebase.
- Before `git push`, the workflow runs `git pull --rebase origin "$GITHUB_REF_NAME"` to replay the generated commit on top of the latest remote branch, making the push fast-forward.

#### Test plan
- [ ] Trigger the workflow via `workflow_dispatch` and confirm it pushes successfully even when `master` has advanced since the last run.
- [ ] Confirm a run with no chart changes still exits cleanly at the `git diff --quiet` check.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs/pull/11240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved automated repository update reliability by allowing runs on different branches to proceed independently.
  - Enabled full history access during automated updates.
  - Added up to five publishing retries, with rebasing after the initial failed attempt and continued retries when rebasing or pushing fails.
  - Reduced unnecessary rebasing during the initial publishing attempt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->