### PR TITLE
s3 sink: report the source read error the SDK hides

### DIFF
--- a/weed/filer/stream.go
+++ b/weed/filer/stream.go
@@ -541,8 +541,6 @@ func (c *ChunkStreamReader) fetchChunkToBuffer(chunkView *ChunkView) error {
 	return nil
 }
 
-// rememberSourceError keeps the first lookup or chunk read failure.
-// Callers hold bufferLock, as fetchChunkToBuffer does.
 func (c *ChunkStreamReader) rememberSourceError(err error) error {
 	if c.sourceErr == nil {
 		c.sourceErr = err
@@ -550,17 +548,14 @@ func (c *ChunkStreamReader) rememberSourceError(err error) error {
 	return err
 }
 
-// SourceError returns the first lookup or chunk read failure, or nil. It is for
-// callers that pass this reader to a library dropping the error of a failed
-// read, such as the AWS SDK.
+// SourceError returns the first lookup or chunk read failure, or nil.
 func (c *ChunkStreamReader) SourceError() error {
 	c.bufferLock.Lock()
 	defer c.bufferLock.Unlock()
 	return c.sourceErr
 }
 
-// ReaderSourceError returns the SourceError of a reader from NewFileReader,
-// or nil for a reader of inlined content.
+// ReaderSourceError returns the SourceError of a reader from NewFileReader, or nil.
 func ReaderSourceError(r io.Reader) error {
 	if csr, ok := r.(*ChunkStreamReader); ok {
 		return csr.SourceError()

--- a/weed/filer/stream.go
+++ b/weed/filer/stream.go
@@ -369,6 +369,7 @@ type ChunkStreamReader struct {
 	bufferLock   sync.Mutex
 	chunk        string
 	lookupFileId wdclient.LookupFileIdFunctionType
+	sourceErr    error
 }
 
 var _ = io.ReadSeeker(&ChunkStreamReader{})
@@ -507,7 +508,7 @@ func (c *ChunkStreamReader) fetchChunkToBuffer(chunkView *ChunkView) error {
 	urlStrings, err := c.lookupFileId(context.Background(), chunkView.FileId)
 	if err != nil {
 		glog.V(1).Infof("operation LookupFileId %s failed, err: %v", chunkView.FileId, err)
-		return err
+		return c.rememberSourceError(err)
 	}
 	var buffer bytes.Buffer
 	// pre-size to the known chunk size; avoids bytes.Buffer's doubling regrowth
@@ -529,7 +530,7 @@ func (c *ChunkStreamReader) fetchChunkToBuffer(chunkView *ChunkView) error {
 		}
 	}
 	if err != nil {
-		return err
+		return c.rememberSourceError(err)
 	}
 	c.buffer = buffer.Bytes()
 	c.bufferOffset = chunkView.ViewOffset
@@ -537,6 +538,33 @@ func (c *ChunkStreamReader) fetchChunkToBuffer(chunkView *ChunkView) error {
 
 	// glog.V(0).Infof("fetched %s [%d,%d)", chunkView.FileId, chunkView.ViewOffset, chunkView.ViewOffset+int64(chunkView.ViewSize))
 
+	return nil
+}
+
+// rememberSourceError keeps the first lookup or chunk read failure.
+// Callers hold bufferLock, as fetchChunkToBuffer does.
+func (c *ChunkStreamReader) rememberSourceError(err error) error {
+	if c.sourceErr == nil {
+		c.sourceErr = err
+	}
+	return err
+}
+
+// SourceError returns the first lookup or chunk read failure, or nil. It is for
+// callers that pass this reader to a library dropping the error of a failed
+// read, such as the AWS SDK.
+func (c *ChunkStreamReader) SourceError() error {
+	c.bufferLock.Lock()
+	defer c.bufferLock.Unlock()
+	return c.sourceErr
+}
+
+// ReaderSourceError returns the SourceError of a reader from NewFileReader,
+// or nil for a reader of inlined content.
+func ReaderSourceError(r io.Reader) error {
+	if csr, ok := r.(*ChunkStreamReader); ok {
+		return csr.SourceError()
+	}
 	return nil
 }
 

--- a/weed/filer/stream_source_error_test.go
+++ b/weed/filer/stream_source_error_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
 )
 
-// A chunk whose needle is gone answers 404, and that error is what tells a gone
-// source from a sink failure. The AWS SDK drops it, so the reader keeps it.
 func TestChunkStreamReaderSourceError(t *testing.T) {
 	server := createTestServer(map[string][]byte{})
 	defer server.Close()
@@ -36,7 +34,6 @@ func TestChunkStreamReaderSourceError(t *testing.T) {
 	}
 }
 
-// A lookup that cannot place the chunk fails before any volume is read.
 func TestChunkStreamReaderSourceErrorOnLookup(t *testing.T) {
 	master := &testMasterClient{urls: map[string][]string{}}
 	reader := NewChunkStreamReaderFromLookup(context.Background(), master.GetLookupFileIdFunction(),
@@ -50,7 +47,6 @@ func TestChunkStreamReaderSourceErrorOnLookup(t *testing.T) {
 	}
 }
 
-// Inlined content reaches no volume server and has no source error.
 func TestReaderSourceErrorInlineEntry(t *testing.T) {
 	reader := NewFileReader(nil, &filer_pb.Entry{Content: []byte("inline")})
 	if err := ReaderSourceError(reader); err != nil {

--- a/weed/filer/stream_source_error_test.go
+++ b/weed/filer/stream_source_error_test.go
@@ -1,0 +1,59 @@
+package filer
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/seaweedfs/seaweedfs/weed/pb/filer_pb"
+)
+
+// A chunk whose needle is gone answers 404, and that error is what tells a gone
+// source from a sink failure. The AWS SDK drops it, so the reader keeps it.
+func TestChunkStreamReaderSourceError(t *testing.T) {
+	server := createTestServer(map[string][]byte{})
+	defer server.Close()
+
+	lookup := func(ctx context.Context, fileId string) ([]string, error) {
+		return []string{server.URL + "/" + fileId}, nil
+	}
+	reader := NewChunkStreamReaderFromLookup(context.Background(), lookup,
+		[]*filer_pb.FileChunk{{FileId: "7,01637037d6", Size: 8}})
+
+	if _, err := io.ReadAll(reader); err == nil {
+		t.Fatal("reading a gone chunk succeeded")
+	}
+	sourceErr := reader.SourceError()
+	if sourceErr == nil {
+		t.Fatal("reader kept no source error")
+	}
+	if !strings.Contains(sourceErr.Error(), "404") {
+		t.Fatalf("source error does not name the volume answer: %v", sourceErr)
+	}
+	if ReaderSourceError(reader) != sourceErr {
+		t.Fatal("ReaderSourceError does not return the kept error")
+	}
+}
+
+// A lookup that cannot place the chunk fails before any volume is read.
+func TestChunkStreamReaderSourceErrorOnLookup(t *testing.T) {
+	master := &testMasterClient{urls: map[string][]string{}}
+	reader := NewChunkStreamReaderFromLookup(context.Background(), master.GetLookupFileIdFunction(),
+		[]*filer_pb.FileChunk{{FileId: "7,01637037d6", Size: 8}})
+
+	if _, err := io.ReadAll(reader); err == nil {
+		t.Fatal("reading a chunk with no location succeeded")
+	}
+	if reader.SourceError() == nil {
+		t.Fatal("reader kept no source error")
+	}
+}
+
+// Inlined content reaches no volume server and has no source error.
+func TestReaderSourceErrorInlineEntry(t *testing.T) {
+	reader := NewFileReader(nil, &filer_pb.Entry{Content: []byte("inline")})
+	if err := ReaderSourceError(reader); err != nil {
+		t.Fatalf("inline content reported a source error: %v", err)
+	}
+}

--- a/weed/replication/sink/s3sink/s3_sink.go
+++ b/weed/replication/sink/s3sink/s3_sink.go
@@ -221,8 +221,6 @@ func (s3sink *S3Sink) CreateEntry(key string, entry *filer_pb.Entry, signatures 
 	}
 	_, err = uploader.Upload(&uploadInput)
 	if err != nil {
-		// A failed body read reaches the caller as "ContentLength=N with Body
-		// length 0" without the cause, which reads as a sink failure.
 		if sourceErr := filer.ReaderSourceError(reader); sourceErr != nil {
 			return fmt.Errorf("read source %s: %w", key, sourceErr)
 		}

--- a/weed/replication/sink/s3sink/s3_sink.go
+++ b/weed/replication/sink/s3sink/s3_sink.go
@@ -220,6 +220,13 @@ func (s3sink *S3Sink) CreateEntry(key string, entry *filer_pb.Entry, signatures 
 		uploadInput.ContentMD5 = aws.String(base64.StdEncoding.EncodeToString([]byte(entry.Attributes.Md5)))
 	}
 	_, err = uploader.Upload(&uploadInput)
+	if err != nil {
+		// A failed body read reaches the caller as "ContentLength=N with Body
+		// length 0" without the cause, which reads as a sink failure.
+		if sourceErr := filer.ReaderSourceError(reader); sourceErr != nil {
+			return fmt.Errorf("read source %s: %w", key, sourceErr)
+		}
+	}
 
 	return err
 


### PR DESCRIPTION
Fixes #11276.

When the uploader's body read fails, the AWS SDK returns `ContentLength=N with Body length 0` and drops the cause, so a source chunk that is gone reads as a sink-side transport failure. `filer.backup` then retries that event forever and its checkpoint never advances — `isIgnorable404` would have skipped it, but the volume server's 404 never reaches it.

`ChunkStreamReader` now keeps its first source failure, and the s3 sink returns that instead of the SDK's error when an upload fails. Other sinks copy through a write callback and already propagate the read error.

Tests cover a gone chunk, a chunk with no location, and inlined content.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs/pull/11277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved source read errors encountered while streaming file content.
  - Retained useful details for failures caused by missing file chunks or lookup errors.
  - Improved S3 upload error reporting by identifying failures while reading source files.
  - Prevented opaque upload errors from masking the underlying source read failure.
  - Maintained normal behavior for inline file content when no source error occurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->