### PR TITLE
rust: prevent phantom volumes + validate collection hint in mount_volume_by_id

### DIFF
--- a/seaweed-volume/src/storage/disk_location.rs
+++ b/seaweed-volume/src/storage/disk_location.rs
@@ -1265,7 +1265,7 @@ fn check_dat_file_exists(path: &str) -> bool {
 /// True when a `.vif` references remote-tier files: a remote-only volume
 /// that has no local `.dat` but must still load via the remote path,
 /// rather than be skipped as a lone EC sidecar.
-fn vif_references_remote_file(vif_path: &str) -> bool {
+pub(crate) fn vif_references_remote_file(vif_path: &str) -> bool {
     fs::read_to_string(vif_path)
         .ok()
         .and_then(|s| serde_json::from_str::<VifVolumeInfo>(&s).ok())

--- a/seaweed-volume/src/storage/store.rs
+++ b/seaweed-volume/src/storage/store.rs
@@ -507,37 +507,97 @@ impl Store {
             return Err(VolumeError::AlreadyExists);
         }
         if let Some(collection) = collection {
-            for loc in &mut self.locations {
-                let base =
-                    crate::storage::volume::volume_file_name(&loc.directory, collection, vid);
-                for ext in [".vif", ".idx"] {
-                    if let Ok(meta) = std::fs::metadata(format!("{}{}", base, ext)) {
-                        if !meta.is_dir() {
-                            return loc.create_volume(
-                                vid,
-                                collection,
-                                self.needle_map_kind,
-                                None,
-                                None,
-                                0,
-                                Version::current(),
-                            );
-                        }
+            // The hint is only an optimization: a collection carrying a path
+            // separator or parent reference could route file creation outside
+            // the storage directory, so skip the shortcut and let the safe
+            // directory scan resolve the volume instead.
+            let hint_safe = !collection.is_empty()
+                && !collection.contains('/')
+                && !collection.contains('\\')
+                && !collection.contains("..");
+            if hint_safe {
+                for loc in &mut self.locations {
+                    let base = crate::storage::volume::volume_file_name(
+                        &loc.directory,
+                        collection,
+                        vid,
+                    );
+                    // Confirm a collection-named sidecar exists before using the
+                    // hint. A lone .vif/.idx (e.g. an EC sidecar whose .ecx is on
+                    // a sibling disk) must NOT mount here: create_volume would
+                    // write an empty .dat and register a phantom normal volume
+                    // that shadows the real EC volume. Match the guard in
+                    // load_existing_volumes: only mount when a real .dat is
+                    // present, or the .vif points at a remote-tiered file.
+                    let sidecar_present = [".vif", ".idx"].iter().any(|ext| {
+                        std::fs::metadata(format!("{}{}", base, ext))
+                            .map(|m| !m.is_dir())
+                            .unwrap_or(false)
+                    });
+                    if !sidecar_present {
+                        continue;
                     }
+                    let dat_path = format!("{}.dat", base);
+                    let dat_exists = std::fs::metadata(&dat_path)
+                        .map(|m| !m.is_dir())
+                        .unwrap_or(false);
+                    let idx_base = crate::storage::volume::volume_file_name(
+                        &loc.idx_directory,
+                        collection,
+                        vid,
+                    );
+                    let has_remote = crate::storage::disk_location::vif_references_remote_file(
+                        &format!("{}.vif", base),
+                    ) || crate::storage::disk_location::vif_references_remote_file(
+                        &format!("{}.vif", idx_base),
+                    );
+                    if dat_exists || has_remote {
+                        return loc.create_volume(
+                            vid,
+                            collection,
+                            self.needle_map_kind,
+                            None,
+                            None,
+                            0,
+                            Version::current(),
+                        );
+                    }
+                    // Lone sidecar: leave it for the directory scan below.
                 }
             }
         }
-        if let Some((loc_idx, _base_path, collection)) = self.find_volume_file_base(vid) {
-            let loc = &mut self.locations[loc_idx];
-            return loc.create_volume(
-                vid,
+        if let Some((loc_idx, base_path, collection)) = self.find_volume_file_base(vid) {
+            // The scan matches any volume file (.dat/.vif/.idx). A lone .vif/.idx
+            // sidecar (e.g. an EC sidecar whose .ecx is on a sibling disk) must
+            // NOT mount here: create_volume would write an empty .dat and
+            // register a phantom normal volume that shadows the real EC volume.
+            // Match the guard in load_existing_volumes: only mount when a real
+            // .dat is present, or the .vif points at a remote-tiered file.
+            let dat_exists = std::fs::metadata(&format!("{}.dat", base_path))
+                .map(|m| !m.is_dir())
+                .unwrap_or(false);
+            let idx_base = crate::storage::volume::volume_file_name(
+                &self.locations[loc_idx].idx_directory,
                 &collection,
-                self.needle_map_kind,
-                None,
-                None,
-                0,
-                Version::current(),
+                vid,
             );
+            let has_remote = crate::storage::disk_location::vif_references_remote_file(
+                &format!("{}.vif", base_path),
+            ) || crate::storage::disk_location::vif_references_remote_file(
+                &format!("{}.vif", idx_base),
+            );
+            if dat_exists || has_remote {
+                let loc = &mut self.locations[loc_idx];
+                return loc.create_volume(
+                    vid,
+                    &collection,
+                    self.needle_map_kind,
+                    None,
+                    None,
+                    0,
+                    Version::current(),
+                );
+            }
         }
         Err(VolumeError::Io(io::Error::new(
             io::ErrorKind::NotFound,
@@ -1529,6 +1589,97 @@ mod tests {
         assert!(store.has_volume(VolumeId(1)));
         assert!(!store.has_volume(VolumeId(2)));
         assert_eq!(store.total_volume_count(), 1);
+    }
+
+    #[test]
+    fn test_mount_volume_by_id_hint_skips_lone_sidecar() {
+        // A lone .vif/.idx sidecar (e.g. an EC sidecar whose .ecx is on a
+        // sibling disk) must NOT make the collection hint create a phantom
+        // empty .dat. The hint is skipped and the directory scan finds nothing.
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().to_str().unwrap();
+        let mut store = make_test_store(&[dir]);
+
+        let base = volume_file_name(dir, "coll", VolumeId(5));
+        std::fs::write(format!("{}.vif", base), "{}").unwrap();
+        std::fs::write(format!("{}.idx", base), b"").unwrap();
+        // No .dat, and the .vif does not reference a remote file.
+
+        let err = store
+            .mount_volume_by_id(VolumeId(5), Some("coll"))
+            .unwrap_err();
+        assert!(matches!(err, VolumeError::Io(ref e)
+            if e.kind() == std::io::ErrorKind::NotFound));
+        // No phantom .dat was created.
+        assert!(!std::path::Path::new(&format!("{}.dat", base)).exists());
+        assert!(store.find_volume(VolumeId(5)).is_none());
+    }
+
+    #[test]
+    fn test_mount_volume_by_id_hint_rejects_traversal_collection() {
+        // A collection carrying a parent reference must not route file
+        // creation outside the storage directory; the hint is dropped.
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().to_str().unwrap();
+        let mut store = make_test_store(&[dir]);
+
+        let escaped = format!(
+            "{}/../evil_5.dat",
+            dir
+        );
+        let err = store
+            .mount_volume_by_id(VolumeId(5), Some("../evil"))
+            .unwrap_err();
+        assert!(matches!(err, VolumeError::Io(ref e)
+            if e.kind() == std::io::ErrorKind::NotFound));
+        assert!(!std::path::Path::new(&escaped).exists());
+        assert!(store.find_volume(VolumeId(5)).is_none());
+    }
+
+    #[test]
+    fn test_mount_volume_by_id_hint_loads_real_volume() {
+        // With a real .dat on disk, the collection hint mounts the volume
+        // directly without scanning the directory.
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().to_str().unwrap();
+        let mut store = make_test_store(&[dir]);
+        store
+            .add_volume(
+                VolumeId(7),
+                "coll",
+                None,
+                None,
+                0,
+                DiskType::HardDrive,
+                Version::current(),
+            )
+            .unwrap();
+        // Write a needle so the volume has real data, then unmount it so the
+        // .dat stays on disk but is no longer registered.
+        let mut n = Needle {
+            id: NeedleId(1),
+            cookie: Cookie(0xaa),
+            data: b"hint me".to_vec(),
+            data_size: 7,
+            ..Needle::default()
+        };
+        store
+            .write_volume_needle(VolumeId(7), &mut n, false)
+            .unwrap();
+        assert!(store.unmount_volume(VolumeId(7)));
+
+        store
+            .mount_volume_by_id(VolumeId(7), Some("coll"))
+            .unwrap();
+        assert!(store.find_volume(VolumeId(7)).is_some());
+
+        let mut got = Needle {
+            id: NeedleId(1),
+            ..Needle::default()
+        };
+        let count = store.read_volume_needle(VolumeId(7), &mut got).unwrap();
+        assert_eq!(count, 7);
+        assert_eq!(got.data, b"hint me");
     }
 
     #[test]

--- a/seaweed-volume/src/storage/store.rs
+++ b/seaweed-volume/src/storage/store.rs
@@ -508,13 +508,16 @@ impl Store {
         }
         if let Some(collection) = collection {
             // The hint is only an optimization: a collection carrying a path
-            // separator or parent reference could route file creation outside
-            // the storage directory, so skip the shortcut and let the safe
-            // directory scan resolve the volume instead.
+            // separator could route file creation outside the storage
+            // directory, so skip the shortcut and let the safe directory scan
+            // resolve the volume instead. Rejecting the exact ".." name is
+            // sufficient — a collection like "foo..bar" is a valid name and
+            // stays inside the directory (the ".." is part of the filename, not
+            // a parent reference, because volume_file_name joins with "_").
             let hint_safe = !collection.is_empty()
                 && !collection.contains('/')
                 && !collection.contains('\\')
-                && !collection.contains("..");
+                && collection != "..";
             if hint_safe {
                 for loc in &mut self.locations {
                     let base = crate::storage::volume::volume_file_name(
@@ -552,6 +555,14 @@ impl Store {
                         &format!("{}.vif", idx_base),
                     );
                     if dat_exists || has_remote {
+                        // A persisting .note means the copy that produced these
+                        // files never completed; mounting it would expose a
+                        // truncated volume. Skip this candidate and keep
+                        // searching (matches load_existing_volumes).
+                        let note_path = format!("{}.note", base);
+                        if std::path::Path::new(&note_path).exists() {
+                            continue;
+                        }
                         return loc.create_volume(
                             vid,
                             collection,
@@ -566,7 +577,10 @@ impl Store {
                 }
             }
         }
-        if let Some((loc_idx, base_path, collection)) = self.find_volume_file_base(vid) {
+        // Iterate every matching candidate, not just the first. A lone
+        // sidecar on an earlier disk must not hide a real .dat on a later
+        // disk (the split-disk EC layout the guard above protects against).
+        for (loc_idx, base_path, collection) in self.find_volume_file_bases(vid) {
             // The scan matches any volume file (.dat/.vif/.idx). A lone .vif/.idx
             // sidecar (e.g. an EC sidecar whose .ecx is on a sibling disk) must
             // NOT mount here: create_volume would write an empty .dat and
@@ -587,6 +601,14 @@ impl Store {
                 &format!("{}.vif", idx_base),
             );
             if dat_exists || has_remote {
+                // A persisting .note means the copy that produced these files
+                // never completed; mounting it would expose a truncated volume.
+                // Skip this candidate and keep searching (matches
+                // load_existing_volumes).
+                let note_path = format!("{}.note", base_path);
+                if std::path::Path::new(&note_path).exists() {
+                    continue;
+                }
                 let loc = &mut self.locations[loc_idx];
                 return loc.create_volume(
                     vid,
@@ -606,6 +628,15 @@ impl Store {
     }
 
     fn find_volume_file_base(&self, vid: VolumeId) -> Option<(usize, String, String)> {
+        self.find_volume_file_bases(vid).into_iter().next()
+    }
+
+    /// Collect every location/collection whose directory holds a volume file
+    /// (.dat/.vif/.idx) for `vid`, in scan order. Callers that need to skip
+    /// lone sidecars (mount_volume_by_id) must see all candidates so a sidecar
+    /// on an earlier disk does not hide a real .dat on a later one.
+    fn find_volume_file_bases(&self, vid: VolumeId) -> Vec<(usize, String, String)> {
+        let mut results = Vec::new();
         for (loc_idx, loc) in self.locations.iter().enumerate() {
             if let Ok(entries) = std::fs::read_dir(&loc.directory) {
                 for entry in entries.flatten() {
@@ -613,15 +644,16 @@ impl Store {
                     let name = name.to_string_lossy();
                     if let Some((collection, file_vid)) = parse_volume_filename(&name) {
                         if file_vid == vid {
-                            let base = strip_volume_suffix(&name)?;
-                            let base_path = format!("{}/{}", loc.directory, base);
-                            return Some((loc_idx, base_path, collection));
+                            if let Some(base) = strip_volume_suffix(&name) {
+                                let base_path = format!("{}/{}", loc.directory, base);
+                                results.push((loc_idx, base_path, collection));
+                            }
                         }
                     }
                 }
             }
         }
-        None
+        results
     }
 
     /// Configure a volume's replica placement on disk.
@@ -1680,6 +1712,149 @@ mod tests {
         let count = store.read_volume_needle(VolumeId(7), &mut got).unwrap();
         assert_eq!(count, 7);
         assert_eq!(got.data, b"hint me");
+    }
+
+    #[test]
+    fn test_mount_volume_by_id_hint_accepts_double_dot_collection() {
+        // A valid collection like "foo..bar" contains ".." but is not a parent
+        // reference — volume_file_name joins with "_" so it stays in the dir.
+        // The hint must NOT be rejected for it.
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().to_str().unwrap();
+        let mut store = make_test_store(&[dir]);
+        store
+            .add_volume(
+                VolumeId(9),
+                "foo..bar",
+                None,
+                None,
+                0,
+                DiskType::HardDrive,
+                Version::current(),
+            )
+            .unwrap();
+        let mut n = Needle {
+            id: NeedleId(1),
+            cookie: Cookie(0xaa),
+            data: b"dots".to_vec(),
+            data_size: 4,
+            ..Needle::default()
+        };
+        store.write_volume_needle(VolumeId(9), &mut n, false).unwrap();
+        assert!(store.unmount_volume(VolumeId(9)));
+
+        // The hint is accepted and mounts the volume.
+        store
+            .mount_volume_by_id(VolumeId(9), Some("foo..bar"))
+            .unwrap();
+        assert!(store.find_volume(VolumeId(9)).is_some());
+
+        let mut got = Needle {
+            id: NeedleId(1),
+            ..Needle::default()
+        };
+        let count = store.read_volume_needle(VolumeId(9), &mut got).unwrap();
+        assert_eq!(count, 4);
+        assert_eq!(got.data, b"dots");
+    }
+
+    #[test]
+    fn test_mount_volume_by_id_skips_incomplete_note() {
+        // A persisting .note means a VolumeCopy was interrupted; the volume
+        // must not mount as live (would expose truncated data). The candidate
+        // is skipped and mount returns NotFound.
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().to_str().unwrap();
+        let mut store = make_test_store(&[dir]);
+        store
+            .add_volume(
+                VolumeId(11),
+                "coll",
+                None,
+                None,
+                0,
+                DiskType::HardDrive,
+                Version::current(),
+            )
+            .unwrap();
+        let mut n = Needle {
+            id: NeedleId(1),
+            cookie: Cookie(0xaa),
+            data: b"partial".to_vec(),
+            data_size: 7,
+            ..Needle::default()
+        };
+        store.write_volume_needle(VolumeId(11), &mut n, false).unwrap();
+        assert!(store.unmount_volume(VolumeId(11)));
+
+        // Simulate an interrupted copy: drop a .note marker.
+        let base = volume_file_name(dir, "coll", VolumeId(11));
+        std::fs::write(format!("{}.note", base), "interrupted").unwrap();
+
+        // Hint path: skipped because of .note.
+        let err = store
+            .mount_volume_by_id(VolumeId(11), Some("coll"))
+            .unwrap_err();
+        assert!(matches!(err, VolumeError::Io(ref e)
+            if e.kind() == std::io::ErrorKind::NotFound));
+        assert!(store.find_volume(VolumeId(11)).is_none());
+
+        // Fallback path (no hint): also skipped because of .note.
+        let err = store.mount_volume_by_id(VolumeId(11), None).unwrap_err();
+        assert!(matches!(err, VolumeError::Io(ref e)
+            if e.kind() == std::io::ErrorKind::NotFound));
+        assert!(store.find_volume(VolumeId(11)).is_none());
+    }
+
+    #[test]
+    fn test_mount_volume_by_id_fallback_skips_sidecar_finds_real_dat() {
+        // A lone sidecar on disk 0 must not hide a real .dat on disk 1.
+        // The fallback now iterates all candidates instead of stopping at
+        // the first (sidecar-only) match.
+        let tmp1 = TempDir::new().unwrap();
+        let tmp2 = TempDir::new().unwrap();
+        let dir0 = tmp1.path().to_str().unwrap();
+        let dir1 = tmp2.path().to_str().unwrap();
+
+        // disk 0: lone .vif sidecar, no .dat, no remote.
+        let base0 = volume_file_name(dir0, "coll", VolumeId(13));
+        std::fs::write(format!("{}.vif", base0), "{}").unwrap();
+
+        // disk 1: real volume with data.
+        let mut store = make_test_store(&[dir0, dir1]);
+        store
+            .add_volume(
+                VolumeId(13),
+                "coll",
+                None,
+                None,
+                0,
+                DiskType::HardDrive,
+                Version::current(),
+            )
+            .unwrap();
+        let mut n = Needle {
+            id: NeedleId(1),
+            cookie: Cookie(0xaa),
+            data: b"real".to_vec(),
+            data_size: 4,
+            ..Needle::default()
+        };
+        store.write_volume_needle(VolumeId(13), &mut n, false).unwrap();
+        assert!(store.unmount_volume(VolumeId(13)));
+
+        // No hint: the fallback scan finds the sidecar on disk 0 first (skip,
+        // no .dat), then the real .dat on disk 1 (mount).
+        store.mount_volume_by_id(VolumeId(13), None).unwrap();
+        assert!(store.find_volume(VolumeId(13)).is_some());
+
+        let mut got = Needle {
+            id: NeedleId(1),
+            ..Needle::default()
+        };
+        let count = store.read_volume_needle(VolumeId(13), &mut got).unwrap();
+        assert_eq!(count, 4);
+        assert_eq!(got.data, b"real");
     }
 
     #[test]

--- a/seaweed-volume/src/storage/store.rs
+++ b/seaweed-volume/src/storage/store.rs
@@ -506,6 +506,10 @@ impl Store {
         if self.find_volume(vid).is_some() {
             return Err(VolumeError::AlreadyExists);
         }
+        // Remember the last non-NotFound error so a caller gets a useful
+        // message when every candidate fails to open, instead of a generic
+        // NotFound. A successful mount returns immediately.
+        let mut last_err: Option<VolumeError> = None;
         if let Some(collection) = collection {
             // The hint is only an optimization: a collection carrying a path
             // separator could route file creation outside the storage
@@ -563,7 +567,10 @@ impl Store {
                         if std::path::Path::new(&note_path).exists() {
                             continue;
                         }
-                        return loc.create_volume(
+                        // An open failure on one candidate must not block a
+                        // valid volume on a later disk — remember the error and
+                        // keep scanning (matches open_volumes / Go mountVolume).
+                        match loc.create_volume(
                             vid,
                             collection,
                             self.needle_map_kind,
@@ -571,7 +578,13 @@ impl Store {
                             None,
                             0,
                             Version::current(),
-                        );
+                        ) {
+                            Ok(()) => return Ok(()),
+                            Err(e) => {
+                                last_err = Some(e);
+                                continue;
+                            }
+                        }
                     }
                     // Lone sidecar: leave it for the directory scan below.
                 }
@@ -609,8 +622,11 @@ impl Store {
                 if std::path::Path::new(&note_path).exists() {
                     continue;
                 }
+                // An open failure on one candidate must not block a valid
+                // volume on a later disk — remember the error and keep
+                // scanning (matches open_volumes / Go mountVolume).
                 let loc = &mut self.locations[loc_idx];
-                return loc.create_volume(
+                match loc.create_volume(
                     vid,
                     &collection,
                     self.needle_map_kind,
@@ -618,13 +634,19 @@ impl Store {
                     None,
                     0,
                     Version::current(),
-                );
+                ) {
+                    Ok(()) => return Ok(()),
+                    Err(e) => {
+                        last_err = Some(e);
+                        continue;
+                    }
+                }
             }
         }
-        Err(VolumeError::Io(io::Error::new(
+        Err(last_err.unwrap_or_else(|| VolumeError::Io(io::Error::new(
             io::ErrorKind::NotFound,
             format!("volume {} not found on disk", vid),
-        )))
+        ))))
     }
 
     fn find_volume_file_base(&self, vid: VolumeId) -> Option<(usize, String, String)> {
@@ -1855,6 +1877,77 @@ mod tests {
         let count = store.read_volume_needle(VolumeId(13), &mut got).unwrap();
         assert_eq!(count, 4);
         assert_eq!(got.data, b"real");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_mount_volume_by_id_continues_past_open_failure() {
+        // A create_volume failure on an earlier candidate must not block a
+        // valid volume on a later disk. The scan remembers the error and
+        // keeps going (matches open_volumes / Go mountVolume).
+        use std::os::unix::fs::PermissionsExt;
+        use std::sync::atomic::Ordering;
+        let tmp1 = TempDir::new().unwrap();
+        let tmp2 = TempDir::new().unwrap();
+        let dir0 = tmp1.path().to_str().unwrap();
+        let dir1 = tmp2.path().to_str().unwrap();
+
+        let mut store = make_test_store(&[dir0, dir1]);
+
+        // Force add_volume onto disk 1 by marking disk 0 as low on space.
+        store.locations[0].is_disk_space_low.store(true, Ordering::Relaxed);
+        store
+            .add_volume(
+                VolumeId(15),
+                "coll",
+                None,
+                None,
+                0,
+                DiskType::HardDrive,
+                Version::current(),
+            )
+            .unwrap();
+        let mut n = Needle {
+            id: NeedleId(1),
+            cookie: Cookie(0xaa),
+            data: b"later".to_vec(),
+            data_size: 5,
+            ..Needle::default()
+        };
+        store.write_volume_needle(VolumeId(15), &mut n, false).unwrap();
+        assert!(store.unmount_volume(VolumeId(15)));
+        // Clear the low-space flag so mount_volume_by_id considers disk 0.
+        store.locations[0].is_disk_space_low.store(false, Ordering::Relaxed);
+
+        // disk 0: a .dat that exists but is unreadable (chmod 000). The guard
+        // sees dat_exists=true (metadata succeeds, not a dir), but
+        // create_volume -> Volume::new -> load fails opening it.
+        let base0 = volume_file_name(dir0, "coll", VolumeId(15));
+        std::fs::write(format!("{}.dat", base0), b"").unwrap();
+        std::fs::set_permissions(
+            format!("{}.dat", base0),
+            std::fs::Permissions::from_mode(0o000),
+        )
+        .unwrap();
+
+        // The fallback scan hits disk 0 first (create_volume fails on the
+        // unreadable .dat), then disk 1 (succeeds). Mount succeeds from disk 1.
+        store.mount_volume_by_id(VolumeId(15), None).unwrap();
+        assert!(store.find_volume(VolumeId(15)).is_some());
+
+        let mut got = Needle {
+            id: NeedleId(1),
+            ..Needle::default()
+        };
+        let count = store.read_volume_needle(VolumeId(15), &mut got).unwrap();
+        assert_eq!(count, 5);
+        assert_eq!(got.data, b"later");
+
+        // Restore permissions so TempDir cleanup can remove the file.
+        let _ = std::fs::set_permissions(
+            format!("{}.dat", base0),
+            std::fs::Permissions::from_mode(0o644),
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Follow-up fix for the Rust mirror of #11249 ("Mount req with collection"), addressing the two review comments left on that PR:

- **Devin (bug) — "lone sidecars create phantom volumes"**: `mount_volume_by_id` called `create_volume` on any matching `.vif`/`.idx` sidecar. `create_volume` → `Volume::new` → `load(create_dat_if_missing=true)` writes an empty `.dat` and registers a phantom normal volume, which can shadow a real EC volume whose `.ecx` lives on a sibling disk. This affected both the new collection-hint path **and** the pre-existing `find_volume_file_base` fallback (it matches `.vif`/`.idx` too).
- **Greptile (P1 security) — "collection escapes storage directory"**: the unvalidated `collection` was interpolated into the file path, so a traversal-bearing collection could route `.dat` creation outside the storage directory.

The Go side of #11249 was correct — `LoadVolume`'s collection hint calls `loadExistingVolume`, which already enforces the "never create a phantom `.dat`" guards. The Rust mirror diverged and reintroduced the phantom-volume bug the codebase explicitly guards against in `load_existing_volumes`.

## The fix
Apply the same guard `load_existing_volumes` uses to **both** the collection-hint path and the `find_volume_file_base` fallback: only mount when a real `.dat` is present or the `.vif` references a remote-tiered file; otherwise skip the candidate (no phantom). Reject path-bearing collection hints (`/`, `\`, `..`) so the shortcut falls back to the safe directory scan.

Rebased onto master (commit `13bf056a1`, the #11249 merge).

## Tests
3 new regression tests in `seaweed-volume/src/storage/store.rs`:
- lone `.vif`/`.idx` sidecar → no phantom `.dat` created, mount returns `NotFound`
- traversal collection (`../evil`) → no file created outside the storage dir
- real `.dat` on disk → collection hint still mounts and serves reads

`cargo check --lib` clean; all **336 `storage::` tests pass**.

#### Test plan
- [ ] `cargo test --lib storage::` passes
- [ ] lone-sidecar / traversal / real-volume regression tests pass
- [ ] CI green

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs/pull/11254" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved volume mounting reliability by allowing collection names containing double dots while continuing to reject the exact parent-directory marker.
  - Skipped volume candidates with interrupted-copy markers and continued searching for valid volume data.
  - Ensured fallback mounting checks all matching disks, preventing an earlier sidecar from hiding valid data on a later disk.
  - Preserved the underlying mounting error when all candidate volume openings fail.

- **Tests**
  - Added coverage for collection names, interrupted-copy markers, split volumes, and mounting failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->