### PR TITLE
rust volume: honour is_last in the tail sender instead of rescanning the whole volume

### DIFF
--- a/seaweed-volume/src/server/grpc_server.rs
+++ b/seaweed-volume/src/server/grpc_server.rs
@@ -2728,15 +2728,18 @@ impl VolumeServer for VolumeGrpcService {
                 // idle timeout expired. Measured at ~2.17 GB re-read six times in
                 // 35s for a 2.15 GB volume, which OOM-kills the source under a
                 // per-process memory cap.
-                // Resolve the start offset and the caught-up flag FIRST, under a
-                // brief lock, and only scan if there is actually something new.
-                // The binary search is over the .idx and is cheap; the scan is the
-                // expensive part and must not be run speculatively.
+                // Resolve the start offset and the caught-up flag FIRST, and only
+                // scan if there is actually something new. The binary search is
+                // over the .idx and is cheap; the scan is the expensive part and
+                // must not be run speculatively. Both run under ONE store read
+                // guard: a vacuum commit takes the store write lock and rewrites
+                // .dat/.idx, so an offset resolved under one guard would point
+                // into a different file under the next.
                 let resolved = {
                     let store = state.store.read().unwrap();
                     match store.find_volume(vid) {
                         Some((_, vol)) => {
-                            if last_timestamp_ns > 0 {
+                            let start = if last_timestamp_ns > 0 {
                                 match vol.binary_search_by_append_at_ns(last_timestamp_ns) {
                                     Ok((offset, is_last)) => {
                                         let off = if offset.is_zero() {
@@ -2744,7 +2747,7 @@ impl VolumeServer for VolumeGrpcService {
                                         } else {
                                             offset.to_actual_offset() as u64
                                         };
-                                        Some(Ok((off, is_last)))
+                                        Ok((off, is_last))
                                     }
                                     Err(e) => {
                                         tracing::warn!(
@@ -2752,32 +2755,39 @@ impl VolumeServer for VolumeGrpcService {
                                             last_timestamp_ns,
                                             e
                                         );
-                                        Some(Err(format!(
+                                        Err(format!(
                                             "fail to locate by appendAtNs {}: {}",
                                             last_timestamp_ns, e
-                                        )))
+                                        ))
                                     }
                                 }
                             } else {
                                 // No timestamp yet: the caller wants everything.
-                                Some(Ok((sb_size, false)))
-                            }
+                                Ok((sb_size, false))
+                            };
+                            Some(start.map(|(off, is_last)| {
+                                if is_last {
+                                    None
+                                } else {
+                                    Some(vol.scan_raw_needles_from(off))
+                                }
+                            }))
                         }
                         None => None,
                     }
                 };
 
-                let (start_offset, is_last) = match resolved {
+                let scan_result = match resolved {
                     None => break,
                     Some(Err(msg)) => {
                         let _ = tx.send(Err(Status::internal(msg))).await;
                         return;
                     }
-                    Some(Ok(v)) => v,
+                    Some(Ok(scan_result)) => scan_result,
                 };
 
                 // Caught up: heartbeat WITHOUT scanning, as Go does.
-                if is_last {
+                let Some(scan_result) = scan_result else {
                     let msg = volume_server_pb::VolumeTailSenderResponse {
                         is_last_chunk: true,
                         version,
@@ -2795,15 +2805,6 @@ impl VolumeServer for VolumeGrpcService {
                         return; // EOF
                     }
                     continue;
-                }
-
-                // Not caught up: now do the expensive scan.
-                let scan_result = {
-                    let store = state.store.read().unwrap();
-                    match store.find_volume(vid) {
-                        Some((_, vol)) => vol.scan_raw_needles_from(start_offset),
-                        None => break,
-                    }
                 };
 
                 let entries = match scan_result {

--- a/seaweed-volume/src/server/grpc_server.rs
+++ b/seaweed-volume/src/server/grpc_server.rs
@@ -2714,27 +2714,15 @@ impl VolumeServer for VolumeGrpcService {
             let mut draining_seconds = idle_timeout as i64;
 
             loop {
-                // Use binary search to find starting offset, then scan from there.
-                //
-                // `is_last` means the client is already caught up: nothing in the
-                // volume is newer than last_timestamp_ns. Go answers that with a
-                // heartbeat and does NOT scan (volume_grpc_tail.go, `if isLastOne`).
-                // Dropping that flag here is expensive, not just untidy: the scan
-                // below materialises every needle from its start offset to EOF, and
-                // when the search yields offset 0 the start offset falls back to
-                // sb_size -- the whole volume. A volume being moved is marked
-                // read-only first, so it is ALWAYS caught up, and the tail loop
-                // would re-read and discard the entire volume every 2s until the
-                // idle timeout expired. Measured at ~2.17 GB re-read six times in
-                // 35s for a 2.15 GB volume, which OOM-kills the source under a
-                // per-process memory cap.
-                // Resolve the start offset and the caught-up flag FIRST, and only
-                // scan if there is actually something new. The binary search is
-                // over the .idx and is cheap; the scan is the expensive part and
-                // must not be run speculatively. Both run under ONE store read
-                // guard: a vacuum commit takes the store write lock and rewrites
-                // .dat/.idx, so an offset resolved under one guard would point
-                // into a different file under the next.
+                // Resolve the start offset and the caught-up flag under one
+                // store read guard. is_last means the caller is caught up: send
+                // a heartbeat without scanning, as Go does. Dropping that flag
+                // re-reads the whole volume every iteration (a moved volume is
+                // read-only, so it is always caught up). The single guard
+                // spans both the search and the scan: a vacuum commit takes
+                // the store write lock and rewrites .dat/.idx, so an offset
+                // resolved under one guard would point into a different file
+                // under the next.
                 let resolved = {
                     let store = state.store.read().unwrap();
                     match store.find_volume(vid) {

--- a/seaweed-volume/src/server/grpc_server.rs
+++ b/seaweed-volume/src/server/grpc_server.rs
@@ -2714,56 +2714,102 @@ impl VolumeServer for VolumeGrpcService {
             let mut draining_seconds = idle_timeout as i64;
 
             loop {
-                // Use binary search to find starting offset, then scan from there
-                let scan_result = {
+                // Use binary search to find starting offset, then scan from there.
+                //
+                // `is_last` means the client is already caught up: nothing in the
+                // volume is newer than last_timestamp_ns. Go answers that with a
+                // heartbeat and does NOT scan (volume_grpc_tail.go, `if isLastOne`).
+                // Dropping that flag here is expensive, not just untidy: the scan
+                // below materialises every needle from its start offset to EOF, and
+                // when the search yields offset 0 the start offset falls back to
+                // sb_size -- the whole volume. A volume being moved is marked
+                // read-only first, so it is ALWAYS caught up, and the tail loop
+                // would re-read and discard the entire volume every 2s until the
+                // idle timeout expired. Measured at ~2.17 GB re-read six times in
+                // 35s for a 2.15 GB volume, which OOM-kills the source under a
+                // per-process memory cap.
+                // Resolve the start offset and the caught-up flag FIRST, under a
+                // brief lock, and only scan if there is actually something new.
+                // The binary search is over the .idx and is cheap; the scan is the
+                // expensive part and must not be run speculatively.
+                let resolved = {
                     let store = state.store.read().unwrap();
-                    if let Some((_, vol)) = store.find_volume(vid) {
-                        let start_offset = if last_timestamp_ns > 0 {
-                            match vol.binary_search_by_append_at_ns(last_timestamp_ns) {
-                                Ok((offset, _is_last)) => {
-                                    if offset.is_zero() {
-                                        Ok(sb_size)
-                                    } else {
-                                        Ok(offset.to_actual_offset() as u64)
+                    match store.find_volume(vid) {
+                        Some((_, vol)) => {
+                            if last_timestamp_ns > 0 {
+                                match vol.binary_search_by_append_at_ns(last_timestamp_ns) {
+                                    Ok((offset, is_last)) => {
+                                        let off = if offset.is_zero() {
+                                            sb_size
+                                        } else {
+                                            offset.to_actual_offset() as u64
+                                        };
+                                        Some(Ok((off, is_last)))
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            "fail to locate by appendAtNs {}: {}",
+                                            last_timestamp_ns,
+                                            e
+                                        );
+                                        Some(Err(format!(
+                                            "fail to locate by appendAtNs {}: {}",
+                                            last_timestamp_ns, e
+                                        )))
                                     }
                                 }
-                                Err(e) => {
-                                    tracing::warn!(
-                                        "fail to locate by appendAtNs {}: {}",
-                                        last_timestamp_ns,
-                                        e
-                                    );
-                                    Err(format!(
-                                        "fail to locate by appendAtNs {}: {}",
-                                        last_timestamp_ns, e
-                                    ))
-                                }
+                            } else {
+                                // No timestamp yet: the caller wants everything.
+                                Some(Ok((sb_size, false)))
                             }
-                        } else {
-                            Ok(sb_size)
-                        };
-                        match start_offset {
-                            Ok(off) => Ok(vol.scan_raw_needles_from(off)),
-                            Err(msg) => Err(msg),
                         }
-                    } else {
-                        break;
+                        None => None,
                     }
                 };
 
-                let scan_inner = match scan_result {
-                    Ok(r) => r,
-                    Err(msg) => {
+                let (start_offset, is_last) = match resolved {
+                    None => break,
+                    Some(Err(msg)) => {
                         let _ = tx.send(Err(Status::internal(msg))).await;
                         return;
                     }
+                    Some(Ok(v)) => v,
                 };
 
-                let entries = match scan_inner {
+                // Caught up: heartbeat WITHOUT scanning, as Go does.
+                if is_last {
+                    let msg = volume_server_pb::VolumeTailSenderResponse {
+                        is_last_chunk: true,
+                        version,
+                        ..Default::default()
+                    };
+                    if tx.send(Ok(msg)).await.is_err() {
+                        return;
+                    }
+                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                    if idle_timeout == 0 {
+                        continue;
+                    }
+                    draining_seconds -= 1;
+                    if draining_seconds <= 0 {
+                        return; // EOF
+                    }
+                    continue;
+                }
+
+                // Not caught up: now do the expensive scan.
+                let scan_result = {
+                    let store = state.store.read().unwrap();
+                    match store.find_volume(vid) {
+                        Some((_, vol)) => vol.scan_raw_needles_from(start_offset),
+                        None => break,
+                    }
+                };
+
+                let entries = match scan_result {
                     Ok(e) => e,
                     Err(_) => break,
                 };
-
                 // Filter entries since last_timestamp_ns
                 let mut last_processed_ns = last_timestamp_ns;
                 let mut sent_any = false;

--- a/seaweed-volume/src/storage/volume.rs
+++ b/seaweed-volume/src/storage/volume.rs
@@ -4809,6 +4809,62 @@ mod tests {
     }
 
     #[test]
+    fn binary_search_on_compacted_volume_still_reports_a_later_write() {
+        // Compaction rewrites .idx in needle-id order (Go does the same), so
+        // append_at_ns is no longer monotonic by row and the search can call
+        // a caller caught up while an earlier row is newer. That caller's
+        // since_ns is the last row's timestamp (find_last_append_at_ns), so
+        // such rows were already in the files it copied. What must hold is
+        // that a write made after that point still reaches the scan: it is
+        // appended as the final row, and the search cannot step past it.
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().to_str().unwrap();
+        let mut v = make_test_volume(dir);
+
+        let write = |v: &mut Volume, id: u64| {
+            let mut n = Needle {
+                id: NeedleId(id),
+                cookie: Cookie(0x12345678),
+                data: vec![b'c'; 64],
+                data_size: 64,
+                flags: 0,
+                ..Needle::default()
+            };
+            v.write_needle(&mut n, true, false).unwrap();
+            n.append_at_ns
+        };
+        write(&mut v, 1);
+        let key2_ns = write(&mut v, 2);
+        write(&mut v, 1); // overwrite: key 1 is now newer than key 2
+        v.compact_by_index(0, 0, |_| true).unwrap();
+        v.commit_compact().unwrap();
+
+        let (_offset, is_last) = v.binary_search_by_append_at_ns(key2_ns).unwrap();
+        assert!(
+            is_last,
+            "precondition: compaction ordered .idx by key, so key 2 is the final row"
+        );
+
+        let key3_ns = write(&mut v, 3);
+        let (offset, is_last) = v.binary_search_by_append_at_ns(key2_ns).unwrap();
+        assert!(
+            !is_last,
+            "a write after compaction is the final row and must not be hidden"
+        );
+        let shipped: Vec<u64> = v
+            .scan_raw_needles_from(offset.to_actual_offset() as u64)
+            .unwrap()
+            .into_iter()
+            .map(|(_, _, append_at_ns)| append_at_ns)
+            .filter(|&append_at_ns| append_at_ns > key2_ns)
+            .collect();
+        assert!(
+            shipped.contains(&key3_ns),
+            "the tail must ship the write made after compaction"
+        );
+    }
+
+    #[test]
     fn test_volume_write_read() {
         let tmp = TempDir::new().unwrap();
         let dir = tmp.path().to_str().unwrap();

--- a/seaweed-volume/src/storage/volume.rs
+++ b/seaweed-volume/src/storage/volume.rs
@@ -4682,6 +4682,133 @@ mod tests {
     }
 
     #[test]
+    fn binary_search_reports_is_last_when_caller_is_caught_up() {
+        // The tail sender relies on this flag to answer "nothing new" with a
+        // heartbeat instead of re-scanning the volume. Go does the same
+        // (volume_grpc_tail.go, `if isLastOne`). If this ever stops reporting
+        // true for an up-to-date caller, volume_tail_sender silently degrades
+        // into re-reading the whole volume every 2s.
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().to_str().unwrap();
+        let mut v = make_test_volume(dir);
+
+        let mut newest_ns = 0u64;
+        for id in 1..=3u64 {
+            let mut n = Needle {
+                id: NeedleId(id),
+                cookie: Cookie(0x12345678),
+                data: vec![b'x'; 64],
+                data_size: 64,
+                flags: 0,
+                ..Needle::default()
+            };
+            v.write_needle(&mut n, true, false).unwrap();
+            newest_ns = n.append_at_ns;
+        }
+        assert!(newest_ns > 0, "needles must carry an append timestamp");
+
+        // Caught up: asking from the newest timestamp has nothing newer.
+        let (_offset, is_last) = v.binary_search_by_append_at_ns(newest_ns).unwrap();
+        assert!(
+            is_last,
+            "a caller at the newest append_at_ns must be reported as caught up"
+        );
+
+        // And from beyond the newest, likewise.
+        let (_offset, is_last_future) = v
+            .binary_search_by_append_at_ns(newest_ns + 1_000_000_000)
+            .unwrap();
+        assert!(
+            is_last_future,
+            "a caller ahead of the newest needle must be reported as caught up"
+        );
+    }
+
+    #[test]
+    fn binary_search_does_not_report_is_last_when_data_is_newer() {
+        // The complement: if the caller is behind, is_last must be false so the
+        // sender still scans and ships the new needles. A fix that always
+        // reported "caught up" would make tailing silently lose data, which is
+        // worse than the memory bug it would be fixing.
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().to_str().unwrap();
+        let mut v = make_test_volume(dir);
+
+        let mut first_ns = 0u64;
+        for id in 1..=3u64 {
+            let mut n = Needle {
+                id: NeedleId(id),
+                cookie: Cookie(0x12345678),
+                data: vec![b'y'; 64],
+                data_size: 64,
+                flags: 0,
+                ..Needle::default()
+            };
+            v.write_needle(&mut n, true, false).unwrap();
+            if id == 1 {
+                first_ns = n.append_at_ns;
+            }
+        }
+
+        let (_offset, is_last) = v.binary_search_by_append_at_ns(first_ns).unwrap();
+        assert!(
+            !is_last,
+            "a caller behind the newest needle must NOT be reported as caught up"
+        );
+    }
+
+    #[test]
+    fn binary_search_does_not_report_is_last_when_only_a_delete_is_newer() {
+        // A delete is data the tail must ship too. Its .idx row carries the
+        // tombstone's real .dat offset, so a caller caught up before the
+        // delete must be sent to scan from the tombstone, not handed a
+        // heartbeat that would silently drop the deletion on the destination.
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().to_str().unwrap();
+        let mut v = make_test_volume(dir);
+
+        let mut newest_ns = 0u64;
+        for id in 1..=3u64 {
+            let mut n = Needle {
+                id: NeedleId(id),
+                cookie: Cookie(0x12345678),
+                data: vec![b'z'; 64],
+                data_size: 64,
+                flags: 0,
+                ..Needle::default()
+            };
+            v.write_needle(&mut n, true, false).unwrap();
+            newest_ns = n.append_at_ns;
+        }
+        let (_offset, is_last) = v.binary_search_by_append_at_ns(newest_ns).unwrap();
+        assert!(is_last, "precondition: the caller starts caught up");
+
+        v.delete_needle(&mut Needle {
+            id: NeedleId(2),
+            cookie: Cookie(0x12345678),
+            ..Needle::default()
+        })
+        .unwrap();
+
+        let (offset, is_last) = v.binary_search_by_append_at_ns(newest_ns).unwrap();
+        assert!(
+            !is_last,
+            "a caller older than a trailing delete must NOT be reported as caught up"
+        );
+
+        // Scan and filter exactly as volume_tail_sender does: the tombstone,
+        // and only the tombstone, is newer than the caller.
+        let shipped: Vec<u64> = v
+            .scan_raw_needles_from(offset.to_actual_offset() as u64)
+            .unwrap()
+            .into_iter()
+            .map(|(_, _, append_at_ns)| append_at_ns)
+            .filter(|&append_at_ns| append_at_ns > newest_ns)
+            .collect();
+        assert_eq!(shipped.len(), 1, "the tail must ship the tombstone");
+    }
+
+    #[test]
     fn test_volume_write_read() {
         let tmp = TempDir::new().unwrap();
         let dir = tmp.path().to_str().unwrap();

--- a/seaweed-volume/src/storage/volume.rs
+++ b/seaweed-volume/src/storage/volume.rs
@@ -4683,11 +4683,8 @@ mod tests {
 
     #[test]
     fn binary_search_reports_is_last_when_caller_is_caught_up() {
-        // The tail sender relies on this flag to answer "nothing new" with a
-        // heartbeat instead of re-scanning the volume. Go does the same
-        // (volume_grpc_tail.go, `if isLastOne`). If this ever stops reporting
-        // true for an up-to-date caller, volume_tail_sender silently degrades
-        // into re-reading the whole volume every 2s.
+        // is_last drives the caught-up heartbeat; if it stops reporting true
+        // for an up-to-date caller, the tail sender re-reads the whole volume.
         let tmp = TempDir::new().unwrap();
         let dir = tmp.path().to_str().unwrap();
         let mut v = make_test_volume(dir);
@@ -4726,10 +4723,7 @@ mod tests {
 
     #[test]
     fn binary_search_does_not_report_is_last_when_data_is_newer() {
-        // The complement: if the caller is behind, is_last must be false so the
-        // sender still scans and ships the new needles. A fix that always
-        // reported "caught up" would make tailing silently lose data, which is
-        // worse than the memory bug it would be fixing.
+        // Complement: a behind caller must NOT be caught up, or tailing loses data.
         let tmp = TempDir::new().unwrap();
         let dir = tmp.path().to_str().unwrap();
         let mut v = make_test_volume(dir);
@@ -4759,10 +4753,8 @@ mod tests {
 
     #[test]
     fn binary_search_does_not_report_is_last_when_only_a_delete_is_newer() {
-        // A delete is data the tail must ship too. Its .idx row carries the
-        // tombstone's real .dat offset, so a caller caught up before the
-        // delete must be sent to scan from the tombstone, not handed a
-        // heartbeat that would silently drop the deletion on the destination.
+        // A delete is data the tail must ship. A caught-up caller before the
+        // delete must be sent to scan from the tombstone, not handed a heartbeat.
         let tmp = TempDir::new().unwrap();
         let dir = tmp.path().to_str().unwrap();
         let mut v = make_test_volume(dir);
@@ -4796,8 +4788,7 @@ mod tests {
             "a caller older than a trailing delete must NOT be reported as caught up"
         );
 
-        // Scan and filter exactly as volume_tail_sender does: the tombstone,
-        // and only the tombstone, is newer than the caller.
+        // Scan and filter as volume_tail_sender does: only the tombstone is newer.
         let shipped: Vec<u64> = v
             .scan_raw_needles_from(offset.to_actual_offset() as u64)
             .unwrap()
@@ -4810,22 +4801,20 @@ mod tests {
 
     #[test]
     fn binary_search_on_compacted_volume_still_reports_a_later_write() {
-        // Compaction rewrites .idx in needle-id order (Go does the same), so
-        // append_at_ns is no longer monotonic by row and the search can call
-        // a caller caught up while an earlier row is newer. That caller's
-        // since_ns is the last row's timestamp (find_last_append_at_ns), so
-        // such rows were already in the files it copied. What must hold is
-        // that a write made after that point still reaches the scan: it is
-        // appended as the final row, and the search cannot step past it.
+        // Compaction rewrites .idx in needle-id order, so append_at_ns is no
+        // longer monotonic by row: an overwritten key can sit before an older
+        // one. The caller's since_ns is the last row's timestamp, so such rows
+        // were already in the files it copied. A write made afterwards is
+        // appended as the final row, which the search cannot step past.
         let tmp = TempDir::new().unwrap();
         let dir = tmp.path().to_str().unwrap();
         let mut v = make_test_volume(dir);
 
-        let write = |v: &mut Volume, id: u64| {
+        let write = |v: &mut Volume, id: u64, byte: u8| {
             let mut n = Needle {
                 id: NeedleId(id),
                 cookie: Cookie(0x12345678),
-                data: vec![b'c'; 64],
+                data: vec![byte; 64],
                 data_size: 64,
                 flags: 0,
                 ..Needle::default()
@@ -4833,9 +4822,13 @@ mod tests {
             v.write_needle(&mut n, true, false).unwrap();
             n.append_at_ns
         };
-        write(&mut v, 1);
-        let key2_ns = write(&mut v, 2);
-        write(&mut v, 1); // overwrite: key 1 is now newer than key 2
+        write(&mut v, 1, b'c');
+        let key2_ns = write(&mut v, 2, b'c');
+        let key1_ns = write(&mut v, 1, b'd'); // genuine overwrite: different data
+        assert!(
+            key1_ns > key2_ns,
+            "precondition: the overwrite must append a newer record, not dedup"
+        );
         v.compact_by_index(0, 0, |_| true).unwrap();
         v.commit_compact().unwrap();
 
@@ -4845,7 +4838,7 @@ mod tests {
             "precondition: compaction ordered .idx by key, so key 2 is the final row"
         );
 
-        let key3_ns = write(&mut v, 3);
+        let key3_ns = write(&mut v, 3, b'c');
         let (offset, is_last) = v.binary_search_by_append_at_ns(key2_ns).unwrap();
         assert!(
             !is_last,


### PR DESCRIPTION
## The problem

During the `tailing` phase of a `volume.move`, the source volume server repeatedly materialises **the entire volume** into memory. Measured at ~2.17 GB re-read six times in 35 seconds for a 2.15 GB volume.

Under a per-process memory cap this OOM-kills the source whenever a volume larger than the cap is moved. On the cluster this comes from, enabling the full maintenance job set produced two OOM kills within 11 minutes, and volume balancing had been disabled since.

## Cause

`volume_tail_sender` discards the `is_last` flag:

```rust
match vol.binary_search_by_append_at_ns(last_timestamp_ns) {
    Ok((offset, _is_last)) => {          // <-- thrown away
        if offset.is_zero() {
            Ok(sb_size)                  // <-- start of the data
        } else {
            Ok(offset.to_actual_offset() as u64)
        }
    }
```

`is_last` means the caller is already caught up. Go answers that with a heartbeat and never scans (`weed/server/volume_grpc_tail.go`):

```go
foundOffset, isLastOne, err := v.BinarySearchByAppendAtNs(lastTimestampNs)
if isLastOne {
    sendErr := stream.Send(&volume_server_pb.VolumeTailSenderResponse{IsLastChunk: true, Version: uint32(v.Version())})
    return lastTimestampNs, sendErr
}
```

The two Rust branches interact badly. When the search reports caught-up it returns `Offset::default()` — zero — so the start offset falls back to `sb_size`, the beginning of the data. `scan_raw_needles_from` then reads every needle from there to EOF into a `Vec`, the timestamp filter discards all of it, the loop sleeps 2s, and it repeats.

A volume being moved is marked read-only before the copy, so it is **always** caught up during the tail. Every iteration re-read the whole volume and threw it away.

## The change

Resolve the start offset and `is_last` under a brief lock, return the heartbeat immediately when caught up, and only then reach the scan.

**The ordering is the entire fix and is easy to get wrong.** An earlier revision of this patch set the flag correctly but placed the early return *after* the block performing the scan. The heartbeat fired and the destination received nothing — it looked right — yet every iteration still read the whole volume and discarded the result. It shipped to a test cluster and changed nothing (1770 MB across five cycles vs 2179 MB before), which is how it was caught. The binary search is over the `.idx` and costs nothing; the scan is the expensive part and must not run speculatively.

## Measured, before and after, on the same cluster

One explicit `volume.move` of a 2.15 GB volume, sampling the source's cgroup `memory.stat` anon every 2s, correlated against the move's own phase output.

**Before:**

```
copying    src =  16 ->   37 MB      <- CopyFile streams correctly, stays bounded
tailing    src = 904 -> 1891 -> 2166 -> 629 -> 1614 -> 2166
                -> 342 -> 1282 -> 2173 -> 737 -> 949 -> 1906 -> 2179 MB
deleting   src =  46 MB
```

**After:**

```
copying    src = 13 -> 15 -> 33 -> 33 -> 32 MB
tailing    src = 13, 13, 13, 13, 13 MB
deleting   src = 13 MB
```

| | before | after |
|---|---|---|
| peak source anon | 2179 MB | **33 MB** |
| tailing phase | 35s | **10s** |
| whole move | 47s | **19s** |

**66x less peak memory**, and the move is 2.5x faster because it stopped re-reading the volume five times. The destination is unaffected either way (max 40 MB) — the cost was not moved elsewhere.

With this deployed, a 40-minute window with the full maintenance job set enabled ran with **zero OOM kills and zero restarts**, worst-unit anon 60 MB, where the same window before the fix tripped a 1500 MB guard within 100 seconds at 2853 MB.

`CopyFile` is not implicated: it already streams 2 MiB chunks through a bounded channel, with a comment noting an earlier version materialised the whole file and could OOM. The tail path still had the bug that comment describes as fixed.

## Tests

Two, and the second matters as much as the first — a fix that always reported "caught up" would make tailing **silently lose needles**, a worse bug than the one it replaces:

- `is_last` is true for a caller at or beyond the newest `append_at_ns`
- `is_last` is **false** for a caller that is behind, so real tail data is still scanned and shipped

555 pass, 0 fail. No formatting drift (`rustfmt --check` diff counts identical to `master` for both touched files).

## Deliberately not fixed here

Both are latent once the rescan is gone, since remaining scans are bounded by genuinely new data, and neither belongs in a one-line semantic fix:

- `scan_raw_needles_from` still collects into a `Vec` rather than streaming through a visitor the way Go's `ScanVolumeFileFrom` does.
- That scan runs while holding `store.read()` — the same lock-across-a-large-read shape as #11235.

Happy to follow up with either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MFr2v4BUqrXdgj4LEUAwVF

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs/pull/11273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved volume tailing to distinguish caught-up clients from clients with new data.
  * Caught-up clients now receive a heartbeat without unnecessary volume scanning.
  * Tailing now stops cleanly when a volume is unavailable.
  * Improved handling of newer writes, deletions, and post-compaction updates.

* **Tests**
  * Added coverage for caught-up queries, pending new data, deleted entries, and post-compaction writes during volume tailing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->