### PR TITLE
fix(filer): use path.Split instead of filepath.Split for filer paths

### DIFF
--- a/weed/util/fullpath.go
+++ b/weed/util/fullpath.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"path"
-	"path/filepath"
 	"strings"
 	"unicode/utf8"
 )
@@ -40,7 +39,7 @@ func NewFullPath(dir, name string) FullPath {
 }
 
 func (fp FullPath) DirAndName() (string, string) {
-	dir, name := filepath.Split(string(fp))
+	dir, name := path.Split(string(fp))
 	name = SanitizeUTF8Name(name)
 	if dir == "/" {
 		return dir, name
@@ -55,7 +54,7 @@ func (fp FullPath) DirAndName() (string, string) {
 // via SanitizeUTF8Name so the result is always safe to place in a proto
 // string field or HTTP URL.
 func (fp FullPath) Name() string {
-	_, name := filepath.Split(string(fp))
+	_, name := path.Split(string(fp))
 	return SanitizeUTF8Name(name)
 }
 
@@ -104,7 +103,7 @@ func (fp FullPath) Split() []string {
 }
 
 func Join(names ...string) string {
-	return filepath.ToSlash(filepath.Join(names...))
+	return path.Join(names...)
 }
 
 func JoinPath(names ...string) FullPath {

--- a/weed/util/fullpath_test.go
+++ b/weed/util/fullpath_test.go
@@ -82,3 +82,94 @@ func TestFullPathDirAndName_OnlyNameSanitized(t *testing.T) {
 		t.Fatalf("regression: dir should remain raw (%q); callers needing a clean path must use Sanitized()", dir)
 	}
 }
+
+// TestFullPathBackslashNotSeparator ensures a literal backslash in a filer
+// path component is treated as a regular character, not as a path separator.
+// Filer paths always use "/" as the separator; using filepath.Split (which
+// treats "\" as a separator on Windows) corrupts paths that contain literal
+// backslashes (#11243). path.Split is OS-independent and only splits on "/".
+func TestFullPathBackslashNotSeparator(t *testing.T) {
+	tests := []struct {
+		fullPath string
+		wantDir  string
+		wantName string
+	}{
+		// Backslash in the filename — must stay in the name, not split the path.
+		{"/test/special\\reverseslash4.jpg", "/test", "special\\reverseslash4.jpg"},
+		// Backslash in a directory component — the dir keeps it, name is after last "/".
+		{"/a\\b/c.jpg", "/a\\b", "c.jpg"},
+		// Multiple backslashes in the filename.
+		{"/dir/a\\b\\c.txt", "/dir", "a\\b\\c.txt"},
+		// Backslash at the start of the filename.
+		{"/dir/\\file.txt", "/dir", "\\file.txt"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.fullPath, func(t *testing.T) {
+			fp := FullPath(tc.fullPath)
+			dir, name := fp.DirAndName()
+			if dir != tc.wantDir {
+				t.Errorf("DirAndName dir: got %q want %q", dir, tc.wantDir)
+			}
+			if name != tc.wantName {
+				t.Errorf("DirAndName name: got %q want %q", name, tc.wantName)
+			}
+			if got := fp.Name(); got != tc.wantName {
+				t.Errorf("Name: got %q want %q", got, tc.wantName)
+			}
+		})
+	}
+}
+
+// TestFullPathSpecialCharactersInName ensures that special characters that are
+// valid in filenames (#, ?, %) are preserved by DirAndName and Name. These
+// characters must be percent-encoded by the client when constructing the HTTP
+// request URL, but once decoded by the server they are regular path bytes.
+// The "/" in the path is always a separator; special chars in a directory
+// component stay in the dir, and the last component is the name.
+func TestFullPathSpecialCharactersInName(t *testing.T) {
+	tests := []struct {
+		fullPath string
+		wantDir  string
+		wantName string
+	}{
+		// "#" in a directory component — dir keeps it, name is after last "/".
+		{"/test/special#/endhashfolder.jpg", "/test/special#", "endhashfolder.jpg"},
+		// "?" in a directory component.
+		{"/test/special?/endqfolder.jpg", "/test/special?", "endqfolder.jpg"},
+		// "%" in a directory component.
+		{"/test/special%/endpctfolder.jpg", "/test/special%", "endpctfolder.jpg"},
+		// "&" in a directory component.
+		{"/test/special&/endampfolder.jpg", "/test/special&", "endampfolder.jpg"},
+		// "=" in a directory component.
+		{"/test/special=/endeqfolder.jpg", "/test/special=", "endeqfolder.jpg"},
+		// Special chars in the filename itself (no "/" after them).
+		{"/test/hash#file.jpg", "/test", "hash#file.jpg"},
+		{"/test/q?file.jpg", "/test", "q?file.jpg"},
+		{"/test/pct%file.jpg", "/test", "pct%file.jpg"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.fullPath, func(t *testing.T) {
+			fp := FullPath(tc.fullPath)
+			dir, name := fp.DirAndName()
+			if dir != tc.wantDir {
+				t.Errorf("DirAndName dir: got %q want %q", dir, tc.wantDir)
+			}
+			if name != tc.wantName {
+				t.Errorf("DirAndName name: got %q want %q", name, tc.wantName)
+			}
+			if got := fp.Name(); got != tc.wantName {
+				t.Errorf("Name: got %q want %q", got, tc.wantName)
+			}
+		})
+	}
+}
+
+// TestJoinPreservesBackslash ensures Join does not convert backslashes to
+// forward slashes — they are regular filename characters in filer paths.
+func TestJoinPreservesBackslash(t *testing.T) {
+	got := Join("/parent", "child\\name.txt")
+	want := "/parent/child\\name.txt"
+	if got != want {
+		t.Fatalf("Join: got %q want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #11243

`FullPath.DirAndName()` and `FullPath.Name()` used `filepath.Split`, which is **OS-dependent**: on Windows it treats `\` as a path separator, corrupting filer paths that contain literal backslashes. Filer paths always use `/` as the separator, so this PR switches to `path.Split` (and `path.Join`) which only split on `/` regardless of the host OS.

### Root cause

The filer path namespace is a virtual hierarchical key that always uses `/` as the component separator — it is not an OS filesystem path. However, `FullPath.DirAndName()` and `FullPath.Name()` in `weed/util/fullpath.go` used `filepath.Split`, which on Windows treats `\` as a path separator. This meant a filer path like `/test/special\reverseslash4.jpg` (where `\` is a literal character in the filename) would be split as `dir="/test/special"`, `name="reverseslash4.jpg"` on Windows, corrupting the stored path.

### What this fixes

- **Backslash (`\`)**: Now treated as a literal character in filenames on all platforms (Windows and Linux), not as a path separator. This was the server-side bug.
- **`#`, `?`, `%`**: These are client-side URL-encoding issues — the HTTP server never receives the raw characters if they are not percent-encoded. Once the client properly encodes them (`%23`, `%3F`, `%25`), Go's HTTP server decodes them and the filer now handles the decoded path correctly on all platforms via the `path.Split` fix.

### Changes

- `weed/util/fullpath.go`: `DirAndName()` and `Name()` now use `path.Split` instead of `filepath.Split`; `Join()` now uses `path.Join` instead of `filepath.Join` + `filepath.ToSlash`. Removed the unused `path/filepath` import.
- `weed/util/fullpath_test.go`: Added `TestFullPathBackslashNotSeparator`, `TestFullPathSpecialCharactersInName`, and `TestJoinPreservesBackslash` to verify backslashes and special characters are preserved as literal filename characters.

#### Test plan
- [x] `go test ./weed/util/... -run TestFullPath -v` — new tests pass
- [x] `go test ./weed/server/... -count=1` — existing server tests pass
- [x] `go test ./weed/filer/... -count=1` — existing filer tests pass
- [x] `go build ./weed/...` — full build succeeds
- [ ] GitHub CI
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs/pull/11246" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Path handling now consistently uses forward slashes across platforms.
  * Backslashes in path components are preserved as literal characters.
  * Special characters such as `#`, `?`, `%`, `&`, and `=` are preserved in path names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->