### PR TITLE
s3: close list-type / ownership-controls routing mismatch

### DIFF
--- a/weed/s3api/s3_action_resolver.go
+++ b/weed/s3api/s3_action_resolver.go
@@ -212,6 +212,12 @@ func resolveFromQueryParameters(query url.Values, method string, hasObject bool)
 		}
 	}
 
+	if query.Has("list-type") {
+		if method == http.MethodGet && !hasObject {
+			return s3_constants.S3_ACTION_LIST_BUCKET
+		}
+	}
+
 	// Check bucket-level query parameters using data-driven approach
 	// These are strictly bucket-level operations, so only apply when !hasObject
 	if !hasObject {

--- a/weed/s3api/s3_action_resolver.go
+++ b/weed/s3api/s3_action_resolver.go
@@ -212,7 +212,7 @@ func resolveFromQueryParameters(query url.Values, method string, hasObject bool)
 		}
 	}
 
-	if query.Has("list-type") {
+	if query.Get("list-type") == "2" {
 		if method == http.MethodGet && !hasObject {
 			return s3_constants.S3_ACTION_LIST_BUCKET
 		}

--- a/weed/s3api/s3_action_resolver_test.go
+++ b/weed/s3api/s3_action_resolver_test.go
@@ -158,6 +158,30 @@ func TestResolveS3Action_CreateBucket(t *testing.T) {
 	}
 }
 
+// list-type selects ListObjectsV2, which the router registers ahead of the
+// bucket subresource routes. The resolver must align with routing and resolve
+// it to s3:ListBucket even when an operation subresource like ownershipControls
+// is also present, so authorization checks the listing action the handler runs.
+func TestResolveS3Action_ListType(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+		want  string
+	}{
+		{"list-type alone", "list-type=2", s3_constants.S3_ACTION_LIST_BUCKET},
+		{"list-type with listing params", "list-type=2&prefix=a&continuation-token=x", s3_constants.S3_ACTION_LIST_BUCKET},
+		{"list-type with ownershipControls", "list-type=2&ownershipControls=", s3_constants.S3_ACTION_LIST_BUCKET},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, _ := http.NewRequest(http.MethodGet, "http://localhost/bucket?"+tt.query, nil)
+			if got := ResolveS3Action(r, s3_constants.ACTION_LIST, "bucket", ""); got != tt.want {
+				t.Errorf("ResolveS3Action() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 // A base action naming another service carries no S3 request shape, so a query
 // parameter on the request must not redirect it to an S3 action.
 func TestResolveS3ActionKeepsNonS3Service(t *testing.T) {

--- a/weed/s3api/s3_action_resolver_test.go
+++ b/weed/s3api/s3_action_resolver_test.go
@@ -171,6 +171,9 @@ func TestResolveS3Action_ListType(t *testing.T) {
 		{"list-type alone", "list-type=2", s3_constants.S3_ACTION_LIST_BUCKET},
 		{"list-type with listing params", "list-type=2&prefix=a&continuation-token=x", s3_constants.S3_ACTION_LIST_BUCKET},
 		{"list-type with ownershipControls", "list-type=2&ownershipControls=", s3_constants.S3_ACTION_LIST_BUCKET},
+		// The router only selects ListObjectsV2 for list-type=2; another value
+		// falls through to the subresource route, so ownershipControls wins.
+		{"list-type=1 with ownershipControls", "list-type=1&ownershipControls=", s3_constants.S3_ACTION_GET_BUCKET_OWNERSHIP_CONTROLS},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/weed/s3api/s3api_ambiguous_subresource_test.go
+++ b/weed/s3api/s3api_ambiguous_subresource_test.go
@@ -45,6 +45,10 @@ func TestAmbiguousSubresource(t *testing.T) {
 		"delete=&policy=",
 		"uploads=&uploadId=xyz",
 		"policy=&tagging=&cors=",
+		"list-type=2&ownershipControls=",
+		"list-type=2&tagging=",
+		"ownershipControls=&list-type=2",
+		"list-type=2&versions=",
 	} {
 		req, _ := http.NewRequest("PUT", "http://localhost/bucket?"+query, nil)
 		assert.True(t, hasAmbiguousSubresource(req.URL.Query()), "%q names two operations", query)
@@ -72,4 +76,28 @@ func TestAmbiguousSubresourceRejectedBeforeHandler(t *testing.T) {
 	rec = httptest.NewRecorder()
 	handler.ServeHTTP(rec, req)
 	assert.True(t, served, "an unambiguous request must still be served")
+}
+
+// The listing disclosure: GET /bucket?list-type=2&ownershipControls= routes to
+// ListObjectsV2 while resolving as s3:GetBucketOwnershipControls, so a principal
+// denied s3:ListBucket but allowed the ownership-controls read would list the
+// bucket. The guard has to reject the combined request before the listing handler.
+func TestListTypeOwnershipControlsRejectedBeforeHandler(t *testing.T) {
+	served := false
+	handler := validateRequestPath(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		served = true
+	}))
+
+	req, _ := http.NewRequest("GET", "http://localhost/bucket?list-type=2&ownershipControls=", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.False(t, served, "a list-type+ownershipControls request must not reach a handler")
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	served = false
+	req, _ = http.NewRequest("GET", "http://localhost/bucket?list-type=2&prefix=a", nil)
+	rec = httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	assert.True(t, served, "a plain list-type request must still be served")
 }

--- a/weed/s3api/s3api_path_validation.go
+++ b/weed/s3api/s3api_path_validation.go
@@ -49,9 +49,9 @@ func hasPathSegmentQuery(rawQuery string) bool {
 var operationSubresources = map[string]bool{
 	"accelerate": true, "acl": true, "analytics": true, "attributes": true,
 	"cors": true, "delete": true, "encryption": true, "intelligent-tiering": true,
-	"inventory": true, "legal-hold": true, "lifecycle": true, "location": true,
-	"logging": true, "metrics": true, "notification": true, "object-lock": true,
-	"ownershipControls": true, "policy": true, "policyStatus": true,
+	"inventory": true, "legal-hold": true, "lifecycle": true, "list-type": true,
+	"location": true, "logging": true, "metrics": true, "notification": true,
+	"object-lock": true, "ownershipControls": true, "policy": true, "policyStatus": true,
 	"publicAccessBlock": true, "renameObject": true, "replication": true,
 	"requestPayment": true, "retention": true, "tagging": true, "uploadId": true,
 	"uploads": true, "versioning": true, "versions": true, "website": true,


### PR DESCRIPTION
## Summary

`?list-type=2&ownershipControls=` is routed to `ListObjectsV2` (the `list-type` route is registered first) while the IAM action resolver resolves the `ownershipControls` selector to `s3:GetBucketOwnershipControls`. A principal denied `s3:ListBucket` but allowed `s3:GetBucketOwnershipControls` would therefore be authorized for the combined request and served a bucket listing, disclosing object keys, sizes, ETags and modification times.

This is the same router/resolver disagreement class fixed for `policy&tagging` in #10987, but `list-type` was left out of the ambiguity validation.

Two independent changes, one per commit:

- Add `list-type` to `operationSubresources` so `hasAmbiguousSubresource` rejects `list-type` paired with any other operation selector (e.g. `ownershipControls`, `tagging`, `versions`) before routing. `list-type` alone and with pure listing modifiers (`prefix`, `delimiter`, `continuation-token`, ...) still pass.
- Resolve `list-type` to `s3:ListBucket` ahead of the `bucketQueryActions` loop, mirroring how `versions` is handled, so the resolver stays aligned with the router even if the ambiguity guard is bypassed.

The Go S3 layer is the only component that performs S3 routing and IAM action resolution; the Rust volume server is storage-only and has no analogous logic to mirror.

#### Test plan
- [x] `go test ./weed/s3api/...` passes
- [x] `TestAmbiguousSubresource` covers the new `list-type` combinations
- [x] `TestListTypeOwnershipControlsRejectedBeforeHandler` guards the disclosure path
- [x] `TestResolveS3Action_ListType` covers resolver alignment
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs/pull/11280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - S3 bucket listing requests using `list-type=2` are now correctly recognized and authorized as bucket-list operations.
  - Valid listing requests with supported parameters continue to be served successfully.
  - Requests combining `list-type` with another operation-specific subresource are now rejected with a `400 Bad Request` response instead of being processed ambiguously.
  - Validation occurs before request handling to prevent conflicting operations from reaching service logic.
  - Other `list-type` values no longer trigger the bucket-list operation and are resolved according to their applicable request action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->