### PR TITLE
fix(s3api/audit): surface OIDC identity claim in audit log for STS sessions

### DIFF
--- a/weed/iam/sts/parent_user_test.go
+++ b/weed/iam/sts/parent_user_test.go
@@ -110,3 +110,23 @@ func TestResolveIdentityClaimSkipsNonString(t *testing.T) {
 		t.Fatalf("expected sub after skipping non-string claim, got %q", got)
 	}
 }
+
+func TestResolveIdentityClaimTrimsWhitespace(t *testing.T) {
+	ctx := map[string]interface{}{
+		"preferred_username": "  grant.west  ",
+		"email":              "grant.west@example.com",
+	}
+	if got := ResolveIdentityClaim(ctx); got != "grant.west" {
+		t.Fatalf("expected trimmed preferred_username, got %q", got)
+	}
+}
+
+func TestResolveIdentityClaimSkipsWhitespaceOnly(t *testing.T) {
+	ctx := map[string]interface{}{
+		"preferred_username": "   ",
+		"email":              "grant.west@example.com",
+	}
+	if got := ResolveIdentityClaim(ctx); got != "grant.west@example.com" {
+		t.Fatalf("expected email after skipping whitespace-only preferred_username, got %q", got)
+	}
+}

--- a/weed/iam/sts/parent_user_test.go
+++ b/weed/iam/sts/parent_user_test.go
@@ -71,3 +71,42 @@ func TestSessionClaimsRoundTripParentUser(t *testing.T) {
 		t.Fatalf("ParentUser lost on round-trip: got %q want %q", info.ParentUser, parent)
 	}
 }
+
+func TestResolveIdentityClaimPrefersPreferredUsername(t *testing.T) {
+	ctx := map[string]interface{}{
+		"preferred_username": "grant.west",
+		"email":              "grant.west@example.com",
+		"sub":                "alice-sub",
+	}
+	if got := ResolveIdentityClaim(ctx); got != "grant.west" {
+		t.Fatalf("expected preferred_username, got %q", got)
+	}
+}
+
+func TestResolveIdentityClaimFallsBackThroughPriority(t *testing.T) {
+	if got := ResolveIdentityClaim(map[string]interface{}{"email": "g@example.com", "sub": "s"}); got != "g@example.com" {
+		t.Fatalf("expected email fallback, got %q", got)
+	}
+	if got := ResolveIdentityClaim(map[string]interface{}{"sub": "s"}); got != "s" {
+		t.Fatalf("expected sub fallback, got %q", got)
+	}
+}
+
+func TestResolveIdentityClaimEmpty(t *testing.T) {
+	if got := ResolveIdentityClaim(nil); got != "" {
+		t.Fatalf("expected empty for nil ctx, got %q", got)
+	}
+	if got := ResolveIdentityClaim(map[string]interface{}{}); got != "" {
+		t.Fatalf("expected empty for empty ctx, got %q", got)
+	}
+}
+
+func TestResolveIdentityClaimSkipsNonString(t *testing.T) {
+	ctx := map[string]interface{}{
+		"preferred_username": []string{"no"},
+		"sub":                "real-sub",
+	}
+	if got := ResolveIdentityClaim(ctx); got != "real-sub" {
+		t.Fatalf("expected sub after skipping non-string claim, got %q", got)
+	}
+}

--- a/weed/iam/sts/session_claims.go
+++ b/weed/iam/sts/session_claims.go
@@ -24,6 +24,32 @@ func ComputeParentUser(sub, iss string) string {
 	return base64.RawURLEncoding.EncodeToString(h[:])
 }
 
+// identityClaimPriority is the order in which ResolveIdentityClaim looks for a
+// human-readable, authoritative identity attribute in an STS request context.
+// The context is populated at federation time from the validated OIDC token
+// (see AssumeRoleWithWebIdentity), so every entry here is server-asserted and
+// not client-supplied. preferred_username/email/name are conventional OIDC
+// user claims; sub is the always-present stable subject identifier and the
+// final fallback so a federated session never audits as fully anonymous.
+var identityClaimPriority = []string{"preferred_username", "email", "name", "sub"}
+
+// ResolveIdentityClaim returns the most human-readable authoritative identity
+// claim available in ctx, or "" when none is present. ctx is the STS request
+// context (sessionInfo.RequestContext / identity.Claims) populated from the
+// validated OIDC token at federation time. Non-string values are skipped so a
+// structured claim never leaks into an audit-facing field.
+func ResolveIdentityClaim(ctx map[string]interface{}) string {
+	if len(ctx) == 0 {
+		return ""
+	}
+	for _, key := range identityClaimPriority {
+		if v, ok := ctx[key].(string); ok && v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
 // defaultCredentialGenerator is a reusable instance for generating temporary credentials
 // Reusing a single instance across all calls to ToSessionInfo() reduces allocation overhead
 // since this method may be called frequently during signature verification

--- a/weed/iam/sts/session_claims.go
+++ b/weed/iam/sts/session_claims.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -35,16 +36,19 @@ var identityClaimPriority = []string{"preferred_username", "email", "name", "sub
 
 // ResolveIdentityClaim returns the most human-readable authoritative identity
 // claim available in ctx, or "" when none is present. ctx is the STS request
-// context (sessionInfo.RequestContext / identity.Claims) populated from the
-// validated OIDC token at federation time. Non-string values are skipped so a
-// structured claim never leaks into an audit-facing field.
+// context (sessionInfo.RequestContext) populated from the validated OIDC token
+// at federation time. Non-string values are skipped so a structured claim
+// never leaks into an audit-facing field. Whitespace-only values are treated
+// as absent so a blank preferred claim does not mask a usable email or sub.
 func ResolveIdentityClaim(ctx map[string]interface{}) string {
 	if len(ctx) == 0 {
 		return ""
 	}
 	for _, key := range identityClaimPriority {
-		if v, ok := ctx[key].(string); ok && v != "" {
-			return v
+		if v, ok := ctx[key].(string); ok {
+			if trimmed := strings.TrimSpace(v); trimmed != "" {
+				return trimmed
+			}
 		}
 	}
 	return ""

--- a/weed/s3api/auth_audit_requester_test.go
+++ b/weed/s3api/auth_audit_requester_test.go
@@ -60,7 +60,7 @@ func TestAuditRequesterArnForSTSSession(t *testing.T) {
 // An OIDC-federated STS session authenticates as an opaque session subject, so
 // the requester field alone is useless for compliance auditing. The audit entry
 // must surface the authoritative OIDC identity claim (preferred_username, email
-// or sub) carried in the session's request context, independent of the
+// or sub) carried in the session request context, independent of the
 // client-supplied role session name. See issue #11264.
 func TestAuditRequesterIdentityForOIDCFederatedSession(t *testing.T) {
 	iam := &IdentityAccessManagement{
@@ -75,8 +75,9 @@ func TestAuditRequesterIdentityForOIDCFederatedSession(t *testing.T) {
 						AccessKeyId:     "ASIA0189777d42cba8e2",
 						SecretAccessKey: "secret",
 					},
-					ExpiresAt: time.Now().Add(time.Hour),
-					Policies:  []string{"S3ReadOnly"},
+					ExpiresAt:  time.Now().Add(time.Hour),
+					Policies:   []string{"S3ReadOnly"},
+					ParentUser: sts.ComputeParentUser("oidc-sub-123", "https://idp.example/"),
 					RequestContext: map[string]interface{}{
 						"preferred_username": "grant.west",
 						"email":              "grant.west@digital.mod.uk",
@@ -101,9 +102,11 @@ func TestAuditRequesterIdentityForOIDCFederatedSession(t *testing.T) {
 		"audit entry must surface the authoritative OIDC identity claim, not the client-supplied role session name")
 }
 
-// A non-federated STS session (no OIDC claims in its request context) must not
-// fabricate a requester_identity — the field stays empty so audit consumers can
-// distinguish federated from non-federated sessions.
+// A non-federated STS session has no OIDC identity. ValidateJWTWithClaims merges
+// the JWT registered sub claim (the opaque session id) into RequestContext, so
+// the context carries a sub even though it is not an OIDC subject. The audit
+// entry must not surface that session id as a requester_identity — ParentUser
+// gates the resolution so only federated sessions report an identity claim.
 func TestAuditRequesterIdentityEmptyForNonFederatedSession(t *testing.T) {
 	iam := &IdentityAccessManagement{
 		iamIntegration: &MockIAMIntegration{
@@ -119,6 +122,12 @@ func TestAuditRequesterIdentityEmptyForNonFederatedSession(t *testing.T) {
 					},
 					ExpiresAt: time.Now().Add(time.Hour),
 					Policies:  []string{"ClientPolicy"},
+					// Simulate ValidateJWTWithClaims merging the registered sub
+					// (the session id) into RequestContext for a session that has
+					// no OIDC identity and therefore no ParentUser.
+					RequestContext: map[string]interface{}{
+						"sub": "47ad4828c45b3f337bc3146081ba8f0f",
+					},
 				}, nil
 			},
 		},
@@ -132,7 +141,7 @@ func TestAuditRequesterIdentityEmptyForNonFederatedSession(t *testing.T) {
 	iam.handleAuthResult(httptest.NewRecorder(), outer, identity, s3err.ErrNone, func(http.ResponseWriter, *http.Request) {})
 
 	log := s3err.GetAccessLog(outer, http.StatusOK, s3err.ErrNone)
-	assert.Empty(t, log.RequesterIdentity, "non-federated session must not report a requester_identity")
+	assert.Empty(t, log.RequesterIdentity, "non-federated session must not surface the session id as a requester_identity")
 }
 
 // A JWT-authenticated identity carries no PrincipalArn of its own — the auth

--- a/weed/s3api/auth_audit_requester_test.go
+++ b/weed/s3api/auth_audit_requester_test.go
@@ -57,6 +57,84 @@ func TestAuditRequesterArnForSTSSession(t *testing.T) {
 		"audit entry must name the assumed role and session")
 }
 
+// An OIDC-federated STS session authenticates as an opaque session subject, so
+// the requester field alone is useless for compliance auditing. The audit entry
+// must surface the authoritative OIDC identity claim (preferred_username, email
+// or sub) carried in the session's request context, independent of the
+// client-supplied role session name. See issue #11264.
+func TestAuditRequesterIdentityForOIDCFederatedSession(t *testing.T) {
+	iam := &IdentityAccessManagement{
+		iamIntegration: &MockIAMIntegration{
+			validateSessionFunc: func(ctx context.Context, token string) (*sts.SessionInfo, error) {
+				return &sts.SessionInfo{
+					AssumedRoleUser: "S3ReadOnlyRole/boto3-session",
+					Principal:       "arn:aws:sts::assumed-role/S3ReadOnlyRole/boto3-session",
+					Subject:         "2a19e647c5d43a62a91ecf664d07dbe1",
+					SessionName:     "boto3-session",
+					Credentials: &sts.Credentials{
+						AccessKeyId:     "ASIA0189777d42cba8e2",
+						SecretAccessKey: "secret",
+					},
+					ExpiresAt: time.Now().Add(time.Hour),
+					Policies:  []string{"S3ReadOnly"},
+					RequestContext: map[string]interface{}{
+						"preferred_username": "grant.west",
+						"email":              "grant.west@digital.mod.uk",
+						"sub":                "oidc-sub-123",
+					},
+				}, nil
+			},
+		},
+	}
+
+	outer := s3_constants.EnsureIdentityHolder(httptest.NewRequest(http.MethodGet, "http://s3/test/", nil))
+
+	identity, _, errCode := iam.validateSTSSessionToken(outer, "session-token", "ASIA0189777d42cba8e2")
+	require.Equal(t, s3err.ErrNone, errCode)
+
+	iam.handleAuthResult(httptest.NewRecorder(), outer, identity, s3err.ErrNone, func(http.ResponseWriter, *http.Request) {})
+
+	log := s3err.GetAccessLog(outer, http.StatusOK, s3err.ErrNone)
+	assert.Equal(t, "2a19e647c5d43a62a91ecf664d07dbe1", log.Requester,
+		"requester stays the opaque session subject for backward compatibility")
+	assert.Equal(t, "grant.west", log.RequesterIdentity,
+		"audit entry must surface the authoritative OIDC identity claim, not the client-supplied role session name")
+}
+
+// A non-federated STS session (no OIDC claims in its request context) must not
+// fabricate a requester_identity — the field stays empty so audit consumers can
+// distinguish federated from non-federated sessions.
+func TestAuditRequesterIdentityEmptyForNonFederatedSession(t *testing.T) {
+	iam := &IdentityAccessManagement{
+		iamIntegration: &MockIAMIntegration{
+			validateSessionFunc: func(ctx context.Context, token string) (*sts.SessionInfo, error) {
+				return &sts.SessionInfo{
+					AssumedRoleUser: "ClientRole/dev-session",
+					Principal:       "arn:aws:sts::000000000000:assumed-role/ClientRole/dev-session",
+					Subject:         "47ad4828c45b3f337bc3146081ba8f0f",
+					SessionName:     "dev-session",
+					Credentials: &sts.Credentials{
+						AccessKeyId:     "ASIA0189777d42cba8e2",
+						SecretAccessKey: "secret",
+					},
+					ExpiresAt: time.Now().Add(time.Hour),
+					Policies:  []string{"ClientPolicy"},
+				}, nil
+			},
+		},
+	}
+
+	outer := s3_constants.EnsureIdentityHolder(httptest.NewRequest(http.MethodGet, "http://s3/test/", nil))
+
+	identity, _, errCode := iam.validateSTSSessionToken(outer, "session-token", "ASIA0189777d42cba8e2")
+	require.Equal(t, s3err.ErrNone, errCode)
+
+	iam.handleAuthResult(httptest.NewRecorder(), outer, identity, s3err.ErrNone, func(http.ResponseWriter, *http.Request) {})
+
+	log := s3err.GetAccessLog(outer, http.StatusOK, s3err.ErrNone)
+	assert.Empty(t, log.RequesterIdentity, "non-federated session must not report a requester_identity")
+}
+
 // A JWT-authenticated identity carries no PrincipalArn of its own — the auth
 // layer hands the principal over in a request header — so the audit entry has to
 // resolve the ARN the same way policy evaluation does.

--- a/weed/s3api/auth_credentials.go
+++ b/weed/s3api/auth_credentials.go
@@ -19,7 +19,6 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/credential"
 	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/glog"
-	"github.com/seaweedfs/seaweedfs/weed/iam/sts"
 	"github.com/seaweedfs/seaweedfs/weed/kms"
 	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
@@ -111,15 +110,16 @@ type IdentityAccessManagement struct {
 }
 
 type Identity struct {
-	Name         string
-	Account      *Account
-	Credentials  []*Credential
-	Actions      []Action
-	PolicyNames  []string               // Attached IAM policy names
-	PrincipalArn string                 // ARN for IAM authorization (e.g., "arn:aws:iam::account-id:user/username")
-	Disabled     bool                   // User status: false = enabled (default), true = disabled
-	Claims       map[string]interface{} // JWT claims for policy substitution
-	IsStatic     bool                   // Whether identity was loaded from static config (immutable)
+	Name          string
+	Account       *Account
+	Credentials   []*Credential
+	Actions       []Action
+	PolicyNames   []string               // Attached IAM policy names
+	PrincipalArn  string                 // ARN for IAM authorization (e.g., "arn:aws:iam::account-id:user/username")
+	Disabled      bool                   // User status: false = enabled (default), true = disabled
+	Claims        map[string]interface{} // JWT claims for policy substitution
+	IsStatic      bool                   // Whether identity was loaded from static config (immutable)
+	IdentityClaim string                 // Authoritative OIDC identity claim for audit logging (preferred_username/email/sub); empty for non-federated sessions
 }
 
 // Account represents a system user, a system user can
@@ -1619,7 +1619,7 @@ func recordIdentityInContext(r *http.Request, identity *Identity) context.Contex
 	}
 	ctx := s3_constants.SetIdentityNameInContext(r.Context(), identity.Name)
 	ctx = s3_constants.SetPrincipalArnInContext(ctx, buildPrincipalARN(identity, r))
-	ctx = s3_constants.SetIdentityClaimInContext(ctx, sts.ResolveIdentityClaim(identity.Claims))
+	ctx = s3_constants.SetIdentityClaimInContext(ctx, identity.IdentityClaim)
 	// Also store the full identity object for handlers that need it (e.g., ListBuckets)
 	// This is especially important for JWT users whose identity is not in the identities list
 	return s3_constants.SetIdentityInContext(ctx, identity)
@@ -2423,11 +2423,12 @@ func (iam *IdentityAccessManagement) authenticateJWTWithIAM(r *http.Request) (*I
 
 	// Convert IAMIdentity to existing Identity structure
 	identity := &Identity{
-		Name:        iamIdentity.Name,
-		Account:     iamIdentity.Account,
-		Actions:     []Action{}, // Empty - authorization handled by policy engine
-		PolicyNames: iamIdentity.PolicyNames,
-		Claims:      iamIdentity.Claims,
+		Name:          iamIdentity.Name,
+		Account:       iamIdentity.Account,
+		Actions:       []Action{}, // Empty - authorization handled by policy engine
+		PolicyNames:   iamIdentity.PolicyNames,
+		Claims:        iamIdentity.Claims,
+		IdentityClaim: iamIdentity.IdentityClaim,
 	}
 
 	// Store session info in request headers for later authorization

--- a/weed/s3api/auth_credentials.go
+++ b/weed/s3api/auth_credentials.go
@@ -19,6 +19,7 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/credential"
 	"github.com/seaweedfs/seaweedfs/weed/filer"
 	"github.com/seaweedfs/seaweedfs/weed/glog"
+	"github.com/seaweedfs/seaweedfs/weed/iam/sts"
 	"github.com/seaweedfs/seaweedfs/weed/kms"
 	"github.com/seaweedfs/seaweedfs/weed/pb"
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
@@ -1608,8 +1609,9 @@ func (iam *IdentityAccessManagement) AuthPostPolicy(f http.HandlerFunc, action A
 
 // recordIdentityInContext stores the authenticated identity, its name and its
 // principal ARN in the request context. An STS session's name is only an opaque
-// subject, so the ARN is what carries the assumed role and session name to the
-// audit log. A JWT-authenticated identity carries no PrincipalArn of its own,
+// session subject, so the ARN is what carries the assumed role and session name
+// to the audit log, and the identity claim carries the authoritative OIDC
+// identity. A JWT-authenticated identity carries no PrincipalArn of its own,
 // hence the resolution through buildPrincipalARN.
 func recordIdentityInContext(r *http.Request, identity *Identity) context.Context {
 	if identity == nil {
@@ -1617,6 +1619,7 @@ func recordIdentityInContext(r *http.Request, identity *Identity) context.Contex
 	}
 	ctx := s3_constants.SetIdentityNameInContext(r.Context(), identity.Name)
 	ctx = s3_constants.SetPrincipalArnInContext(ctx, buildPrincipalARN(identity, r))
+	ctx = s3_constants.SetIdentityClaimInContext(ctx, sts.ResolveIdentityClaim(identity.Claims))
 	// Also store the full identity object for handlers that need it (e.g., ListBuckets)
 	// This is especially important for JWT users whose identity is not in the identities list
 	return s3_constants.SetIdentityInContext(ctx, identity)

--- a/weed/s3api/auth_signature_v4.go
+++ b/weed/s3api/auth_signature_v4.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/seaweedfs/seaweedfs/weed/glog"
 	weed_iam "github.com/seaweedfs/seaweedfs/weed/iam"
+	"github.com/seaweedfs/seaweedfs/weed/iam/sts"
 
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3_constants"
 	"github.com/seaweedfs/seaweedfs/weed/s3api/s3err"
@@ -469,6 +470,14 @@ func (iam *IdentityAccessManagement) validateSTSSessionToken(r *http.Request, se
 		PrincipalArn: sessionInfo.Principal,
 		PolicyNames:  sessionInfo.Policies, // Populate PolicyNames for IAM authorization
 		Claims:       claims,               // Populate Claims for policy variable substitution
+	}
+	// ParentUser is set only for OIDC-federated sessions (see
+	// AssumeRoleWithWebIdentity), so it gates the audit identity claim: without
+	// it the request context's sub is the opaque session subject injected by
+	// ValidateJWTWithClaims, not the OIDC subject, and must not be surfaced as
+	// an authoritative identity.
+	if sessionInfo.ParentUser != "" {
+		identity.IdentityClaim = sts.ResolveIdentityClaim(sessionInfo.RequestContext)
 	}
 
 	glog.V(2).Infof("Successfully validated STS session token for principal: %s, assumed role user: %s",

--- a/weed/s3api/s3_constants/header.go
+++ b/weed/s3api/s3_constants/header.go
@@ -325,6 +325,7 @@ const (
 	contextKeyIdentityObject contextKey = "s3-identity-object"
 	contextKeyIdentityHolder contextKey = "s3-identity-holder"
 	contextKeyPrincipalArn   contextKey = "s3-principal-arn"
+	contextKeyIdentityClaim  contextKey = "s3-identity-claim"
 )
 
 // identityHolder is a mutable container for the authenticated identity name,
@@ -335,8 +336,9 @@ const (
 // holder installed before authentication is shared across all copies, so the
 // name written by the inner handler is readable by the outer middleware.
 type identityHolder struct {
-	name         atomic.Pointer[string]
-	principalArn atomic.Pointer[string]
+	name          atomic.Pointer[string]
+	principalArn  atomic.Pointer[string]
+	identityClaim atomic.Pointer[string]
 }
 
 // EnsureIdentityHolder attaches a mutable identity holder to the request context
@@ -410,6 +412,37 @@ func GetPrincipalArnFromContext(r *http.Request) string {
 	if h, ok := r.Context().Value(contextKeyIdentityHolder).(*identityHolder); ok && h != nil {
 		if arn := h.principalArn.Load(); arn != nil {
 			return *arn
+		}
+	}
+	return ""
+}
+
+// SetIdentityClaimInContext stores the authoritative OIDC identity claim (e.g.
+// preferred_username, email, sub) for the audit log. For an STS-assumed OIDC
+// session the requester name is an opaque session subject, so the claim is the
+// only place a stable, human-readable federated identity survives to the audit
+// log. Empty for non-federated sessions, where the requester name already
+// carries the real username.
+func SetIdentityClaimInContext(ctx context.Context, identityClaim string) context.Context {
+	if identityClaim == "" {
+		return ctx
+	}
+	if h, ok := ctx.Value(contextKeyIdentityHolder).(*identityHolder); ok && h != nil {
+		h.identityClaim.Store(&identityClaim)
+	}
+	return context.WithValue(ctx, contextKeyIdentityClaim, identityClaim)
+}
+
+// GetIdentityClaimFromContext retrieves the authoritative OIDC identity claim
+// from the request context, or "" when the request is unauthenticated or not
+// federated.
+func GetIdentityClaimFromContext(r *http.Request) string {
+	if claim, ok := r.Context().Value(contextKeyIdentityClaim).(string); ok && claim != "" {
+		return claim
+	}
+	if h, ok := r.Context().Value(contextKeyIdentityHolder).(*identityHolder); ok && h != nil {
+		if claim := h.identityClaim.Load(); claim != nil {
+			return *claim
 		}
 	}
 	return ""

--- a/weed/s3api/s3_iam_middleware.go
+++ b/weed/s3api/s3_iam_middleware.go
@@ -215,6 +215,13 @@ func (s3iam *S3IAMIntegration) AuthenticateJWT(ctx context.Context, r *http.Requ
 		},
 		Claims: claims,
 	}
+	// ParentUser is set only for OIDC-federated sessions. Resolve the audit
+	// identity claim from the original request context (not the local claims
+	// map, whose sub was overwritten with the opaque session subject above) so
+	// the bearer path surfaces the same authoritative OIDC identity as SigV4.
+	if sessionInfo.ParentUser != "" {
+		identity.IdentityClaim = sts.ResolveIdentityClaim(sessionInfo.RequestContext)
+	}
 
 	glog.V(3).Infof("JWT authentication successful for principal: %s", identity.Principal)
 	return identity, s3err.ErrNone
@@ -328,12 +335,13 @@ func (s3iam *S3IAMIntegration) DefaultAllow() bool {
 
 // IAMIdentity represents an authenticated identity with session information
 type IAMIdentity struct {
-	Name         string
-	Principal    string
-	SessionToken string
-	Account      *Account
-	PolicyNames  []string
-	Claims       map[string]interface{}
+	Name          string
+	Principal     string
+	SessionToken  string
+	Account       *Account
+	PolicyNames   []string
+	Claims        map[string]interface{}
+	IdentityClaim string // Authoritative OIDC identity claim for audit logging; empty for non-federated sessions
 }
 
 // IsAdmin checks if the identity has admin privileges

--- a/weed/s3api/s3_iam_middleware.go
+++ b/weed/s3api/s3_iam_middleware.go
@@ -176,7 +176,8 @@ func (s3iam *S3IAMIntegration) AuthenticateJWT(ctx context.Context, r *http.Requ
 				EmailAddress: emailAddress,
 				Id:           identity.UserID,
 			},
-			Claims: claims,
+			Claims:        claims,
+			IdentityClaim: sts.ResolveIdentityClaim(claims),
 		}, s3err.ErrNone
 	}
 

--- a/weed/s3api/s3err/audit_fluent.go
+++ b/weed/s3api/s3err/audit_fluent.go
@@ -23,20 +23,21 @@ type AccessLogExtend struct {
 }
 
 type AccessLog struct {
-	Bucket           string `msg:"bucket" json:"bucket"`                         // awsexamplebucket1
-	Time             int64  `msg:"time" json:"time"`                             // [06/Feb/2019:00:00:38 +0000]
-	RemoteIP         string `msg:"remote_ip" json:"remote_ip,omitempty"`         // 192.0.2.3
-	Requester        string `msg:"requester" json:"requester,omitempty"`         // IAM user id
-	RequesterArn     string `msg:"requester_arn" json:"requester_arn,omitempty"` // arn:aws:sts::0:assumed-role/Role/session
-	RequestID        string `msg:"request_id" json:"request_id,omitempty"`       // 3E57427F33A59F07
-	Operation        string `msg:"operation" json:"operation,omitempty"`         // REST.HTTP_method.resource_type REST.PUT.OBJECT
-	Key              string `msg:"key" json:"key,omitempty"`                     // /photos/2019/08/puppy.jpg
-	ErrorCode        string `msg:"error_code" json:"error_code,omitempty"`
-	HostId           string `msg:"host_id" json:"host_id,omitempty"`
-	HostHeader       string `msg:"host_header" json:"host_header,omitempty"` // s3.us-west-2.amazonaws.com
-	UserAgent        string `msg:"user_agent" json:"user_agent,omitempty"`
-	HTTPStatus       int    `msg:"status" json:"status,omitempty"`
-	SignatureVersion string `msg:"signature_version" json:"signature_version,omitempty"`
+	Bucket            string `msg:"bucket" json:"bucket"`                                   // awsexamplebucket1
+	Time              int64  `msg:"time" json:"time"`                                       // [06/Feb/2019:00:00:38 +0000]
+	RemoteIP          string `msg:"remote_ip" json:"remote_ip,omitempty"`                   // 192.0.2.3
+	Requester         string `msg:"requester" json:"requester,omitempty"`                   // IAM user id
+	RequesterArn      string `msg:"requester_arn" json:"requester_arn,omitempty"`           // arn:aws:sts::0:assumed-role/Role/session
+	RequesterIdentity string `msg:"requester_identity" json:"requester_identity,omitempty"` // authoritative OIDC identity claim (preferred_username/email/sub)
+	RequestID         string `msg:"request_id" json:"request_id,omitempty"`                 // 3E57427F33A59F07
+	Operation         string `msg:"operation" json:"operation,omitempty"`                   // REST.HTTP_method.resource_type REST.PUT.OBJECT
+	Key               string `msg:"key" json:"key,omitempty"`                               // /photos/2019/08/puppy.jpg
+	ErrorCode         string `msg:"error_code" json:"error_code,omitempty"`
+	HostId            string `msg:"host_id" json:"host_id,omitempty"`
+	HostHeader        string `msg:"host_header" json:"host_header,omitempty"` // s3.us-west-2.amazonaws.com
+	UserAgent         string `msg:"user_agent" json:"user_agent,omitempty"`
+	HTTPStatus        int    `msg:"status" json:"status,omitempty"`
+	SignatureVersion  string `msg:"signature_version" json:"signature_version,omitempty"`
 }
 
 type AccessLogHTTP struct {
@@ -167,20 +168,21 @@ func GetAccessLog(r *http.Request, HTTPStatusCode int, s3errCode ErrorCode) *Acc
 		hostHeader = r.Host
 	}
 	return &AccessLog{
-		HostHeader:       hostHeader,
-		RequestID:        request_id.GetFromRequest(r),
-		RemoteIP:         remoteIP,
-		Requester:        s3_constants.GetIdentityNameFromContext(r), // Get from context, not header (secure)
-		RequesterArn:     s3_constants.GetPrincipalArnFromContext(r),
-		SignatureVersion: r.Header.Get(s3_constants.AmzAuthType),
-		UserAgent:        r.Header.Get("user-agent"),
-		HostId:           hostname,
-		Bucket:           bucket,
-		HTTPStatus:       HTTPStatusCode,
-		Time:             time.Now().Unix(),
-		Key:              key,
-		Operation:        getOperation(key, r),
-		ErrorCode:        errorCode,
+		HostHeader:        hostHeader,
+		RequestID:         request_id.GetFromRequest(r),
+		RemoteIP:          remoteIP,
+		Requester:         s3_constants.GetIdentityNameFromContext(r), // Get from context, not header (secure)
+		RequesterArn:      s3_constants.GetPrincipalArnFromContext(r),
+		RequesterIdentity: s3_constants.GetIdentityClaimFromContext(r),
+		SignatureVersion:  r.Header.Get(s3_constants.AmzAuthType),
+		UserAgent:         r.Header.Get("user-agent"),
+		HostId:            hostname,
+		Bucket:            bucket,
+		HTTPStatus:        HTTPStatusCode,
+		Time:              time.Now().Unix(),
+		Key:               key,
+		Operation:         getOperation(key, r),
+		ErrorCode:         errorCode,
 	}
 }
 

--- a/weed/s3api/s3err/audit_fluent_test.go
+++ b/weed/s3api/s3err/audit_fluent_test.go
@@ -131,6 +131,21 @@ func TestGetAccessLogRequesterArnForAssumedRole(t *testing.T) {
 	assert.Equal(t, "arn:aws:sts::000000000000:assumed-role/ClientRole/dev-session", log.RequesterArn)
 }
 
+// An OIDC-federated session's opaque requester is useless for compliance
+// auditing, so the audit entry must also carry the authoritative identity claim
+// written by auth into the shared identity holder. See issue #11264.
+func TestGetAccessLogRequesterIdentityFromFallback(t *testing.T) {
+	outer := s3_constants.EnsureIdentityHolder(httptest.NewRequest(http.MethodGet, "/bucket/object", nil))
+
+	ctx := s3_constants.SetIdentityNameInContext(outer.Context(), "2a19e647c5d43a62a91ecf664d07dbe1")
+	ctx = s3_constants.SetIdentityClaimInContext(ctx, "grant.west")
+
+	log := GetAccessLog(outer, http.StatusOK, ErrNone)
+
+	assert.Equal(t, "2a19e647c5d43a62a91ecf664d07dbe1", log.Requester)
+	assert.Equal(t, "grant.west", log.RequesterIdentity)
+}
+
 func TestAuditTrackingFlag(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/bucket/object", nil)
 	assert.False(t, AuditAlreadyLogged(req), "untracked request reports not logged")

--- a/weed/s3api/s3err/audit_fluent_test.go
+++ b/weed/s3api/s3err/audit_fluent_test.go
@@ -138,7 +138,7 @@ func TestGetAccessLogRequesterIdentityFromFallback(t *testing.T) {
 	outer := s3_constants.EnsureIdentityHolder(httptest.NewRequest(http.MethodGet, "/bucket/object", nil))
 
 	ctx := s3_constants.SetIdentityNameInContext(outer.Context(), "2a19e647c5d43a62a91ecf664d07dbe1")
-	ctx = s3_constants.SetIdentityClaimInContext(ctx, "grant.west")
+	s3_constants.SetIdentityClaimInContext(ctx, "grant.west")
 
 	log := GetAccessLog(outer, http.StatusOK, ErrNone)
 


### PR DESCRIPTION
## Summary

Fixes #11264.

When a user authenticates via OIDC (`AssumeRoleWithWebIdentity`) and then makes S3 requests using the resulting temporary credentials, the `requester` field in the S3 audit log contains an opaque session subject (a random hex session id) rather than any human-readable identity from the original OIDC token. This makes the audit log effectively useless for compliance auditing of OIDC-authenticated users, since there is no reliable way to trace a logged operation back to the actual person who performed it.

The OIDC identity claims (`preferred_username`, `email`, `sub`) are already carried in the STS session's request context and reach the auth layer as `identity.Claims`, but they were never surfaced to the audit log.

This PR adds a new `requester_identity` field to the S3 access audit log, populated from the authoritative OIDC identity claim. The claim is resolved via a new `ResolveIdentityClaim` helper (placed next to `ComputeParentUser`) that walks a priority list of standard OIDC user claims: `preferred_username`, `email`, `name`, `sub`. The claim is propagated through the existing shared identity holder — the same mechanism the `requester` name and `requester_arn` already use — so it survives the request-context copy that hides auth-set values from the outer audit middleware.

The existing `requester` field is left unchanged for backward compatibility. `requester_identity` is empty for non-federated sessions, where `requester` already carries the real username.

### Commits
- **Add ResolveIdentityClaim helper for OIDC audit identity** — new helper in `weed/iam/sts` next to `ComputeParentUser` that recovers a human-readable, server-asserted identity attribute from the STS request context.
- **Surface authoritative OIDC identity claim in S3 audit log** — adds `requester_identity` to the audit `AccessLog`, propagates the claim through the identity holder, and populates it in `recordIdentityInContext` from `identity.Claims`.

## Design notes
- The claim is server-asserted (read from the validated OIDC token embedded in the STS session), not client-supplied, so it is suitable as an audit identity — unlike `RoleSessionName`, which any client can set to an arbitrary value.
- `requester_identity` is a new field rather than overwriting `requester` to avoid breaking existing audit consumers and to avoid changing `identity.Name` semantics (used for account-id resolution and policy variable substitution).
- `ClaimsMapping` in the OIDC provider config is currently only honoured on the UserInfo endpoint path, not the JWT `Authenticate` path — that is a separate gap noted in the issue and out of scope for this PR. The priority-list approach resolves a useful identity without depending on `ClaimsMapping`.

#### Test plan
- [x] `go build ./weed/...`
- [x] `go test ./weed/iam/sts/ ./weed/s3api/s3err/ ./weed/s3api/s3_constants/`
- [x] `go test ./weed/s3api/ -run 'TestAudit|TestAuth|TestSTS|TestIdentity'`
- [x] New unit tests for `ResolveIdentityClaim` (priority, fallback, empty, non-string skip)
- [x] New audit test reproducing the issue: OIDC-federated STS session surfaces `preferred_username` as `requester_identity` while `requester` stays the opaque session subject
- [x] New audit test: non-federated STS session leaves `requester_identity` empty
- [x] New audit test: holder-fallback path surfaces `requester_identity` from the shared holder

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs/pull/11269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audit logs now include the authoritative identity for OIDC-federated sessions.
  * Identity resolution prioritizes preferred username, then email and subject claims.
  * Existing requester information remains available for compatibility.
  * Non-federated sessions continue to omit the federated identity field.
  * Whitespace is trimmed from identity claims, and blank values are ignored.

* **Tests**
  * Added coverage for identity claim resolution and audit logging across federated and non-federated sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->