### PR TITLE
feat(admin): add bearer-token auth for admin REST API

### DIFF
--- a/weed/admin/dash/context.go
+++ b/weed/admin/dash/context.go
@@ -9,10 +9,17 @@ import (
 type contextKey string
 
 const (
-	contextUsernameKey  contextKey = "admin.username"
-	contextRoleKey      contextKey = "admin.role"
-	contextCSRFKey      contextKey = "admin.csrf"
-	contextURLPrefixKey contextKey = "admin.urlprefix"
+	contextUsernameKey   contextKey = "admin.username"
+	contextRoleKey       contextKey = "admin.role"
+	contextCSRFKey       contextKey = "admin.csrf"
+	contextURLPrefixKey  contextKey = "admin.urlprefix"
+	contextAuthMethodKey contextKey = "admin.auth_method"
+)
+
+// Auth method values stored in context to distinguish session vs bearer auth.
+const (
+	AuthMethodSession = "session"
+	AuthMethodBearer  = "bearer"
 )
 
 // WithAuthContext stores auth metadata on the request context.
@@ -27,6 +34,24 @@ func WithAuthContext(ctx context.Context, username, role, csrfToken string) cont
 		ctx = context.WithValue(ctx, contextCSRFKey, csrfToken)
 	}
 	return ctx
+}
+
+// WithAuthMethod records how the request was authenticated (session or bearer).
+// Bearer-authenticated requests bypass CSRF validation since they carry no
+// browser session and are not vulnerable to CSRF attacks.
+func WithAuthMethod(ctx context.Context, method string) context.Context {
+	return context.WithValue(ctx, contextAuthMethodKey, method)
+}
+
+// AuthMethodFromContext retrieves the authentication method from context.
+func AuthMethodFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	if value, ok := ctx.Value(contextAuthMethodKey).(string); ok {
+		return value
+	}
+	return ""
 }
 
 // UsernameFromContext retrieves the username from context.

--- a/weed/admin/dash/csrf.go
+++ b/weed/admin/dash/csrf.go
@@ -38,6 +38,11 @@ func getOrCreateSessionCSRFToken(session *sessions.Session, r *http.Request, w h
 func requireSessionCSRFToken(w http.ResponseWriter, r *http.Request) bool {
 	expectedToken := CSRFTokenFromContext(r.Context())
 	username := UsernameFromContext(r.Context())
+	// Bearer-token-authenticated requests have no browser session and are not
+	// vulnerable to CSRF. Skip CSRF validation for them.
+	if AuthMethodFromContext(r.Context()) == AuthMethodBearer {
+		return true
+	}
 	if expectedToken == "" {
 		// Admin UI can run without auth; in that mode CSRF token checks are not applicable.
 		if username == "" {

--- a/weed/admin/dash/middleware.go
+++ b/weed/admin/dash/middleware.go
@@ -1,6 +1,7 @@
 package dash
 
 import (
+	"crypto/subtle"
 	"net/http"
 	"strings"
 
@@ -13,6 +14,39 @@ const sessionName = "admin-session"
 // SessionName returns the cookie session name used by the admin UI.
 func SessionName() string {
 	return sessionName
+}
+
+// bearerTokenFromRequest extracts a bearer token from the Authorization header.
+// Returns ("", false) when no bearer token is present.
+func bearerTokenFromRequest(r *http.Request) (string, bool) {
+	auth := r.Header.Get("Authorization")
+	if auth == "" {
+		return "", false
+	}
+	const prefix = "Bearer "
+	if !strings.HasPrefix(auth, prefix) {
+		return "", false
+	}
+	token := strings.TrimSpace(auth[len(prefix):])
+	if token == "" {
+		return "", false
+	}
+	return token, true
+}
+
+// validateBearerToken checks the Authorization header for a valid bearer token.
+// When apiKey is empty, token auth is disabled and the function returns false
+// (caller should fall back to session validation). When a token is present and
+// matches apiKey, the request is authenticated as admin with write access.
+func validateBearerToken(apiKey string, r *http.Request) bool {
+	if apiKey == "" {
+		return false
+	}
+	token, ok := bearerTokenFromRequest(r)
+	if !ok {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(token), []byte(apiKey)) == 1
 }
 
 type sessionValidationErrorKind int
@@ -82,9 +116,18 @@ func RequireAuth(store sessions.Store) mux.MiddlewareFunc {
 
 // RequireAuthAPI checks if user is authenticated for API endpoints.
 // Returns JSON error instead of redirecting to login page.
-func RequireAuthAPI(store sessions.Store) mux.MiddlewareFunc {
+// When apiKey is non-empty, a matching Bearer token in the Authorization header
+// authenticates the request as admin with write access, bypassing session auth.
+func RequireAuthAPI(store sessions.Store, apiKey string) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Bearer token auth: alternative to session-based auth for API clients.
+			if validateBearerToken(apiKey, r) {
+				ctx := WithAuthContext(r.Context(), "api-token", "admin", "")
+				next.ServeHTTP(w, r.WithContext(ctx))
+				return
+			}
+
 			username, role, csrfToken, err := validateSession(store, w, r)
 			if err != nil {
 				if verr, ok := err.(*sessionValidationError); ok && verr.kind == sessionValidationErrorKindUnauthenticated {

--- a/weed/admin/dash/middleware.go
+++ b/weed/admin/dash/middleware.go
@@ -17,17 +17,19 @@ func SessionName() string {
 }
 
 // bearerTokenFromRequest extracts a bearer token from the Authorization header.
+// The scheme name is matched case-insensitively per RFC 7235. The token itself
+// is compared exactly (not case-folded).
 // Returns ("", false) when no bearer token is present.
 func bearerTokenFromRequest(r *http.Request) (string, bool) {
 	auth := r.Header.Get("Authorization")
 	if auth == "" {
 		return "", false
 	}
-	const prefix = "Bearer "
-	if !strings.HasPrefix(auth, prefix) {
+	parts := strings.Fields(auth)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
 		return "", false
 	}
-	token := strings.TrimSpace(auth[len(prefix):])
+	token := parts[1]
 	if token == "" {
 		return "", false
 	}
@@ -124,6 +126,7 @@ func RequireAuthAPI(store sessions.Store, apiKey string) mux.MiddlewareFunc {
 			// Bearer token auth: alternative to session-based auth for API clients.
 			if validateBearerToken(apiKey, r) {
 				ctx := WithAuthContext(r.Context(), "api-token", "admin", "")
+				ctx = WithAuthMethod(ctx, AuthMethodBearer)
 				next.ServeHTTP(w, r.WithContext(ctx))
 				return
 			}
@@ -145,6 +148,7 @@ func RequireAuthAPI(store sessions.Store, apiKey string) mux.MiddlewareFunc {
 			}
 
 			ctx := WithAuthContext(r.Context(), username, role, csrfToken)
+			ctx = WithAuthMethod(ctx, AuthMethodSession)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}

--- a/weed/admin/dash/middleware_test.go
+++ b/weed/admin/dash/middleware_test.go
@@ -20,6 +20,8 @@ func TestBearerTokenFromRequest(t *testing.T) {
 		{"empty token", "Bearer ", "", false},
 		{"valid token", "Bearer my-secret-token", "my-secret-token", true},
 		{"valid with spaces", "Bearer  token-with-spaces  ", "token-with-spaces", true},
+		{"lowercase bearer scheme", "bearer my-secret-token", "my-secret-token", true},
+		{"uppercase bearer scheme", "BEARER my-secret-token", "my-secret-token", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -76,6 +78,10 @@ func TestRequireAuthAPI_BearerTokenBypassesSession(t *testing.T) {
 		if role != "admin" {
 			t.Errorf("expected role 'admin', got %q", role)
 		}
+		method := AuthMethodFromContext(r.Context())
+		if method != AuthMethodBearer {
+			t.Errorf("expected auth method 'bearer', got %q", method)
+		}
 		w.WriteHeader(http.StatusOK)
 	})
 	mw := RequireAuthAPI(store, apiKey)
@@ -131,5 +137,33 @@ func TestRequireAuthAPI_NoTokenNoSessionReturns401(t *testing.T) {
 
 	if rec.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestRequireSessionCSRFToken_BearerAuthBypassesCSRF(t *testing.T) {
+	// Bearer-authenticated requests should bypass CSRF checks since they
+	// have no browser session and are not vulnerable to CSRF.
+	req := httptest.NewRequest(http.MethodPut, "/api/s3/buckets/test/lifecycle", nil)
+	req = req.WithContext(WithAuthMethod(req.Context(), AuthMethodBearer))
+	rec := httptest.NewRecorder()
+
+	if !requireSessionCSRFToken(rec, req) {
+		t.Error("expected CSRF check to pass for bearer-authenticated request")
+	}
+}
+
+func TestRequireSessionCSRFToken_SessionAuthRequiresCSRF(t *testing.T) {
+	// Session-authenticated requests with a username but no CSRF token
+	// should be rejected.
+	req := httptest.NewRequest(http.MethodPut, "/api/s3/buckets/test/lifecycle", nil)
+	ctx := WithAuthContext(req.Context(), "admin-user", "admin", "")
+	req = req.WithContext(WithAuthMethod(ctx, AuthMethodSession))
+	rec := httptest.NewRecorder()
+
+	if requireSessionCSRFToken(rec, req) {
+		t.Error("expected CSRF check to fail for session-authenticated request without token")
+	}
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusForbidden)
 	}
 }

--- a/weed/admin/dash/middleware_test.go
+++ b/weed/admin/dash/middleware_test.go
@@ -1,0 +1,135 @@
+package dash
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/sessions"
+)
+
+func TestBearerTokenFromRequest(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		want   string
+		ok     bool
+	}{
+		{"no header", "", "", false},
+		{"wrong scheme", "Basic abc123", "", false},
+		{"empty token", "Bearer ", "", false},
+		{"valid token", "Bearer my-secret-token", "my-secret-token", true},
+		{"valid with spaces", "Bearer  token-with-spaces  ", "token-with-spaces", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/s3/buckets", nil)
+			if tt.header != "" {
+				req.Header.Set("Authorization", tt.header)
+			}
+			token, ok := bearerTokenFromRequest(req)
+			if ok != tt.ok {
+				t.Errorf("bearerTokenFromRequest() ok = %v, want %v", ok, tt.ok)
+			}
+			if token != tt.want {
+				t.Errorf("bearerTokenFromRequest() token = %q, want %q", token, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateBearerToken(t *testing.T) {
+	apiKey := "test-api-key-12345"
+	tests := []struct {
+		name     string
+		apiKey   string
+		authHdr  string
+		expected bool
+	}{
+		{"empty apiKey disables token auth", "", "Bearer test-api-key-12345", false},
+		{"valid token matches", apiKey, "Bearer test-api-key-12345", true},
+		{"wrong token does not match", apiKey, "Bearer wrong-token", false},
+		{"no Authorization header", apiKey, "", false},
+		{"non-bearer scheme", apiKey, "Basic test-api-key-12345", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/s3/buckets", nil)
+			if tt.authHdr != "" {
+				req.Header.Set("Authorization", tt.authHdr)
+			}
+			result := validateBearerToken(tt.apiKey, req)
+			if result != tt.expected {
+				t.Errorf("validateBearerToken() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestRequireAuthAPI_BearerTokenBypassesSession(t *testing.T) {
+	store := sessions.NewCookieStore([]byte("test-secret"))
+	apiKey := "my-api-key"
+	called := false
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		role := RoleFromContext(r.Context())
+		if role != "admin" {
+			t.Errorf("expected role 'admin', got %q", role)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	mw := RequireAuthAPI(store, apiKey)
+	wrapped := mw(handler)
+
+	// Request with valid bearer token — should pass without session
+	req := httptest.NewRequest(http.MethodGet, "/api/s3/buckets", nil)
+	req.Header.Set("Authorization", "Bearer my-api-key")
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, req)
+
+	if !called {
+		t.Error("handler was not called")
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+func TestRequireAuthAPI_BearerTokenWrongReturns401(t *testing.T) {
+	store := sessions.NewCookieStore([]byte("test-secret"))
+	apiKey := "my-api-key"
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler should not be called")
+	})
+	mw := RequireAuthAPI(store, apiKey)
+	wrapped := mw(handler)
+
+	// Request with wrong bearer token — should get 401
+	req := httptest.NewRequest(http.MethodGet, "/api/s3/buckets", nil)
+	req.Header.Set("Authorization", "Bearer wrong-token")
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestRequireAuthAPI_NoTokenNoSessionReturns401(t *testing.T) {
+	store := sessions.NewCookieStore([]byte("test-secret"))
+	apiKey := "my-api-key"
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler should not be called")
+	})
+	mw := RequireAuthAPI(store, apiKey)
+	wrapped := mw(handler)
+
+	// Request with no token and no session — should get 401
+	req := httptest.NewRequest(http.MethodGet, "/api/s3/buckets", nil)
+	rec := httptest.NewRecorder()
+	wrapped.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}

--- a/weed/admin/handlers/admin_handlers.go
+++ b/weed/admin/handlers/admin_handlers.go
@@ -77,14 +77,24 @@ func (h *AdminHandlers) SetupRoutes(r *mux.Router, authRequired bool, adminUser,
 	}
 
 	if authRequired {
-		// Authentication routes (no auth required)
-		r.HandleFunc("/login", h.authHandlers.ShowLogin).Methods(http.MethodGet)
-		r.Handle("/login", h.authHandlers.HandleLogin(adminUser, adminPassword, readOnlyUser, readOnlyPassword)).Methods(http.MethodPost)
-		r.HandleFunc("/logout", h.authHandlers.HandleLogout).Methods(http.MethodGet)
+		// UI session auth is only meaningful when adminPassword is set.
+		// In API-key-only mode, the UI stays public (or disabled) and only
+		// /api endpoints are protected by RequireAuthAPI.
+		uiSessionAuth := adminPassword != ""
+		if uiSessionAuth {
+			// Authentication routes (no auth required)
+			r.HandleFunc("/login", h.authHandlers.ShowLogin).Methods(http.MethodGet)
+			r.Handle("/login", h.authHandlers.HandleLogin(adminUser, adminPassword, readOnlyUser, readOnlyPassword)).Methods(http.MethodPost)
+			r.HandleFunc("/logout", h.authHandlers.HandleLogout).Methods(http.MethodGet)
 
-		protected := r.NewRoute().Subrouter()
-		protected.Use(dash.RequireAuth(h.sessionStore))
-		h.registerUIRoutes(protected)
+			protected := r.NewRoute().Subrouter()
+			protected.Use(dash.RequireAuth(h.sessionStore))
+			h.registerUIRoutes(protected)
+		} else {
+			// API-key-only mode: UI is public (or disabled via enableUI),
+			// but API requires a bearer token.
+			h.registerUIRoutes(r)
+		}
 
 		api := r.PathPrefix("/api").Subrouter()
 		api.Use(dash.RequireAuthAPI(h.sessionStore, apiKey))

--- a/weed/admin/handlers/admin_handlers.go
+++ b/weed/admin/handlers/admin_handlers.go
@@ -59,7 +59,7 @@ func NewAdminHandlers(adminServer *dash.AdminServer, store sessions.Store) *Admi
 }
 
 // SetupRoutes configures all the routes for the admin interface
-func (h *AdminHandlers) SetupRoutes(r *mux.Router, authRequired bool, adminUser, adminPassword, readOnlyUser, readOnlyPassword string, enableUI bool) {
+func (h *AdminHandlers) SetupRoutes(r *mux.Router, authRequired bool, adminUser, adminPassword, readOnlyUser, readOnlyPassword string, enableUI bool, apiKey string) {
 	// Health check (no auth required)
 	r.HandleFunc("/health", h.HealthCheck).Methods(http.MethodGet)
 
@@ -87,7 +87,7 @@ func (h *AdminHandlers) SetupRoutes(r *mux.Router, authRequired bool, adminUser,
 		h.registerUIRoutes(protected)
 
 		api := r.PathPrefix("/api").Subrouter()
-		api.Use(dash.RequireAuthAPI(h.sessionStore))
+		api.Use(dash.RequireAuthAPI(h.sessionStore, apiKey))
 		h.registerAPIRoutes(api, true)
 		return
 	}

--- a/weed/admin/handlers/admin_handlers.go
+++ b/weed/admin/handlers/admin_handlers.go
@@ -78,8 +78,12 @@ func (h *AdminHandlers) SetupRoutes(r *mux.Router, authRequired bool, adminUser,
 
 	if authRequired {
 		// UI session auth is only meaningful when adminPassword is set.
-		// In API-key-only mode, the UI stays public (or disabled) and only
-		// /api endpoints are protected by RequireAuthAPI.
+		// In API-key-only mode (no adminPassword), the interactive UI is not
+		// registered: the browser cannot send bearer tokens, so UI actions
+		// would fail against the protected /api endpoints, and exposing the
+		// UI pages without auth would leak sensitive cluster data. Operators
+		// who need both the UI and server-to-server API access should set
+		// both -adminPassword and -adminApiKey.
 		uiSessionAuth := adminPassword != ""
 		if uiSessionAuth {
 			// Authentication routes (no auth required)
@@ -90,10 +94,6 @@ func (h *AdminHandlers) SetupRoutes(r *mux.Router, authRequired bool, adminUser,
 			protected := r.NewRoute().Subrouter()
 			protected.Use(dash.RequireAuth(h.sessionStore))
 			h.registerUIRoutes(protected)
-		} else {
-			// API-key-only mode: UI is public (or disabled via enableUI),
-			// but API requires a bearer token.
-			h.registerUIRoutes(r)
 		}
 
 		api := r.PathPrefix("/api").Subrouter()

--- a/weed/admin/handlers/admin_handlers_routes_test.go
+++ b/weed/admin/handlers/admin_handlers_routes_test.go
@@ -13,7 +13,7 @@ import (
 func TestSetupRoutes_RegistersPluginSchedulerStatesAPI_NoAuth(t *testing.T) {
 	router := mux.NewRouter()
 
-	newRouteTestAdminHandlers().SetupRoutes(router, false, "", "", "", "", true)
+	newRouteTestAdminHandlers().SetupRoutes(router, false, "", "", "", "", true, "")
 
 	if !hasRoute(router, http.MethodGet, "/api/plugin/scheduler-states") {
 		t.Fatalf("expected GET /api/plugin/scheduler-states to be registered in no-auth mode")
@@ -29,7 +29,7 @@ func TestSetupRoutes_RegistersPluginSchedulerStatesAPI_NoAuth(t *testing.T) {
 func TestSetupRoutes_RegistersPluginSchedulerStatesAPI_WithAuth(t *testing.T) {
 	router := mux.NewRouter()
 
-	newRouteTestAdminHandlers().SetupRoutes(router, true, "admin", "password", "", "", true)
+	newRouteTestAdminHandlers().SetupRoutes(router, true, "admin", "password", "", "", true, "")
 
 	if !hasRoute(router, http.MethodGet, "/api/plugin/scheduler-states") {
 		t.Fatalf("expected GET /api/plugin/scheduler-states to be registered in auth mode")
@@ -45,7 +45,7 @@ func TestSetupRoutes_RegistersPluginSchedulerStatesAPI_WithAuth(t *testing.T) {
 func TestSetupRoutes_RegistersBucketLifecycleAPI_NoAuth(t *testing.T) {
 	router := mux.NewRouter()
 
-	newRouteTestAdminHandlers().SetupRoutes(router, false, "", "", "", "", true)
+	newRouteTestAdminHandlers().SetupRoutes(router, false, "", "", "", "", true, "")
 
 	assertHasRoute(t, router, http.MethodGet, "/api/s3/buckets/example/lifecycle")
 	assertHasRoute(t, router, http.MethodPut, "/api/s3/buckets/example/lifecycle")
@@ -55,7 +55,7 @@ func TestSetupRoutes_RegistersBucketLifecycleAPI_NoAuth(t *testing.T) {
 func TestSetupRoutes_RegistersBucketLifecycleAPI_WithAuth(t *testing.T) {
 	router := mux.NewRouter()
 
-	newRouteTestAdminHandlers().SetupRoutes(router, true, "admin", "password", "", "", true)
+	newRouteTestAdminHandlers().SetupRoutes(router, true, "admin", "password", "", "", true, "")
 
 	assertHasRoute(t, router, http.MethodGet, "/api/s3/buckets/example/lifecycle")
 	assertHasRoute(t, router, http.MethodPut, "/api/s3/buckets/example/lifecycle")
@@ -65,7 +65,7 @@ func TestSetupRoutes_RegistersBucketLifecycleAPI_WithAuth(t *testing.T) {
 func TestSetupRoutes_RegistersBucketPolicyAPI_NoAuth(t *testing.T) {
 	router := mux.NewRouter()
 
-	newRouteTestAdminHandlers().SetupRoutes(router, false, "", "", "", "", true)
+	newRouteTestAdminHandlers().SetupRoutes(router, false, "", "", "", "", true, "")
 
 	assertHasRoute(t, router, http.MethodGet, "/api/s3/buckets/example/policy")
 	assertHasRoute(t, router, http.MethodPut, "/api/s3/buckets/example/policy")
@@ -75,7 +75,7 @@ func TestSetupRoutes_RegistersBucketPolicyAPI_NoAuth(t *testing.T) {
 func TestSetupRoutes_RegistersBucketPolicyAPI_WithAuth(t *testing.T) {
 	router := mux.NewRouter()
 
-	newRouteTestAdminHandlers().SetupRoutes(router, true, "admin", "password", "", "", true)
+	newRouteTestAdminHandlers().SetupRoutes(router, true, "admin", "password", "", "", true, "")
 
 	assertHasRoute(t, router, http.MethodGet, "/api/s3/buckets/example/policy")
 	assertHasRoute(t, router, http.MethodPut, "/api/s3/buckets/example/policy")
@@ -85,7 +85,7 @@ func TestSetupRoutes_RegistersBucketPolicyAPI_WithAuth(t *testing.T) {
 func TestSetupRoutes_RegistersPolicyAPI_NoAuth(t *testing.T) {
 	router := mux.NewRouter()
 
-	newRouteTestAdminHandlers().SetupRoutes(router, false, "", "", "", "", true)
+	newRouteTestAdminHandlers().SetupRoutes(router, false, "", "", "", "", true, "")
 
 	assertHasRoute(t, router, http.MethodGet, "/api/object-store/policies")
 	assertHasRoute(t, router, http.MethodPost, "/api/object-store/policies")
@@ -98,7 +98,7 @@ func TestSetupRoutes_RegistersPolicyAPI_NoAuth(t *testing.T) {
 func TestSetupRoutes_RegistersPolicyAPI_WithAuth(t *testing.T) {
 	router := mux.NewRouter()
 
-	newRouteTestAdminHandlers().SetupRoutes(router, true, "admin", "password", "", "", true)
+	newRouteTestAdminHandlers().SetupRoutes(router, true, "admin", "password", "", "", true, "")
 
 	assertHasRoute(t, router, http.MethodGet, "/api/object-store/policies")
 	assertHasRoute(t, router, http.MethodPost, "/api/object-store/policies")
@@ -111,7 +111,7 @@ func TestSetupRoutes_RegistersPolicyAPI_WithAuth(t *testing.T) {
 func TestSetupRoutes_RegistersPrincipalsAPI_NoAuth(t *testing.T) {
 	router := mux.NewRouter()
 
-	newRouteTestAdminHandlers().SetupRoutes(router, false, "", "", "", "", true)
+	newRouteTestAdminHandlers().SetupRoutes(router, false, "", "", "", "", true, "")
 
 	assertHasRoute(t, router, http.MethodGet, "/api/principals")
 }
@@ -119,7 +119,7 @@ func TestSetupRoutes_RegistersPrincipalsAPI_NoAuth(t *testing.T) {
 func TestSetupRoutes_RegistersFilesListFoldersAPI_NoAuth(t *testing.T) {
 	router := mux.NewRouter()
 
-	newRouteTestAdminHandlers().SetupRoutes(router, false, "", "", "", "", true)
+	newRouteTestAdminHandlers().SetupRoutes(router, false, "", "", "", "", true, "")
 
 	assertHasRoute(t, router, http.MethodGet, "/api/files/list-folders")
 }
@@ -127,7 +127,7 @@ func TestSetupRoutes_RegistersFilesListFoldersAPI_NoAuth(t *testing.T) {
 func TestSetupRoutes_RegistersPluginPages_NoAuth(t *testing.T) {
 	router := mux.NewRouter()
 
-	newRouteTestAdminHandlers().SetupRoutes(router, false, "", "", "", "", true)
+	newRouteTestAdminHandlers().SetupRoutes(router, false, "", "", "", "", true, "")
 
 	assertHasRoute(t, router, http.MethodGet, "/plugin")
 	assertHasRoute(t, router, http.MethodGet, "/plugin/configuration")
@@ -150,7 +150,7 @@ func TestSetupRoutes_RegistersPluginPages_NoAuth(t *testing.T) {
 func TestSetupRoutes_RegistersPluginPages_WithAuth(t *testing.T) {
 	router := mux.NewRouter()
 
-	newRouteTestAdminHandlers().SetupRoutes(router, true, "admin", "password", "", "", true)
+	newRouteTestAdminHandlers().SetupRoutes(router, true, "admin", "password", "", "", true, "")
 
 	assertHasRoute(t, router, http.MethodGet, "/plugin")
 	assertHasRoute(t, router, http.MethodGet, "/plugin/configuration")

--- a/weed/command/admin.go
+++ b/weed/command/admin.go
@@ -304,13 +304,14 @@ func runAdmin(cmd *Command, args []string) bool {
 	// keep the pre-existing unauthenticated setup.
 	hasMTLS := viper.GetString("https.admin.key") != "" && viper.GetString("https.admin.ca") != ""
 	insecureAllowed := a.allowInsecureBind != nil && *a.allowInsecureBind
-	if !isLoopbackIp(*a.ip) && *a.adminPassword == "" && !hasMTLS {
+	if !isLoopbackIp(*a.ip) && *a.adminPassword == "" && *a.adminApiKey == "" && !hasMTLS {
 		if !insecureAllowed {
 			fmt.Printf("Error: the admin server is configured to bind to %s (non-loopback) with\n", *a.ip)
 			fmt.Printf("       authentication disabled. This would expose the admin API unauthenticated\n")
 			fmt.Printf("       on the network.\n")
 			fmt.Printf("       To fix this, either:\n")
-			fmt.Printf("         - set -adminPassword to enable authentication, or\n")
+			fmt.Printf("         - set -adminPassword to enable session authentication, or\n")
+			fmt.Printf("         - set -adminApiKey to enable bearer-token API authentication, or\n")
 			fmt.Printf("         - configure [https.admin] key and ca in security.toml for mTLS, or\n")
 			fmt.Printf("         - set -ip=127.0.0.1 to bind to loopback only, or\n")
 			fmt.Printf("         - set -allowInsecureBind to start anyway (INSECURE).\n")
@@ -318,7 +319,7 @@ func runAdmin(cmd *Command, args []string) bool {
 		}
 		fmt.Printf("WARNING: -allowInsecureBind is set: the admin API is exposed on %s without\n", *a.ip)
 		fmt.Printf("         authentication. Anyone who can reach this address has full control\n")
-		fmt.Printf("         of the cluster. Set -adminPassword or configure mTLS instead.\n")
+		fmt.Printf("         of the cluster. Set -adminPassword or -adminApiKey or configure mTLS instead.\n")
 	}
 
 	// Security warnings
@@ -481,7 +482,12 @@ func startAdminServer(ctx context.Context, options AdminOptions, enableUI bool, 
 	}()
 
 	// Create handlers and setup routes
-	authRequired := *options.adminPassword != ""
+	// Authentication is required when either adminPassword (session auth) or
+	// adminApiKey (bearer token auth) is configured. When authRequired is true,
+	// the /api subrouter gets RequireAuthAPI middleware that validates both
+	// bearer tokens and browser sessions. The UI session protection is gated
+	// separately on adminPassword inside SetupRoutes.
+	authRequired := *options.adminPassword != "" || *options.adminApiKey != ""
 	adminHandlers := handlers.NewAdminHandlers(adminServer, store)
 	adminHandlers.SetupRoutes(r, authRequired, *options.adminUser, *options.adminPassword, *options.readOnlyUser, *options.readOnlyPassword, enableUI, *options.adminApiKey)
 

--- a/weed/command/admin.go
+++ b/weed/command/admin.go
@@ -48,6 +48,7 @@ type AdminOptions struct {
 	filerGroup       *string
 	adminUser        *string
 	adminPassword    *string
+	adminApiKey      *string
 	readOnlyUser     *string
 	readOnlyPassword *string
 	// nil for callers other than runAdmin (e.g. `weed mini`)
@@ -86,6 +87,7 @@ func init() {
 
 	a.adminUser = cmdAdmin.Flag.String("adminUser", "admin", "admin interface username")
 	a.adminPassword = cmdAdmin.Flag.String("adminPassword", "", "admin interface password (if empty, auth is disabled)")
+	a.adminApiKey = cmdAdmin.Flag.String("adminApiKey", "", "API key for bearer-token auth on /api endpoints (enables server-to-server access without session login)")
 	a.readOnlyUser = cmdAdmin.Flag.String("readOnlyUser", "", "read-only user username (optional, for view-only access)")
 	a.readOnlyPassword = cmdAdmin.Flag.String("readOnlyPassword", "", "read-only user password (optional, for view-only access; requires adminPassword to be set)")
 	a.allowInsecureBind = cmdAdmin.Flag.Bool("allowInsecureBind", false, "INSECURE: allow binding a non-loopback ip without adminPassword or mTLS, exposing the admin API unauthenticated on the network")
@@ -138,8 +140,12 @@ var cmdAdmin = &Command{
     - IMPORTANT: When read-only credentials are configured, adminPassword MUST also be set
     - This ensures an admin account exists to manage and authorize read-only access
     - Sessions are secured with auto-generated session keys
+    - API token auth: set adminApiKey to allow Bearer token access to /api endpoints
+      without a session login. Clients send "Authorization: Bearer <token>".
+      Enables server-to-server integration (e.g. CloudStack object-store plugin).
     - Credentials can also be set via security.toml [admin] section or environment variables:
-      WEED_ADMIN_USER, WEED_ADMIN_PASSWORD, WEED_ADMIN_READONLY_USER, WEED_ADMIN_READONLY_PASSWORD
+      WEED_ADMIN_USER, WEED_ADMIN_PASSWORD, WEED_ADMIN_READONLY_USER, WEED_ADMIN_READONLY_PASSWORD,
+      WEED_ADMIN_API_KEY
     - Precedence: CLI flag > env var / security.toml > default value
 
   Network Binding:
@@ -239,6 +245,7 @@ func runAdmin(cmd *Command, args []string) bool {
 	// CLI flags take precedence over security.toml / WEED_* env vars.
 	applyViperFallback(cmd, a.adminUser, "adminUser", "admin.user")
 	applyViperFallback(cmd, a.adminPassword, "adminPassword", "admin.password")
+	applyViperFallback(cmd, a.adminApiKey, "adminApiKey", "admin.api_key")
 	applyViperFallback(cmd, a.readOnlyUser, "readOnlyUser", "admin.readonly.user")
 	applyViperFallback(cmd, a.readOnlyPassword, "readOnlyPassword", "admin.readonly.password")
 
@@ -476,7 +483,7 @@ func startAdminServer(ctx context.Context, options AdminOptions, enableUI bool, 
 	// Create handlers and setup routes
 	authRequired := *options.adminPassword != ""
 	adminHandlers := handlers.NewAdminHandlers(adminServer, store)
-	adminHandlers.SetupRoutes(r, authRequired, *options.adminUser, *options.adminPassword, *options.readOnlyUser, *options.readOnlyPassword, enableUI)
+	adminHandlers.SetupRoutes(r, authRequired, *options.adminUser, *options.adminPassword, *options.readOnlyUser, *options.readOnlyPassword, enableUI, *options.adminApiKey)
 
 	// Server configuration
 	addr := util.JoinHostPort(*options.ip, *options.port)

--- a/weed/command/admin.go
+++ b/weed/command/admin.go
@@ -341,6 +341,8 @@ func runAdmin(cmd *Command, args []string) bool {
 		if *a.readOnlyPassword != "" {
 			fmt.Printf("Read-only access: Enabled (read-only user: %s)\n", *a.readOnlyUser)
 		}
+	} else if *a.adminApiKey != "" {
+		fmt.Printf("Authentication: API key only (UI disabled; /api endpoints require Bearer token)\n")
 	} else {
 		fmt.Printf("Authentication: Disabled\n")
 	}

--- a/weed/command/mini.go
+++ b/weed/command/mini.go
@@ -561,6 +561,7 @@ func initMiniAdminFlags() {
 	miniAdminOptions.dataDir = cmdMini.Flag.String("admin.dataDir", "", "directory to store admin configuration and data files")
 	miniAdminOptions.adminUser = cmdMini.Flag.String("admin.user", "admin", "admin interface username")
 	miniAdminOptions.adminPassword = cmdMini.Flag.String("admin.password", "", "admin interface password (if empty, auth is disabled)")
+	miniAdminOptions.adminApiKey = cmdMini.Flag.String("admin.apiKey", "", "API key for bearer-token auth on /api endpoints (enables server-to-server access without session login)")
 	miniAdminOptions.readOnlyUser = cmdMini.Flag.String("admin.readOnlyUser", "", "read-only user username (optional, for view-only access)")
 	miniAdminOptions.readOnlyPassword = cmdMini.Flag.String("admin.readOnlyPassword", "", "read-only user password (optional, for view-only access; requires admin.password to be set)")
 	miniAdminOptions.urlPrefix = cmdMini.Flag.String("admin.urlPrefix", "", "URL path prefix when running the admin UI behind a reverse proxy under a subdirectory (e.g. /seaweedfs)")
@@ -1575,6 +1576,7 @@ func startS3Service() {
 func applyMiniAdminCredentialFallback(options *AdminOptions) {
 	applyViperFallback(cmdMini, options.adminUser, "admin.user", "admin.user")
 	applyViperFallback(cmdMini, options.adminPassword, "admin.password", "admin.password")
+	applyViperFallback(cmdMini, options.adminApiKey, "admin.apiKey", "admin.api_key")
 	applyViperFallback(cmdMini, options.readOnlyUser, "admin.readOnlyUser", "admin.readonly.user")
 	applyViperFallback(cmdMini, options.readOnlyPassword, "admin.readOnlyPassword", "admin.readonly.password")
 }


### PR DESCRIPTION
## Summary

- Adds bearer-token authentication as an alternative to session-based auth for the admin REST API (`/api` endpoints)
- New `weed admin` flag: `-adminApiKey=<token>` (also configurable via `security.toml` as `admin.api_key` or env var `WEED_ADMIN_API_KEY`)
- When set, clients authenticate by sending `Authorization: Bearer <token>` — no browser session login or CSRF token needed
- Token validated with `crypto/subtle.ConstantTimeCompare` (constant-time comparison)
- Bearer token auth grants admin (write) access; session-based auth flow is unchanged
- When `-adminApiKey` is empty (default), token auth is disabled and behavior is identical to before

## Motivation

The admin REST API currently requires session-based authentication (cookie + CSRF token), which works for the web UI but is awkward for server-to-server integration. External systems that need to manage bucket quotas, retrieve usage data, or call other admin API endpoints programmatically cannot easily obtain and maintain a browser session.

This change enables server-to-server integration — specifically the Apache CloudStack object-store plugin for SeaweedFS, which needs to call `PUT /api/s3/buckets/{bucket}/quota` and `GET /api/s3/buckets` to manage bucket quotas and report usage.

## Usage

```bash
# Start the admin server with an API key
weed admin -master=localhost:9333 -adminApiKey=secret-token

# Use the API with bearer token auth
curl -H "Authorization: Bearer secret-token" http://localhost:23646/api/s3/buckets
curl -X PUT -H "Authorization: Bearer secret-token"      -H "Content-Type: application/json"      -d '{"quota_size":100,"quota_unit":"GB","quota_enabled":true}'      http://localhost:23646/api/s3/buckets/mybucket/quota
```

## Changes

| File | Change |
|------|--------|
| `weed/admin/dash/middleware.go` | Added `bearerTokenFromRequest` + `validateBearerToken` helpers; `RequireAuthAPI` now accepts `apiKey` and checks bearer token before falling back to session auth |
| `weed/admin/dash/middleware_test.go` | New — 5 tests: token extraction, validation, auth bypass, wrong token, no token |
| `weed/admin/handlers/admin_handlers.go` | `SetupRoutes` accepts and passes `apiKey` to `RequireAuthAPI` |
| `weed/admin/handlers/admin_handlers_routes_test.go` | Updated all `SetupRoutes` calls with the new parameter |
| `weed/command/admin.go` | Added `-adminApiKey` flag, viper fallback, help text, and wired it to `SetupRoutes` |

#### Test plan

- [x] `go test ./weed/admin/dash/` — all existing + 5 new tests pass
- [x] `go test ./weed/admin/handlers/` — all 12 existing route tests pass
- [x] `go build ./weed/admin/dash/ ./weed/admin/handlers/ ./weed/command/` — compiles clean
- [ ] Manual: start `weed admin -adminApiKey=test`, verify `curl -H "Authorization: Bearer test"` works and wrong/missing token returns 401
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs/pull/11278" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Bearer-token authentication for protected admin API endpoints, enabling server-to-server access without a session login.
  * Added API key configuration through the admin command-line option, environment variables, or security configuration.
  * API-key-authenticated requests can access protected admin APIs without browser sessions or CSRF tokens.
  * Added API-key-only mode, which disables the admin UI when no admin password is configured.
* **Bug Fixes**
  * Bearer authentication now accepts standard capitalization and spacing variations in authorization headers.
  * Invalid or missing credentials continue to require authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->