### PR TITLE
s3: fail closed on unsupported bucket-policy condition operators

### DIFF
--- a/weed/s3api/policy_engine/bucket_policy.go
+++ b/weed/s3api/policy_engine/bucket_policy.go
@@ -49,6 +49,12 @@ func ValidateBucketPolicy(policyDoc *PolicyDocument, bucket string) error {
 				return fmt.Errorf("statement %d: bucket policies only support S3 actions, got %s", i, action)
 			}
 		}
+
+		for operator := range statement.Condition {
+			if _, err := GetConditionEvaluator(operator); err != nil {
+				return fmt.Errorf("statement %d: unsupported condition operator %q: %v", i, operator, err)
+			}
+		}
 	}
 
 	return nil

--- a/weed/s3api/policy_engine/conditions.go
+++ b/weed/s3api/policy_engine/conditions.go
@@ -248,36 +248,6 @@ func (e *StringNotEqualsIgnoreCaseEvaluator) Evaluate(conditionValue interface{}
 	return true
 }
 
-// StringLikeIgnoreCaseEvaluator evaluates StringLikeIgnoreCase conditions
-type StringLikeIgnoreCaseEvaluator struct{}
-
-func (e *StringLikeIgnoreCaseEvaluator) Evaluate(conditionValue interface{}, contextValues []string) bool {
-	patterns := getCachedNormalizedValues(conditionValue)
-	for _, pattern := range patterns {
-		for _, contextValue := range contextValues {
-			if wildcard.MatchesWildcard(strings.ToLower(pattern), strings.ToLower(contextValue)) {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-// StringNotLikeIgnoreCaseEvaluator evaluates StringNotLikeIgnoreCase conditions
-type StringNotLikeIgnoreCaseEvaluator struct{}
-
-func (e *StringNotLikeIgnoreCaseEvaluator) Evaluate(conditionValue interface{}, contextValues []string) bool {
-	patterns := getCachedNormalizedValues(conditionValue)
-	for _, pattern := range patterns {
-		for _, contextValue := range contextValues {
-			if wildcard.MatchesWildcard(strings.ToLower(pattern), strings.ToLower(contextValue)) {
-				return false
-			}
-		}
-	}
-	return true
-}
-
 // NumericEqualsEvaluator evaluates NumericEquals conditions
 type NumericEqualsEvaluator struct{}
 
@@ -714,10 +684,6 @@ func GetConditionEvaluator(operator string) (ConditionEvaluator, error) {
 		return &StringEqualsIgnoreCaseEvaluator{}, nil
 	case "StringNotEqualsIgnoreCase":
 		return &StringNotEqualsIgnoreCaseEvaluator{}, nil
-	case "StringLikeIgnoreCase":
-		return &StringLikeIgnoreCaseEvaluator{}, nil
-	case "StringNotLikeIgnoreCase":
-		return &StringNotLikeIgnoreCaseEvaluator{}, nil
 	case "NumericEquals":
 		return &NumericEqualsEvaluator{}, nil
 	case "NumericNotEquals":

--- a/weed/s3api/policy_engine/conditions.go
+++ b/weed/s3api/policy_engine/conditions.go
@@ -798,7 +798,7 @@ func EvaluateConditions(conditions PolicyConditions, contextValues map[string][]
 		conditionEvaluator, err := GetConditionEvaluator(operator)
 		if err != nil {
 			glog.Warningf("Unsupported condition operator: %s", operator)
-			continue
+			return false
 		}
 
 		for key, value := range conditionMap {

--- a/weed/s3api/policy_engine/conditions.go
+++ b/weed/s3api/policy_engine/conditions.go
@@ -218,6 +218,66 @@ func (e *StringNotLikeEvaluator) Evaluate(conditionValue interface{}, contextVal
 	return true
 }
 
+// StringEqualsIgnoreCaseEvaluator evaluates StringEqualsIgnoreCase conditions
+type StringEqualsIgnoreCaseEvaluator struct{}
+
+func (e *StringEqualsIgnoreCaseEvaluator) Evaluate(conditionValue interface{}, contextValues []string) bool {
+	expectedValues := getCachedNormalizedValues(conditionValue)
+	for _, expected := range expectedValues {
+		for _, contextValue := range contextValues {
+			if strings.EqualFold(expected, contextValue) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// StringNotEqualsIgnoreCaseEvaluator evaluates StringNotEqualsIgnoreCase conditions
+type StringNotEqualsIgnoreCaseEvaluator struct{}
+
+func (e *StringNotEqualsIgnoreCaseEvaluator) Evaluate(conditionValue interface{}, contextValues []string) bool {
+	expectedValues := getCachedNormalizedValues(conditionValue)
+	for _, expected := range expectedValues {
+		for _, contextValue := range contextValues {
+			if strings.EqualFold(expected, contextValue) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// StringLikeIgnoreCaseEvaluator evaluates StringLikeIgnoreCase conditions
+type StringLikeIgnoreCaseEvaluator struct{}
+
+func (e *StringLikeIgnoreCaseEvaluator) Evaluate(conditionValue interface{}, contextValues []string) bool {
+	patterns := getCachedNormalizedValues(conditionValue)
+	for _, pattern := range patterns {
+		for _, contextValue := range contextValues {
+			if wildcard.MatchesWildcard(strings.ToLower(pattern), strings.ToLower(contextValue)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// StringNotLikeIgnoreCaseEvaluator evaluates StringNotLikeIgnoreCase conditions
+type StringNotLikeIgnoreCaseEvaluator struct{}
+
+func (e *StringNotLikeIgnoreCaseEvaluator) Evaluate(conditionValue interface{}, contextValues []string) bool {
+	patterns := getCachedNormalizedValues(conditionValue)
+	for _, pattern := range patterns {
+		for _, contextValue := range contextValues {
+			if wildcard.MatchesWildcard(strings.ToLower(pattern), strings.ToLower(contextValue)) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 // NumericEqualsEvaluator evaluates NumericEquals conditions
 type NumericEqualsEvaluator struct{}
 
@@ -650,6 +710,14 @@ func GetConditionEvaluator(operator string) (ConditionEvaluator, error) {
 		return &StringLikeEvaluator{}, nil
 	case "StringNotLike":
 		return &StringNotLikeEvaluator{}, nil
+	case "StringEqualsIgnoreCase":
+		return &StringEqualsIgnoreCaseEvaluator{}, nil
+	case "StringNotEqualsIgnoreCase":
+		return &StringNotEqualsIgnoreCaseEvaluator{}, nil
+	case "StringLikeIgnoreCase":
+		return &StringLikeIgnoreCaseEvaluator{}, nil
+	case "StringNotLikeIgnoreCase":
+		return &StringNotLikeIgnoreCaseEvaluator{}, nil
 	case "NumericEquals":
 		return &NumericEqualsEvaluator{}, nil
 	case "NumericNotEquals":

--- a/weed/s3api/policy_engine/conditions_failclosed_test.go
+++ b/weed/s3api/policy_engine/conditions_failclosed_test.go
@@ -1,0 +1,18 @@
+package policy_engine
+
+import (
+	"testing"
+)
+
+func TestEvaluateConditionsFailsClosedOnUnsupportedOperator(t *testing.T) {
+	conditions := PolicyConditions{
+		"StringEqualsBogus": {
+			"aws:username": NewStringOrStringSlice("alice"),
+		},
+	}
+	contextValues := map[string][]string{}
+	got := EvaluateConditions(conditions, contextValues, nil, nil)
+	if got {
+		t.Fatalf("EvaluateConditions returned true for unsupported operator; expected false (fail closed)")
+	}
+}

--- a/weed/s3api/policy_engine/conditions_ignorecase_test.go
+++ b/weed/s3api/policy_engine/conditions_ignorecase_test.go
@@ -16,10 +16,6 @@ func TestConditionEvaluatorsIgnoreCase(t *testing.T) {
 		{"StringEqualsIgnoreCase - no match", "StringEqualsIgnoreCase", "alice", []string{"bob"}, false},
 		{"StringNotEqualsIgnoreCase - match", "StringNotEqualsIgnoreCase", "alice", []string{"bob"}, true},
 		{"StringNotEqualsIgnoreCase - no match", "StringNotEqualsIgnoreCase", "ALICE", []string{"alice"}, false},
-		{"StringLikeIgnoreCase - wildcard match", "StringLikeIgnoreCase", "TEST-*", []string{"test-value"}, true},
-		{"StringLikeIgnoreCase - wildcard no match", "StringLikeIgnoreCase", "TEST-*", []string{"other-value"}, false},
-		{"StringNotLikeIgnoreCase - wildcard match", "StringNotLikeIgnoreCase", "TEST-*", []string{"other-value"}, true},
-		{"StringNotLikeIgnoreCase - wildcard no match", "StringNotLikeIgnoreCase", "TEST-*", []string{"test-value"}, false},
 	}
 
 	for _, tt := range tests {
@@ -33,5 +29,13 @@ func TestConditionEvaluatorsIgnoreCase(t *testing.T) {
 				t.Errorf("Expected %v, got %v", tt.expected, result)
 			}
 		})
+	}
+}
+
+func TestGetConditionEvaluatorRejectsNonAWSIgnoreCaseOperators(t *testing.T) {
+	for _, op := range []string{"StringLikeIgnoreCase", "StringNotLikeIgnoreCase"} {
+		if _, err := GetConditionEvaluator(op); err == nil {
+			t.Fatalf("GetConditionEvaluator accepted non-AWS operator %q; expected error", op)
+		}
 	}
 }

--- a/weed/s3api/policy_engine/conditions_ignorecase_test.go
+++ b/weed/s3api/policy_engine/conditions_ignorecase_test.go
@@ -1,0 +1,37 @@
+package policy_engine
+
+import (
+	"testing"
+)
+
+func TestConditionEvaluatorsIgnoreCase(t *testing.T) {
+	tests := []struct {
+		name           string
+		operator       string
+		conditionValue interface{}
+		contextValues  []string
+		expected       bool
+	}{
+		{"StringEqualsIgnoreCase - match", "StringEqualsIgnoreCase", "ALICE", []string{"alice"}, true},
+		{"StringEqualsIgnoreCase - no match", "StringEqualsIgnoreCase", "alice", []string{"bob"}, false},
+		{"StringNotEqualsIgnoreCase - match", "StringNotEqualsIgnoreCase", "alice", []string{"bob"}, true},
+		{"StringNotEqualsIgnoreCase - no match", "StringNotEqualsIgnoreCase", "ALICE", []string{"alice"}, false},
+		{"StringLikeIgnoreCase - wildcard match", "StringLikeIgnoreCase", "TEST-*", []string{"test-value"}, true},
+		{"StringLikeIgnoreCase - wildcard no match", "StringLikeIgnoreCase", "TEST-*", []string{"other-value"}, false},
+		{"StringNotLikeIgnoreCase - wildcard match", "StringNotLikeIgnoreCase", "TEST-*", []string{"other-value"}, true},
+		{"StringNotLikeIgnoreCase - wildcard no match", "StringNotLikeIgnoreCase", "TEST-*", []string{"test-value"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			evaluator, err := GetConditionEvaluator(tt.operator)
+			if err != nil {
+				t.Fatalf("Failed to get condition evaluator: %v", err)
+			}
+			result := evaluator.Evaluate(tt.conditionValue, tt.contextValues)
+			if result != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}

--- a/weed/s3api/policy_engine/conditions_validation_test.go
+++ b/weed/s3api/policy_engine/conditions_validation_test.go
@@ -4,59 +4,71 @@ import (
 	"testing"
 )
 
-func TestValidatePolicyRejectsUnsupportedConditionOperator(t *testing.T) {
-	tests := []struct {
-		name        string
-		policyJSON  string
-		expectError bool
-	}{
-		{
-			name: "unsupported operator rejected",
-			policyJSON: `{
-				"Version": "2012-10-17",
-				"Statement": [{
-					"Effect": "Allow",
-					"Action": "s3:GetObject",
-					"Resource": "arn:aws:s3:::test-bucket/*",
-					"Condition": {"StringEqualsBogus": {"aws:username": "alice"}}
-				}]
-			}`,
-			expectError: true,
-		},
-		{
-			name: "supported IgnoreCase operator accepted",
-			policyJSON: `{
-				"Version": "2012-10-17",
-				"Statement": [{
-					"Effect": "Allow",
-					"Action": "s3:GetObject",
-					"Resource": "arn:aws:s3:::test-bucket/*",
-					"Condition": {"StringEqualsIgnoreCase": {"aws:username": "alice"}}
-				}]
-			}`,
-			expectError: false,
-		},
-		{
-			name: "supported StringEquals operator accepted",
-			policyJSON: `{
-				"Version": "2012-10-17",
-				"Statement": [{
-					"Effect": "Allow",
-					"Action": "s3:GetObject",
-					"Resource": "arn:aws:s3:::test-bucket/*",
-					"Condition": {"StringEquals": {"aws:username": "alice"}}
-				}]
-			}`,
-			expectError: false,
-		},
-	}
+func TestValidateBucketPolicyRejectsUnsupportedConditionOperator(t *testing.T) {
+	unsupported := `{
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Principal": "*",
+			"Action": "s3:GetObject",
+			"Resource": "arn:aws:s3:::test-bucket/*",
+			"Condition": {"StringEqualsBogus": {"aws:username": "alice"}}
+		}]
+	}`
+	supportedIgnoreCase := `{
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Principal": "*",
+			"Action": "s3:GetObject",
+			"Resource": "arn:aws:s3:::test-bucket/*",
+			"Condition": {"StringEqualsIgnoreCase": {"aws:username": "alice"}}
+		}]
+	}`
+	supportedStringEquals := `{
+		"Version": "2012-10-17",
+		"Statement": [{
+			"Effect": "Allow",
+			"Principal": "*",
+			"Action": "s3:GetObject",
+			"Resource": "arn:aws:s3:::test-bucket/*",
+			"Condition": {"StringEquals": {"aws:username": "alice"}}
+		}]
+	}`
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, err := ParsePolicy(tt.policyJSON)
-			if (err != nil) != tt.expectError {
-				t.Errorf("ParsePolicy expected error: %v, got: %v", tt.expectError, err)
-			}
-		})
-	}
+	t.Run("upload rejects unsupported operator", func(t *testing.T) {
+		policy, err := ParsePolicy(unsupported)
+		if err != nil {
+			t.Fatalf("ParsePolicy failed: %v", err)
+		}
+		if err := ValidateBucketPolicy(policy, "test-bucket"); err == nil {
+			t.Fatalf("ValidateBucketPolicy expected error for unsupported operator, got nil")
+		}
+	})
+
+	t.Run("upload accepts supported IgnoreCase operator", func(t *testing.T) {
+		policy, err := ParsePolicy(supportedIgnoreCase)
+		if err != nil {
+			t.Fatalf("ParsePolicy failed: %v", err)
+		}
+		if err := ValidateBucketPolicy(policy, "test-bucket"); err != nil {
+			t.Fatalf("ValidateBucketPolicy unexpected error: %v", err)
+		}
+	})
+
+	t.Run("upload accepts supported StringEquals operator", func(t *testing.T) {
+		policy, err := ParsePolicy(supportedStringEquals)
+		if err != nil {
+			t.Fatalf("ParsePolicy failed: %v", err)
+		}
+		if err := ValidateBucketPolicy(policy, "test-bucket"); err != nil {
+			t.Fatalf("ValidateBucketPolicy unexpected error: %v", err)
+		}
+	})
+
+	t.Run("load tolerates legacy unsupported operator", func(t *testing.T) {
+		if _, err := ParsePolicy(unsupported); err != nil {
+			t.Fatalf("ParsePolicy must not reject legacy unsupported operator at load time: %v", err)
+		}
+	})
 }

--- a/weed/s3api/policy_engine/conditions_validation_test.go
+++ b/weed/s3api/policy_engine/conditions_validation_test.go
@@ -1,0 +1,62 @@
+package policy_engine
+
+import (
+	"testing"
+)
+
+func TestValidatePolicyRejectsUnsupportedConditionOperator(t *testing.T) {
+	tests := []struct {
+		name        string
+		policyJSON  string
+		expectError bool
+	}{
+		{
+			name: "unsupported operator rejected",
+			policyJSON: `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Action": "s3:GetObject",
+					"Resource": "arn:aws:s3:::test-bucket/*",
+					"Condition": {"StringEqualsBogus": {"aws:username": "alice"}}
+				}]
+			}`,
+			expectError: true,
+		},
+		{
+			name: "supported IgnoreCase operator accepted",
+			policyJSON: `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Action": "s3:GetObject",
+					"Resource": "arn:aws:s3:::test-bucket/*",
+					"Condition": {"StringEqualsIgnoreCase": {"aws:username": "alice"}}
+				}]
+			}`,
+			expectError: false,
+		},
+		{
+			name: "supported StringEquals operator accepted",
+			policyJSON: `{
+				"Version": "2012-10-17",
+				"Statement": [{
+					"Effect": "Allow",
+					"Action": "s3:GetObject",
+					"Resource": "arn:aws:s3:::test-bucket/*",
+					"Condition": {"StringEquals": {"aws:username": "alice"}}
+				}]
+			}`,
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParsePolicy(tt.policyJSON)
+			if (err != nil) != tt.expectError {
+				t.Errorf("ParsePolicy expected error: %v, got: %v", tt.expectError, err)
+			}
+		})
+	}
+}

--- a/weed/s3api/policy_engine/types.go
+++ b/weed/s3api/policy_engine/types.go
@@ -400,12 +400,6 @@ func validateStatement(stmt *PolicyStatement) error {
 		return fmt.Errorf("statement cannot specify both Principal and NotPrincipal")
 	}
 
-	for operator := range stmt.Condition {
-		if _, err := GetConditionEvaluator(operator); err != nil {
-			return fmt.Errorf("unsupported condition operator %q: %v", operator, err)
-		}
-	}
-
 	return nil
 }
 

--- a/weed/s3api/policy_engine/types.go
+++ b/weed/s3api/policy_engine/types.go
@@ -400,6 +400,12 @@ func validateStatement(stmt *PolicyStatement) error {
 		return fmt.Errorf("statement cannot specify both Principal and NotPrincipal")
 	}
 
+	for operator := range stmt.Condition {
+		if _, err := GetConditionEvaluator(operator); err != nil {
+			return fmt.Errorf("unsupported condition operator %q: %v", operator, err)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

The S3 bucket-policy condition engine failed open on unrecognized condition operators. `EvaluateConditions` logged a warning and `continue`d past an unsupported operator, leaving no condition to fail, so it returned `true` and made a conditional `Allow` statement unconditional. This could let an unauthenticated request bypass a non-matching condition (e.g. a `StringEquals: aws:username` guard) and read private objects, simply by using an operator the engine does not recognize.

Commits (one logical change each):

1. **Support the AWS IgnoreCase string operators** (`StringEqualsIgnoreCase`, `StringNotEqualsIgnoreCase`) in the S3 policy engine. These are valid AWS operators (per the IAM condition-operators reference) that the engine previously rejected; `StringLikeIgnoreCase`/`StringNotLikeIgnoreCase` are intentionally **not** added because AWS does not define them (`StringLike`/`StringNotLike` are case-sensitive only).
2. **Reject policies with unsupported condition operators at upload time.** `ValidateBucketPolicy` (run only by the PutBucketPolicy handler and admin UI) now reuses `GetConditionEvaluator` to reject unknown operators when a policy is stored, so a typo or unsupported key is refused at the entry point.
3. **Fail closed at evaluation time.** `EvaluateConditions` now returns `false` on an unsupported operator instead of skipping it, so an unrecognized operator fails the condition block (the statement does not match) rather than granting access. This mirrors the fail-closed posture of the IAM policy engine.
4. **Validate at upload time only, not load time.** The operator check lives in `ValidateBucketPolicy` (upload path) rather than `validateStatement`/`ParsePolicy` (load path), so a legacy policy saved before this change that contains an unsupported operator still loads — preserving its valid statements, including explicit Denies — while `EvaluateConditions` fails the unsupported statement closed. A regression test locks this in.

#### Test plan
- [x] `go test ./weed/s3api/policy_engine/` — new tests for the IgnoreCase evaluators, upload-time validation rejection, load-time tolerance, and fail-closed behavior
- [x] `go test ./weed/s3api/...` — no regressions
- [x] `go build ./weed` — builds cleanly
- [ ] CI (running)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added case-insensitive string equality and inequality matching for bucket policy conditions.

- **Bug Fixes**
  - Unsupported policy condition operators now fail validation and cause condition evaluation to fail closed instead of being ignored.

- **Tests**
  - Added coverage for case-insensitive equality conditions and rejection of unsupported or wildcard-style case-insensitive operators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->