### PR TITLE
filer: end local-only metadata subscriptions when remote peers appear

### DIFF
--- a/weed/filer/meta_aggregator.go
+++ b/weed/filer/meta_aggregator.go
@@ -61,7 +61,13 @@ type MetaAggregator struct {
 	lowFlushWatermarkTsNs int64
 	deliveryAdvanced      chan struct{}
 	flushAdvanced         chan struct{}
-	peerWatermarksLock    sync.Mutex
+	// remotePeerArrived is closed and replaced when the peer set transitions
+	// from "no remote peers" to "has remote peers". A SubscribeMetadata stream
+	// that started before that transition is serving a filer-local view and
+	// parks on it to end and let the client reconnect into the aggregated
+	// stream (#11247).
+	remotePeerArrived  chan struct{}
+	peerWatermarksLock sync.Mutex
 }
 
 // MetaAggregator only aggregates data "on the fly". The logs are not re-persisted to disk.
@@ -95,6 +101,9 @@ func (ma *MetaAggregator) OnPeerUpdate(update *master_pb.ClusterNodeUpdate, star
 		}
 		stopChan := make(chan struct{})
 		ma.peerChans[address] = stopChan
+		if address != ma.self {
+			ma.noteRemotePeerArrivalLocked()
+		}
 		// Account for the peer before its stream signals; keep prior values
 		// on reconnect.
 		ma.initPeerWatermark(address)
@@ -272,13 +281,47 @@ func lowWatermarkOf(watermarks map[pb.ServerAddress]int64) int64 {
 func (ma *MetaAggregator) HasRemotePeers() bool {
 	ma.peerChansLock.Lock()
 	defer ma.peerChansLock.Unlock()
+	return ma.hasRemotePeersLocked()
+}
 
+func (ma *MetaAggregator) hasRemotePeersLocked() bool {
 	for address := range ma.peerChans {
 		if address != ma.self {
 			return true
 		}
 	}
 	return false
+}
+
+// RemotePeerArrivedChan returns a channel closed when the aggregator learns
+// its first remote peer. Streams that started while no remote peer was known
+// park on it to end instead of serving a filer-local view forever. The
+// channel is one-shot: the reconnected stream takes the aggregated path,
+// which no longer depends on the transition. Returns nil when a remote peer
+// is already known: the caller must not park at all.
+func (ma *MetaAggregator) RemotePeerArrivedChan() <-chan struct{} {
+	ma.peerChansLock.Lock()
+	defer ma.peerChansLock.Unlock()
+	if ma.hasRemotePeersLocked() {
+		return nil
+	}
+	return ma.remotePeerArrivedChanLocked()
+}
+
+// remotePeerArrivedChanLocked returns the arrival channel, arming it first
+// if no transition happened yet. Caller must hold peerChansLock.
+func (ma *MetaAggregator) remotePeerArrivedChanLocked() <-chan struct{} {
+	if ma.remotePeerArrived == nil {
+		ma.remotePeerArrived = make(chan struct{})
+	}
+	return ma.remotePeerArrived
+}
+
+// noteRemotePeerArrivalLocked closes and clears the arrival channel when a
+// remote peer is added, waking every local-pinned stream parked on it.
+// Caller must hold peerChansLock.
+func (ma *MetaAggregator) noteRemotePeerArrivalLocked() {
+	ma.remotePeerArrived = closeWatermarkChan(ma.remotePeerArrived)
 }
 
 // HasPeer reports whether address is currently a tracked filer peer (or this

--- a/weed/filer/meta_aggregator.go
+++ b/weed/filer/meta_aggregator.go
@@ -61,13 +61,8 @@ type MetaAggregator struct {
 	lowFlushWatermarkTsNs int64
 	deliveryAdvanced      chan struct{}
 	flushAdvanced         chan struct{}
-	// remotePeerArrived is closed and replaced when the peer set transitions
-	// from "no remote peers" to "has remote peers". A SubscribeMetadata stream
-	// that started before that transition is serving a filer-local view and
-	// parks on it to end and let the client reconnect into the aggregated
-	// stream (#11247).
-	remotePeerArrived  chan struct{}
-	peerWatermarksLock sync.Mutex
+	remotePeerArrived     chan struct{}
+	peerWatermarksLock    sync.Mutex
 }
 
 // MetaAggregator only aggregates data "on the fly". The logs are not re-persisted to disk.
@@ -294,11 +289,7 @@ func (ma *MetaAggregator) hasRemotePeersLocked() bool {
 }
 
 // RemotePeerArrivedChan returns a channel closed when the aggregator learns
-// its first remote peer. Streams that started while no remote peer was known
-// park on it to end instead of serving a filer-local view forever. The
-// channel is one-shot: the reconnected stream takes the aggregated path,
-// which no longer depends on the transition. Returns nil when a remote peer
-// is already known: the caller must not park at all.
+// its first remote peer, or nil if one is already known.
 func (ma *MetaAggregator) RemotePeerArrivedChan() <-chan struct{} {
 	ma.peerChansLock.Lock()
 	defer ma.peerChansLock.Unlock()
@@ -308,8 +299,7 @@ func (ma *MetaAggregator) RemotePeerArrivedChan() <-chan struct{} {
 	return ma.remotePeerArrivedChanLocked()
 }
 
-// remotePeerArrivedChanLocked returns the arrival channel, arming it first
-// if no transition happened yet. Caller must hold peerChansLock.
+// remotePeerArrivedChanLocked arms and returns the arrival channel. Caller must hold peerChansLock.
 func (ma *MetaAggregator) remotePeerArrivedChanLocked() <-chan struct{} {
 	if ma.remotePeerArrived == nil {
 		ma.remotePeerArrived = make(chan struct{})
@@ -317,9 +307,7 @@ func (ma *MetaAggregator) remotePeerArrivedChanLocked() <-chan struct{} {
 	return ma.remotePeerArrived
 }
 
-// noteRemotePeerArrivalLocked closes and clears the arrival channel when a
-// remote peer is added, waking every local-pinned stream parked on it.
-// Caller must hold peerChansLock.
+// noteRemotePeerArrivalLocked closes the arrival channel when a remote peer is added. Caller must hold peerChansLock.
 func (ma *MetaAggregator) noteRemotePeerArrivalLocked() {
 	ma.remotePeerArrived = closeWatermarkChan(ma.remotePeerArrived)
 }

--- a/weed/filer/meta_aggregator_testing.go
+++ b/weed/filer/meta_aggregator_testing.go
@@ -10,6 +10,9 @@ import (
 func (ma *MetaAggregator) TrackPeerForTesting(peer pb.ServerAddress) {
 	ma.peerChansLock.Lock()
 	ma.peerChans[peer] = make(chan struct{})
+	if peer != ma.self {
+		ma.noteRemotePeerArrivalLocked()
+	}
 	ma.peerChansLock.Unlock()
 	ma.initPeerWatermark(peer)
 }

--- a/weed/server/filer_grpc_server_sub_meta.go
+++ b/weed/server/filer_grpc_server_sub_meta.go
@@ -41,6 +41,13 @@ var (
 	metadataGapSettledHorizon = 2 * filer.LogFlushInterval
 )
 
+// errAggregationUpgrade ends a delegated local stream whose filer learned
+// remote peers after the stream started, so the client re-subscribes and
+// lands on the aggregated stream (#11247). It is an error, not a clean end:
+// RetryUntil-driven followers (mount, s3api IAM) treat a clean end as
+// "following finished" and stop reconnecting.
+var errAggregationUpgrade = errors.New("remote filer peers discovered after subscription started; reconnect for aggregated metadata")
+
 const (
 	// MaxUnsyncedEvents send empty notification with timestamp when certain amount of events have been filtered
 	MaxUnsyncedEvents = 1e3
@@ -70,6 +77,13 @@ const (
 // metadataStreamSender is satisfied by both gRPC stream types and pipelinedSender.
 type metadataStreamSender interface {
 	Send(*filer_pb.SubscribeMetadataResponse) error
+}
+
+// metadataLocalStream is the subset of the local-subscribe gRPC server stream
+// the local loop uses, so the aggregated stream type can delegate to it.
+type metadataLocalStream interface {
+	Send(*filer_pb.SubscribeMetadataResponse) error
+	Context() context.Context
 }
 
 const (
@@ -577,8 +591,21 @@ func (p *gapPass) park(ctx context.Context, cursor *log_buffer.MessagePosition, 
 }
 
 func (fs *FilerServer) SubscribeMetadata(req *filer_pb.SubscribeMetadataRequest, stream filer_pb.SeaweedFiler_SubscribeMetadataServer) error {
-	if fs.filer.MetaAggregator == nil || !fs.filer.MetaAggregator.HasRemotePeers() {
-		return fs.SubscribeLocalMetadata(req, stream)
+	// A filer that has not learned remote peers yet serves the local log and
+	// upgrades when the first remote peer appears: Peer discovery is
+	// asynchronous with the gRPC server accepting streams, and a subscriber
+	// that connected inside that window would otherwise be pinned to a
+	// filer-local view for the life of the stream (#11247).
+	// RemotePeerArrivedChan takes the arrival channel under the same lock as
+	// the peer check, so a peer learned in between returns nil and the
+	// stream goes straight to the aggregated path. A nil aggregator
+	// (aggregation never started) has no upgrade to wait on.
+	if fs.filer.MetaAggregator != nil {
+		if arrival := fs.filer.MetaAggregator.RemotePeerArrivedChan(); arrival != nil {
+			return fs.subscribeLocalMetadata(req, stream, arrival)
+		}
+	} else {
+		return fs.subscribeLocalMetadata(req, stream, nil)
 	}
 
 	ctx := stream.Context()
@@ -914,6 +941,17 @@ func (fs *FilerServer) SubscribeMetadata(req *filer_pb.SubscribeMetadataRequest,
 }
 
 func (fs *FilerServer) SubscribeLocalMetadata(req *filer_pb.SubscribeMetadataRequest, stream filer_pb.SeaweedFiler_SubscribeLocalMetadataServer) error {
+	return fs.subscribeLocalMetadata(req, stream, nil)
+}
+
+// subscribeLocalMetadata serves the filer's own log to the stream. Peer
+// aggregation streams pass upgradeOnRemotePeer == nil. The SubscribeMetadata
+// delegation, taken while no remote peer was known yet, passes the
+// aggregator's arrival channel instead: the filer learned this cluster has
+// more filers after the stream started, and a filer-local view would silently
+// hide their writes from this subscriber for the rest of the stream, so the
+// stream ends and the client reconnects into the aggregated path (#11247).
+func (fs *FilerServer) subscribeLocalMetadata(req *filer_pb.SubscribeMetadataRequest, stream metadataLocalStream, upgradeOnRemotePeer <-chan struct{}) error {
 
 	ctx := stream.Context()
 	peerAddress := findClientAddress(ctx, 0)
@@ -974,6 +1012,11 @@ func (fs *FilerServer) SubscribeLocalMetadata(req *filer_pb.SubscribeMetadataReq
 	var lastDiskReadTsNs int64 = -1     // Track the last read position we used for disk read
 	sentRefs := make(map[string]sentRefState)
 
+	// upgradedToAggregation records that the arrival channel fired while this
+	// delegated stream ran local, so the loop exits with the reconnect error
+	// after the read pass unwinds.
+	var upgradedToAggregation bool
+
 	localBuffer := fs.filer.LocalMetaLogBuffer
 	gaps := &gapPass{
 		fs:       fs,
@@ -991,6 +1034,18 @@ func (fs *FilerServer) SubscribeLocalMetadata(req *filer_pb.SubscribeMetadataReq
 	}
 
 	for {
+		// The aggregator learned a remote peer after this stream started:
+		// end it now so the client reconnects to the aggregated stream,
+		// before another disk pass ships more local-only events.
+		if upgradeOnRemotePeer != nil {
+			select {
+			case <-upgradeOnRemotePeer:
+				glog.V(0).Infof("remote peer discovered after local subscribe %s started: ending stream so the client reconnects to the aggregated stream", clientName)
+				return errAggregationUpgrade
+			default:
+			}
+		}
+
 		// Check if new data has been flushed to disk since last check, or if read position advanced
 		currentFlushTsNs := fs.filer.LocalMetaLogBuffer.GetLastFlushTsNs()
 		currentReadTsNs := lastReadTime.Time.UnixNano()
@@ -1055,6 +1110,14 @@ func (fs *FilerServer) SubscribeLocalMetadata(req *filer_pb.SubscribeMetadataReq
 				return false
 			default:
 			}
+			if upgradeOnRemotePeer != nil {
+				select {
+				case <-upgradeOnRemotePeer:
+					upgradedToAggregation = true
+					return false
+				default:
+				}
+			}
 			if !fs.hasClient(req.ClientId, req.ClientEpoch) {
 				return false
 			}
@@ -1062,6 +1125,10 @@ func (fs *FilerServer) SubscribeLocalMetadata(req *filer_pb.SubscribeMetadataReq
 			lastFlushReportNs = fs.maybeSendFlushReport(req, sender, lastFlushReportNs)
 			return true
 		}, eachLogEntryFn)
+		if upgradedToAggregation {
+			glog.V(0).Infof("remote peer discovered after local subscribe %s started: ending stream so the client reconnects to the aggregated stream", clientName)
+			return errAggregationUpgrade
+		}
 		if readInMemoryLogErr != nil {
 			if errors.Is(readInMemoryLogErr, log_buffer.ResumeFromDiskError) {
 				// Fell behind the ring: back to the disk pass (it re-runs when

--- a/weed/server/filer_grpc_server_sub_meta.go
+++ b/weed/server/filer_grpc_server_sub_meta.go
@@ -417,17 +417,17 @@ func (r *gapStallReporter) close() {
 // corresponds to the event being waited for. The park is where a stalled
 // subscriber spends all its time, so every exit the read loop relies on has to
 // be checked here too.
-func (fs *FilerServer) parkOnGap(ctx context.Context, req *filer_pb.SubscribeMetadataRequest, gapStall *gapStallReporter, evictedTsNs func() int64, cursor log_buffer.MessagePosition, notifyChan <-chan struct{}, reason string) (skipToTsNs int64, skip bool, done bool) {
+func (fs *FilerServer) parkOnGap(ctx context.Context, req *filer_pb.SubscribeMetadataRequest, gapStall *gapStallReporter, evictedTsNs func() int64, cursor log_buffer.MessagePosition, notifyChan <-chan struct{}, reason string, upgradeOnRemotePeer <-chan struct{}) (skipToTsNs int64, skip bool, done bool, upgrade bool) {
 	// Done exits run before park(): a finished stream was never parked, and
 	// marking it so leaves a false "still behind" trace. A cursor at UntilNs is
 	// finished - the bound is inclusive, cursors are exclusive, and
 	// LoopProcessLogData (the only place UntilNs ends a stream) is unreachable
 	// from a park.
 	if req.UntilNs != 0 && cursor.Time.UnixNano() >= req.UntilNs {
-		return 0, false, true
+		return 0, false, true, false
 	}
 	if !fs.hasClient(req.ClientId, req.ClientEpoch) {
-		return 0, false, true
+		return 0, false, true, false
 	}
 	gapStall.park(cursor.Time, reason)
 	if gapStall.stalledFor() >= maxGapStall {
@@ -435,7 +435,7 @@ func (fs *FilerServer) parkOnGap(ctx context.Context, req *filer_pb.SubscribeMet
 		// strictly after it, so the recorded loss is exactly (cursor, skipTo].
 		if evicted := evictedTsNs(); evicted > cursor.Time.UnixNano() {
 			gapStall.gaveUp(cursor.Time, evicted, reason)
-			return evicted, true, false
+			return evicted, true, false, false
 		}
 		// Nothing was withheld past the cursor - nothing to skip, nothing being
 		// lost; keep waiting on a fresh stall cycle.
@@ -459,13 +459,15 @@ func (fs *FilerServer) parkOnGap(ctx context.Context, req *filer_pb.SubscribeMet
 				continue
 			}
 		case <-ctx.Done():
-			return 0, false, true
+			return 0, false, true, false
+		case <-upgradeOnRemotePeer:
+			return 0, false, false, true
 		case <-retry:
 		}
 		if !fs.hasClient(req.ClientId, req.ClientEpoch) {
-			return 0, false, true
+			return 0, false, true, false
 		}
-		return 0, false, false
+		return 0, false, false, false
 	}
 }
 
@@ -511,15 +513,16 @@ func resolveGapResume(currentTsNs, currentOffset, earliestMemTsNs, flushedTsNs, 
 // the two subscribe loops; everything else about them must stay identical, and
 // this PR's history shows they drift when edited separately.
 type gapPass struct {
-	fs        *FilerServer
-	req       *filer_pb.SubscribeMetadataRequest
-	gapStall  *gapStallReporter
-	earliest  func() time.Time
-	evicted   func() int64 // gap-proof watermark; aggregated uses the received-ts space
-	flushed   func() int64 // what the last disk read proved covered: flushed AND inside its listing
-	gapChan   <-chan struct{}
-	dataChan  <-chan struct{}
-	gapReason func(earliest time.Time, evictedTsNs int64) string
+	fs                  *FilerServer
+	req                 *filer_pb.SubscribeMetadataRequest
+	gapStall            *gapStallReporter
+	earliest            func() time.Time
+	evicted             func() int64 // gap-proof watermark; aggregated uses the received-ts space
+	flushed             func() int64 // what the last disk read proved covered: flushed AND inside its listing
+	gapChan             <-chan struct{}
+	dataChan            <-chan struct{}
+	gapReason           func(earliest time.Time, evictedTsNs int64) string
+	upgradeOnRemotePeer <-chan struct{}
 }
 
 type gapOutcome int
@@ -528,6 +531,7 @@ const (
 	gapProceed  gapOutcome = iota // read memory
 	gapContinue                   // restart the pass
 	gapDone                       // the stream is over
+	gapUpgrade                    // remote peer arrived; end for reconnect
 )
 
 // resolve is the gap decision both loops run between the disk pass and the
@@ -579,9 +583,12 @@ func (p *gapPass) resolve(ctx context.Context, cursor *log_buffer.MessagePositio
 }
 
 func (p *gapPass) park(ctx context.Context, cursor *log_buffer.MessagePosition, latch *error, notifyChan <-chan struct{}, reason string) gapOutcome {
-	skipTo, skip, done := p.fs.parkOnGap(ctx, p.req, p.gapStall, p.evicted, *cursor, notifyChan, reason)
+	skipTo, skip, done, upgrade := p.fs.parkOnGap(ctx, p.req, p.gapStall, p.evicted, *cursor, notifyChan, reason, p.upgradeOnRemotePeer)
 	if done {
 		return gapDone
+	}
+	if upgrade {
+		return gapUpgrade
 	}
 	if skip {
 		*cursor = log_buffer.NewMessagePosition(skipTo, gapResumeCursorOffset)
@@ -1016,14 +1023,15 @@ func (fs *FilerServer) subscribeLocalMetadata(req *filer_pb.SubscribeMetadataReq
 
 	localBuffer := fs.filer.LocalMetaLogBuffer
 	gaps := &gapPass{
-		fs:       fs,
-		req:      req,
-		gapStall: gapStall,
-		earliest: localBuffer.GetEarliestTime,
-		evicted:  localBuffer.GetLastEvictedTsNs, // local disk carries the ring's own timestamps
-		flushed:  func() int64 { return lastCheckedFlushTsNs },
-		gapChan:  localFlushChan,
-		dataChan: localFlushChan,
+		fs:                  fs,
+		req:                 req,
+		gapStall:            gapStall,
+		earliest:            localBuffer.GetEarliestTime,
+		evicted:             localBuffer.GetLastEvictedTsNs, // local disk carries the ring's own timestamps
+		flushed:             func() int64 { return lastCheckedFlushTsNs },
+		gapChan:             localFlushChan,
+		dataChan:            localFlushChan,
+		upgradeOnRemotePeer: upgradeOnRemotePeer,
 		gapReason: func(earliest time.Time, evictedTsNs int64) string {
 			return fmt.Sprintf("gap is not flushed yet (earliest memory %v, flushed through %v)",
 				earliest, time.Unix(0, lastCheckedFlushTsNs))
@@ -1095,6 +1103,8 @@ func (fs *FilerServer) subscribeLocalMetadata(req *filer_pb.SubscribeMetadataReq
 		switch gaps.resolve(ctx, &lastReadTime, &readInMemoryLogErr, diskAdvanced) {
 		case gapDone:
 			return nil
+		case gapUpgrade:
+			return errAggregationUpgrade
 		case gapContinue:
 			continue
 		}

--- a/weed/server/filer_grpc_server_sub_meta.go
+++ b/weed/server/filer_grpc_server_sub_meta.go
@@ -41,12 +41,12 @@ var (
 	metadataGapSettledHorizon = 2 * filer.LogFlushInterval
 )
 
-// errAggregationUpgrade ends a delegated local stream whose filer learned
-// remote peers after the stream started, so the client re-subscribes and
-// lands on the aggregated stream (#11247). It is an error, not a clean end:
-// RetryUntil-driven followers (mount, s3api IAM) treat a clean end as
-// "following finished" and stop reconnecting.
-var errAggregationUpgrade = errors.New("remote filer peers discovered after subscription started; reconnect for aggregated metadata")
+// errAggregationUpgrade ends a delegated local stream when remote peers
+// appear, so the client reconnects to the aggregated stream. It is an
+// error, not a clean end: RetryUntil-driven followers treat a clean end as
+// "following finished" and stop reconnecting. It wraps StopReadingError so
+// LoopProcessLogData does not log it.
+var errAggregationUpgrade = fmt.Errorf("remote filer peers discovered after subscription started; reconnect for aggregated metadata: %w", log_buffer.StopReadingError)
 
 const (
 	// MaxUnsyncedEvents send empty notification with timestamp when certain amount of events have been filtered
@@ -592,14 +592,10 @@ func (p *gapPass) park(ctx context.Context, cursor *log_buffer.MessagePosition, 
 
 func (fs *FilerServer) SubscribeMetadata(req *filer_pb.SubscribeMetadataRequest, stream filer_pb.SeaweedFiler_SubscribeMetadataServer) error {
 	// A filer that has not learned remote peers yet serves the local log and
-	// upgrades when the first remote peer appears: Peer discovery is
-	// asynchronous with the gRPC server accepting streams, and a subscriber
-	// that connected inside that window would otherwise be pinned to a
-	// filer-local view for the life of the stream (#11247).
-	// RemotePeerArrivedChan takes the arrival channel under the same lock as
-	// the peer check, so a peer learned in between returns nil and the
-	// stream goes straight to the aggregated path. A nil aggregator
-	// (aggregation never started) has no upgrade to wait on.
+	// upgrades when the first one appears. RemotePeerArrivedChan takes the
+	// arrival channel under the same lock as the peer check, so a peer
+	// learned in between returns nil and the stream goes straight to the
+	// aggregated path.
 	if fs.filer.MetaAggregator != nil {
 		if arrival := fs.filer.MetaAggregator.RemotePeerArrivedChan(); arrival != nil {
 			return fs.subscribeLocalMetadata(req, stream, arrival)
@@ -771,7 +767,7 @@ func (fs *FilerServer) SubscribeMetadata(req *filer_pb.SubscribeMetadataRequest,
 				diskPassProvenTsNs = refsStopTsNs
 			}
 			if refsStopTsNs > lastReadTime.Time.UnixNano() {
-				processedTsNs, isDone, readPersistedLogErr = fs.chunkDiskPass(ctx, sender, lastReadTime, refsStopTsNs, sentRefs)
+				processedTsNs, isDone, readPersistedLogErr = fs.chunkDiskPass(ctx, sender, lastReadTime, refsStopTsNs, sentRefs, nil)
 			} else {
 				processedTsNs, isDone, readPersistedLogErr = 0, false, nil
 			}
@@ -945,12 +941,9 @@ func (fs *FilerServer) SubscribeLocalMetadata(req *filer_pb.SubscribeMetadataReq
 }
 
 // subscribeLocalMetadata serves the filer's own log to the stream. Peer
-// aggregation streams pass upgradeOnRemotePeer == nil. The SubscribeMetadata
-// delegation, taken while no remote peer was known yet, passes the
-// aggregator's arrival channel instead: the filer learned this cluster has
-// more filers after the stream started, and a filer-local view would silently
-// hide their writes from this subscriber for the rest of the stream, so the
-// stream ends and the client reconnects into the aggregated path (#11247).
+// aggregation streams pass upgradeOnRemotePeer == nil; the SubscribeMetadata
+// delegation passes the aggregator's arrival channel so the stream ends
+// when a remote peer appears and the client reconnects to the aggregated path.
 func (fs *FilerServer) subscribeLocalMetadata(req *filer_pb.SubscribeMetadataRequest, stream metadataLocalStream, upgradeOnRemotePeer <-chan struct{}) error {
 
 	ctx := stream.Context()
@@ -1000,6 +993,13 @@ func (fs *FilerServer) subscribeLocalMetadata(req *filer_pb.SubscribeMetadataReq
 	var lastFlushReportNs int64
 	baseEachLogEntryFn := eachLogEntryFn(req, sender, eachEventNotificationFn, &unsyncedEvents)
 	eachLogEntryFn := func(logEntry *filer_pb.LogEntry) (bool, error) {
+		if upgradeOnRemotePeer != nil {
+			select {
+			case <-upgradeOnRemotePeer:
+				return false, errAggregationUpgrade
+			default:
+			}
+		}
 		lastSeenTsNs = logEntry.TsNs
 		return baseEachLogEntryFn(logEntry)
 	}
@@ -1012,9 +1012,6 @@ func (fs *FilerServer) subscribeLocalMetadata(req *filer_pb.SubscribeMetadataReq
 	var lastDiskReadTsNs int64 = -1     // Track the last read position we used for disk read
 	sentRefs := make(map[string]sentRefState)
 
-	// upgradedToAggregation records that the arrival channel fired while this
-	// delegated stream ran local, so the loop exits with the reconnect error
-	// after the read pass unwinds.
 	var upgradedToAggregation bool
 
 	localBuffer := fs.filer.LocalMetaLogBuffer
@@ -1034,9 +1031,6 @@ func (fs *FilerServer) subscribeLocalMetadata(req *filer_pb.SubscribeMetadataReq
 	}
 
 	for {
-		// The aggregator learned a remote peer after this stream started:
-		// end it now so the client reconnects to the aggregated stream,
-		// before another disk pass ships more local-only events.
 		if upgradeOnRemotePeer != nil {
 			select {
 			case <-upgradeOnRemotePeer:
@@ -1060,11 +1054,14 @@ func (fs *FilerServer) subscribeLocalMetadata(req *filer_pb.SubscribeMetadataReq
 			lastDiskReadTsNs = currentReadTsNs
 			glog.V(4).Infof("read on disk %v local subscribe %s from %+v (lastFlushed: %v)", clientName, req.PathPrefix, lastReadTime, time.Unix(0, currentFlushTsNs))
 			if req.ClientSupportsMetadataChunks {
-				processedTsNs, isDone, readPersistedLogErr = fs.chunkDiskPass(ctx, sender, lastReadTime, req.UntilNs, sentRefs)
+				processedTsNs, isDone, readPersistedLogErr = fs.chunkDiskPass(ctx, sender, lastReadTime, req.UntilNs, sentRefs, upgradeOnRemotePeer)
 			} else {
 				processedTsNs, isDone, readPersistedLogErr = fs.filer.ReadPersistedLogBuffer(ctx, lastReadTime, req.UntilNs, eachLogEntryFn)
 			}
 			if readPersistedLogErr != nil {
+				if errors.Is(readPersistedLogErr, errAggregationUpgrade) {
+					return errAggregationUpgrade
+				}
 				glog.V(0).Infof("read on disk %v local subscribe %s from %+v: %v", clientName, req.PathPrefix, lastReadTime, readPersistedLogErr)
 				return fmt.Errorf("reading from persisted logs: %w", readPersistedLogErr)
 			}
@@ -1130,6 +1127,9 @@ func (fs *FilerServer) subscribeLocalMetadata(req *filer_pb.SubscribeMetadataReq
 			return errAggregationUpgrade
 		}
 		if readInMemoryLogErr != nil {
+			if errors.Is(readInMemoryLogErr, errAggregationUpgrade) {
+				return errAggregationUpgrade
+			}
 			if errors.Is(readInMemoryLogErr, log_buffer.ResumeFromDiskError) {
 				// Fell behind the ring: back to the disk pass (it re-runs when
 				// the flush or the cursor moved), and from there to the gap
@@ -1290,7 +1290,7 @@ func (fs *FilerServer) maybeSendIdleHeartbeat(req *filer_pb.SubscribeMetadataReq
 // empty-notification marker: both chunk consumers buffer refs until a non-ref
 // message, so an idle source would otherwise strand the backlog in the
 // client's pending list until the next mutation.
-func (fs *FilerServer) chunkDiskPass(ctx context.Context, sender metadataStreamSender, startPos log_buffer.MessagePosition, untilNs int64, sent map[string]sentRefState) (processedTsNs int64, isDone bool, err error) {
+func (fs *FilerServer) chunkDiskPass(ctx context.Context, sender metadataStreamSender, startPos log_buffer.MessagePosition, untilNs int64, sent map[string]sentRefState, upgradeOnRemotePeer <-chan struct{}) (processedTsNs int64, isDone bool, err error) {
 	collected, _, err := fs.filer.CollectLogFileRefs(ctx, startPos, untilNs)
 	if err != nil {
 		return 0, false, err
@@ -1301,6 +1301,13 @@ func (fs *FilerServer) chunkDiskPass(ctx context.Context, sender metadataStreamS
 	}
 	if err := fs.sendRefsBatched(sender, refs); err != nil {
 		return 0, false, err
+	}
+	if upgradeOnRemotePeer != nil {
+		select {
+		case <-upgradeOnRemotePeer:
+			return 0, false, errAggregationUpgrade
+		default:
+		}
 	}
 
 	// Shipped content end, read from the shipped chunks alone - a fresh

--- a/weed/server/filer_grpc_server_sub_meta.go
+++ b/weed/server/filer_grpc_server_sub_meta.go
@@ -1299,7 +1299,7 @@ func (fs *FilerServer) chunkDiskPass(ctx context.Context, sender metadataStreamS
 	if len(refs) == 0 {
 		return startPos.Time.UnixNano(), false, nil
 	}
-	if err := fs.sendRefsBatched(sender, refs); err != nil {
+	if err := fs.sendRefsBatched(sender, refs, upgradeOnRemotePeer); err != nil {
 		return 0, false, err
 	}
 	if upgradeOnRemotePeer != nil {
@@ -1359,9 +1359,16 @@ func (fs *FilerServer) chunkDiskPass(ctx context.Context, sender metadataStreamS
 // sendRefsBatched sends refs through the pipelined sender, which keeps them
 // out of Events batches; gRPC allows one sending goroutine per stream and the
 // sender's goroutine is it.
-func (fs *FilerServer) sendRefsBatched(sender metadataStreamSender, refs []*filer_pb.LogFileChunkRef) error {
+func (fs *FilerServer) sendRefsBatched(sender metadataStreamSender, refs []*filer_pb.LogFileChunkRef, upgradeOnRemotePeer <-chan struct{}) error {
 	const maxRefsPerMessage = 64
 	for i := 0; i < len(refs); i += maxRefsPerMessage {
+		if upgradeOnRemotePeer != nil {
+			select {
+			case <-upgradeOnRemotePeer:
+				return errAggregationUpgrade
+			default:
+			}
+		}
 		end := i + maxRefsPerMessage
 		if end > len(refs) {
 			end = len(refs)

--- a/weed/server/filer_grpc_server_sub_meta_gap_test.go
+++ b/weed/server/filer_grpc_server_sub_meta_gap_test.go
@@ -285,7 +285,7 @@ func TestParkOnGapExits(t *testing.T) {
 		gapStall := newStall()
 		defer gapStall.resumed()
 		start := time.Now()
-		_, skip, done := fs.parkOnGap(context.Background(), req, gapStall, noEviction, cursor, nil, "test")
+		_, skip, done, _ := fs.parkOnGap(context.Background(), req, gapStall, noEviction, cursor, nil, "test", nil)
 		if skip || done {
 			t.Fatalf("skip=%v done=%v, want a plain retry", skip, done)
 		}
@@ -299,7 +299,7 @@ func TestParkOnGapExits(t *testing.T) {
 		// old one keeps scanning the filer store until its TCP connection dies.
 		gapStall := newStall()
 		superseded := &filer_pb.SubscribeMetadataRequest{ClientId: 7, ClientEpoch: 2}
-		if _, _, done := fs.parkOnGap(context.Background(), superseded, gapStall, noEviction, cursor, nil, "test"); !done {
+		if _, _, done, _ := fs.parkOnGap(context.Background(), superseded, gapStall, noEviction, cursor, nil, "test", nil); !done {
 			t.Fatal("want done")
 		}
 		if !gapStall.since.IsZero() {
@@ -310,7 +310,7 @@ func TestParkOnGapExits(t *testing.T) {
 	t.Run("a bounded subscription past its window ends without parking", func(t *testing.T) {
 		gapStall := newStall()
 		bounded := &filer_pb.SubscribeMetadataRequest{ClientId: 7, ClientEpoch: 3, UntilNs: cursorTs - 1}
-		if _, _, done := fs.parkOnGap(context.Background(), bounded, gapStall, noEviction, cursor, nil, "test"); !done {
+		if _, _, done, _ := fs.parkOnGap(context.Background(), bounded, gapStall, noEviction, cursor, nil, "test", nil); !done {
 			t.Fatal("want done")
 		}
 		if !gapStall.since.IsZero() {
@@ -324,7 +324,7 @@ func TestParkOnGapExits(t *testing.T) {
 		// everything <= UntilNs delivered. Parking would make fs.verify hang.
 		gapStall := newStall()
 		bounded := &filer_pb.SubscribeMetadataRequest{ClientId: 7, ClientEpoch: 3, UntilNs: cursorTs}
-		if _, _, done := fs.parkOnGap(context.Background(), bounded, gapStall, noEviction, cursor, nil, "test"); !done {
+		if _, _, done, _ := fs.parkOnGap(context.Background(), bounded, gapStall, noEviction, cursor, nil, "test", nil); !done {
 			t.Fatal("want done")
 		}
 		if !gapStall.since.IsZero() {
@@ -338,7 +338,7 @@ func TestParkOnGapExits(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		start := time.Now()
-		if _, _, done := fs.parkOnGap(ctx, req, gapStall, noEviction, cursor, nil, "test"); !done {
+		if _, _, done, _ := fs.parkOnGap(ctx, req, gapStall, noEviction, cursor, nil, "test", nil); !done {
 			t.Fatal("want done")
 		}
 		if elapsed := time.Since(start); elapsed >= unflushedGapRetryInterval {
@@ -354,7 +354,7 @@ func TestParkOnGapExits(t *testing.T) {
 		closed := make(chan struct{})
 		close(closed)
 		start := time.Now()
-		_, skip, done := fs.parkOnGap(context.Background(), req, gapStall, noEviction, cursor, closed, "test")
+		_, skip, done, _ := fs.parkOnGap(context.Background(), req, gapStall, noEviction, cursor, closed, "test", nil)
 		if skip || done {
 			t.Fatalf("skip=%v done=%v, want a plain retry", skip, done)
 		}
@@ -369,7 +369,7 @@ func TestParkOnGapExits(t *testing.T) {
 		notify := make(chan struct{}, 1)
 		notify <- struct{}{}
 		start := time.Now()
-		_, skip, done := fs.parkOnGap(context.Background(), req, gapStall, noEviction, cursor, notify, "test")
+		_, skip, done, _ := fs.parkOnGap(context.Background(), req, gapStall, noEviction, cursor, notify, "test", nil)
 		if skip || done {
 			t.Fatalf("skip=%v done=%v, want a plain retry", skip, done)
 		}
@@ -507,7 +507,7 @@ func TestParkOnGapStallOutcomes(t *testing.T) {
 		gapStall.since = time.Now().Add(-maxGapStall)
 
 		before := crossings()
-		skipTo, skip, done := fs.parkOnGap(context.Background(), req, gapStall, lb.GetLastEvictedTsNs, cursor, nil, "test")
+		skipTo, skip, done, _ := fs.parkOnGap(context.Background(), req, gapStall, lb.GetLastEvictedTsNs, cursor, nil, "test", nil)
 		if done || !skip {
 			t.Fatalf("skip=%v done=%v, want a forced skip", skip, done)
 		}
@@ -530,7 +530,7 @@ func TestParkOnGapStallOutcomes(t *testing.T) {
 		defer gapStall.close() // release the gauge this test's park holds
 
 		before := crossings()
-		_, skip, done := fs.parkOnGap(context.Background(), req, gapStall, lb.GetLastEvictedTsNs, cursor, nil, "test")
+		_, skip, done, _ := fs.parkOnGap(context.Background(), req, gapStall, lb.GetLastEvictedTsNs, cursor, nil, "test", nil)
 		if skip || done {
 			t.Fatalf("skip=%v done=%v, want neither: nothing is being lost", skip, done)
 		}

--- a/weed/server/filer_subscribe_upgrade_test.go
+++ b/weed/server/filer_subscribe_upgrade_test.go
@@ -1,0 +1,131 @@
+package weed_server
+
+// Regression tests for the aggregated-subscribe entrypoint's peer-discovery
+// window (#11247). SubscribeMetadata delegates to the local loop when the
+// aggregator knows no remote peers yet. Peer discovery is asynchronous - the
+// master announces filers after the gRPC server starts accepting streams - so
+// a subscriber that connects inside that window used to be pinned to a
+// filer-local stream for its whole life, silently missing every other
+// filer's writes. These tests pin the upgrade: the local stream ends when a
+// remote peer appears, so the client reconnects into the aggregated stream.
+
+import (
+	"testing"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/filer"
+)
+
+// startAggregatorWithoutPeers gives the harness an aggregator that tracks
+// only self, the state of a filer whose gRPC server is up but whose master
+// connection has not announced the other filers yet.
+func (h *subscribeHarness) startAggregatorWithoutPeers() *filer.MetaAggregator {
+	ma := filer.NewMetaAggregator(h.f, testSelfAddress, nil)
+	ma.TrackPeerForTesting(testSelfAddress)
+	h.f.MetaAggregator = ma
+	h.t.Cleanup(ma.MetaLogBuffer.ShutdownLogBuffer)
+	return ma
+}
+
+// TestSubscribeMetadataLocalStreamEndsWhenRemotePeerAppears pins the upgrade
+// path: a stream that started local-only because no remote peer was known yet
+// must not stay local forever. When the first remote peer appears, the stream
+// ends so the client reconnects (from its persisted offset) into the
+// aggregated stream that carries the whole cluster's events.
+func TestSubscribeMetadataLocalStreamEndsWhenRemotePeerAppears(t *testing.T) {
+	h := newSubscribeHarness(t)
+
+	ma := h.startAggregatorWithoutPeers()
+	if ma.HasRemotePeers() {
+		t.Fatal("test setup: aggregator must start without remote peers")
+	}
+
+	localTs := time.Now().UnixNano()
+	h.append(localTs)
+
+	// The subscriber connects inside the discovery window: SubscribeMetadata
+	// takes the local path and delivers the local event.
+	r := h.subscribeAggregated(0)
+	waitForEvents(t, r, []int64{localTs}, 3*time.Second)
+
+	// The master announces a second filer, exactly as OnPeerUpdate does in
+	// production. TrackPeerForTesting registers the peer without its
+	// subscription goroutine, which keeps the test deterministic.
+	ma.TrackPeerForTesting(testPeerAddress)
+
+	// The local stream must end so the client reconnects into the aggregated
+	// path. Before the fix it never ended and every other filer's writes
+	// were silently invisible to this subscriber.
+	select {
+	case err := <-r.done:
+		if err == nil {
+			t.Fatal("local stream ended cleanly; the upgrade must surface as an error so RetryUntil-driven followers reconnect")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("local-only stream stayed alive after a remote peer appeared; the subscriber is pinned to a partial cluster view")
+	}
+}
+
+// TestSubscribeMetadataAggregatedPathAfterPeerArrival pins the other half: the
+// reconnection lands on the aggregated stream, which carries events appended
+// to the aggregated buffer (every peer's writes reach it through the peer
+// subscriptions) after the local events already delivered.
+func TestSubscribeMetadataAggregatedPathAfterPeerArrival(t *testing.T) {
+	h := newSubscribeHarness(t)
+
+	ma := h.startAggregatorWithoutPeers()
+	if ma.HasRemotePeers() {
+		t.Fatal("test setup: aggregator must start without remote peers")
+	}
+
+	localTs := time.Now().UnixNano()
+	h.append(localTs)
+	r := h.subscribeAggregated(0)
+	waitForEvents(t, r, []int64{localTs}, 3*time.Second)
+
+	ma.TrackPeerForTesting(testPeerAddress)
+	select {
+	case <-r.done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("local-only stream stayed alive after a remote peer appeared")
+	}
+
+	// The client reconnects from the last delivered offset: the aggregated
+	// path now serves the peer's events. The peers report delivery through
+	// the peer event - the aggregated read is held at the low watermark
+	// until then, which is the completeness contract the hold enforces.
+	peerTs := time.Now().UnixNano()
+	h.appendAggregated(peerTs)
+	reportPeers(ma, peerTs)
+	r2 := h.subscribeAggregated(localTs)
+	waitForEvents(t, r2, []int64{peerTs}, 3*time.Second)
+}
+
+// TestSubscribeMetadataLocalStreamPersistsWithoutPeers pins the boundary: on
+// a genuinely standalone filer the local stream keeps serving indefinitely;
+// ending it on every idle tick would turn a standalone deployment into a
+// reconnect loop.
+func TestSubscribeMetadataLocalStreamPersistsWithoutPeers(t *testing.T) {
+	h := newSubscribeHarness(t)
+
+	ma := h.startAggregatorWithoutPeers()
+	if ma.HasRemotePeers() {
+		t.Fatal("test setup: aggregator must start without remote peers")
+	}
+
+	localTs := time.Now().UnixNano()
+	h.append(localTs)
+	r := h.subscribeAggregated(0)
+	waitForEvents(t, r, []int64{localTs}, 3*time.Second)
+
+	// No peer ever appears; the stream must still be alive and still deliver.
+	moreTs := time.Now().UnixNano()
+	h.append(moreTs)
+	waitForEventsAtLeastOnce(t, r, []int64{localTs, moreTs}, 3*time.Second)
+
+	select {
+	case err := <-r.done:
+		t.Fatalf("local stream ended (%v) on a standalone filer; it must keep serving", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+}

--- a/weed/server/filer_subscribe_upgrade_test.go
+++ b/weed/server/filer_subscribe_upgrade_test.go
@@ -1,13 +1,10 @@
 package weed_server
 
 // Regression tests for the aggregated-subscribe entrypoint's peer-discovery
-// window (#11247). SubscribeMetadata delegates to the local loop when the
-// aggregator knows no remote peers yet. Peer discovery is asynchronous - the
-// master announces filers after the gRPC server starts accepting streams - so
-// a subscriber that connects inside that window used to be pinned to a
-// filer-local stream for its whole life, silently missing every other
-// filer's writes. These tests pin the upgrade: the local stream ends when a
-// remote peer appears, so the client reconnects into the aggregated stream.
+// window. SubscribeMetadata delegates to the local loop when the aggregator
+// knows no remote peers yet; these tests pin the upgrade: the local stream
+// ends when a remote peer appears, so the client reconnects into the
+// aggregated stream.
 
 import (
 	"testing"
@@ -28,10 +25,8 @@ func (h *subscribeHarness) startAggregatorWithoutPeers() *filer.MetaAggregator {
 }
 
 // TestSubscribeMetadataLocalStreamEndsWhenRemotePeerAppears pins the upgrade
-// path: a stream that started local-only because no remote peer was known yet
-// must not stay local forever. When the first remote peer appears, the stream
-// ends so the client reconnects (from its persisted offset) into the
-// aggregated stream that carries the whole cluster's events.
+// path: a stream that started local-only must end when the first remote peer
+// appears, so the client reconnects into the aggregated stream.
 func TestSubscribeMetadataLocalStreamEndsWhenRemotePeerAppears(t *testing.T) {
 	h := newSubscribeHarness(t)
 
@@ -43,19 +38,14 @@ func TestSubscribeMetadataLocalStreamEndsWhenRemotePeerAppears(t *testing.T) {
 	localTs := time.Now().UnixNano()
 	h.append(localTs)
 
-	// The subscriber connects inside the discovery window: SubscribeMetadata
-	// takes the local path and delivers the local event.
+	// The subscriber connects inside the discovery window.
 	r := h.subscribeAggregated(0)
 	waitForEvents(t, r, []int64{localTs}, 3*time.Second)
 
-	// The master announces a second filer, exactly as OnPeerUpdate does in
-	// production. TrackPeerForTesting registers the peer without its
-	// subscription goroutine, which keeps the test deterministic.
+	// The master announces a second filer, as OnPeerUpdate does in production.
 	ma.TrackPeerForTesting(testPeerAddress)
 
-	// The local stream must end so the client reconnects into the aggregated
-	// path. Before the fix it never ended and every other filer's writes
-	// were silently invisible to this subscriber.
+	// The local stream must end so the client reconnects to the aggregated path.
 	select {
 	case err := <-r.done:
 		if err == nil {
@@ -66,10 +56,9 @@ func TestSubscribeMetadataLocalStreamEndsWhenRemotePeerAppears(t *testing.T) {
 	}
 }
 
-// TestSubscribeMetadataAggregatedPathAfterPeerArrival pins the other half: the
-// reconnection lands on the aggregated stream, which carries events appended
-// to the aggregated buffer (every peer's writes reach it through the peer
-// subscriptions) after the local events already delivered.
+// TestSubscribeMetadataAggregatedPathAfterPeerArrival pins the other half:
+// after the upgrade, a re-subscribe from the last delivered offset takes the
+// aggregated path and receives the peer's events.
 func TestSubscribeMetadataAggregatedPathAfterPeerArrival(t *testing.T) {
 	h := newSubscribeHarness(t)
 
@@ -90,10 +79,8 @@ func TestSubscribeMetadataAggregatedPathAfterPeerArrival(t *testing.T) {
 		t.Fatal("local-only stream stayed alive after a remote peer appeared")
 	}
 
-	// The client reconnects from the last delivered offset: the aggregated
-	// path now serves the peer's events. The peers report delivery through
-	// the peer event - the aggregated read is held at the low watermark
-	// until then, which is the completeness contract the hold enforces.
+	// The client reconnects from the last delivered offset; the aggregated
+	// path now serves the peer's events.
 	peerTs := time.Now().UnixNano()
 	h.appendAggregated(peerTs)
 	reportPeers(ma, peerTs)
@@ -102,9 +89,7 @@ func TestSubscribeMetadataAggregatedPathAfterPeerArrival(t *testing.T) {
 }
 
 // TestSubscribeMetadataLocalStreamPersistsWithoutPeers pins the boundary: on
-// a genuinely standalone filer the local stream keeps serving indefinitely;
-// ending it on every idle tick would turn a standalone deployment into a
-// reconnect loop.
+// a standalone filer the local stream keeps serving indefinitely.
 func TestSubscribeMetadataLocalStreamPersistsWithoutPeers(t *testing.T) {
 	h := newSubscribeHarness(t)
 


### PR DESCRIPTION
# What problem are we solving?

`FilerServer.SubscribeMetadata` delegates to `SubscribeLocalMetadata` whenever the `MetaAggregator` has no remote peers at the moment the stream is set up. Peer discovery is asynchronous with the gRPC server accepting streams: `ListExistingPeerUpdates` runs at `Filer.Init` and `OnPeerUpdate` fires later when the master announces filers. A subscriber that connects inside that window is pinned to a filer-local stream for the life of that stream, silently missing every other filer's writes. No error, no log line beyond the initial `local subscribe` message, nothing unhealthy-looking.

For `filer.remote.sync` in a multi-filer cluster this means the remote tier permanently stops receiving writes served by any other filer (#11247). Long-lived clients (S3 gateways, CSI mounts, remote sync) are all-or-nothing per filer, so some buckets silently lose replication while others stay clean.

# How are we solving the problem?

End the delegated local stream when the aggregator learns its first remote peer, so the client reconnects into the aggregated stream, which carries the whole cluster's events through the peer subscriptions.

- `MetaAggregator` gains a one-shot `remotePeerArrived` broadcast channel, closed when a remote peer is added (`OnPeerUpdate` and the peer-tracking test hook), following the existing `deliveryAdvanced`/`flushAdvanced` pattern.
- `RemotePeerArrivedChan()` arms and returns that channel under `peerChansLock`. It returns nil when a remote peer is already known, so a peer learned between the check and the channel arming sends the stream straight to the aggregated path instead of parking on a channel that would never fire.
- `SubscribeMetadata` keeps delegating while no remote peer is known, but the delegated stream watches the arrival channel and ends when it fires. `SubscribeLocalMetadata` itself (used by peer aggregation) is unchanged: it passes a nil watch channel.
- The end surfaces as an error (`errAggregationUpgrade`), not a clean EOF: `util.RetryUntil`-driven followers (mount meta cache, s3api IAM) treat a nil return as "following finished" and stop reconnecting. All in-tree consumers of `SubscribeMetadata` (filer.sync, filer.backup, filer.meta.backup, remote sync/gateway, mount, s3api) reconnect on stream error with their persisted offset and a bumped epoch, so the reconnect lands on the aggregated path.
- A standalone filer is unaffected: no remote peer ever appears, the channel never fires, and the local stream serves indefinitely.

# How is the PR tested?

Three regression tests in `weed/server/filer_subscribe_upgrade_test.go`, using the existing subscribe harness (real filer with a leveldb store, fake gRPC stream):

- `TestSubscribeMetadataLocalStreamEndsWhenRemotePeerAppears`: subscribe with zero remote peers, add the peer as the master would, and assert the stream ends with an error instead of living forever. Fails on master with "local-only stream stayed alive after a remote peer appeared".
- `TestSubscribeMetadataAggregatedPathAfterPeerArrival`: after the upgrade, a re-subscribe from the last delivered offset takes the aggregated path and receives the peer's events.
- `TestSubscribeMetadataLocalStreamPersistsWithoutPeers`: a standalone filer's local stream keeps serving; the upgrade must not turn standalone deployments into reconnect loops.

Also verified locally: `go vet` clean on the touched packages, the full `weed/server` and `weed/filer` test suites pass, and the `weed` binary builds.

# Checks
- [x] I have added unit tests if possible.
- [x] I will add related wiki document changes and link to this PR after merging.
- [ ] All AI code review comments have been addressed. No more comments to fix if reviewed again. Reviewer may request additional gemini and copilot reviews.

# Checks for AI generated PRs
- [x] I have reviewed every line of code.
- [x] The PR is kept as minimum as possible. Large PRs would not be accepted.

Fixes #11247

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs/pull/11251" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Metadata subscriptions now transition from local delivery to aggregated delivery when a remote filer becomes available.
  - Subscribers can reconnect from their current position and continue receiving metadata events through the aggregated stream.
  - Remote peer availability is detected promptly to support seamless subscription upgrades.

- **Bug Fixes**
  - Local subscriptions remain active on standalone filers when no remote peers are present.
  - Subscription handling now avoids reporting expected transitions between local and aggregated delivery as errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->