### PR TITLE
fix(s3api/sts): respect MaxSessionLength config in DurationSeconds validation

### DIFF
--- a/weed/iam/sts/sts_service.go
+++ b/weed/iam/sts/sts_service.go
@@ -807,7 +807,7 @@ func (s *STSService) issueSession(roleArn, roleSessionName, sessionPolicy string
 // validateSessionDurationSeconds bounds a requested session lifetime the way
 // AWS STS does. Every assume-role entry point runs it, so a duration that came
 // from configuration is checked the same as one from a request.
-func validateSessionDurationSeconds(durationSeconds *int64) error {
+func (s *STSService) validateSessionDurationSeconds(durationSeconds *int64) error {
 	if durationSeconds == nil {
 		return nil
 	}
@@ -857,7 +857,7 @@ func (s *STSService) AssumeRoleForPrincipal(ctx context.Context, request *Assume
 	if request.Principal == "" {
 		return nil, fmt.Errorf("principal cannot be empty")
 	}
-	if err := validateSessionDurationSeconds(request.DurationSeconds); err != nil {
+	if err := s.validateSessionDurationSeconds(request.DurationSeconds); err != nil {
 		return nil, fmt.Errorf("invalid request: %w", err)
 	}
 
@@ -935,7 +935,7 @@ func (s *STSService) validateAssumeRoleWithWebIdentityRequest(request *AssumeRol
 		return fmt.Errorf("RoleSessionName is required")
 	}
 
-	return validateSessionDurationSeconds(request.DurationSeconds)
+	return s.validateSessionDurationSeconds(request.DurationSeconds)
 }
 
 // validateWebIdentityToken validates the web identity token with strict issuer-to-provider mapping
@@ -1152,7 +1152,7 @@ func (s *STSService) validateAssumeRoleWithCredentialsRequest(request *AssumeRol
 		return fmt.Errorf("ProviderName is required")
 	}
 
-	return validateSessionDurationSeconds(request.DurationSeconds)
+	return s.validateSessionDurationSeconds(request.DurationSeconds)
 }
 
 // ExpireSessionForTesting manually expires a session for testing purposes

--- a/weed/iam/sts/sts_service.go
+++ b/weed/iam/sts/sts_service.go
@@ -811,8 +811,12 @@ func (s *STSService) validateSessionDurationSeconds(durationSeconds *int64) erro
 	if durationSeconds == nil {
 		return nil
 	}
-	if *durationSeconds < 900 || *durationSeconds > 43200 { // 15min to 12 hours
-		return fmt.Errorf("DurationSeconds must be between 900 and 43200 seconds")
+	maxSec := int64(DefaultMaxSessionLength)
+	if s.Config != nil && s.Config.MaxSessionLength.Duration > 0 {
+		maxSec = int64(s.Config.MaxSessionLength.Duration / time.Second)
+	}
+	if *durationSeconds < 900 || *durationSeconds > maxSec {
+		return fmt.Errorf("DurationSeconds must be between 900 and %d seconds", maxSec)
 	}
 	return nil
 }

--- a/weed/iam/sts/sts_service.go
+++ b/weed/iam/sts/sts_service.go
@@ -813,7 +813,10 @@ func (s *STSService) validateSessionDurationSeconds(durationSeconds *int64) erro
 	}
 	maxSec := int64(DefaultMaxSessionLength)
 	if s.Config != nil && s.Config.MaxSessionLength.Duration > 0 {
-		maxSec = int64(s.Config.MaxSessionLength.Duration / time.Second)
+		configuredMax := int64(s.Config.MaxSessionLength.Duration / time.Second)
+		if configuredMax >= 900 {
+			maxSec = configuredMax
+		}
 	}
 	if *durationSeconds < 900 || *durationSeconds > maxSec {
 		return fmt.Errorf("DurationSeconds must be between 900 and %d seconds", maxSec)

--- a/weed/iam/sts/sts_service_duration_test.go
+++ b/weed/iam/sts/sts_service_duration_test.go
@@ -1,0 +1,50 @@
+package sts
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func newSTSServiceWithMaxSession(t *testing.T, maxSession time.Duration) *STSService {
+	t.Helper()
+	s := NewSTSService()
+	assert.NoError(t, s.Initialize(&STSConfig{
+		Issuer:           "test-issuer",
+		SigningKey:       []byte("test-signing-key-at-least-32-bytes-long"),
+		TokenDuration:    FlexibleDuration{Duration: time.Hour},
+		MaxSessionLength: FlexibleDuration{Duration: maxSession},
+	}))
+	return s
+}
+
+func secondsPtr(v int64) *int64 { return &v }
+
+func TestValidateSessionDurationSeconds_RespectsConfiguredMaxSessionLength(t *testing.T) {
+	s := newSTSServiceWithMaxSession(t, 168*time.Hour)
+	assert.NoError(t, s.validateSessionDurationSeconds(secondsPtr(604800)))
+}
+
+func TestValidateSessionDurationSeconds_RejectsAboveConfiguredMaxSessionLength(t *testing.T) {
+	s := newSTSServiceWithMaxSession(t, 24*time.Hour)
+	err := s.validateSessionDurationSeconds(secondsPtr(90000))
+	assert.Error(t, err)
+}
+
+func TestValidateSessionDurationSeconds_FallsBackToDefaultWhenUnset(t *testing.T) {
+	s := &STSService{}
+	assert.NoError(t, s.validateSessionDurationSeconds(secondsPtr(43200)))
+	err := s.validateSessionDurationSeconds(secondsPtr(43201))
+	assert.Error(t, err)
+}
+
+func TestValidateSessionDurationSeconds_EnforcesMinimum(t *testing.T) {
+	s := newSTSServiceWithMaxSession(t, 168*time.Hour)
+	assert.Error(t, s.validateSessionDurationSeconds(secondsPtr(899)))
+}
+
+func TestValidateSessionDurationSeconds_NilReturnsNil(t *testing.T) {
+	s := newSTSServiceWithMaxSession(t, 168*time.Hour)
+	assert.NoError(t, s.validateSessionDurationSeconds(nil))
+}

--- a/weed/iam/sts/sts_service_duration_test.go
+++ b/weed/iam/sts/sts_service_duration_test.go
@@ -48,3 +48,10 @@ func TestValidateSessionDurationSeconds_NilReturnsNil(t *testing.T) {
 	s := newSTSServiceWithMaxSession(t, 168*time.Hour)
 	assert.NoError(t, s.validateSessionDurationSeconds(nil))
 }
+
+func TestValidateSessionDurationSeconds_SubMinimumMaxSessionLengthKeepsCapping(t *testing.T) {
+	s := newSTSServiceWithMaxSession(t, 5*time.Minute)
+	assert.NoError(t, s.validateSessionDurationSeconds(secondsPtr(900)))
+	assert.NoError(t, s.validateSessionDurationSeconds(secondsPtr(43200)))
+	assert.Error(t, s.validateSessionDurationSeconds(secondsPtr(43201)))
+}

--- a/weed/s3api/s3api_sts.go
+++ b/weed/s3api/s3api_sts.go
@@ -135,7 +135,10 @@ func parseDurationSecondsWithBounds(r *http.Request, minSec, maxSec int64) (*int
 func (h *STSHandlers) parseDurationSeconds(r *http.Request) (*int64, STSErrorCode, error) {
 	maxSec := maxDurationSeconds
 	if h.stsService != nil && h.stsService.Config != nil && h.stsService.Config.MaxSessionLength.Duration > 0 {
-		maxSec = int64(h.stsService.Config.MaxSessionLength.Duration / time.Second)
+		configuredMax := int64(h.stsService.Config.MaxSessionLength.Duration / time.Second)
+		if configuredMax >= minDurationSeconds {
+			maxSec = configuredMax
+		}
 	}
 	return parseDurationSecondsWithBounds(r, minDurationSeconds, maxSec)
 }

--- a/weed/s3api/s3api_sts.go
+++ b/weed/s3api/s3api_sts.go
@@ -131,9 +131,13 @@ func parseDurationSecondsWithBounds(r *http.Request, minSec, maxSec int64) (*int
 	return &ds, "", nil
 }
 
-// parseDurationSeconds parses DurationSeconds for AssumeRole (15 min to 12 hours)
+// parseDurationSeconds parses DurationSeconds for AssumeRole (15 min to MaxSessionLength)
 func (h *STSHandlers) parseDurationSeconds(r *http.Request) (*int64, STSErrorCode, error) {
-	return parseDurationSecondsWithBounds(r, minDurationSeconds, maxDurationSeconds)
+	maxSec := maxDurationSeconds
+	if h.stsService != nil && h.stsService.Config != nil && h.stsService.Config.MaxSessionLength.Duration > 0 {
+		maxSec = int64(h.stsService.Config.MaxSessionLength.Duration / time.Second)
+	}
+	return parseDurationSecondsWithBounds(r, minDurationSeconds, maxSec)
 }
 
 // Removed generateSecureCredentials - now using STS service's JWT token generation

--- a/weed/s3api/s3api_sts.go
+++ b/weed/s3api/s3api_sts.go
@@ -132,7 +132,7 @@ func parseDurationSecondsWithBounds(r *http.Request, minSec, maxSec int64) (*int
 }
 
 // parseDurationSeconds parses DurationSeconds for AssumeRole (15 min to 12 hours)
-func parseDurationSeconds(r *http.Request) (*int64, STSErrorCode, error) {
+func (h *STSHandlers) parseDurationSeconds(r *http.Request) (*int64, STSErrorCode, error) {
 	return parseDurationSecondsWithBounds(r, minDurationSeconds, maxDurationSeconds)
 }
 
@@ -253,7 +253,7 @@ func (h *STSHandlers) handleAssumeRoleWithWebIdentity(w http.ResponseWriter, r *
 	}
 
 	// Parse and validate DurationSeconds using helper
-	durationSeconds, errCode, err := parseDurationSeconds(r)
+	durationSeconds, errCode, err := h.parseDurationSeconds(r)
 	if err != nil {
 		h.writeSTSErrorResponse(w, r, errCode, err)
 		return
@@ -350,7 +350,7 @@ func (h *STSHandlers) handleAssumeRole(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Parse and validate DurationSeconds using helper
-	durationSeconds, errCode, err := parseDurationSeconds(r)
+	durationSeconds, errCode, err := h.parseDurationSeconds(r)
 	if err != nil {
 		h.writeSTSErrorResponse(w, r, errCode, err)
 		return
@@ -506,7 +506,7 @@ func (h *STSHandlers) handleAssumeRoleWithLDAPIdentity(w http.ResponseWriter, r 
 	}
 
 	// Parse and validate DurationSeconds using helper
-	durationSeconds, errCode, err := parseDurationSeconds(r)
+	durationSeconds, errCode, err := h.parseDurationSeconds(r)
 	if err != nil {
 		h.writeSTSErrorResponse(w, r, errCode, err)
 		return

--- a/weed/s3api/s3api_sts_duration_test.go
+++ b/weed/s3api/s3api_sts_duration_test.go
@@ -88,3 +88,18 @@ func TestParseDurationSeconds_EmptyReturnsNil(t *testing.T) {
 	assert.Equal(t, STSErrorCode(""), errCode)
 	assert.Nil(t, ds)
 }
+
+func TestParseDurationSeconds_SubMinimumMaxSessionLengthKeepsCapping(t *testing.T) {
+	h := newSTSHandlersWithMaxSession(t, 5*time.Minute)
+
+	ds, errCode, err := h.parseDurationSeconds(newDurationSecondsRequest(t, "900"))
+	require.NoError(t, err)
+	assert.Equal(t, STSErrorCode(""), errCode)
+	if assert.NotNil(t, ds) {
+		assert.Equal(t, int64(900), *ds)
+	}
+
+	_, errCode, err = h.parseDurationSeconds(newDurationSecondsRequest(t, "43201"))
+	assert.Error(t, err)
+	assert.Equal(t, STSErrInvalidParameterValue, errCode)
+}

--- a/weed/s3api/s3api_sts_duration_test.go
+++ b/weed/s3api/s3api_sts_duration_test.go
@@ -1,0 +1,90 @@
+package s3api
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/seaweedfs/seaweedfs/weed/iam/sts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newDurationSecondsRequest(t *testing.T, seconds string) *http.Request {
+	t.Helper()
+	form := url.Values{}
+	if seconds != "" {
+		form.Set("DurationSeconds", seconds)
+	}
+	req, err := http.NewRequest("POST", "/", strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	require.NoError(t, req.ParseForm())
+	return req
+}
+
+func newSTSHandlersWithMaxSession(t *testing.T, maxSession time.Duration) *STSHandlers {
+	t.Helper()
+	s := sts.NewSTSService()
+	require.NoError(t, s.Initialize(&sts.STSConfig{
+		Issuer:           "test-issuer",
+		SigningKey:       []byte("test-signing-key-at-least-32-bytes-long-for-security"),
+		TokenDuration:    sts.FlexibleDuration{Duration: time.Hour},
+		MaxSessionLength: sts.FlexibleDuration{Duration: maxSession},
+	}))
+	return NewSTSHandlers(s, nil)
+}
+
+func TestParseDurationSeconds_RespectsConfiguredMaxSessionLength(t *testing.T) {
+	h := newSTSHandlersWithMaxSession(t, 168*time.Hour)
+
+	ds, errCode, err := h.parseDurationSeconds(newDurationSecondsRequest(t, "604800"))
+	require.NoError(t, err)
+	assert.Equal(t, STSErrorCode(""), errCode)
+	if assert.NotNil(t, ds) {
+		assert.Equal(t, int64(604800), *ds)
+	}
+}
+
+func TestParseDurationSeconds_RejectsAboveConfiguredMaxSessionLength(t *testing.T) {
+	h := newSTSHandlersWithMaxSession(t, 24*time.Hour)
+
+	ds, errCode, err := h.parseDurationSeconds(newDurationSecondsRequest(t, "90000"))
+	assert.Error(t, err)
+	assert.Equal(t, STSErrInvalidParameterValue, errCode)
+	assert.Nil(t, ds)
+}
+
+func TestParseDurationSeconds_FallsBackToDefaultWhenUnset(t *testing.T) {
+	h := &STSHandlers{stsService: nil}
+
+	ds, errCode, err := h.parseDurationSeconds(newDurationSecondsRequest(t, "43200"))
+	require.NoError(t, err)
+	assert.Equal(t, STSErrorCode(""), errCode)
+	if assert.NotNil(t, ds) {
+		assert.Equal(t, int64(43200), *ds)
+	}
+
+	_, errCode, err = h.parseDurationSeconds(newDurationSecondsRequest(t, "43201"))
+	assert.Error(t, err)
+	assert.Equal(t, STSErrInvalidParameterValue, errCode)
+}
+
+func TestParseDurationSeconds_EnforcesMinimum(t *testing.T) {
+	h := newSTSHandlersWithMaxSession(t, 168*time.Hour)
+
+	_, errCode, err := h.parseDurationSeconds(newDurationSecondsRequest(t, "899"))
+	assert.Error(t, err)
+	assert.Equal(t, STSErrInvalidParameterValue, errCode)
+}
+
+func TestParseDurationSeconds_EmptyReturnsNil(t *testing.T) {
+	h := newSTSHandlersWithMaxSession(t, 168*time.Hour)
+
+	ds, errCode, err := h.parseDurationSeconds(newDurationSecondsRequest(t, ""))
+	require.NoError(t, err)
+	assert.Equal(t, STSErrorCode(""), errCode)
+	assert.Nil(t, ds)
+}


### PR DESCRIPTION
## Summary

Fixes #11265.

`AssumeRole`, `AssumeRoleWithWebIdentity`, and `AssumeRoleWithLDAPIdentity` validated `DurationSeconds` against a hardcoded `43200`s (12h) ceiling in **two** places, so raising `maxSessionLength` in `iam.json` above 12h had no effect — requests were rejected with:

```
DurationSeconds must be between 900 and 43200 seconds
```

The two gates:
1. **HTTP handler** — `parseDurationSeconds` (`weed/s3api/s3api_sts.go`) rejected before the request reached the service.
2. **STS service** — `validateSessionDurationSeconds` (`weed/iam/sts/sts_service.go`) rejected again inside `AssumeRoleWithWebIdentity` / `AssumeRoleForPrincipal` / `AssumeRoleWithCredentials` (both the IAMManager-dispatched and bare-STS paths go through here).

This PR derives the upper bound from the configured STS `MaxSessionLength` in both gates, falling back to `DefaultMaxSessionLength` (`43200`s) when unset. When `MaxSessionLength` is configured below the 900s API minimum, the default bound is kept so the previous capping behavior (via `calculateSessionDuration`) is preserved instead of creating an empty valid range. The service layer (`calculateSessionDuration`) already caps the issued duration at `MaxSessionLength`, so this only relaxes the input-validation gates.

### Commits (one per logic change)
- `Refactor parseDurationSeconds into a STSHandlers method` — pure refactor, no behavior change; lets the handler validator reach the STS config.
- `Respect MaxSessionLength config in STS DurationSeconds validation` — handler-layer fix.
- `Add tests for STS DurationSeconds MaxSessionLength bound` — handler-layer tests.
- `Refactor validateSessionDurationSeconds into a STSService method` — pure refactor, no behavior change; lets the service validator reach the STS config.
- `Respect MaxSessionLength config in STS service DurationSeconds validation` — service-layer fix (the second gate flagged by review).
- `Add tests for STS service DurationSeconds MaxSessionLength bound` — service-layer tests.
- `Preserve capping when MaxSessionLength is below the API minimum` — guard against an empty valid range for sub-900s configs (review feedback).
- `Add tests for sub-minimum MaxSessionLength capping behavior` — tests for the guard.

#### Test plan
- [x] `go build ./weed/iam/sts/... ./weed/s3api/...`
- [x] `go test ./weed/iam/sts/... ./weed/s3api/...`
- [ ] Repro from the issue: with `iam.json` `maxSessionLength: "168h"`, `aws sts assume-role-with-web-identity --duration-seconds 604800` succeeds (previously rejected).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - STS session duration limits now respect the configured maximum session length.
  - When no valid custom maximum is configured, the service uses its default maximum.
  - The minimum session duration remains 900 seconds, including when a configured maximum is lower than this threshold.

- **Bug Fixes**
  - Improved consistency in duration validation across supported STS authentication flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->