### PR TITLE
fix(master): stop goraft server on shutdown and bump raft to v1.2.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/seaweedfs/goexif v2.0.0+incompatible
-	github.com/seaweedfs/raft v1.2.0
+	github.com/seaweedfs/raft v1.2.1
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1821,8 +1821,8 @@ github.com/seaweedfs/go-fuse/v2 v2.9.4 h1:ACyloiuopdhRSjdLLeSWbsVaemMPskORaRF01T
 github.com/seaweedfs/go-fuse/v2 v2.9.4/go.mod h1:zABdmWEa6A0bwaBeEOBUeUkGIZlxUhcdv+V1Dcc/U/I=
 github.com/seaweedfs/goexif v2.0.0+incompatible h1:x8pckiT12QQhifwhDQpeISgDfsqmQ6VR4LFPQ64JRps=
 github.com/seaweedfs/goexif v2.0.0+incompatible/go.mod h1:Oni780Z236sXpIQzk1XoJlTwqrJ02smEin9zQeff7Fk=
-github.com/seaweedfs/raft v1.2.0 h1:Ez4Hw9ifBbTT7wg54DvGHBjw1vRlTb4roH0TKl0Oj9Y=
-github.com/seaweedfs/raft v1.2.0/go.mod h1:fgs/rAVEzjQ7e04XMzG3eJhwZZRmBW+2uRtjakeCGeU=
+github.com/seaweedfs/raft v1.2.1 h1:QgFl/aaPnagpUxYB6Bx+fFss1NyetVVcJmraMmnaQ5Q=
+github.com/seaweedfs/raft v1.2.1/go.mod h1:fgs/rAVEzjQ7e04XMzG3eJhwZZRmBW+2uRtjakeCGeU=
 github.com/secure-systems-lab/go-securesystemslib v0.11.0 h1:iuCR9kcMFD4QurdKrGvPLoKZLv9YvwPYVr0473BdtFs=
 github.com/secure-systems-lab/go-securesystemslib v0.11.0/go.mod h1:+PMOTjUGwHj2vcZ+TFKlb1tXRbrdWE1LYDT5i9JC80Q=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=

--- a/weed/server/master_server.go
+++ b/weed/server/master_server.go
@@ -621,13 +621,27 @@ func (ms *MasterServer) missingRaftPeerName(peerAddress pb.ServerAddress) (strin
 }
 
 func (ms *MasterServer) Shutdown() {
-	if ms.Topo == nil || ms.Topo.HashicorpRaft == nil {
+	if ms.Topo == nil {
 		return
 	}
-	if ms.Topo.HashicorpRaft.State() == hashicorpRaft.Leader {
-		ms.Topo.HashicorpRaft.LeadershipTransfer()
+	ms.Topo.RaftServerAccessLock.RLock()
+	raftServer := ms.Topo.RaftServer
+	hashRaft := ms.Topo.HashicorpRaft
+	ms.Topo.RaftServerAccessLock.RUnlock()
+
+	if hashRaft != nil {
+		if hashRaft.State() == hashicorpRaft.Leader {
+			hashRaft.LeadershipTransfer()
+		}
+		hashRaft.Shutdown()
 	}
-	ms.Topo.HashicorpRaft.Shutdown()
+	// Stop the goraft server too. Without this, the raft event loop
+	// goroutine (leaderLoop/followerLoop) keeps running after the master
+	// shuts down, leaking goroutines across test runs and occasionally
+	// processing stale events that trigger safety assertions.
+	if raftServer != nil {
+		raftServer.Stop()
+	}
 }
 
 func (ms *MasterServer) Reload() {


### PR DESCRIPTION
## Summary

Fixes a hard-to-reproduce CI panic that crashed the S3 Policy Shell test suite (CI run 34670959967, originally reported on PR #11279 but not caused by that PR).

**Symptom:** `panic: assertion failed: leader.elected.at.same.term.0` from `github.com/seaweedfs/raft`, crashing the whole test binary during `TestShellServiceAccountLifecycle` startup.

**Root cause** (two issues combining):
1. `MasterServer.Shutdown()` only stopped the Hashicorp raft backend. When using the default goraft backend (which `weed mini` uses), the raft event-loop goroutine (`leaderLoop`/`followerLoop`) kept running after the master shut down. In the in-process test harness this leaked goroutines across sequential test runs, and a stale event occasionally reached a leader at term 0.
2. The goraft `_assert(s.State() != Leader, "leader.elected.at.same.term.%d")` in `processAppendEntriesRequest` panicked instead of recovering — a debug check that is far too aggressive for production.

**Fix:**
- `weed/server/master_server.go`: `Shutdown()` now stops the goraft server too, so its goroutines exit cleanly instead of leaking across test runs.
- Bump `github.com/seaweedfs/raft` from v1.2.0 to v1.2.1, which replaces the panicking assertion with a graceful step-down to Follower (mirroring the existing `checkQuorumActive` step-down path in `leaderLoop`). See seaweedfs/raft@3260b2c.

#### Test plan
- [x] `go build ./weed/...`
- [x] `go test -timeout 10m ./test/s3/policy/` (full suite, including the previously-flaking `TestShellServiceAccountLifecycle`)
- [x] `go test -timeout 120s ./...` in seaweedfs/raft (all 30 tests pass)
- [x] `go test -timeout 5m ./weed/server/ -run "Raft|Master|Shutdown"`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/seaweedfs/seaweedfs/pull/11284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved server shutdown handling to more reliably stop active coordination services and background activity.
  - Shutdown now completes correctly when one coordination service is unavailable, instead of exiting prematurely.
- **Maintenance**
  - Updated an internal consensus component to a newer patch release for improved stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->